### PR TITLE
fix: audit and fix 9 jq compatibility bugs

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -1677,6 +1677,38 @@ fn eval_arith_raw(
     }
 }
 
+/// Does the raw JSON value `val` satisfy `val <op> cmp_n` under jq's cross-type ordering?
+///
+/// jq compares values in the order null < false < true < number < string < array < object,
+/// so e.g. `[1] > 1` is true because arrays outrank numbers. The fast paths driving this
+/// helper bypass full JSON parsing, so we dispatch on the first byte.
+fn select_cmp_passes(val: &[u8], op: jq_jit::ir::BinOp, cmp_n: f64) -> bool {
+    use jq_jit::ir::BinOp;
+    if val.is_empty() { return false; }
+    match val[0] {
+        b'-' | b'0'..=b'9' => {
+            if let Some(v) = parse_json_num(val) {
+                match op {
+                    BinOp::Gt => v > cmp_n,
+                    BinOp::Lt => v < cmp_n,
+                    BinOp::Ge => v >= cmp_n,
+                    BinOp::Le => v <= cmp_n,
+                    BinOp::Eq => v == cmp_n,
+                    BinOp::Ne => v != cmp_n,
+                    _ => false,
+                }
+            } else {
+                false
+            }
+        }
+        // null, false, true all rank below numbers.
+        b'n' | b'f' | b't' => matches!(op, BinOp::Lt | BinOp::Le | BinOp::Ne),
+        // strings, arrays, objects all rank above numbers.
+        b'"' | b'[' | b'{' => matches!(op, BinOp::Gt | BinOp::Ge | BinOp::Ne),
+        _ => false,
+    }
+}
+
 fn main() {
     // Run on a thread with a large stack to handle deep recursion.
     // macOS lazily pages the stack, so the physical memory usage is proportional to actual depth.
@@ -11458,7 +11490,6 @@ fn real_main() {
                     })
                 } else if let Some((ref cmp_op, cmp_n)) = collect_each_select_cmp {
                     // [.[] | select(. cmp N)] — collect values passing numeric comparison
-                    use jq_jit::ir::BinOp;
                     let op = *cmp_op;
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
@@ -11466,24 +11497,12 @@ fn real_main() {
                         compact_buf.push(b'[');
                         let mut first_elem = true;
                         let ok = json_each_value_cb(raw, 0, |vs, ve| {
-                            if let Some(v) = parse_json_num(&raw[vs..ve]) {
-                                let pass = match op {
-                                    BinOp::Gt => v > cmp_n,
-                                    BinOp::Lt => v < cmp_n,
-                                    BinOp::Ge => v >= cmp_n,
-                                    BinOp::Le => v <= cmp_n,
-                                    BinOp::Eq => v == cmp_n,
-                                    BinOp::Ne => v != cmp_n,
-                                    _ => false,
-                                };
-                                if pass {
-                                    if !first_elem { compact_buf.push(b','); }
-                                    first_elem = false;
-                                    compact_buf.extend_from_slice(&raw[vs..ve]);
-                                }
-                            } else {
-                                // Non-numeric values: in jq, comparison with number is false for strings
-                                // so they are just skipped
+                            let val = &raw[vs..ve];
+                            let pass = select_cmp_passes(val, op, cmp_n);
+                            if pass {
+                                if !first_elem { compact_buf.push(b','); }
+                                first_elem = false;
+                                compact_buf.extend_from_slice(val);
                             }
                         });
                         if ok {
@@ -20703,7 +20722,6 @@ fn real_main() {
                 })
             } else if let Some((ref cmp_op, cmp_n)) = collect_each_select_cmp {
                 // [.[] | select(. cmp N)] — collect values passing comparison (stdin)
-                use jq_jit::ir::BinOp;
                 let op = *cmp_op;
                 let content_bytes = content.as_bytes();
                 json_stream_raw(content, |start, end| {
@@ -20712,21 +20730,12 @@ fn real_main() {
                     compact_buf.push(b'[');
                     let mut first_elem = true;
                     let ok = json_each_value_cb(raw, 0, |vs, ve| {
-                        if let Some(v) = parse_json_num(&raw[vs..ve]) {
-                            let pass = match op {
-                                BinOp::Gt => v > cmp_n,
-                                BinOp::Lt => v < cmp_n,
-                                BinOp::Ge => v >= cmp_n,
-                                BinOp::Le => v <= cmp_n,
-                                BinOp::Eq => v == cmp_n,
-                                BinOp::Ne => v != cmp_n,
-                                _ => false,
-                            };
-                            if pass {
-                                if !first_elem { compact_buf.push(b','); }
-                                first_elem = false;
-                                compact_buf.extend_from_slice(&raw[vs..ve]);
-                            }
+                        let val = &raw[vs..ve];
+                        let pass = select_cmp_passes(val, op, cmp_n);
+                        if pass {
+                            if !first_elem { compact_buf.push(b','); }
+                            first_elem = false;
+                            compact_buf.extend_from_slice(val);
                         }
                     });
                     if ok {

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -2199,49 +2199,45 @@ pub fn eval(
                 let mut acc = init_val;
                 eval(source, input.clone(), env, &mut |val| {
                     let acc_val = std::mem::replace(&mut acc, Value::Null);
-                    if acc_used {
-                        let (old_var, old_acc) = {
-                            let mut e = env.borrow_mut();
-                            let ov = std::mem::replace(&mut e.vars[vi as usize], val);
-                            let oa = std::mem::replace(&mut e.vars[ai as usize], acc_val.clone());
-                            (ov, oa)
+                    let (old_var, old_acc) = {
+                        let mut e = env.borrow_mut();
+                        let ov = std::mem::replace(&mut e.vars[vi as usize], val);
+                        let oa = if acc_used {
+                            std::mem::replace(&mut e.vars[ai as usize], acc_val.clone())
+                        } else {
+                            Value::Null
                         };
-                        eval(update, acc_val, env, &mut |new_acc| { acc = new_acc; Ok(true) })?;
+                        (ov, oa)
+                    };
+                    let mut stopped = false;
+                    // jq semantics: for each value yielded by update, update the
+                    // accumulator and emit extract(acc) (or acc itself when no extract).
+                    let update_result = eval(update, acc_val, env, &mut |new_acc| {
+                        acc = new_acc.clone();
+                        if acc_used {
+                            env.borrow_mut().vars[ai as usize] = new_acc.clone();
+                        }
                         let cont = if let Some(extract_expr) = extract {
-                            match eval_one_filter(extract_expr, &acc, env) {
+                            match eval_one_filter(extract_expr, &new_acc, env) {
                                 Ok(Some(v)) => cb(v)?,
                                 Ok(None) => true,
-                                Err(()) => eval(extract_expr, acc.clone(), env, cb)?,
+                                Err(()) => eval(extract_expr, new_acc, env, cb)?,
                             }
                         } else {
-                            cb(acc.clone())?
+                            cb(new_acc)?
                         };
-                        {
-                            let mut e = env.borrow_mut();
+                        if !cont { stopped = true; }
+                        Ok(cont)
+                    });
+                    {
+                        let mut e = env.borrow_mut();
+                        if acc_used {
                             e.vars[ai as usize] = old_acc;
-                            e.vars[vi as usize] = old_var;
                         }
-                        Ok(cont)
-                    } else {
-                        let old_var = std::mem::replace(&mut env.borrow_mut().vars[vi as usize], val);
-                        // Try scalar fast path for update to avoid callback dispatch
-                        if let Ok(new_acc) = eval_one(update, &acc_val, env) {
-                            acc = new_acc;
-                        } else {
-                            eval(update, acc_val, env, &mut |new_acc| { acc = new_acc; Ok(true) })?;
-                        }
-                        let cont = if let Some(extract_expr) = extract {
-                            match eval_one_filter(extract_expr, &acc, env) {
-                                Ok(Some(v)) => cb(v)?,
-                                Ok(None) => true,
-                                Err(()) => eval(extract_expr, acc.clone(), env, cb)?,
-                            }
-                        } else {
-                            cb(acc.clone())?
-                        };
-                        env.borrow_mut().vars[vi as usize] = old_var;
-                        Ok(cont)
+                        e.vars[vi as usize] = old_var;
                     }
+                    update_result?;
+                    Ok(!stopped)
                 })
             })
         }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -122,6 +122,12 @@ impl Env {
         // SAFETY: bounds ensured above
         unsafe { *self.vars.get_unchecked_mut(idx) = val; }
     }
+    /// Public setter used by the JIT runtime when it delegates complex paths
+    /// back to eval — the JIT has its own var storage, so we copy the live
+    /// bindings into the eval Env before dispatch.
+    pub fn seed_var(&mut self, idx: u16, val: Value) {
+        self.set_var(idx, val);
+    }
     fn ensure_var(&mut self, idx: u16) {
         let idx = idx as usize;
         if idx >= self.vars.len() { self.vars.resize(idx + 1, Value::Null); }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -840,19 +840,27 @@ fn simplify_expr(expr: &crate::ir::Expr) -> crate::ir::Expr {
                     }
                     let mut elems = Vec::new();
                     collect_elems_for_add(lg, &mut elems);
-                    if elems.len() == 1 {
-                        // [expr] | add → expr (single element, add is identity)
-                        return elems.remove(0);
-                    } else if elems.len() >= 2 {
-                        let mut result = elems.remove(0);
-                        for elem in elems {
-                            result = Expr::BinOp {
-                                op: crate::ir::BinOp::Add,
-                                lhs: Box::new(result),
-                                rhs: Box::new(elem),
-                            };
+                    // Only safe when every element yields exactly one value. An `Empty`
+                    // branch yields zero, so the rewrite would either drop outputs
+                    // (`[] | add` becoming the `Empty` branch itself) or produce the
+                    // wrong sum when mixed with other branches.
+                    let all_single = !elems.is_empty()
+                        && elems.iter().all(|e| !matches!(e, Expr::Empty));
+                    if all_single {
+                        if elems.len() == 1 {
+                            // [expr] | add → expr (single element, add is identity)
+                            return elems.remove(0);
+                        } else if elems.len() >= 2 {
+                            let mut result = elems.remove(0);
+                            for elem in elems {
+                                result = Expr::BinOp {
+                                    op: crate::ir::BinOp::Add,
+                                    lhs: Box::new(result),
+                                    rhs: Box::new(elem),
+                                };
+                            }
+                            return result;
                         }
-                        return result;
                     }
                 }
             }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -525,9 +525,26 @@ fn simplify_expr(expr: &crate::ir::Expr) -> crate::ir::Expr {
             }
             // Semantic: {pairs} | length → N (number of keys)
             // Also: {pairs} | to_entries | ... gets simplified via to_entries | length → constant
+            // Only safe when all keys are literal strings — otherwise we can't know whether two
+            // pairs refer to the same key. And even with literal keys, duplicates collapse, so
+            // count distinct keys rather than the raw pair count.
             if let Expr::ObjectConstruct { pairs } = &sl {
                 if matches!(&sr, Expr::UnaryOp { op: UnaryOp::Length, operand } if matches!(operand.as_ref(), Expr::Input)) {
-                    return Expr::Literal(Literal::Num(pairs.len() as f64, None));
+                    let mut distinct: Vec<&str> = Vec::with_capacity(pairs.len());
+                    let mut all_literal = true;
+                    for (k, _) in pairs {
+                        if let Expr::Literal(Literal::Str(s)) = k {
+                            if !distinct.iter().any(|d| *d == s.as_str()) {
+                                distinct.push(s.as_str());
+                            }
+                        } else {
+                            all_literal = false;
+                            break;
+                        }
+                    }
+                    if all_literal {
+                        return Expr::Literal(Literal::Num(distinct.len() as f64, None));
+                    }
                 }
             }
             // Semantic: [elements] | length → N (number of elements, if known at compile time)
@@ -1792,10 +1809,28 @@ fn push_const_json(expr: &crate::ir::Expr, buf: &mut Vec<u8>) -> bool {
             true
         }
         Expr::ObjectConstruct { pairs } => {
+            // Pre-check: all keys must be string literals. Values may need further
+            // recursion, but we need to know the final key order before writing so
+            // that duplicate keys collapse to the last occurrence (as jq does).
+            let mut ordered_keys: Vec<&str> = Vec::with_capacity(pairs.len());
+            let mut chosen: Vec<usize> = Vec::with_capacity(pairs.len());
+            for (i, (key, _)) in pairs.iter().enumerate() {
+                let k = match key {
+                    Expr::Literal(Literal::Str(k)) => k.as_str(),
+                    _ => return false,
+                };
+                if let Some(pos) = ordered_keys.iter().position(|&ok| ok == k) {
+                    // Later occurrence wins — overwrite the pair we'd emit, keep position.
+                    chosen[pos] = i;
+                } else {
+                    ordered_keys.push(k);
+                    chosen.push(i);
+                }
+            }
             buf.push(b'{');
-            for (i, (key, val)) in pairs.iter().enumerate() {
+            for (i, &pair_idx) in chosen.iter().enumerate() {
                 if i > 0 { buf.push(b','); }
-                // Key must be a literal string
+                let (key, val) = &pairs[pair_idx];
                 if let Expr::Literal(Literal::Str(k)) = key {
                     buf.push(b'"');
                     buf.extend_from_slice(k.as_bytes());
@@ -3380,13 +3415,25 @@ impl Filter {
             }
             None
         }
+        // Collapse duplicate keys (later wins), preserving insertion order.
+        fn dedup_pairs(pairs: Vec<(String, String)>) -> Vec<(String, String)> {
+            let mut out: Vec<(String, String)> = Vec::with_capacity(pairs.len());
+            for (k, v) in pairs {
+                if let Some(existing) = out.iter_mut().find(|(ek, _)| *ek == k) {
+                    existing.1 = v;
+                } else {
+                    out.push((k, v));
+                }
+            }
+            out
+        }
         // Direct ObjectConstruct
-        if let Some(r) = extract_remap_pairs(expr) { return Some(r); }
+        if let Some(r) = extract_remap_pairs(expr) { return Some(dedup_pairs(r)); }
         // {a:.x} + {b:.y} — merged object constructs
         if let Expr::BinOp { op: BinOp::Add, lhs, rhs } = expr {
             if let (Some(mut left), Some(right)) = (extract_remap_pairs(lhs), extract_remap_pairs(rhs)) {
                 left.extend(right);
-                return Some(left);
+                return Some(dedup_pairs(left));
             }
         }
         None
@@ -3417,16 +3464,28 @@ impl Filter {
             let _ = this; // silence unused
             None
         }
+        // Collapse duplicate keys (later wins), preserving original insertion order.
+        fn dedup_keys(pairs: Vec<(String, RemapExpr)>) -> Vec<(String, RemapExpr)> {
+            let mut out: Vec<(String, RemapExpr)> = Vec::with_capacity(pairs.len());
+            for (k, v) in pairs {
+                if let Some(existing) = out.iter_mut().find(|(ek, _)| *ek == k) {
+                    existing.1 = v;
+                } else {
+                    out.push((k, v));
+                }
+            }
+            out
+        }
         // Direct ObjectConstruct
         if let Some((result, has_computed)) = extract_computed_pairs(self, expr) {
-            if has_computed { return Some(result); }
+            if has_computed { return Some(dedup_keys(result)); }
             return None;
         }
         // {a:.x,b:(.y*2)} + {c:.z} — merged object constructs
         if let Expr::BinOp { op: BinOp::Add, lhs, rhs } = expr {
             if let (Some((mut left, lc)), Some((right, rc))) = (extract_computed_pairs(self, lhs), extract_computed_pairs(self, rhs)) {
                 left.extend(right);
-                if lc || rc { return Some(left); }
+                if lc || rc { return Some(dedup_keys(left)); }
             }
         }
         None

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1631,8 +1631,9 @@ fn simplify_expr(expr: &crate::ir::Expr) -> crate::ir::Expr {
                     if is_single_output(&sg) {
                         return sg;
                     }
-                    // first(a, b, ...) where a is single-output → a
-                    if *n >= 1.0 {
+                    // first(a, b, ...) where a is single-output → a. Only valid for
+                    // limit(1; ...): for larger counts we must keep the full generator.
+                    if *n == 1.0 {
                         let mut g = &sg;
                         while let Expr::Comma { left, .. } = g {
                             if is_single_output(left) {

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -6899,6 +6899,7 @@ extern "C" fn jit_rt_call_builtin(dst: *mut Value, name_ptr: *const u8, name_len
                 if let (Some(path_expr), Some(value_expr)) = (path_expr, value_expr) {
                     let input = if !args.is_empty() { args[0].clone() } else { Value::Null };
                     let env = Rc::new(RefCell::new(crate::eval::Env::new(vec![])));
+                    seed_eval_env_from_jit(&env, &[&path_expr, &value_expr]);
                     match crate::eval::eval_assign_standalone(&path_expr, &value_expr, input, &env) {
                         Ok(v) => { std::ptr::write(dst, v); return 0; }
                         Err(e) => { set_jit_error(format!("{}", e)); std::ptr::write(dst, Value::Null); return GEN_ERROR; }
@@ -6920,6 +6921,7 @@ extern "C" fn jit_rt_call_builtin(dst: *mut Value, name_ptr: *const u8, name_len
                 if let (Some(path_expr), Some(update_expr)) = (path_expr, update_expr) {
                     let input = if !args.is_empty() { args[0].clone() } else { Value::Null };
                     let env = Rc::new(RefCell::new(crate::eval::Env::new(vec![])));
+                    seed_eval_env_from_jit(&env, &[&path_expr, &update_expr]);
                     match crate::eval::eval_update_standalone(&path_expr, &update_expr, input, &env) {
                         Ok(v) => { std::ptr::write(dst, v); return 0; }
                         Err(e) => { set_jit_error(format!("{}", e)); std::ptr::write(dst, Value::Null); return GEN_ERROR; }
@@ -9004,6 +9006,28 @@ unsafe extern "C" fn collect_callback(value: *const Value, ctx: *mut u8) -> i64 
 struct GlobalJitEnv(std::cell::UnsafeCell<Option<JitEnv>>);
 unsafe impl Sync for GlobalJitEnv {}
 static REUSABLE_ENV: GlobalJitEnv = GlobalJitEnv(std::cell::UnsafeCell::new(None));
+
+/// Copy live LoadVar bindings from the JIT env into the eval Env before we delegate
+/// a complex path expression back to eval. Without this, constructs like
+/// `let $r = 100 in (.a, .b) |= . + $r` (emitted as `+=` desugaring) lose `$r`
+/// when the Update falls off the JIT's fast path and is handed to eval with a
+/// fresh Env.
+fn seed_eval_env_from_jit(env: &Rc<RefCell<crate::eval::Env>>, exprs: &[&Expr]) {
+    let mut indices: Vec<u16> = Vec::new();
+    for e in exprs {
+        Flattener::collect_loadvar_indices(e, &mut indices);
+    }
+    if indices.is_empty() { return; }
+    let jit_env_opt = unsafe { &mut *REUSABLE_ENV.0.get() };
+    let jit_env = match jit_env_opt.as_ref() { Some(e) => e, None => return };
+    let mut env_mut = env.borrow_mut();
+    for idx in indices {
+        let i = idx as usize;
+        if i < jit_env.vars.len() {
+            env_mut.seed_var(idx, jit_env.vars[i].clone());
+        }
+    }
+}
 
 fn with_jit_env<R>(f: impl FnOnce(&mut JitEnv) -> R) -> R {
     let env_opt = unsafe { &mut *REUSABLE_ENV.0.get() };

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3952,7 +3952,12 @@ fn optimize_pipe(left: Expr, right: Expr) -> Expr {
                     }
                 }
                 collect_comma(generator, &mut elems);
-                if elems.len() >= 2 {
+                // Only safe when every branch yields exactly one value. An `Empty`
+                // branch contributes nothing to the array, but `x + empty` (or
+                // `empty + x`) yields nothing — the rewrite would silently drop the
+                // whole output.
+                let all_single = elems.iter().all(|e| !matches!(e, Expr::Empty));
+                if all_single && elems.len() >= 2 {
                     // Rewrite [a, b, c, ...] | add → a + b + c + ...
                     let mut result = elems.remove(0);
                     for elem in elems {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2627,6 +2627,7 @@ impl Parser {
             | "IN" | "INDEX" | "JOIN" | "strflocaltime"
             | "fromcsv" | "fromtsv" | "fromcsvh" | "fromtsvh"
             | "fromisodate" | "toisodate"
+            | "input_line_number"
             if !matches!(self.current(), Token::LParen) => {
                 self.compile_builtin_noargs(name)
             }
@@ -2811,6 +2812,12 @@ impl Parser {
             }
             "halt_error" => {
                 Ok(Expr::CallBuiltin { name: "halt_error".to_string(), args: vec![] })
+            }
+            "input_line_number" => {
+                // Line tracking is not plumbed through our input pipeline; returning 0
+                // matches jq's behaviour before any line is consumed and, more importantly,
+                // avoids a libjq assertion crash when delegating this builtin.
+                Ok(Expr::Literal(Literal::Num(0.0, None)))
             }
             "fromcsv" | "fromtsv" | "fromcsvh" | "fromtsvh" => {
                 Ok(Expr::CallBuiltin { name: name.to_string(), args: vec![] })

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2711,14 +2711,26 @@ impl Parser {
                         rhs: Box::new(Expr::Literal(Literal::Str("object".to_string()))),
                     }),
                 };
-                Ok(Expr::PathExpr {
-                    expr: Box::new(Expr::Pipe {
-                        left: Box::new(Expr::Recurse { input_expr: Box::new(Expr::Input) }),
-                        right: Box::new(Expr::IfThenElse {
-                            cond: Box::new(scalars_cond),
-                            then_branch: Box::new(Expr::Input),
-                            else_branch: Box::new(Expr::Empty),
+                // Same shape as `paths(f)`: filter out the empty root path.
+                Ok(Expr::Pipe {
+                    left: Box::new(Expr::PathExpr {
+                        expr: Box::new(Expr::Pipe {
+                            left: Box::new(Expr::Recurse { input_expr: Box::new(Expr::Input) }),
+                            right: Box::new(Expr::IfThenElse {
+                                cond: Box::new(scalars_cond),
+                                then_branch: Box::new(Expr::Input),
+                                else_branch: Box::new(Expr::Empty),
+                            }),
                         }),
+                    }),
+                    right: Box::new(Expr::IfThenElse {
+                        cond: Box::new(Expr::BinOp {
+                            op: BinOp::Gt,
+                            lhs: Box::new(Expr::UnaryOp { op: UnaryOp::Length, operand: Box::new(Expr::Input) }),
+                            rhs: Box::new(Expr::Literal(Literal::Num(0.0, None))),
+                        }),
+                        then_branch: Box::new(Expr::Input),
+                        else_branch: Box::new(Expr::Empty),
                     }),
                 })
             }
@@ -3088,16 +3100,28 @@ impl Parser {
             }
             ("paths", 1) => {
                 let f = args.into_iter().next().unwrap();
-                // paths(f) = path(recurse | select(f))... actually it's more complex
-                // paths(node_filter) outputs paths to nodes matching filter
-                Ok(Expr::PathExpr {
-                    expr: Box::new(Expr::Pipe {
-                        left: Box::new(Expr::Recurse { input_expr: Box::new(Expr::Input) }),
-                        right: Box::new(Expr::IfThenElse {
-                            cond: Box::new(f),
-                            then_branch: Box::new(Expr::Input),
-                            else_branch: Box::new(Expr::Empty),
+                // paths(f) = paths | select(getpath(.) | f) in jq's builtin.jq.
+                // We approximate as path(recurse | select(f)), but must also drop the
+                // root (empty) path that recurse yields — jq's `paths` filters `length > 0`.
+                Ok(Expr::Pipe {
+                    left: Box::new(Expr::PathExpr {
+                        expr: Box::new(Expr::Pipe {
+                            left: Box::new(Expr::Recurse { input_expr: Box::new(Expr::Input) }),
+                            right: Box::new(Expr::IfThenElse {
+                                cond: Box::new(f),
+                                then_branch: Box::new(Expr::Input),
+                                else_branch: Box::new(Expr::Empty),
+                            }),
                         }),
+                    }),
+                    right: Box::new(Expr::IfThenElse {
+                        cond: Box::new(Expr::BinOp {
+                            op: BinOp::Gt,
+                            lhs: Box::new(Expr::UnaryOp { op: UnaryOp::Length, operand: Box::new(Expr::Input) }),
+                            rhs: Box::new(Expr::Literal(Literal::Num(0.0, None))),
+                        }),
+                        then_branch: Box::new(Expr::Input),
+                        else_branch: Box::new(Expr::Empty),
                     }),
                 })
             }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1078,14 +1078,16 @@ fn rt_add_all(v: &Value) -> Result<Value> {
 fn rt_any(v: &Value) -> Result<Value> {
     match v {
         Value::Arr(a) => Ok(Value::from_bool(a.iter().any(|v| v.is_true()))),
-        _ => bail!("{} is not an array", v.type_name()),
+        Value::Obj(o) => Ok(Value::from_bool(o.values().any(|v| v.is_true()))),
+        _ => bail!("Cannot iterate over {}", v.type_name()),
     }
 }
 
 fn rt_all(v: &Value) -> Result<Value> {
     match v {
         Value::Arr(a) => Ok(Value::from_bool(a.iter().all(|v| v.is_true()))),
-        _ => bail!("{} is not an array", v.type_name()),
+        Value::Obj(o) => Ok(Value::from_bool(o.values().all(|v| v.is_true()))),
+        _ => bail!("Cannot iterate over {}", v.type_name()),
     }
 }
 

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -172,6 +172,23 @@ null
 ["a","b"]
 "[\"a\",\"b\"]"
 
+# [.[] | select(. cmp N)] must respect jq's cross-type ordering, not only numbers
+
+# Array and object values outrank numbers
+[.[] | select(. > 1)]
+{"a":1,"b":[1,2,3],"c":{"x":9}}
+[[1,2,3],{"x":9}]
+
+# null and booleans rank below numbers, so they pass <
+[.[] | select(. < 1)]
+[null,1,"hi",[0],{},true,false]
+[null,true,false]
+
+# `!=` holds across mismatched types
+[.[] | select(. != 1)]
+{"a":null,"b":1,"c":"hi","d":[0]}
+[null,"hi",[0]]
+
 # `[gen] | add` rewrite must not drop generator branches that yield zero values
 
 # [] | add should be null, not empty

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -172,6 +172,23 @@ null
 ["a","b"]
 "[\"a\",\"b\"]"
 
+# foreach must emit once per value yielded by update, not once per source value
+
+# update yielding multiple values in 2-arg foreach (no extract)
+[foreach range(3) as $i (null; $i, "x")]
+null
+[0,"x",1,"x",2,"x"]
+
+# update yielding multiple values in 3-arg foreach with identity extract
+[foreach range(3) as $i (0; ., . + $i; .)]
+null
+[0,0,0,1,1,3]
+
+# break inside update emits the preceding yield, then exits the label
+[label $out | foreach range(10) as $i (null; if $i > 3 then ., break $out else $i end)]
+null
+[0,1,2,3,3]
+
 # limit(n; comma_generator) must yield n values, not just the first
 
 # limit with number literals as generator

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -172,6 +172,28 @@ null
 ["a","b"]
 "[\"a\",\"b\"]"
 
+# paths(f) and leaf_paths must drop the root (empty) path just like bare paths
+
+# paths(f) on a scalar yields no paths
+[paths(type == "string")]
+"hello"
+[]
+
+# paths(f) on a scalar number still yields no paths
+[paths(type == "number")]
+42
+[]
+
+# Mix of matching/non-matching nested values
+[paths(type == "string")]
+{"a":1,"b":{"c":"x"}}
+[["b","c"]]
+
+# leaf_paths on a scalar yields no paths
+[leaf_paths]
+"hello"
+[]
+
 # [.[] | select(. cmp N)] must respect jq's cross-type ordering, not only numbers
 
 # Array and object values outrank numbers

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -172,6 +172,28 @@ null
 ["a","b"]
 "[\"a\",\"b\"]"
 
+# `[gen] | add` rewrite must not drop generator branches that yield zero values
+
+# [] | add should be null, not empty
+[] | add
+null
+null
+
+# Keeps the null output when followed by another value
+[[] | add, 999]
+null
+[null,999]
+
+# Array literal containing an empty generator mixed with values
+[empty, 1] | add
+null
+1
+
+# Empty generator after value in array literal
+[1, empty] | add
+null
+1
+
 # foreach must emit once per value yielded by update, not once per source value
 
 # update yielding multiple values in 2-arg foreach (no extract)

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -172,6 +172,33 @@ null
 ["a","b"]
 "[\"a\",\"b\"]"
 
+# all/any should iterate object values, not error
+
+# all on object with all truthy values
+all
+{"a":1,"b":2}
+true
+
+# all on object with a null value
+all
+{"a":1,"b":null}
+false
+
+# any on object with at least one truthy value
+any
+{"a":null,"b":1}
+true
+
+# any on empty object
+any
+{}
+false
+
+# all on empty object
+all
+{}
+true
+
 # Issue #10: split returns [""] instead of [] for empty string input
 
 # split on empty string with non-empty separator

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -172,6 +172,33 @@ null
 ["a","b"]
 "[\"a\",\"b\"]"
 
+# Duplicate keys in object literals must collapse so later values win
+
+# Literal-only object with repeated key
+{a:1, a:2}
+null
+{"a":2}
+
+# Duplicate key surrounded by other keys keeps the original position
+{a:1, b:2, a:3}
+null
+{"a":3,"b":2}
+
+# Object merge (`+`) with overlapping key collapses to last
+{a:1} + {a:2}
+null
+{"a":2}
+
+# Computed values also dedupe via the remap fast path
+{a:.x, a:.x + 1}
+{"x":5}
+{"a":6}
+
+# length of a constructed object counts distinct keys
+{a:1, a:2, b:3} | length
+null
+2
+
 # paths(f) and leaf_paths must drop the root (empty) path just like bare paths
 
 # paths(f) on a scalar yields no paths

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -172,6 +172,24 @@ null
 ["a","b"]
 "[\"a\",\"b\"]"
 
+# (.a, .b) += N must hit every path — the += desugaring wraps Update in a
+# LetBinding, so the JIT runtime fallback needs the let-bound value seeded.
+
+# += on a comma path updates every field
+(.a, .b) += 100
+{"a":1,"b":2}
+{"a":101,"b":102}
+
+# -= on a comma path
+(.a, .b) -= 1
+{"a":1,"b":2}
+{"a":0,"b":1}
+
+# *= on a comma path
+(.a, .b) *= 10
+{"a":1,"b":2}
+{"a":10,"b":20}
+
 # Duplicate keys in object literals must collapse so later values win
 
 # Literal-only object with repeated key

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -172,6 +172,13 @@ null
 ["a","b"]
 "[\"a\",\"b\"]"
 
+# input_line_number must not trigger a libjq assertion crash
+
+# input_line_number returns 0 before any line has been consumed
+input_line_number
+null
+0
+
 # all/any should iterate object values, not error
 
 # all on object with all truthy values

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -172,6 +172,28 @@ null
 ["a","b"]
 "[\"a\",\"b\"]"
 
+# limit(n; comma_generator) must yield n values, not just the first
+
+# limit with number literals as generator
+[limit(3; 1,2,3,4,5)]
+null
+[1,2,3]
+
+# limit with string literals as generator
+[limit(2; "a","b","c","d")]
+null
+["a","b"]
+
+# limit(1; ...) on comma generator still acts like first()
+limit(1; 1,2,3)
+null
+1
+
+# limit with arithmetic expressions in comma generator
+[limit(2; 1+1, 2+2, 3+3)]
+null
+[2,4]
+
 # input_line_number must not trigger a libjq assertion crash
 
 # input_line_number returns 0 before any line has been consumed


### PR DESCRIPTION
## Summary

Audit sweep against `jq 1.8.1` that turned up nine cases where jq-jit silently
diverged from jq. Each fix lands as its own commit with a focused regression
test; the official jq suite stays at 509/509 and the regression suite grew
from 33 → 65.

## Bugs fixed

1. **`all` / `any` on object** — errored with "object is not an array" instead
   of iterating the values.
2. **`input_line_number`** — fell through to libjq and tripped an assertion
   (`execute.c:347`). Now stubs to `0`.
3. **`limit(n; gen)` with `n > 1`** — a `first()` rewrite in `simplify_expr`
   collapsed every comma-generator to its first branch.
4. **`foreach`** — emitted once per source value. jq emits once per value
   yielded by `update`, so multi-yield bodies and `., break $out` patterns
   lost outputs.
5. **`[gen] | add`** — two rewrites turned this into `a + b + …` even when a
   branch was `Empty`, silently dropping outputs (`[] | add` printed nothing,
   `[empty, 1] | add` too).
6. **`[.[] | select(. cmp N)]`** — the raw-byte fast path skipped any
   non-numeric value. jq orders `null < bool < number < string < array < object`,
   so `[1, [1,2,3]] | …select(. > 1)` should keep the array.
7. **`paths(f)` / `leaf_paths`** — yielded the empty root path, so
   `"hello" | [paths(type=="string")]` returned `[[]]` instead of `[]`.
8. **Duplicate keys in object literals** — three fast paths emitted every
   pair verbatim. jq normalises `{a:1, a:2}` to `{"a":2}`; our output still
   had both keys (and `| length` reported 2).
9. **`(.a, .b) += N`** — the `+=` desugaring wraps `Update` in a `LetBinding`,
   and the JIT's complex-path runtime delegation spun up a fresh `eval::Env`
   with no vars, so the `$rhs` binding was lost and the update became a no-op.

## Test plan

- [x] `cargo build --release` — zero warnings
- [x] `cargo test --release` — 509/509 official + 65/65 regression
- [x] `./bench/comprehensive.sh --quick` — no measurable regression vs v1.1.0
      (all deltas within ±0.002s run-to-run noise)

🤖 Generated with [Claude Code](https://claude.com/claude-code)