### PR TITLE
test: add differential harness comparing jq-jit output against jq 1.8.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,11 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install jq oniguruma
 
+      - name: Verify jq version
+        run: |
+          jq --version
+          jq --version | grep -q '^jq-1\.8\.'
+
       - name: Build
         run: cargo build --release
 

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -46,6 +46,13 @@ done
 
 エラーメッセージの差は無視（`jq: error` を含むペアは除外）。実値の差と crash だけを拾う。
 
+### 常設 differential harness
+
+`cargo test --release --test differential` が `tests/differential/corpus.test` の
+`(filter, input)` ペアを jq 1.8.x と突き合わせる。新しい compat バグを直したら
+コーパスに 1 件追加すること（`tests/regression.test` の追加に加えて）。
+jq バイナリは `JQ_BIN` → `/opt/homebrew/opt/jq/bin/jq` → `PATH` の順で解決する。
+
 ### テスト出力
 
 `cargo test --release` だけだと regression 通過数が非表示。必ず `--nocapture`:

--- a/tests/differential.rs
+++ b/tests/differential.rs
@@ -1,0 +1,307 @@
+//! Differential test harness: run `(filter, input)` pairs through both
+//! `jq-jit` and reference `jq` (jq-1.8.x) and flag value-level divergences.
+//!
+//! Error-message wording differs between implementations, so cases where both
+//! sides error are treated as agreement. One-sided errors and any value-level
+//! difference are failures.
+//!
+//! The reference `jq` binary is resolved via, in order:
+//!   1. `$JQ_BIN` — explicit override (used by CI / local dev).
+//!   2. `/opt/homebrew/opt/jq/bin/jq` — Homebrew canonical path (see
+//!      `docs/maintenance.md`).
+//!   3. `jq` in `$PATH`.
+//!
+//! If no binary whose `--version` matches `jq-1.8.` can be found, the test is
+//! skipped with a diagnostic instead of failing — this keeps local `cargo
+//! test` usable without 1.8.1 installed.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::Duration;
+
+struct Case {
+    filter: String,
+    input: String,
+    line: usize,
+}
+
+fn parse_corpus(content: &str) -> Vec<Case> {
+    let mut cases = Vec::new();
+    let mut filter: Option<(String, usize)> = None;
+    let mut input: Option<String> = None;
+
+    for (idx, raw) in content.lines().enumerate() {
+        let line_no = idx + 1;
+        let line = raw;
+        if line.trim_start().starts_with('#') {
+            continue;
+        }
+        if line.trim().is_empty() {
+            if let (Some((f, fl)), Some(i)) = (filter.take(), input.take()) {
+                cases.push(Case { filter: f, input: i, line: fl });
+            } else {
+                filter = None;
+                input = None;
+            }
+            continue;
+        }
+        if filter.is_none() {
+            filter = Some((line.to_string(), line_no));
+        } else if input.is_none() {
+            input = Some(line.to_string());
+        } else {
+            panic!("corpus line {}: expected blank line between cases", line_no);
+        }
+    }
+    if let (Some((f, fl)), Some(i)) = (filter, input) {
+        cases.push(Case { filter: f, input: i, line: fl });
+    }
+    cases
+}
+
+#[derive(Debug)]
+struct RunOutput {
+    stdout: String,
+    is_error: bool,
+}
+
+fn run_once(bin: &str, filter: &str, input: &str) -> Option<RunOutput> {
+    let mut cmd = Command::new(bin);
+    cmd.arg("-c").arg(filter);
+    cmd.stdin(std::process::Stdio::piped());
+    cmd.stdout(std::process::Stdio::piped());
+    cmd.stderr(std::process::Stdio::piped());
+
+    let mut child = cmd.spawn().ok()?;
+    {
+        use std::io::Write;
+        let mut stdin = child.stdin.take()?;
+        let _ = stdin.write_all(input.as_bytes());
+        let _ = stdin.write_all(b"\n");
+    }
+
+    let timeout = Duration::from_secs(5);
+    let start = std::time::Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                let out = child.wait_with_output().ok()?;
+                let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+                let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+                #[cfg(unix)]
+                {
+                    use std::os::unix::process::ExitStatusExt;
+                    if let Some(sig) = status.signal() {
+                        return Some(RunOutput {
+                            stdout: format!("<killed by signal {}> stderr: {}", sig, stderr.trim()),
+                            is_error: true,
+                        });
+                    }
+                }
+                let is_error = !status.success();
+                return Some(RunOutput { stdout, is_error });
+            }
+            Ok(None) => {
+                if start.elapsed() > timeout {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return Some(RunOutput {
+                        stdout: "<timeout after 5s>".to_string(),
+                        is_error: true,
+                    });
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            Err(_) => return None,
+        }
+    }
+}
+
+/// Parse one JSON value per output line and re-serialise compactly with sorted
+/// keys, so output equality is value-level (not format-level).
+fn normalize(output: &str) -> Result<String, String> {
+    let mut normalized_lines = Vec::new();
+    for line in output.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let val: serde_json::Value = serde_json::from_str(trimmed)
+            .map_err(|e| format!("non-JSON line `{}`: {}", trimmed, e))?;
+        normalized_lines.push(serialize_sorted(&normalize_value(val)));
+    }
+    Ok(normalized_lines.join("\n"))
+}
+
+fn normalize_value(val: serde_json::Value) -> serde_json::Value {
+    use serde_json::Value;
+    match val {
+        Value::Number(n) => {
+            if let Some(f) = n.as_f64() {
+                if f.is_finite() && f == (f as i64) as f64 && f.abs() < (1i64 << 53) as f64 {
+                    return Value::Number(serde_json::Number::from(f as i64));
+                }
+            }
+            Value::Number(n)
+        }
+        Value::Array(arr) => Value::Array(arr.into_iter().map(normalize_value).collect()),
+        Value::Object(map) => Value::Object(
+            map.into_iter()
+                .map(|(k, v)| (k, normalize_value(v)))
+                .collect(),
+        ),
+        other => other,
+    }
+}
+
+fn serialize_sorted(val: &serde_json::Value) -> String {
+    use serde_json::Value;
+    match val {
+        Value::Null => "null".to_string(),
+        Value::Bool(b) => b.to_string(),
+        Value::Number(n) => n.to_string(),
+        Value::String(s) => serde_json::to_string(s).unwrap(),
+        Value::Array(arr) => {
+            let items: Vec<String> = arr.iter().map(serialize_sorted).collect();
+            format!("[{}]", items.join(","))
+        }
+        Value::Object(map) => {
+            let mut entries: Vec<(&String, &Value)> = map.iter().collect();
+            entries.sort_by_key(|(k, _)| *k);
+            let items: Vec<String> = entries
+                .iter()
+                .map(|(k, v)| format!("{}:{}", serde_json::to_string(k).unwrap(), serialize_sorted(v)))
+                .collect();
+            format!("{{{}}}", items.join(","))
+        }
+    }
+}
+
+fn resolve_jq() -> Option<String> {
+    let candidates: Vec<String> = std::env::var("JQ_BIN")
+        .ok()
+        .into_iter()
+        .chain(std::iter::once("/opt/homebrew/opt/jq/bin/jq".to_string()))
+        .chain(std::iter::once("jq".to_string()))
+        .collect();
+
+    for cand in &candidates {
+        let Ok(output) = Command::new(cand).arg("--version").output() else {
+            continue;
+        };
+        if !output.status.success() {
+            continue;
+        }
+        let ver = String::from_utf8_lossy(&output.stdout);
+        let ver = ver.trim();
+        if ver.starts_with("jq-1.8.") {
+            return Some(cand.clone());
+        }
+        eprintln!("SKIP differential: candidate `{}` is `{}`, need jq-1.8.x", cand, ver);
+    }
+    None
+}
+
+#[test]
+fn differential_against_jq_1_8() {
+    let Some(jq) = resolve_jq() else {
+        let msg = "no jq-1.8.x binary found. Set JQ_BIN to a jq-1.8.x binary.";
+        if std::env::var_os("CI").is_some() {
+            panic!("differential: {}", msg);
+        }
+        eprintln!("SKIP differential: {}", msg);
+        return;
+    };
+    let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
+
+    let corpus_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/differential/corpus.test");
+    let content = std::fs::read_to_string(&corpus_path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {}", corpus_path.display(), e));
+    let cases = parse_corpus(&content);
+    assert!(!cases.is_empty(), "corpus is empty");
+
+    let mut pass = 0usize;
+    let mut fail = 0usize;
+    let mut failures: Vec<String> = Vec::new();
+
+    for case in &cases {
+        let jq_out = run_once(&jq, &case.filter, &case.input);
+        let jit_out = run_once(jq_jit, &case.filter, &case.input);
+
+        let (Some(a), Some(b)) = (jq_out, jit_out) else {
+            fail += 1;
+            failures.push(format!(
+                "  line {}: spawn failure\n    filter: {}\n    input:  {}",
+                case.line, case.filter, case.input
+            ));
+            continue;
+        };
+
+        // Both errored → agreement, skip value comparison.
+        if a.is_error && b.is_error {
+            pass += 1;
+            continue;
+        }
+        // One side errored → divergence.
+        if a.is_error != b.is_error {
+            fail += 1;
+            failures.push(format!(
+                "  line {}: error mismatch (jq error={}, jit error={})\n    filter: {}\n    input:  {}\n    jq:  {}\n    jit: {}",
+                case.line, a.is_error, b.is_error, case.filter, case.input,
+                a.stdout.trim(), b.stdout.trim()
+            ));
+            continue;
+        }
+
+        // Both succeeded → normalise and compare.
+        let a_norm = match normalize(&a.stdout) {
+            Ok(s) => s,
+            Err(e) => {
+                fail += 1;
+                failures.push(format!(
+                    "  line {}: jq output not JSON-parsable ({})\n    filter: {}\n    input:  {}\n    jq:  {}",
+                    case.line, e, case.filter, case.input, a.stdout.trim()
+                ));
+                continue;
+            }
+        };
+        let b_norm = match normalize(&b.stdout) {
+            Ok(s) => s,
+            Err(e) => {
+                fail += 1;
+                failures.push(format!(
+                    "  line {}: jit output not JSON-parsable ({})\n    filter: {}\n    input:  {}\n    jit: {}",
+                    case.line, e, case.filter, case.input, b.stdout.trim()
+                ));
+                continue;
+            }
+        };
+
+        if a_norm == b_norm {
+            pass += 1;
+        } else {
+            fail += 1;
+            failures.push(format!(
+                "  line {}: value mismatch\n    filter: {}\n    input:  {}\n    jq:  {}\n    jit: {}",
+                case.line, case.filter, case.input, a_norm, b_norm
+            ));
+        }
+    }
+
+    eprintln!();
+    eprintln!("=== Differential (vs {}) ===", jq);
+    eprintln!("PASS: {}", pass);
+    eprintln!("FAIL: {}", fail);
+    eprintln!("TOTAL: {}", cases.len());
+
+    if !failures.is_empty() {
+        eprintln!();
+        eprintln!("=== Divergences ===");
+        for f in &failures {
+            eprintln!("{}", f);
+        }
+    }
+
+    assert_eq!(fail, 0, "{} differential divergences out of {}", fail, cases.len());
+}

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -1,0 +1,238 @@
+# Differential test corpus
+# Format: 3-line groups (filter / input / comment-tag optional on same line as filter)
+#
+# Each group is (filter, input). The harness runs both `jq-jit` and reference
+# `jq` (1.8.x) on the input and flags value-level divergences. Error cases
+# where both implementations error are treated as pass (error-message wording
+# differs). Single-side errors are failures.
+#
+# When a new compat bug ships a fix, add a probe here.
+
+# ---------- PR #27 bug 1: all/any on object ----------
+
+{"a":1,"b":2} | all
+null
+
+{"a":true,"b":false} | any
+null
+
+{"a":true,"b":true} | all
+null
+
+# ---------- PR #27 bug 2: input_line_number ----------
+# Intentionally omitted — jq-jit stubs input_line_number to 0 (crash avoidance,
+# not a semantic match). jq-1.8.x returns the current input index. Tracking
+# this in a differential corpus would block every run on a known divergence.
+
+# ---------- PR #27 bug 3: limit(n>1) ----------
+
+[limit(3; 1,2,3,4,5)]
+null
+
+[limit(2; range(5))]
+null
+
+[limit(1; 1,2,3)]
+null
+
+# ---------- PR #27 bug 4: foreach emits per update yield ----------
+
+[foreach range(3) as $i (0; . + $i; .)]
+null
+
+[foreach range(3) as $i (0; ., . + $i; .)]
+null
+
+[label $out | foreach range(5) as $i (0; if $i == 3 then ., break $out else . + $i end; .)]
+null
+
+# ---------- PR #27 bug 5: [gen] | add with Empty branches ----------
+
+[] | add
+null
+
+[empty, 1] | add
+null
+
+[empty, 1, 2] | add
+null
+
+[[] | add]
+null
+
+[empty] | add
+null
+
+# ---------- PR #27 bug 6: [.[] | select(. cmp N)] cross-type ordering ----------
+
+[.[] | select(. > 1)]
+[1, 2, [1,2,3], "foo", null, true, 3]
+
+[.[] | select(. >= 2)]
+[1, 2, 3, null, "x"]
+
+[.[] | select(. < 3)]
+[1, 2, 3, [1], {"a":1}, null]
+
+[.[] | select(. <= 1)]
+[0, 1, 2, null, false, true]
+
+# ---------- PR #27 bug 7: paths(f) skips the empty root path ----------
+# `leaf_paths` was removed from jq-1.8.x; exercise the same invariant via
+# paths(f) instead. jq-jit still defines leaf_paths for compatibility.
+
+[paths(type=="string")]
+"hello"
+
+[paths(type | (. != "object") and (. != "array"))]
+"scalar"
+
+[paths(type | (. != "object") and (. != "array"))]
+42
+
+[paths]
+{"a":{"b":1}}
+
+[paths(type | (. != "object") and (. != "array"))]
+{"a":{"b":1},"c":[1,2]}
+
+# ---------- PR #27 bug 8: duplicate-key collapse in object literals ----------
+
+{a:1, a:2}
+null
+
+{a:1, a:2} | length
+null
+
+{a:.x, a:.x+1}
+{"x":5}
+
+{a:.x, a:.x+1} | length
+{"x":5}
+
+{a:1, b:2, a:3}
+null
+
+{a:1, a:2, a:3}
+null
+
+# ---------- PR #27 bug 9: (path1, path2) += N loses let-binding ----------
+
+(.a, .b) += 100
+{"a":1,"b":2}
+
+(.a, .b) -= 10
+{"a":100,"b":50}
+
+(.a, .b) *= 2
+{"a":3,"b":4}
+
+(.[0], .[2]) += 1
+[10,20,30]
+
+.[] |= . + 1
+[1,2,3]
+
+# ---------- Extra probes: generator-heavy filters ----------
+
+[range(5) | select(. % 2 == 0)]
+null
+
+[.[] | .a // "none"]
+[{"a":1},{},{"a":null},{"a":3}]
+
+[.. | numbers]
+{"a":1,"b":[2,[3,4]],"c":{"d":5}}
+
+[.. | arrays]
+{"a":1,"b":[2,[3,4]],"c":{"d":5}}
+
+# ---------- Extra probes: object updates ----------
+
+.a.b = 42
+{"a":{"b":1,"c":2}}
+
+.a.b |= . + 1
+{"a":{"b":1}}
+
+del(.a, .b)
+{"a":1,"b":2,"c":3}
+
+.[] |= select(. > 1)
+[1,2,3]
+
+# ---------- Extra probes: arithmetic edge cases ----------
+
+1 + 2
+null
+
+.x - .y
+{"x":5,"y":3}
+
+[range(3) | . * .]
+null
+
+# ---------- Extra probes: string and regex ----------
+
+split(",")
+"a,b,c,"
+
+[scan("[0-9]+")]
+"abc 123 def 456"
+
+test("^\\d+$")
+"42"
+
+# ---------- Extra probes: type functions ----------
+
+type
+null
+
+[.[] | type]
+[1, "x", [1], {"a":1}, null, true]
+
+# ---------- Extra probes: group/unique/sort ----------
+
+group_by(.a)
+[{"a":1,"b":1},{"a":2,"b":2},{"a":1,"b":3}]
+
+unique_by(.a)
+[{"a":1,"b":1},{"a":2,"b":2},{"a":1,"b":3}]
+
+sort_by(.a)
+[{"a":2},{"a":1},{"a":3}]
+
+# ---------- Extra probes: to_entries / from_entries ----------
+
+to_entries
+{"a":1,"b":2}
+
+from_entries
+[{"key":"a","value":1},{"key":"b","value":2}]
+
+with_entries(.value += 10)
+{"a":1,"b":2}
+
+# ---------- Extra probes: recurse and tostream ----------
+
+[recurse] | length
+{"a":{"b":{"c":1}}}
+
+[tostream]
+{"a":[1,2]}
+
+# ---------- Extra probes: reduce ----------
+
+reduce range(5) as $i (0; . + $i)
+null
+
+reduce .[] as $x ({}; .[$x | tostring] = 1)
+[1,2,3,2,1]
+
+# ---------- Extra probes: mixed pipe with comma ----------
+
+(.a, .b, .c) | . + 1
+{"a":10,"b":20,"c":30}
+
+[.a, .b] | add
+{"a":[1,2],"b":[3,4]}


### PR DESCRIPTION
## Summary

- Permanent differential test (`tests/differential.rs`) pipes each
  `(filter, input)` pair in `tests/differential/corpus.test` through both
  jq-jit and a reference jq-1.8.x binary and flags value-level divergences.
  Error-message wording is ignored; single-sided errors and any value
  mismatch fail the test.
- Seed corpus covers all nine PR #27 bug classes plus broader probes for
  generators, updates, reduce/foreach, regex, paths, and duplicate object
  keys (62 cases, all pass today).
- Reference jq resolved from `$JQ_BIN` → `/opt/homebrew/opt/jq/bin/jq` →
  `jq` in `PATH`, must report `jq-1.8.*`. CI panics on a missing/mismatched
  binary; local runs skip cleanly.
- `.github/workflows/ci.yml` now verifies `jq --version` starts with
  `jq-1.8.` before the test step, so the differential guard can't be
  silently skipped.
- `docs/maintenance.md` points at the new harness so future compat fixes
  know to grow the corpus alongside `tests/regression.test`.

## Notes on omissions

- `input_line_number` is intentionally left out of the corpus — jq-jit
  stubs it to `0` (crash avoidance, not semantic match) and jq 1.8.x
  returns the actual input index. Tracking it would block every run.
- `leaf_paths` was removed in jq 1.8.x; equivalent `paths(f)` expressions
  exercise the same root-path-skip invariant.

## Test plan

- [x] `cargo build --release` — zero warnings
- [x] `cargo test --release` — 509/509 official + 65/65 regression +
      **62/62 differential** + 3/3 unit
- [x] `./bench/comprehensive.sh --quick` — no runtime changes, no
      measurable delta vs v1.2.0

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)