### PR TITLE
refactor: centralise object-literal dedup via normalize_object_pairs

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -101,16 +101,23 @@ JIT にまで降りる filter はここ。`flatten_scalar` / `flatten_gen` の m
 
 ### オブジェクト重複キーの dedup
 
-jq は `{a:1, a:2}` → `{"a":2}`（後勝ち、最初の位置を保持）。構築系 fast path すべてでこれを守る:
+jq は `{a:1, a:2}` → `{"a":2}`（後勝ち、最初の位置を保持）。構築系 fast path すべてで
+`interpreter.rs` の `normalize_object_pairs<K, V>` ヘルパを通して守る:
 
 | 場所 | 関数 |
 |---|---|
+| `interpreter.rs` | `const_expr_to_json`（ObjectConstruct 分岐） |
 | `interpreter.rs` | `push_const_json`（`detect_literal_output` 経由） |
 | `interpreter.rs` | `simplify_expr` の `{pairs} | length` 畳み込み |
 | `interpreter.rs` | `detect_field_remap`（戻り値 dedup） |
 | `interpreter.rs` | `detect_computed_remap`（戻り値 dedup） |
 
-新しい object 構築 fast path を足す時は、リテラル string キーの後勝ち collapse を必ず通す。
+新しい object 構築 fast path を足す時は、`(key, value)` ペアのリストを組み立てた後に
+`normalize_object_pairs` を必ず通す（キー型は `PartialEq` でよい）。`| length` 系の
+個数だけ欲しい場合も `.len()` を取れば jq と一致する。
+
+invariant 回帰は `tests/regression.test` の "Issue #30" ブロックと
+`tests/differential/corpus.test` の "duplicate-key collapse" ブロックで監視している。
 
 ### `[gen] | add` の Empty 扱い
 

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -329,6 +329,29 @@ fn extract_strfunc_cond(expr: &crate::ir::Expr) -> Option<StrFuncCond> {
     None
 }
 
+/// Collapse duplicate keys in an object-pair list: keep each key at the
+/// position of its *first* occurrence and overwrite its value with the
+/// value of the *last* occurrence. Matches jq's `{a:1, a:2}` → `{"a":2}`
+/// object-literal semantics.
+///
+/// Every fast path that constructs an object from a static pair list must
+/// route through this helper so new paths inherit the invariant. See
+/// `docs/maintenance.md` §3 "オブジェクト重複キーの dedup".
+pub(crate) fn normalize_object_pairs<K, V>(pairs: Vec<(K, V)>) -> Vec<(K, V)>
+where
+    K: PartialEq,
+{
+    let mut out: Vec<(K, V)> = Vec::with_capacity(pairs.len());
+    for (k, v) in pairs {
+        if let Some(existing) = out.iter_mut().find(|(ek, _)| *ek == k) {
+            existing.1 = v;
+        } else {
+            out.push((k, v));
+        }
+    }
+    out
+}
+
 /// Serialize a constant expression to compact JSON bytes.
 /// Supports string, number, null, true, false, and constant ObjectConstruct/Collect.
 fn const_expr_to_json(expr: &crate::ir::Expr) -> Option<Vec<u8>> {
@@ -364,17 +387,24 @@ fn const_expr_to_json(expr: &crate::ir::Expr) -> Option<Vec<u8>> {
         Expr::Literal(Literal::True) => Some(b"true".to_vec()),
         Expr::Literal(Literal::False) => Some(b"false".to_vec()),
         Expr::ObjectConstruct { pairs } => {
+            let mut extracted: Vec<(&str, &Expr)> = Vec::with_capacity(pairs.len());
+            for (k, v) in pairs {
+                if let Expr::Literal(Literal::Str(key)) = k {
+                    extracted.push((key.as_str(), v));
+                } else {
+                    return None;
+                }
+            }
+            let normalized = normalize_object_pairs(extracted);
             let mut buf = Vec::new();
             buf.push(b'{');
-            for (i, (k, v)) in pairs.iter().enumerate() {
+            for (i, (key, v)) in normalized.iter().enumerate() {
                 if i > 0 { buf.push(b','); }
-                if let Expr::Literal(Literal::Str(key)) = k {
-                    buf.push(b'"');
-                    buf.extend_from_slice(key.as_bytes());
-                    buf.push(b'"');
-                    buf.push(b':');
-                    buf.extend(const_expr_to_json(v)?);
-                } else { return None; }
+                buf.push(b'"');
+                buf.extend_from_slice(key.as_bytes());
+                buf.push(b'"');
+                buf.push(b':');
+                buf.extend(const_expr_to_json(v)?);
             }
             buf.push(b'}');
             Some(buf)
@@ -526,24 +556,23 @@ fn simplify_expr(expr: &crate::ir::Expr) -> crate::ir::Expr {
             // Semantic: {pairs} | length → N (number of keys)
             // Also: {pairs} | to_entries | ... gets simplified via to_entries | length → constant
             // Only safe when all keys are literal strings — otherwise we can't know whether two
-            // pairs refer to the same key. And even with literal keys, duplicates collapse, so
-            // count distinct keys rather than the raw pair count.
+            // pairs refer to the same key. After normalization duplicate keys collapse to one,
+            // so the pair count matches jq's output.
             if let Expr::ObjectConstruct { pairs } = &sl {
                 if matches!(&sr, Expr::UnaryOp { op: UnaryOp::Length, operand } if matches!(operand.as_ref(), Expr::Input)) {
-                    let mut distinct: Vec<&str> = Vec::with_capacity(pairs.len());
+                    let mut extracted: Vec<(&str, ())> = Vec::with_capacity(pairs.len());
                     let mut all_literal = true;
                     for (k, _) in pairs {
                         if let Expr::Literal(Literal::Str(s)) = k {
-                            if !distinct.iter().any(|d| *d == s.as_str()) {
-                                distinct.push(s.as_str());
-                            }
+                            extracted.push((s.as_str(), ()));
                         } else {
                             all_literal = false;
                             break;
                         }
                     }
                     if all_literal {
-                        return Expr::Literal(Literal::Num(distinct.len() as f64, None));
+                        let n = normalize_object_pairs(extracted).len();
+                        return Expr::Literal(Literal::Num(n as f64, None));
                     }
                 }
             }
@@ -1809,35 +1838,22 @@ fn push_const_json(expr: &crate::ir::Expr, buf: &mut Vec<u8>) -> bool {
             true
         }
         Expr::ObjectConstruct { pairs } => {
-            // Pre-check: all keys must be string literals. Values may need further
-            // recursion, but we need to know the final key order before writing so
-            // that duplicate keys collapse to the last occurrence (as jq does).
-            let mut ordered_keys: Vec<&str> = Vec::with_capacity(pairs.len());
-            let mut chosen: Vec<usize> = Vec::with_capacity(pairs.len());
-            for (i, (key, _)) in pairs.iter().enumerate() {
-                let k = match key {
-                    Expr::Literal(Literal::Str(k)) => k.as_str(),
+            // All keys must be string literals. Duplicates collapse via
+            // `normalize_object_pairs` (last value wins, keeps first position).
+            let mut extracted: Vec<(&str, &Expr)> = Vec::with_capacity(pairs.len());
+            for (key, val) in pairs {
+                match key {
+                    Expr::Literal(Literal::Str(k)) => extracted.push((k.as_str(), val)),
                     _ => return false,
-                };
-                if let Some(pos) = ordered_keys.iter().position(|&ok| ok == k) {
-                    // Later occurrence wins — overwrite the pair we'd emit, keep position.
-                    chosen[pos] = i;
-                } else {
-                    ordered_keys.push(k);
-                    chosen.push(i);
                 }
             }
+            let normalized = normalize_object_pairs(extracted);
             buf.push(b'{');
-            for (i, &pair_idx) in chosen.iter().enumerate() {
+            for (i, (k, val)) in normalized.iter().enumerate() {
                 if i > 0 { buf.push(b','); }
-                let (key, val) = &pairs[pair_idx];
-                if let Expr::Literal(Literal::Str(k)) = key {
-                    buf.push(b'"');
-                    buf.extend_from_slice(k.as_bytes());
-                    buf.push(b'"');
-                } else {
-                    return false;
-                }
+                buf.push(b'"');
+                buf.extend_from_slice(k.as_bytes());
+                buf.push(b'"');
                 buf.push(b':');
                 if !push_const_json(val, buf) { return false; }
             }
@@ -3415,25 +3431,13 @@ impl Filter {
             }
             None
         }
-        // Collapse duplicate keys (later wins), preserving insertion order.
-        fn dedup_pairs(pairs: Vec<(String, String)>) -> Vec<(String, String)> {
-            let mut out: Vec<(String, String)> = Vec::with_capacity(pairs.len());
-            for (k, v) in pairs {
-                if let Some(existing) = out.iter_mut().find(|(ek, _)| *ek == k) {
-                    existing.1 = v;
-                } else {
-                    out.push((k, v));
-                }
-            }
-            out
-        }
         // Direct ObjectConstruct
-        if let Some(r) = extract_remap_pairs(expr) { return Some(dedup_pairs(r)); }
+        if let Some(r) = extract_remap_pairs(expr) { return Some(normalize_object_pairs(r)); }
         // {a:.x} + {b:.y} — merged object constructs
         if let Expr::BinOp { op: BinOp::Add, lhs, rhs } = expr {
             if let (Some(mut left), Some(right)) = (extract_remap_pairs(lhs), extract_remap_pairs(rhs)) {
                 left.extend(right);
-                return Some(dedup_pairs(left));
+                return Some(normalize_object_pairs(left));
             }
         }
         None
@@ -3464,28 +3468,16 @@ impl Filter {
             let _ = this; // silence unused
             None
         }
-        // Collapse duplicate keys (later wins), preserving original insertion order.
-        fn dedup_keys(pairs: Vec<(String, RemapExpr)>) -> Vec<(String, RemapExpr)> {
-            let mut out: Vec<(String, RemapExpr)> = Vec::with_capacity(pairs.len());
-            for (k, v) in pairs {
-                if let Some(existing) = out.iter_mut().find(|(ek, _)| *ek == k) {
-                    existing.1 = v;
-                } else {
-                    out.push((k, v));
-                }
-            }
-            out
-        }
         // Direct ObjectConstruct
         if let Some((result, has_computed)) = extract_computed_pairs(self, expr) {
-            if has_computed { return Some(dedup_keys(result)); }
+            if has_computed { return Some(normalize_object_pairs(result)); }
             return None;
         }
         // {a:.x,b:(.y*2)} + {c:.z} — merged object constructs
         if let Expr::BinOp { op: BinOp::Add, lhs, rhs } = expr {
             if let (Some((mut left, lc)), Some((right, rc))) = (extract_computed_pairs(self, lhs), extract_computed_pairs(self, rhs)) {
                 left.extend(right);
-                if lc || rc { return Some(dedup_keys(left)); }
+                if lc || rc { return Some(normalize_object_pairs(left)); }
             }
         }
         None

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -236,3 +236,37 @@ reduce .[] as $x ({}; .[$x | tostring] = 1)
 
 [.a, .b] | add
 {"a":[1,2],"b":[3,4]}
+
+# ---------- Issue #30: duplicate-key collapse across fast paths ----------
+# Each case exercises a different object-construction detector. A new fast
+# path that forgets to run through normalize_object_pairs should flag here.
+
+{a:1, a:2}
+null
+
+{a:1, b:2, a:3}
+null
+
+{"a": .x, "b": .y, "a": .z}
+{"x":1,"y":2,"z":3}
+
+{a: .x + 1, a: .x * 2}
+{"x":3}
+
+{a: {b: 1, b: 2}}
+null
+
+[{a:1, a:2}, {b:3, b:4}]
+null
+
+{a:1, a:2, b:3} | length
+null
+
+{a: .x, b: .y, a: .z} | length
+{"x":1,"y":2,"z":3}
+
+{a: 1, b: 2} + {b: 3}
+null
+
+{a: 1} + {a: 2}
+null

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -217,6 +217,45 @@ null
 null
 2
 
+# Issue #30: every object-construction fast path must route through
+# normalize_object_pairs. The cases below each hit a different detector —
+# adding a new fast path without dedup should fail exactly one of these.
+
+# detect_field_remap: duplicate field-ref keys (`.x`, `.z` both land on `a`)
+{"a": .x, "b": .y, "a": .z}
+{"x":1,"y":2,"z":3}
+{"a":3,"b":2}
+
+# detect_computed_remap: duplicate mixed-computed keys
+{a: .x + 1, a: .x * 2}
+{"x":3}
+{"a":6}
+
+# detect_computed_remap: triple repeat collapses to the last value
+{a:1, a:2, a:3}
+null
+{"a":3}
+
+# Nested object literal with duplicate keys (serialized via const_expr_to_json)
+{a: {b: 1, b: 2}}
+null
+{"a":{"b":2}}
+
+# detect_standalone_array: duplicates inside each array element still collapse
+[{a:1, a:2}, {b:3, b:4}]
+null
+[{"a":2},{"b":4}]
+
+# `+` merge of object literals with overlapping *non-first* keys
+{a: 1, b: 2} + {b: 3}
+null
+{"a":1,"b":3}
+
+# `| length` after a field-ref dup collapses distinct keys first
+{a: .x, b: .y, a: .z} | length
+{"x":1,"y":2,"z":3}
+2
+
 # paths(f) and leaf_paths must drop the root (empty) path just like bare paths
 
 # paths(f) on a scalar yields no paths


### PR DESCRIPTION
## Summary
- Adds `normalize_object_pairs<K, V>` in `src/interpreter.rs` — a generic helper that collapses duplicate object-literal keys with last-value-wins / keep-first-position semantics.
- Routes all five object-building fast paths (`const_expr_to_json`, `push_const_json`, `{pairs} | length` rewrite, `detect_field_remap`, `detect_computed_remap`) through the helper. Inline `dedup_pairs` / `dedup_keys` / index-tracking copies are gone.
- Adds a smoke-test block to `tests/regression.test` and `tests/differential/corpus.test`. Each case targets a different detector — a new fast path that forgets dedup should fail exactly one case.
- Updates `docs/maintenance.md` §3 to name the helper and point maintainers at the smoke tests.

Closes #30

## Test plan
- [x] `cargo build --release` — zero warnings
- [x] `cargo test --release` — 509 official + 72 regression + 72 differential all pass
- [x] `./bench/comprehensive.sh --quick` — numbers within noise of v1.1.0 (helper runs at compile time only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)