### PR TITLE
refactor: auto-seed eval::Env on JIT→eval closure-op delegation

### DIFF
--- a/bench/run.sh
+++ b/bench/run.sh
@@ -1,8 +1,16 @@
 #!/bin/bash
 # Quick daily benchmark — 17 NDJSON workloads, ~30s, colored output with ratios
 # For thorough analysis (80+ patterns), use: bench/comprehensive.sh
-# Usage: bench/run.sh [data_file]
+# Usage:
+#   bench/run.sh [data_file]               # full run incl. jq/gojq/jaq if installed
+#   bench/run.sh --self-only [data_file]   # jq-jit only (skips slow competitors)
 set -e
+
+SELF_ONLY=0
+if [ "$1" = "--self-only" ]; then
+    SELF_ONLY=1
+    shift
+fi
 
 DATAFILE="${1:-/tmp/bench_2m.json}"
 RUNS=3
@@ -27,16 +35,18 @@ fi
 TOOLS=("$JQ_JIT")
 NAMES=("jq-jit")
 
-for cmd in jq gojq jaq; do
-    if command -v "$cmd" > /dev/null 2>&1; then
-        TOOLS+=("$(command -v "$cmd")")
-        case "$cmd" in
-            jq)   NAMES+=("jq $($cmd --version 2>&1 | head -1)") ;;
-            gojq) NAMES+=("gojq $(gojq --version 2>&1 | awk '{print $2}')") ;;
-            jaq)  NAMES+=("jaq $(jaq --version 2>&1 | awk '{print $2}')") ;;
-        esac
-    fi
-done
+if [ "$SELF_ONLY" -eq 0 ]; then
+    for cmd in jq gojq jaq; do
+        if command -v "$cmd" > /dev/null 2>&1; then
+            TOOLS+=("$(command -v "$cmd")")
+            case "$cmd" in
+                jq)   NAMES+=("jq $($cmd --version 2>&1 | head -1)") ;;
+                gojq) NAMES+=("gojq $(gojq --version 2>&1 | awk '{print $2}')") ;;
+                jaq)  NAMES+=("jaq $(jaq --version 2>&1 | awk '{print $2}')") ;;
+            esac
+        fi
+    done
+fi
 
 echo "Tools: ${NAMES[*]}"
 echo "Data:  $DATAFILE ($COUNT NDJSON objects)"

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -135,15 +135,39 @@ invariant 回帰は `tests/regression.test` の "Issue #30" ブロックと
 
 ### JIT → eval 委譲時の env seeding
 
-JIT が複雑な Update/Assign を処理する時、`__update__:path_idx:update_idx` / `__assign__:…` という closure op 経由で `eval_update_standalone` / `eval_assign_standalone` に落とす。このとき**新しい `eval::Env` を作る**ので、JIT が set していた let-binding 変数が消える。
+JIT が複雑な Update/Assign/sort_by/paths(f)/path(..) などを処理する時、
+`__update__:path_idx:update_idx` / `__assign__:…` / `__closure_op__:sort_by:idx`
+/ `__paths_filtered__:idx` / `__path__:idx` といった closure op 経由で eval
+側の `eval_*_standalone` に落とす。このとき**新しい `eval::Env` を作る**ので、
+JIT が set していた let-binding 変数がそのままでは消える。
 
 具体例: `(.a, .b) += 100` は parser で
 ```text
 let $r = 100 in update((.a, .b); . + $r)
 ```
-に desugar される。JIT は `$r` を自分の var slot に入れるが、complex path で runtime 委譲した先の fresh Env は `$r` を知らず、`. + null` になって update が no-op 化する。
+に desugar される。JIT は `$r` を自分の var slot に入れるが、complex path で
+runtime 委譲した先の fresh Env は `$r` を知らず、`. + null` になって update が
+no-op 化する。
 
-対策は `src/jit.rs` の `seed_eval_env_from_jit` で、委譲 expression の `LoadVar` 参照を集めて JIT env から eval env にコピーする。**新しい `__xxx__:` closure op を追加する時は必ず同じ seeding を通す**。
+対策は `src/jit.rs` の `new_delegated_env(&[&expr, ...])` /
+`reset_delegated_env(&env, &[&expr, ...])` を**必ず**使うこと。内部で
+`seed_eval_env_from_jit` を呼び、委譲 expression 内の `LoadVar` 参照を
+`Flattener::collect_loadvar_indices` で exhaustive に歩いて JIT env から
+eval env にコピーする。個別の handler は seeding を意識せずに済む。
+
+つまり、新しい `__xxx__:` closure op を追加する時は:
+
+- fresh Env が欲しいなら `new_delegated_env(&[&delegated_expr])`
+- cached Env を reuse するなら `reset_delegated_env(&env, &[&delegated_expr])`
+
+を呼ぶ。`Rc::new(RefCell::new(crate::eval::Env::new(vec![])))` を直接書いては
+いけない（書くと let-binding がまた消える）。
+
+また、`collect_loadvar_indices` は **全 `Expr` variant を再帰的に歩く契約**。
+Index / ObjectConstruct / StringInterpolation / CallBuiltin / FuncCall 等に
+LoadVar が埋もれていても拾える。新しい `Expr` variant を足した時は、この
+walker にも再帰呼び出しを追加すること（足し忘れると let-binding が潜って
+silently null になる）。
 
 ### `paths` / `leaf_paths` / `paths(f)` は root を落とす
 

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -4226,20 +4226,158 @@ impl Flattener {
     }
 
 
-    /// Collect all LoadVar var_indices referenced in an expression.
+    /// Collect all LoadVar var_indices referenced anywhere in an expression.
+    ///
+    /// Must be exhaustive across every `Expr` variant that can contain sub-expressions:
+    /// the JIT→eval closure-op dispatchers rely on this to seed delegated `eval::Env`
+    /// from the JIT env (see `new_delegated_env` / `reset_delegated_env`). A missing
+    /// variant here silently loses any `$var` buried inside and degrades the
+    /// delegated call to `null`.
     fn collect_loadvar_indices(expr: &Expr, out: &mut Vec<u16>) {
+        use crate::ir::StringPart;
         match expr {
-            Expr::LoadVar { var_index } => { if !out.contains(var_index) { out.push(*var_index); } }
-            Expr::BinOp { lhs, rhs, .. } => { Self::collect_loadvar_indices(lhs, out); Self::collect_loadvar_indices(rhs, out); }
-            Expr::Negate { operand } | Expr::UnaryOp { operand, .. } => Self::collect_loadvar_indices(operand, out),
-            Expr::Pipe { left, right } => { Self::collect_loadvar_indices(left, out); Self::collect_loadvar_indices(right, out); }
+            Expr::LoadVar { var_index } => {
+                if !out.contains(var_index) { out.push(*var_index); }
+            }
+            Expr::Input | Expr::Empty | Expr::Literal(_) | Expr::Not
+            | Expr::Loc { .. } | Expr::Env | Expr::Builtins
+            | Expr::ReadInput | Expr::ReadInputs
+            | Expr::ModuleMeta | Expr::GenLabel => {}
+            Expr::BinOp { lhs, rhs, .. } => {
+                Self::collect_loadvar_indices(lhs, out);
+                Self::collect_loadvar_indices(rhs, out);
+            }
+            Expr::UnaryOp { operand, .. } | Expr::Negate { operand } => {
+                Self::collect_loadvar_indices(operand, out);
+            }
+            Expr::Index { expr, key } | Expr::IndexOpt { expr, key } => {
+                Self::collect_loadvar_indices(expr, out);
+                Self::collect_loadvar_indices(key, out);
+            }
+            Expr::Pipe { left, right } | Expr::Comma { left, right } => {
+                Self::collect_loadvar_indices(left, out);
+                Self::collect_loadvar_indices(right, out);
+            }
             Expr::IfThenElse { cond, then_branch, else_branch } => {
                 Self::collect_loadvar_indices(cond, out);
                 Self::collect_loadvar_indices(then_branch, out);
                 Self::collect_loadvar_indices(else_branch, out);
             }
-            Expr::LetBinding { value, body, .. } => { Self::collect_loadvar_indices(value, out); Self::collect_loadvar_indices(body, out); }
-            _ => {}
+            Expr::TryCatch { try_expr, catch_expr } => {
+                Self::collect_loadvar_indices(try_expr, out);
+                Self::collect_loadvar_indices(catch_expr, out);
+            }
+            Expr::Each { input_expr } | Expr::EachOpt { input_expr }
+            | Expr::Recurse { input_expr } => {
+                Self::collect_loadvar_indices(input_expr, out);
+            }
+            Expr::LetBinding { value, body, .. } => {
+                Self::collect_loadvar_indices(value, out);
+                Self::collect_loadvar_indices(body, out);
+            }
+            Expr::Reduce { source, init, update, .. } => {
+                Self::collect_loadvar_indices(source, out);
+                Self::collect_loadvar_indices(init, out);
+                Self::collect_loadvar_indices(update, out);
+            }
+            Expr::Foreach { source, init, update, extract, .. } => {
+                Self::collect_loadvar_indices(source, out);
+                Self::collect_loadvar_indices(init, out);
+                Self::collect_loadvar_indices(update, out);
+                if let Some(e) = extract { Self::collect_loadvar_indices(e, out); }
+            }
+            Expr::Collect { generator } => Self::collect_loadvar_indices(generator, out),
+            Expr::ObjectConstruct { pairs } => {
+                for (k, v) in pairs {
+                    Self::collect_loadvar_indices(k, out);
+                    Self::collect_loadvar_indices(v, out);
+                }
+            }
+            Expr::Alternative { primary, fallback } => {
+                Self::collect_loadvar_indices(primary, out);
+                Self::collect_loadvar_indices(fallback, out);
+            }
+            Expr::Range { from, to, step } => {
+                Self::collect_loadvar_indices(from, out);
+                Self::collect_loadvar_indices(to, out);
+                if let Some(s) = step { Self::collect_loadvar_indices(s, out); }
+            }
+            Expr::Label { body, .. } => Self::collect_loadvar_indices(body, out),
+            Expr::Break { value, .. } => Self::collect_loadvar_indices(value, out),
+            Expr::Update { path_expr, update_expr } => {
+                Self::collect_loadvar_indices(path_expr, out);
+                Self::collect_loadvar_indices(update_expr, out);
+            }
+            Expr::Assign { path_expr, value_expr } => {
+                Self::collect_loadvar_indices(path_expr, out);
+                Self::collect_loadvar_indices(value_expr, out);
+            }
+            Expr::PathExpr { expr } => Self::collect_loadvar_indices(expr, out),
+            Expr::SetPath { path, value } => {
+                Self::collect_loadvar_indices(path, out);
+                Self::collect_loadvar_indices(value, out);
+            }
+            Expr::GetPath { path } => Self::collect_loadvar_indices(path, out),
+            Expr::DelPaths { paths } => Self::collect_loadvar_indices(paths, out),
+            Expr::FuncCall { args, .. } => {
+                for a in args { Self::collect_loadvar_indices(a, out); }
+            }
+            Expr::StringInterpolation { parts } => {
+                for p in parts {
+                    if let StringPart::Expr(e) = p { Self::collect_loadvar_indices(e, out); }
+                }
+            }
+            Expr::Limit { count, generator } => {
+                Self::collect_loadvar_indices(count, out);
+                Self::collect_loadvar_indices(generator, out);
+            }
+            Expr::While { cond, update } | Expr::Until { cond, update } => {
+                Self::collect_loadvar_indices(cond, out);
+                Self::collect_loadvar_indices(update, out);
+            }
+            Expr::Repeat { update } => Self::collect_loadvar_indices(update, out),
+            Expr::AllShort { generator, predicate }
+            | Expr::AnyShort { generator, predicate } => {
+                Self::collect_loadvar_indices(generator, out);
+                Self::collect_loadvar_indices(predicate, out);
+            }
+            Expr::Error { msg } => {
+                if let Some(m) = msg { Self::collect_loadvar_indices(m, out); }
+            }
+            Expr::Format { expr, .. } => Self::collect_loadvar_indices(expr, out),
+            Expr::ClosureOp { input_expr, key_expr, .. } => {
+                Self::collect_loadvar_indices(input_expr, out);
+                Self::collect_loadvar_indices(key_expr, out);
+            }
+            Expr::RegexTest { input_expr, re, flags }
+            | Expr::RegexMatch { input_expr, re, flags }
+            | Expr::RegexCapture { input_expr, re, flags }
+            | Expr::RegexScan { input_expr, re, flags } => {
+                Self::collect_loadvar_indices(input_expr, out);
+                Self::collect_loadvar_indices(re, out);
+                Self::collect_loadvar_indices(flags, out);
+            }
+            Expr::RegexSub { input_expr, re, tostr, flags }
+            | Expr::RegexGsub { input_expr, re, tostr, flags } => {
+                Self::collect_loadvar_indices(input_expr, out);
+                Self::collect_loadvar_indices(re, out);
+                Self::collect_loadvar_indices(tostr, out);
+                Self::collect_loadvar_indices(flags, out);
+            }
+            Expr::AlternativeDestructure { alternatives } => {
+                for a in alternatives { Self::collect_loadvar_indices(a, out); }
+            }
+            Expr::Slice { expr, from, to } => {
+                Self::collect_loadvar_indices(expr, out);
+                if let Some(f) = from { Self::collect_loadvar_indices(f, out); }
+                if let Some(t) = to { Self::collect_loadvar_indices(t, out); }
+            }
+            Expr::Debug { expr } | Expr::Stderr { expr } => {
+                Self::collect_loadvar_indices(expr, out);
+            }
+            Expr::CallBuiltin { args, .. } => {
+                for a in args { Self::collect_loadvar_indices(a, out); }
+            }
         }
     }
 
@@ -6898,8 +7036,7 @@ extern "C" fn jit_rt_call_builtin(dst: *mut Value, name_ptr: *const u8, name_len
                 };
                 if let (Some(path_expr), Some(value_expr)) = (path_expr, value_expr) {
                     let input = if !args.is_empty() { args[0].clone() } else { Value::Null };
-                    let env = Rc::new(RefCell::new(crate::eval::Env::new(vec![])));
-                    seed_eval_env_from_jit(&env, &[&path_expr, &value_expr]);
+                    let env = new_delegated_env(&[&path_expr, &value_expr]);
                     match crate::eval::eval_assign_standalone(&path_expr, &value_expr, input, &env) {
                         Ok(v) => { std::ptr::write(dst, v); return 0; }
                         Err(e) => { set_jit_error(format!("{}", e)); std::ptr::write(dst, Value::Null); return GEN_ERROR; }
@@ -6920,8 +7057,7 @@ extern "C" fn jit_rt_call_builtin(dst: *mut Value, name_ptr: *const u8, name_len
                 };
                 if let (Some(path_expr), Some(update_expr)) = (path_expr, update_expr) {
                     let input = if !args.is_empty() { args[0].clone() } else { Value::Null };
-                    let env = Rc::new(RefCell::new(crate::eval::Env::new(vec![])));
-                    seed_eval_env_from_jit(&env, &[&path_expr, &update_expr]);
+                    let env = new_delegated_env(&[&path_expr, &update_expr]);
                     match crate::eval::eval_update_standalone(&path_expr, &update_expr, input, &env) {
                         Ok(v) => { std::ptr::write(dst, v); return 0; }
                         Err(e) => { set_jit_error(format!("{}", e)); std::ptr::write(dst, Value::Null); return GEN_ERROR; }
@@ -6945,21 +7081,18 @@ extern "C" fn jit_rt_call_builtin(dst: *mut Value, name_ptr: *const u8, name_len
                         None
                     });
 
-                // For general filters, use cached Env
+                // For general filters, use cached Env (auto-seeded from JIT env).
                 let env = if compiled_filter.is_none() {
                     thread_local! {
                         static PATHS_FILTER_ENV: RefCell<Option<Rc<RefCell<crate::eval::Env>>>> = const { RefCell::new(None) };
                     }
                     Some(PATHS_FILTER_ENV.with(|cell| {
                         let mut opt = cell.borrow_mut();
-                        if let Some(ref env) = *opt {
-                            env.borrow_mut().reset();
-                            env.clone()
-                        } else {
-                            let e = Rc::new(RefCell::new(crate::eval::Env::new(vec![])));
-                            *opt = Some(e.clone());
-                            e
-                        }
+                        let env = opt.get_or_insert_with(|| {
+                            Rc::new(RefCell::new(crate::eval::Env::new(vec![])))
+                        }).clone();
+                        reset_delegated_env(&env, &[&filter_expr]);
+                        env
                     }))
                 } else {
                     None
@@ -7024,7 +7157,7 @@ extern "C" fn jit_rt_call_builtin(dst: *mut Value, name_ptr: *const u8, name_len
             let path_expr = (&*JIT_CLOSURE_OPS.0.get()).get(idx).cloned();
             if let Some(path_expr) = path_expr {
                 let input = if !args.is_empty() { args[0].clone() } else { Value::Null };
-                let env = Rc::new(RefCell::new(crate::eval::Env::new(vec![])));
+                let env = new_delegated_env(&[&path_expr]);
                 match crate::eval::eval_path_standalone(&path_expr, input, &env) {
                     Ok(v) => { std::ptr::write(dst, v); return 0; }
                     Err(e) => { set_jit_error(format!("{}", e)); std::ptr::write(dst, Value::Null); return GEN_ERROR; }
@@ -7051,21 +7184,19 @@ extern "C" fn jit_rt_call_builtin(dst: *mut Value, name_ptr: *const u8, name_len
                             _ => None,
                         };
                         if let Some(op_kind) = op_kind {
-                            // Use eval infrastructure to perform the closure op
-                            // Cache the Env to avoid 2MB allocation per call
+                            // Use eval infrastructure to perform the closure op.
+                            // Cache the Env to avoid 2MB allocation per call, and
+                            // auto-seed any $vars referenced by `key_expr`.
                             thread_local! {
                                 static CLOSURE_OP_ENV: RefCell<Option<Rc<RefCell<crate::eval::Env>>>> = const { RefCell::new(None) };
                             }
                             let env = CLOSURE_OP_ENV.with(|cell| {
                                 let mut opt = cell.borrow_mut();
-                                if let Some(ref env) = *opt {
-                                    env.borrow_mut().reset();
-                                    env.clone()
-                                } else {
-                                    let e = Rc::new(RefCell::new(crate::eval::Env::new(vec![])));
-                                    *opt = Some(e.clone());
-                                    e
-                                }
+                                let env = opt.get_or_insert_with(|| {
+                                    Rc::new(RefCell::new(crate::eval::Env::new(vec![])))
+                                }).clone();
+                                reset_delegated_env(&env, &[&key_expr]);
+                                env
                             });
                             let eval_result = crate::eval::eval_closure_op_standalone(
                                 op_kind, container, &key_expr, &env,
@@ -9008,10 +9139,15 @@ unsafe impl Sync for GlobalJitEnv {}
 static REUSABLE_ENV: GlobalJitEnv = GlobalJitEnv(std::cell::UnsafeCell::new(None));
 
 /// Copy live LoadVar bindings from the JIT env into the eval Env before we delegate
-/// a complex path expression back to eval. Without this, constructs like
+/// a complex closure-op expression back to eval. Without this, constructs like
 /// `let $r = 100 in (.a, .b) |= . + $r` (emitted as `+=` desugaring) lose `$r`
 /// when the Update falls off the JIT's fast path and is handed to eval with a
 /// fresh Env.
+///
+/// Every `__xxx__:` runtime dispatcher must construct its delegated `eval::Env`
+/// through [`new_delegated_env`] or [`reset_delegated_env`] rather than calling
+/// `Env::new` directly — they guarantee the JIT-set let-bindings are seeded so
+/// new closure ops can't silently regress.
 fn seed_eval_env_from_jit(env: &Rc<RefCell<crate::eval::Env>>, exprs: &[&Expr]) {
     let mut indices: Vec<u16> = Vec::new();
     for e in exprs {
@@ -9027,6 +9163,24 @@ fn seed_eval_env_from_jit(env: &Rc<RefCell<crate::eval::Env>>, exprs: &[&Expr]) 
             env_mut.seed_var(idx, jit_env.vars[i].clone());
         }
     }
+}
+
+/// Build a fresh `eval::Env` for a JIT→eval closure-op delegation, auto-seeded
+/// with any `$var` referenced by `exprs`. Use this instead of
+/// `Rc::new(RefCell::new(Env::new(vec![])))` from inside an `__xxx__:` dispatcher.
+fn new_delegated_env(exprs: &[&Expr]) -> Rc<RefCell<crate::eval::Env>> {
+    let env = Rc::new(RefCell::new(crate::eval::Env::new(vec![])));
+    seed_eval_env_from_jit(&env, exprs);
+    env
+}
+
+/// Reset a cached `eval::Env` for a JIT→eval closure-op delegation and re-seed
+/// any `$var` referenced by `exprs` from the JIT env. Use this instead of a
+/// bare `env.borrow_mut().reset()` when the dispatcher caches its Env in a
+/// thread-local to amortize allocation.
+fn reset_delegated_env(env: &Rc<RefCell<crate::eval::Env>>, exprs: &[&Expr]) {
+    env.borrow_mut().reset();
+    seed_eval_env_from_jit(env, exprs);
 }
 
 fn with_jit_env<R>(f: impl FnOnce(&mut JitEnv) -> R) -> R {

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -133,6 +133,14 @@ null
 .[] |= . + 1
 [1,2,3]
 
+# ---------- Issue #31: JIT→eval delegation must seed $vars buried deep in update ----------
+
+[100] as $r | (.a, .b) |= $r[0]
+{"a":1,"b":2}
+
+"x" as $r | (.a, .b) |= "\($r)!"
+{"a":1,"b":2}
+
 # ---------- Extra probes: generator-heavy filters ----------
 
 [range(5) | select(. % 2 == 0)]

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -190,6 +190,21 @@ null
 {"a":1,"b":2}
 {"a":10,"b":20}
 
+# JIT→eval delegated Update must seed $vars no matter where they hide in
+# the update expression. Pre-refactor the LoadVar walker only descended
+# through BinOp/Pipe/etc.; $r buried inside Index/StringInterpolation was
+# silently lost and the update collapsed to a no-op.
+
+# $var inside Index on the update RHS
+[100] as $r | (.a, .b) |= $r[0]
+{"a":1,"b":2}
+{"a":100,"b":100}
+
+# $var inside string interpolation on the update RHS
+"x" as $r | (.a, .b) |= "\($r)!"
+{"a":1,"b":2}
+{"a":"x!","b":"x!"}
+
 # Duplicate keys in object literals must collapse so later values win
 
 # Literal-only object with repeated key


### PR DESCRIPTION
## Summary

- Centralise the JIT→eval env seeding behind `new_delegated_env` / `reset_delegated_env` helpers so every `__xxx__:` closure-op dispatcher (`__assign__`, `__update__`, `__path__`, `__paths_filtered__`, `__closure_op__`) auto-seeds the delegated `eval::Env` from live JIT let-bindings instead of opting in per handler.
- Expand `Flattener::collect_loadvar_indices` to walk every `Expr` variant exhaustively (previously stopped at `Index`, `ObjectConstruct`, `StringInterpolation`, `FuncCall`, …, silently losing any `\$var` buried inside).
- Refresh `docs/maintenance.md` to describe the new contract so new dispatchers can't silently regress.
- Drive-by: add `bench/run.sh --self-only` to skip jq/gojq/jaq when you just want jq-jit numbers for a refactor sanity-check.

Closes #31

## Test plan

- [x] `cargo build --release` — zero warnings
- [x] `cargo test --release` — 509 official + 74 regression (added two cases: `\$r[0]` on update RHS via `Index`, string-interp `\"\\(\$r)!\"` on update RHS) + differential harness green
- [x] Added matching entries to `tests/differential/corpus.test` so the jq-1.8 diff harness keeps watching them
- [x] `./bench/comprehensive.sh --quick` — no regression vs v1.1.0 baseline in `docs/benchmark-history.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)