### PR TITLE
docs(licensing): add third-party attribution and bundle it in releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,8 +50,11 @@ jobs:
 
       - name: Package
         run: |
-          cd target/release
-          tar czf ../../jq-jit-${{ matrix.target }}.tar.gz jq-jit
+          staging="jq-jit-${{ matrix.target }}"
+          mkdir -p "$staging"
+          cp target/release/jq-jit "$staging/"
+          cp LICENSE-MIT LICENSE-APACHE THIRD-PARTY-LICENSES.md README.md "$staging/"
+          tar czf "${staging}.tar.gz" -C "$staging" .
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,7 +417,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jq-jit"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jq-jit"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A JIT-compiling implementation of jq using Cranelift"

--- a/README.md
+++ b/README.md
@@ -204,9 +204,26 @@ This generates 2M NDJSON objects and measures performance across 100+ filter pat
 
 ## License
 
-Licensed under either of
+jq-jit's own source code is licensed under either of
 
 - [MIT License](LICENSE-MIT)
 - [Apache License, Version 2.0](LICENSE-APACHE)
 
 at your option.
+
+### Third-party components
+
+When distributed as a compiled binary, jq-jit also includes or links against
+third-party code — most notably [jq](https://github.com/jqlang/jq) (MIT),
+[Oniguruma](https://github.com/kkos/oniguruma) (BSD-2-Clause), and
+[Cranelift](https://cranelift.dev/) (Apache-2.0 WITH LLVM-exception) — whose
+own license terms must be preserved. Because several required dependencies
+(Cranelift, `ryu`, and others) do not offer an MIT option, **a binary
+distribution in practice must comply with Apache-2.0 terms for those
+components, regardless of which option a user selects for jq-jit's own
+code**.
+
+See [THIRD-PARTY-LICENSES.md](THIRD-PARTY-LICENSES.md) for the full
+attribution listing. In addition, the FFI layer (`src/jq_ffi.rs`,
+`src/bytecode.rs`) mirrors structures from jq's headers and is a derivative
+work of jq, redistributed under the MIT License.

--- a/THIRD-PARTY-LICENSES.md
+++ b/THIRD-PARTY-LICENSES.md
@@ -1,0 +1,115 @@
+# Third-Party Licenses
+
+jq-jit is distributed under the [MIT](LICENSE-MIT) or
+[Apache-2.0](LICENSE-APACHE) license (at your option). However, the compiled
+binary statically links or dynamically links against third-party code whose
+own licenses must be preserved when distributing the binary.
+
+This file enumerates those third-party components and their licenses. Full
+license texts for each component are available from the upstream source
+repositories linked below, and (for Rust crates) inside each crate's
+distribution on [crates.io](https://crates.io).
+
+---
+
+## System libraries (dynamically linked at runtime)
+
+| Component | Version | License | Upstream |
+|-----------|---------|---------|----------|
+| [jq](https://github.com/jqlang/jq) | ≥ 1.7 | MIT | <https://github.com/jqlang/jq/blob/master/COPYING> |
+| [Oniguruma (libonig)](https://github.com/kkos/oniguruma) | runtime dep of jq | BSD-2-Clause | <https://github.com/kkos/oniguruma/blob/master/COPYING> |
+
+### jq
+
+Copyright (C) 2012 Stephen Dolan.
+Licensed under the MIT License. jq-jit's `src/jq_ffi.rs` and `src/bytecode.rs`
+include Rust FFI declarations that mirror data structures from jq's public
+headers (`jv.h`, `jq.h`) and internal bytecode layout. Those portions are
+derivative works of jq and are redistributed under the MIT License.
+
+### Oniguruma
+
+Copyright (c) 2002-2024 K.Kosako.
+Licensed under the BSD 2-Clause License. Oniguruma is used transitively via
+jq's regex support; jq-jit does not call Oniguruma directly.
+
+---
+
+## Rust crate dependencies
+
+The following crates are compiled into the jq-jit binary. Each crate's
+license text is included in its source distribution on crates.io.
+
+### Cranelift / Wasmtime (Apache-2.0 WITH LLVM-exception)
+
+Copyright Bytecode Alliance contributors. Licensed under the Apache License,
+Version 2.0, with the LLVM exception. See
+<https://github.com/bytecodealliance/wasmtime/blob/main/LICENSE>.
+
+- `cranelift-assembler-x64`, `cranelift-assembler-x64-meta`
+- `cranelift-bforest`, `cranelift-bitset`
+- `cranelift-codegen`, `cranelift-codegen-meta`, `cranelift-codegen-shared`
+- `cranelift-control`, `cranelift-entity`, `cranelift-frontend`
+- `cranelift-isle`, `cranelift-jit`, `cranelift-module`
+- `cranelift-native`, `cranelift-srcgen`
+- `regalloc2`
+- `target-lexicon`
+- `wasmtime-internal-core`, `wasmtime-internal-jit-icache-coherence`
+- `ar_archive_writer`
+
+### Dual-licensed MIT OR Apache-2.0
+
+- `allocator-api2`, `anyhow`, `arbitrary`, `autocfg`
+- `bumpalo`, `cc`, `cfg-if`, `chrono`, `core-foundation-sys`
+- `equivalent`, `fast-float`, `find-msvc-tools`, `fnv`, `gimli`
+- `hashbrown`, `heck`, `iana-time-zone`, `indexmap`, `itoa`
+- `libc`, `log`, `memmap2`, `num-traits`, `object`, `psm`
+- `regex`, `regex-automata`, `regex-syntax`
+- `rustc-hash`, `rustversion`, `serde_core`, `serde_json`
+- `shlex`, `smallvec`, `stacker`, `static_assertions`
+- `bitflags` (MIT / Apache-2.0)
+
+### MIT only
+
+- `castaway`
+- `compact_str`
+- `libm`
+- `libmimalloc-sys`, `mimalloc` (© Microsoft Corporation)
+- `region`
+- `zmij`
+
+### Unlicense OR MIT
+
+- `aho-corasick`
+- `csv`, `csv-core`
+- `memchr`
+
+### Multi-license / other
+
+- `mach2` — BSD-2-Clause OR MIT OR Apache-2.0
+- `ryu` — Apache-2.0 OR BSL-1.0
+- `foldhash` — Zlib
+
+---
+
+## Apache-2.0 attribution
+
+Per Section 4 of the Apache License 2.0, this distribution notes that it
+contains code originally distributed by the Bytecode Alliance (Cranelift /
+Wasmtime) and other upstream authors listed above. No `NOTICE` file was
+identified in the upstream crates as of this writing; if one is added
+upstream, it will be mirrored here on the next update.
+
+---
+
+## How this file is maintained
+
+The list above was generated from `cargo tree --prefix none --format "{p} {l}"`
+against the `Cargo.lock` committed to this repository. When dependencies
+change, regenerate the listing with:
+
+```bash
+cargo tree --prefix none --format "{p} | {l}" | sort -u
+```
+
+and update this file accordingly.

--- a/src/bytecode.rs
+++ b/src/bytecode.rs
@@ -1,4 +1,9 @@
 //! Safe wrappers around libjq's bytecode structures.
+//!
+//! The structure mirrors jq's internal bytecode representation and is a
+//! derivative work of [jq](https://github.com/jqlang/jq) (Copyright (C) 2012
+//! Stephen Dolan), redistributed under the MIT License. See
+//! `THIRD-PARTY-LICENSES.md` at the repository root for details.
 
 use std::ffi::{CStr, CString};
 

--- a/src/jq_ffi.rs
+++ b/src/jq_ffi.rs
@@ -1,4 +1,11 @@
 //! Raw FFI bindings for libjq (jq 1.8.1).
+//!
+//! The struct layouts, opcode enum values, and function signatures in this
+//! module mirror declarations from jq's public headers (`jv.h`, `jq.h`) and
+//! internal bytecode layout. Those portions are derivative works of
+//! [jq](https://github.com/jqlang/jq) (Copyright (C) 2012 Stephen Dolan),
+//! redistributed under the MIT License. See `THIRD-PARTY-LICENSES.md` at the
+//! repository root for details.
 
 use std::ffi::c_char;
 use std::ffi::c_int;


### PR DESCRIPTION
## Summary

jq-jit の実配布バイナリでは、MIT OR Apache-2.0 宣言だけでは遵守しきれない依存ライセンスが複数存在する（Cranelift は Apache-2.0 WITH LLVM-exception のみ、ryu は Apache-2.0 OR BSL-1.0、libjq は MIT、libonig は BSD-2-Clause）。

現行のリリースワークフローは `jq-jit` バイナリ単体しか tarball に含めておらず、attribution が全く配布されていなかった。本PRでこれを是正する。

- `THIRD-PARTY-LICENSES.md` を新規追加。システムライブラリ（jq, libonig）と Rust crate 依存をライセンス別に列挙。
- `src/jq_ffi.rs` / `src/bytecode.rs` の module doc に「jq の派生であり MIT で再配布」である旨を明記。
- README の License セクションを拡張し、dual-license の意図とバイナリ配布時の実質的 Apache-2.0 遵守義務を説明。
- `release.yml` を更新し、`LICENSE-MIT` / `LICENSE-APACHE` / `THIRD-PARTY-LICENSES.md` / `README.md` を tarball に同梱。
- 同梱物付きリリースを配布するため、バージョンを 1.2.0 → **1.2.1** に bump。

バイナリ生成や挙動には影響なし。

## Why

過去の /review 等で指摘されていないが、配布物の compliance 観点で下記の GAP があった:

1. dual-license 宣言だけで「依存全部 MIT/Apache で選べる」と誤解されやすい（実際は Cranelift/ryu がそれを許さない）。
2. libjq / libonig の copyright notice が tarball に入っていない → MIT / BSD-2-Clause の要求を満たせない。
3. FFI バインディングは jq のヘッダ構造を写しているので実質的に jq の derivative だが、その旨がファイルに書かれていない。

## Verification

- `cargo build --release` — warning 0
- `cargo test --release` — official (509/509) + regression すべて pass
- ベンチは doc/workflow のみの変更なので実施せず（挙動不変）

## Release plan

本PRを merge しただけでは配布物は更新されないため、merge 後に `v1.2.1` タグを push して release workflow を発火させる必要あり。その操作は手動。

🤖 Generated with [Claude Code](https://claude.com/claude-code)