### PR TITLE
fix: serialise negative zero as "0" to match jq output

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -3971,7 +3971,8 @@ pub fn push_jq_number_str(buf: &mut String, n: f64) {
         return;
     }
     if n == 0.0 {
-        buf.push_str(if n.is_sign_negative() { "-0" } else { "0" });
+        // jq normalises negative zero to "0" on output; match that.
+        buf.push_str("0");
         return;
     }
 
@@ -4335,7 +4336,8 @@ fn write_jq_number(w: &mut dyn io::Write, n: f64) -> io::Result<()> {
         else { w.write_all(b"-1.7976931348623157e+308") };
     }
     if n == 0.0 {
-        return if n.is_sign_negative() { w.write_all(b"-0") } else { w.write_all(b"0") };
+        // jq normalises negative zero to "0" on output; match that.
+        return w.write_all(b"0");
     }
     // Integer fast path
     if n == n.trunc() && n.abs() < 1e16 {
@@ -4621,12 +4623,9 @@ pub fn push_jq_number_bytes(buf: &mut Vec<u8>, n: f64) {
     // The i64 roundtrip check (i as f64 == n) naturally rejects NaN, infinity, and non-integers.
     let i = n as i64;
     if i as f64 == n && i.unsigned_abs() < 10_000_000_000_000_000 {
-        if i == 0 && n.is_sign_negative() {
-            buf.extend_from_slice(b"-0");
-        } else {
-            let mut ibuf = itoa::Buffer::new();
-            buf.extend_from_slice(ibuf.format(i).as_bytes());
-        }
+        // jq normalises negative zero to "0" on output; match that.
+        let mut ibuf = itoa::Buffer::new();
+        buf.extend_from_slice(ibuf.format(i).as_bytes());
         return;
     }
     // Slow path: NaN, infinity, decimals, very large numbers

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -313,3 +313,23 @@ in([10,20,30])
 
 in([10,20,30])
 null
+
+# ---------- Issue #38: Unary minus on 0 emits "-0" instead of "0" ----------
+
+-.
+0
+
+-0
+null
+
+map(-.)
+[0,1,-2,0]
+
+[0, -0]
+null
+
+-.a
+{"a":0}
+
+[0, -0] | add
+null

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -443,3 +443,30 @@ false
 in([10,20,30])
 -1
 false
+
+# Issue #38: Unary minus on 0 emits "-0" instead of "0"
+
+# Unary minus on integer zero
+-.
+0
+0
+
+# Literal -0 in filter source
+-0
+null
+0
+
+# map unary minus over array with zero
+map(-.)
+[0,1,-2,0]
+[0,-1,2,0]
+
+# Literal array containing -0
+[0, -0]
+null
+[0,0]
+
+# tostring on negated zero
+-. | tostring
+0
+"0"


### PR DESCRIPTION
## Summary

- Strip the negative-sign branch from all three number-printing paths (`push_jq_number_bytes`, `push_jq_number_str`, `write_jq_number`) so `-0.0` serialises as `"0"` like jq.
- Covers unary minus on `0`, the literal `-0` in filter source, `map(-.)` over zero-containing arrays, and `[0, -0]`.

## Why

jq (1.7 and 1.8) normalises negative zero to `0` in output; we were emitting `-0`. Even though `-0 == 0` stays true, the byte-level divergence breaks any consumer diffing jq-jit output against jq.

Closes #38

## Test plan

- [x] `cargo build --release` — zero warnings
- [x] `cargo test --release` — official 509 + regression (+5 new) + differential (+6 new) all pass
- [x] Added regression cases in `tests/regression.test`
- [x] Added differential cases in `tests/differential/corpus.test`
- [x] `./bench/comprehensive.sh --quick` — no regression vs latest in `docs/benchmark-history.md` (identity -c within noise of main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)