### PR TITLE
fix: jq 1.8.1 compat — abs/fabs, length, to_entries, add, regex split

### DIFF
--- a/src/jit.rs
+++ b/src/jit.rs
@@ -5606,8 +5606,15 @@ extern "C" fn jit_rt_unaryop(dst: *mut Value, op: i32, input: *const Value) -> i
         if op == 0 {
             let v = match &*input {
                 Value::Null => Value::Num(0.0, None),
-                Value::False => Value::Num(0.0, None),
-                Value::True => Value::Num(1.0, None),
+                Value::True | Value::False => {
+                    set_jit_error(format!(
+                        "{} ({}) has no length",
+                        (*input).type_name(),
+                        crate::value::value_to_json(&*input)
+                    ));
+                    std::ptr::write(dst, Value::Null);
+                    return GEN_ERROR;
+                }
                 Value::Num(n, _) => Value::Num(n.abs(), None),
                 Value::Str(s) => {
                     let len = if s.is_ascii() { s.len() } else { s.chars().count() };

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -51,7 +51,8 @@ pub fn call_builtin(name: &str, args: &[Value]) -> Result<Value> {
         "floor" => unary_op(args, rt_floor),
         "ceil" => unary_op(args, rt_ceil),
         "round" => unary_op(args, rt_round),
-        "fabs" | "abs" => unary_op(args, rt_fabs),
+        "fabs" => unary_op(args, rt_fabs),
+        "abs" => unary_op(args, rt_abs),
         "sqrt" => unary_op(args, rt_sqrt),
         "tostring" => unary_op(args, rt_tostring),
         "tonumber" => unary_op(args, rt_tonumber),
@@ -1118,10 +1119,20 @@ fn rt_fabs(v: &Value) -> Result<Value> {
             if *n >= 0.0 { Ok(Value::Num(*n, repr.clone())) }
             else { Ok(Value::Num(n.abs(), None)) }
         }
-        // abs on non-numbers returns the value for strings, errors for others
-        Value::Str(_) => Ok(v.clone()),
-        Value::Null => Ok(Value::Null),
-        _ => v.length(),
+        _ => bail!("{} ({}) number required", v.type_name(), crate::value::value_to_json(v)),
+    }
+}
+
+fn rt_abs(v: &Value) -> Result<Value> {
+    match v {
+        Value::Num(n, repr) => {
+            if *n >= 0.0 { Ok(Value::Num(*n, repr.clone())) }
+            else { Ok(Value::Num(n.abs(), None)) }
+        }
+        Value::Str(_) | Value::Arr(_) | Value::Obj(_) => Ok(v.clone()),
+        _ => {
+            bail!("{} ({}) cannot be negated", v.type_name(), crate::value::value_to_json(v))
+        }
     }
 }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1587,16 +1587,7 @@ fn rt_split(v: &Value, sep: &Value) -> Result<Value> {
 fn rt_regex_split(v: &Value, re: &Value, flags: &Value) -> Result<Value> {
     match (v, re) {
         (Value::Str(s), Value::Str(r)) => {
-            let mut pat = String::new();
-            if let Value::Str(f) = flags {
-                // Build regex with flags (e.g., "ix" → (?ix)pattern)
-                if !f.is_empty() {
-                    pat.push_str("(?");
-                    pat.push_str(f.as_str());
-                    pat.push(')');
-                }
-            }
-            pat.push_str(r.as_str());
+            let (pat, _global) = apply_regex_flags(r.as_str(), flags);
             with_regex(&pat, |regex| {
                 let parts: Vec<Value> = regex.split(s.as_str())
                     .map(Value::from_str)

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1318,6 +1318,15 @@ fn rt_to_entries(v: &Value) -> Result<Value> {
             }).collect();
             Ok(Value::Arr(Rc::new(entries)))
         }
+        Value::Arr(a) => {
+            let entries: Vec<Value> = a.iter().enumerate().map(|(i, v)| {
+                let mut entry = new_objmap();
+                entry.insert("key".into(), Value::Num(i as f64, None));
+                entry.insert("value".into(), v.clone());
+                Value::Obj(Rc::new(entry))
+            }).collect();
+            Ok(Value::Arr(Rc::new(entries)))
+        }
         _ => bail!("{} has no entries", v.type_name()),
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1072,7 +1072,16 @@ fn rt_add_all(v: &Value) -> Result<Value> {
             }
             Ok(result)
         }
-        _ => bail!("{} is not an array", v.type_name()),
+        Value::Obj(o) => {
+            let mut iter = o.values();
+            let Some(first) = iter.next() else { return Ok(Value::Null); };
+            let mut result = first.clone();
+            for item in iter {
+                result = rt_add(&result, item)?;
+            }
+            Ok(result)
+        }
+        _ => bail!("Cannot iterate over {} ({})", v.type_name(), crate::value::value_to_json(v)),
     }
 }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -495,8 +495,9 @@ impl Value {
     pub fn length(&self) -> Result<Value> {
         match self {
             Value::Null => Ok(Value::Num(0.0, None)),
-            Value::False => Ok(Value::Num(0.0, None)),
-            Value::True => Ok(Value::Num(1.0, None)),
+            Value::True | Value::False => {
+                bail!("{} ({}) has no length", self.type_name(), crate::value::value_to_json(self))
+            }
             Value::Num(n, repr) => {
                 if *n >= 0.0 { Ok(Value::Num(*n, repr.clone())) }
                 else { Ok(Value::Num(n.abs(), None)) }

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -378,3 +378,20 @@ to_entries
 
 to_entries
 ["a","b"]
+
+# ---------- Issue #48: add on object folds values ----------
+
+add
+{}
+
+add
+{"a":1,"b":2}
+
+add
+{"a":"x","b":"y"}
+
+add
+1
+
+add
+"x"

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -333,3 +333,29 @@ null
 
 [0, -0] | add
 null
+
+# ---------- Issue #39: abs/fabs diverge on non-number inputs ----------
+
+fabs
+true
+
+fabs
+"s"
+
+fabs
+[1,2,3]
+
+abs
+null
+
+abs
+true
+
+abs
+"s"
+
+abs
+[1,2,3]
+
+abs
+{"a":1}

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -359,3 +359,14 @@ abs
 
 abs
 {"a":1}
+
+# ---------- Issue #43: length on boolean returns 0/1 instead of erroring ----------
+
+length
+true
+
+length
+false
+
+map(length)
+[true]

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -395,3 +395,14 @@ add
 
 add
 "x"
+
+# ---------- Issue #51: split(regex; "g") rejected the global flag ----------
+
+split(","; "g")
+"a,b,c"
+
+split("a"; "gi")
+"aAbAc"
+
+[splits(","; "g")]
+"a,b,c"

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -370,3 +370,11 @@ false
 
 map(length)
 [true]
+
+# ---------- Issue #44: to_entries rejects array input ----------
+
+to_entries
+[1,2,3]
+
+to_entries
+["a","b"]

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -544,3 +544,20 @@ null
 length
 -3
 3
+
+# Issue #44: to_entries rejects array input
+
+# to_entries on array of numbers
+to_entries
+[1,2,3]
+[{"key":0,"value":1},{"key":1,"value":2},{"key":2,"value":3}]
+
+# to_entries on array of strings
+to_entries
+["a","b"]
+[{"key":0,"value":"a"},{"key":1,"value":"b"}]
+
+# to_entries | from_entries on object round-trips to the same object
+to_entries | from_entries
+{"a":1,"b":2}
+{"a":1,"b":2}

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -520,3 +520,27 @@ abs
 abs
 -5
 5
+
+# Issue #43: length on boolean returns 0/1 instead of erroring
+
+# length on true errors
+length
+true
+
+# length on false errors
+length
+false
+
+# map(length) propagates the error from boolean element
+map(length)
+[true]
+
+# length on null is still 0
+length
+null
+0
+
+# length on number absolute value still works
+length
+-3
+3

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -470,3 +470,53 @@ null
 -. | tostring
 0
 "0"
+
+# Issue #39: abs/fabs diverge on non-number inputs
+
+# fabs errors on null
+fabs
+null
+
+# fabs errors on boolean
+fabs
+true
+
+# fabs errors on string
+fabs
+"s"
+
+# fabs errors on array
+fabs
+[1,2,3]
+
+# fabs errors on object
+fabs
+{"a":1,"b":2}
+
+# abs errors on null
+abs
+null
+
+# abs errors on boolean
+abs
+true
+
+# abs returns string identity
+abs
+"s"
+"s"
+
+# abs returns array identity
+abs
+[1,2,3]
+[1,2,3]
+
+# abs returns object identity
+abs
+{"a":1}
+{"a":1}
+
+# abs negates numbers
+abs
+-5
+5

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -561,3 +561,25 @@ to_entries
 to_entries | from_entries
 {"a":1,"b":2}
 {"a":1,"b":2}
+
+# Issue #48: add folds object values instead of erroring
+
+# add on empty object returns null
+add
+{}
+null
+
+# add on object with one numeric value returns that value
+add
+{"a":1}
+1
+
+# add on object with two numeric values folds them
+add
+{"a":1,"b":2}
+3
+
+# add on object with string values concatenates them
+add
+{"a":"x","b":"y"}
+"xy"

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -583,3 +583,20 @@ add
 add
 {"a":"x","b":"y"}
 "xy"
+
+# Issue #51: split(regex; "g") errored on the global flag
+
+# split with literal and "g" flag
+split(","; "g")
+"a,b,c"
+["a","b","c"]
+
+# split with combined global + case-insensitive flags
+split("a"; "gi")
+"aAbAc"
+["","","b","c"]
+
+# splits expansion propagates flags through the split call
+[splits(","; "g")]
+"a,b,c"
+["a","b","c"]


### PR DESCRIPTION
Batch 1 of jq 1.8.1 compatibility fixes. One commit per issue so each is easy to review and bisect.

## Summary

- Closes #39 — `abs` and `fabs` diverged semantics: `fabs` is strict-number, `abs` is identity for strings/arrays/objects and errors for null/boolean
- Closes #43 — `length` on booleans now errors (was returning 0/1 via both `Value::length` and the JIT fast path)
- Closes #44 — `to_entries` accepts arrays, yielding index/value pairs
- Closes #48 — `add` on objects folds the values (reduce semantics); non-iterable inputs error with "Cannot iterate over ..."
- Closes #51 — regex `split`/`splits` now strip the jq-level `g` flag before compiling the regex

## Test plan
- [x] `cargo build --release` — zero warnings
- [x] `cargo test --release` — regression + differential + official all green (110 regression cases, up from 95)
- [x] Manual reproduction of each issue against jq 1.8.1 — output matches