### PR TITLE
fix: jq 1.8.1 compat — unique_by, capture, interp, computed keys

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -6976,6 +6976,23 @@ fn real_main() {
                                     if val[0] == b'"' && val.len() >= 2 {
                                         // String: copy inner content (already JSON-escaped)
                                         compact_buf.extend_from_slice(&val[1..val.len()-1]);
+                                    } else if val[0] == b'[' || val[0] == b'{' {
+                                        // Container: embed JSON text, re-escaping for the
+                                        // surrounding string literal so the output stays
+                                        // valid JSON. Whitespace is copied as-is, which is
+                                        // fine since json_object_get_fields_raw_buf returns
+                                        // the compact slice from input.
+                                        for &b in val {
+                                            match b {
+                                                b'"' => compact_buf.extend_from_slice(b"\\\""),
+                                                b'\\' => compact_buf.extend_from_slice(b"\\\\"),
+                                                b'\n' => compact_buf.extend_from_slice(b"\\n"),
+                                                b'\r' => compact_buf.extend_from_slice(b"\\r"),
+                                                b'\t' => compact_buf.extend_from_slice(b"\\t"),
+                                                c if c < 0x20 => { let _ = write!(compact_buf, "\\u{:04x}", c); }
+                                                _ => compact_buf.push(b),
+                                            }
+                                        }
                                     } else {
                                         // Number/bool/null: copy as-is (jq tostring behavior)
                                         compact_buf.extend_from_slice(val);
@@ -19981,6 +19998,18 @@ fn real_main() {
                                 let val = &raw[vs..ve];
                                 if val[0] == b'"' && val.len() >= 2 {
                                     compact_buf.extend_from_slice(&val[1..val.len()-1]);
+                                } else if val[0] == b'[' || val[0] == b'{' {
+                                    for &b in val {
+                                        match b {
+                                            b'"' => compact_buf.extend_from_slice(b"\\\""),
+                                            b'\\' => compact_buf.extend_from_slice(b"\\\\"),
+                                            b'\n' => compact_buf.extend_from_slice(b"\\n"),
+                                            b'\r' => compact_buf.extend_from_slice(b"\\r"),
+                                            b'\t' => compact_buf.extend_from_slice(b"\\t"),
+                                            c if c < 0x20 => { let _ = write!(compact_buf, "\\u{:04x}", c); }
+                                            _ => compact_buf.push(b),
+                                        }
+                                    }
                                 } else {
                                     compact_buf.extend_from_slice(val);
                                 }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3404,12 +3404,16 @@ fn eval_closure_op_f64(op: ClosureOpKind, a: &[Value], keys: &[f64], cb: &mut dy
             cb(Value::Arr(Rc::new(groups)))
         }
         ClosureOpKind::UniqueBy => {
-            let mut seen = std::collections::HashSet::with_capacity(a.len().min(4096));
+            // jq: unique_by(f) = group_by(f) | map(.[0]) — sorted by key, deduped.
+            let mut indices: Vec<usize> = (0..a.len()).collect();
+            indices.sort_by(|&i, &j| cmp_f64(&keys[i], &keys[j]));
             let mut result: Vec<Value> = Vec::new();
-            for (i, item) in a.iter().enumerate() {
-                let k = keys[i].to_bits();
-                if seen.insert(k) {
-                    result.push(item.clone());
+            let mut prev: Option<f64> = None;
+            for &idx in &indices {
+                let k = keys[idx];
+                if prev.map_or(true, |pk| cmp_f64(&pk, &k) != std::cmp::Ordering::Equal) {
+                    result.push(a[idx].clone());
+                    prev = Some(k);
                 }
             }
             cb(Value::Arr(Rc::new(result)))
@@ -3494,63 +3498,15 @@ fn eval_closure_op_value_ref(op: ClosureOpKind, a: &[Value], keyed: Vec<(&Value,
             cb(Value::Arr(Rc::new(groups)))
         }
         ClosureOpKind::UniqueBy => {
+            // jq: unique_by(f) = group_by(f) | map(.[0]) — sorted by key, deduped.
+            let mut indexed: Vec<(usize, &Value)> = keyed.iter().enumerate().map(|(i, (k, _))| (i, *k)).collect();
+            sort_indexed_by_key(&mut indexed);
             let mut result: Vec<Value> = Vec::new();
-            // Specialized path based on key type to avoid JSON serialization
-            if !keyed.is_empty() {
-                match keyed[0].0 {
-                    Value::Str(_) => {
-                        let mut seen = std::collections::HashSet::<&str>::with_capacity(keyed.len().min(4096));
-                        for (key, item) in &keyed {
-                            if let Value::Str(s) = key {
-                                if seen.insert(s.as_str()) {
-                                    result.push((*item).clone());
-                                }
-                            } else {
-                                // Mixed types — fall back to JSON
-                                let hash_key = crate::value::value_to_json(key);
-                                let mut seen2 = std::collections::HashSet::new();
-                                for s in &seen { seen2.insert(format!("\"{}\"", s)); }
-                                seen2.insert(hash_key);
-                                result.push((*item).clone());
-                                for (key2, item2) in keyed.iter().skip(result.len()) {
-                                    let h = crate::value::value_to_json(key2);
-                                    if seen2.insert(h) { result.push((*item2).clone()); }
-                                }
-                                return cb(Value::Arr(Rc::new(result)));
-                            }
-                        }
-                    }
-                    Value::Num(..) => {
-                        let mut seen = std::collections::HashSet::<u64>::with_capacity(keyed.len().min(4096));
-                        for (key, item) in &keyed {
-                            if let Value::Num(n, _) = key {
-                                if seen.insert(n.to_bits()) {
-                                    result.push((*item).clone());
-                                }
-                            } else {
-                                // Mixed — fall back
-                                let mut seen2 = std::collections::HashSet::new();
-                                for b in &seen { seen2.insert(format!("{}", f64::from_bits(*b))); }
-                                let hash_key = crate::value::value_to_json(key);
-                                seen2.insert(hash_key);
-                                result.push((*item).clone());
-                                for (key2, item2) in keyed.iter().skip(result.len()) {
-                                    let h = crate::value::value_to_json(key2);
-                                    if seen2.insert(h) { result.push((*item2).clone()); }
-                                }
-                                return cb(Value::Arr(Rc::new(result)));
-                            }
-                        }
-                    }
-                    _ => {
-                        let mut seen = std::collections::HashSet::with_capacity(keyed.len().min(4096));
-                        for (key, item) in &keyed {
-                            let hash_key = crate::value::value_to_json(key);
-                            if seen.insert(hash_key) {
-                                result.push((*item).clone());
-                            }
-                        }
-                    }
+            let mut prev: Option<&Value> = None;
+            for &(idx, key) in &indexed {
+                if prev.map_or(true, |pk| !crate::runtime::values_equal(pk, key)) {
+                    result.push(a[idx].clone());
+                    prev = Some(key);
                 }
             }
             cb(Value::Arr(Rc::new(result)))
@@ -3729,17 +3685,18 @@ fn eval_closure_op(op: ClosureOpKind, container: &Value, key_expr: &Expr, _input
             cb(Value::Arr(Rc::new(groups)))
         }
         ClosureOpKind::UniqueBy => {
-            let mut seen = std::collections::HashSet::with_capacity(keyed.len().min(4096));
+            // jq: unique_by(f) = group_by(f) | map(.[0]) — sorted by key, deduped.
+            keyed.sort_by(|(ka, _), (kb, _)| { ka.iter().zip(kb.iter()).map(|(a, b)| crate::runtime::compare_values(a, b)).find(|o| *o != std::cmp::Ordering::Equal).unwrap_or(std::cmp::Ordering::Equal) });
             let mut result: Vec<Value> = Vec::new();
+            let mut prev: Option<Vec<Value>> = None;
             for (keys, val) in keyed {
-                // Hash by JSON serialization of keys
-                let hash_key = if keys.len() == 1 {
-                    crate::value::value_to_json(&keys[0])
-                } else {
-                    keys.iter().map(|k| crate::value::value_to_json(k)).collect::<Vec<_>>().join("\x00")
+                let is_dup = match &prev {
+                    Some(pk) => pk.len() == keys.len() && pk.iter().zip(keys.iter()).all(|(a, b)| crate::runtime::values_equal(a, b)),
+                    None => false,
                 };
-                if seen.insert(hash_key) {
+                if !is_dup {
                     result.push(val);
+                    prev = Some(keys);
                 }
             }
             cb(Value::Arr(Rc::new(result)))

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -2801,8 +2801,19 @@ pub fn eval(
             eval(input_expr, input.clone(), env, &mut |s| {
                 eval(re, input.clone(), env, &mut |re_val| {
                     eval(flags, input.clone(), env, &mut |fv| {
+                        let global = matches!(&fv, Value::Str(f) if f.as_str().contains('g'));
                         match crate::runtime::call_builtin("capture", &[s.clone(), re_val.clone(), fv.clone()]) {
-                            Ok(v) => cb(v),
+                            Ok(v) => {
+                                if global {
+                                    if let Value::Arr(a) = &v {
+                                        for item in a.iter() {
+                                            if !cb(item.clone())? { return Ok(false); }
+                                        }
+                                        return Ok(true);
+                                    }
+                                }
+                                cb(v)
+                            }
                             Err(_) => Ok(true), // non-match → empty (like jq)
                         }
                     })

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3157,6 +3157,17 @@ fn eval_range(from: &Value, to: &Value, step: Option<&Value>, cb: &mut dyn FnMut
     Ok(true)
 }
 
+fn object_key_from_value(kv: &Value) -> Result<KeyStr> {
+    match kv {
+        Value::Str(s) => Ok(KeyStr::from(s.as_str())),
+        _ => bail!(
+            "Cannot use {} ({}) as object key",
+            kv.type_name(),
+            crate::value::value_to_json(kv)
+        ),
+    }
+}
+
 fn eval_object_construct(pairs: &[(Expr, Expr)], input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) -> GenResult) -> GenResult {
     // Fast path: if all keys and values are scalar expressions, build directly without cloning
     let mut obj = crate::value::new_objmap_with_capacity(pairs.len());
@@ -3165,7 +3176,7 @@ fn eval_object_construct(pairs: &[(Expr, Expr)], input: Value, env: &EnvRef, cb:
             Ok(v) => v,
             Err(()) => return eval_obj_pairs(pairs, 0, crate::value::new_objmap_with_capacity(pairs.len()), input, env, cb),
         };
-        let ks: KeyStr = match &kv { Value::Str(s) => KeyStr::from(s.as_str()), _ => KeyStr::from(crate::value::value_to_json(&kv)) };
+        let ks = object_key_from_value(&kv)?;
         let vv = match eval_one(ve, &input, env) {
             Ok(v) => v,
             Err(()) => return eval_obj_pairs(pairs, 0, crate::value::new_objmap_with_capacity(pairs.len()), input, env, cb),
@@ -3179,7 +3190,7 @@ fn eval_obj_pairs(pairs: &[(Expr, Expr)], idx: usize, cur: crate::value::ObjMap,
     if idx >= pairs.len() { return cb(Value::Obj(Rc::new(cur))); }
     let (ke, ve) = &pairs[idx];
     eval(ke, input.clone(), env, &mut |kv| {
-        let ks: KeyStr = match &kv { Value::Str(s) => KeyStr::from(s.as_str()), _ => KeyStr::from(crate::value::value_to_json(&kv)) };
+        let ks = object_key_from_value(&kv)?;
         eval(ve, input.clone(), env, &mut |vv| {
             let mut next = cur.clone();
             next.insert(ks.clone(), vv);

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -7304,38 +7304,13 @@ impl Filter {
     }
 
     /// Detect `{(.name): .x, static_key: val, ...}` — object with one dynamic key and N static keys.
-    /// Returns (dyn_key_field, dyn_val_rexpr, static_pairs: Vec<(String, RemapExpr)>).
+    ///
+    /// Disabled: the generated output placed the dynamic key first regardless
+    /// of source order and skipped duplicate-key collapse, producing both
+    /// reordered output and invalid JSON when the dynamic key collided with a
+    /// static one (issue #53). Falling back to the generic object-construct
+    /// path preserves both invariants.
     pub fn detect_dynamic_key_mixed_obj(&self) -> Option<(String, RemapExpr, Vec<(String, RemapExpr)>)> {
-        use crate::ir::{Expr, Literal};
-        let expr = self.detect_expr()?;
-        if let Expr::ObjectConstruct { pairs } = expr {
-            if pairs.len() < 2 { return None; }
-            let mut dyn_key: Option<(String, RemapExpr)> = None;
-            let mut static_pairs: Vec<(String, RemapExpr)> = Vec::new();
-            for (k, v) in pairs {
-                match k {
-                    // Dynamic key: (.field)
-                    Expr::Index { expr: base, key } if matches!(base.as_ref(), Expr::Input) => {
-                        if dyn_key.is_some() { return None; } // only one dynamic key
-                        if let Expr::Literal(Literal::Str(f)) = key.as_ref() {
-                            let val_rexpr = Self::classify_remap_value(v)?;
-                            dyn_key = Some((f.clone(), val_rexpr));
-                        } else { return None; }
-                    }
-                    // Static key: "literal_key"
-                    Expr::Literal(Literal::Str(key_name)) => {
-                        let val_rexpr = Self::classify_remap_value(v)?;
-                        static_pairs.push((key_name.clone(), val_rexpr));
-                    }
-                    _ => return None,
-                }
-            }
-            if let Some((dk_field, dk_val)) = dyn_key {
-                if !static_pairs.is_empty() {
-                    return Some((dk_field, dk_val, static_pairs));
-                }
-            }
-        }
         None
     }
 

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -6432,23 +6432,29 @@ extern "C" fn jit_rt_obj_new(dst: *mut Value, cap: usize) {
     unsafe { std::ptr::write(dst, Value::Obj(crate::value::rc_objmap_pool_get(cap))); }
 }
 /// Insert key-value pair into object. Takes ownership of both key and val (ptr::read, no clone).
-extern "C" fn jit_rt_obj_insert(obj: *mut Value, key: *mut Value, val: *mut Value) {
+/// Returns 0 on success, -1 on error (jq errors when the key is not a string).
+extern "C" fn jit_rt_obj_insert(obj: *mut Value, key: *mut Value, val: *mut Value) -> i64 {
     unsafe {
         let key_val = std::ptr::read(key);
         let val_val = std::ptr::read(val);
         if let Value::Obj(o) = &mut *obj {
-            // Move KeyStr out of Value::Str to avoid clone+drop
             let k: crate::value::KeyStr = match key_val {
                 Value::Str(s) => s,
                 other => {
-                    let k = crate::value::KeyStr::from(crate::value::value_to_json(&other));
+                    set_jit_error(format!(
+                        "Cannot use {} ({}) as object key",
+                        other.type_name(),
+                        crate::value::value_to_json(&other)
+                    ));
                     drop(other);
-                    k
+                    drop(val_val);
+                    return -1;
                 }
             };
             // Safety: obj was just created by jit_rt_obj_new, refcount is always 1
             Rc::get_mut(o).unwrap_unchecked().insert(k, val_val);
         }
+        0
     }
 }
 
@@ -8646,7 +8652,20 @@ impl JitCompiler {
                         let o = slot_addr(&mut b, *obj);
                         let k = slot_addr(&mut b, *key);
                         let v = slot_addr(&mut b, *val);
-                        b.ins().call(rt["obj_insert"], &[o, k, v]);
+                        let call = b.ins().call(rt["obj_insert"], &[o, k, v]);
+                        let status = b.inst_results(call)[0];
+                        let zero = b.ins().iconst(ptr_ty, 0);
+                        let is_err = b.ins().icmp(cranelift_codegen::ir::condcodes::IntCC::NotEqual, status, zero);
+                        let err_blk = b.create_block();
+                        let ok_blk = b.create_block();
+                        b.ins().brif(is_err, err_blk, &[], ok_blk, &[]);
+                        b.switch_to_block(err_blk);
+                        b.seal_block(err_blk);
+                        b.ins().call(rt["propagate_error"], &[env_ptr]);
+                        let gerr = b.ins().iconst(ptr_ty, GEN_ERROR);
+                        b.ins().return_(&[gerr]);
+                        b.switch_to_block(ok_blk);
+                        b.seal_block(ok_blk);
                     }
                     JitOp::ObjInsertStrKey { obj, key, val } => {
                         let o = slot_addr(&mut b, *obj);
@@ -9088,7 +9107,7 @@ fn declare_rt_funcs(module: &mut JITModule, map: &mut HashMap<&'static str, Func
     decl!("collect_push", [p, p], []);
     decl!("collect_finish", [p, p], []);
     decl!("obj_new", [p, p], []);
-    decl!("obj_insert", [p, p, p], []);
+    decl!("obj_insert", [p, p, p], [p]);
     decl!("obj_insert_str_key", [p, p, p, p], []);
     decl!("obj_push_str_key", [p, p, p, p], []);
     decl!("obj_copy_field", [p, p, p, p, p, p], []);

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -167,8 +167,13 @@ pub fn call_builtin(name: &str, args: &[Value]) -> Result<Value> {
         }
         "capture" => {
             if args.len() >= 3 {
-                let (pat, _) = apply_regex_flags(args[1].as_str().unwrap_or(""), &args[2]);
-                rt_capture(&args[0], &Value::from_string(pat))
+                let (pat, global) = apply_regex_flags(args[1].as_str().unwrap_or(""), &args[2]);
+                let re = Value::from_string(pat);
+                if global {
+                    rt_capture_global(&args[0], &re)
+                } else {
+                    rt_capture(&args[0], &re)
+                }
             } else {
                 binary_arg(args, rt_capture)
             }
@@ -2238,6 +2243,29 @@ fn rt_capture(v: &Value, re: &Value) -> Result<Value> {
                     }
                     None => bail!("capture failed"),
                 }
+            })?
+        }
+        _ => bail!("capture requires string and regex"),
+    }
+}
+
+pub fn rt_capture_global(v: &Value, re: &Value) -> Result<Value> {
+    match (v, re) {
+        (Value::Str(s), Value::Str(r)) => {
+            with_regex(r, |regex| {
+                let mut results: Vec<Value> = Vec::new();
+                for caps in regex.captures_iter(s) {
+                    let mut obj = new_objmap();
+                    for name in regex.capture_names().flatten() {
+                        if let Some(m) = caps.name(name) {
+                            obj.insert(KeyStr::from(name), Value::from_str(m.as_str()));
+                        } else {
+                            obj.insert(KeyStr::from(name), Value::Null);
+                        }
+                    }
+                    results.push(Value::Obj(Rc::new(obj)));
+                }
+                Ok(Value::Arr(Rc::new(results)))
             })?
         }
         _ => bail!("capture requires string and regex"),

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -437,3 +437,14 @@ capture("(?<n>\\d+)"; "g")
 
 capture("(?<n>\\d+)")
 "1,2,3"
+
+# ---------- Issue #45: string interpolation of container must JSON-escape ----------
+
+"\(.b)"
+{"b":{"c":3}}
+
+"\(.x)"
+{"x":["a","b"]}
+
+"prefix \(.b) suffix"
+{"b":{"c":3}}

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -465,3 +465,20 @@ null
 
 {(.k):1}
 {"k":"a"}
+
+# ---------- Issue #53: computed key ordering + dedup across static/dynamic keys ----------
+
+{a:1, (.k):2}
+{"k":"b"}
+
+{a:1, (.k):2, c:3}
+{"k":"z"}
+
+{a:1, (.k):2}
+{"k":"a"}
+
+{a:1, (.k):2, c:3}
+{"k":"a"}
+
+{(.k):2, a:1}
+{"k":"a"}

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -448,3 +448,20 @@ capture("(?<n>\\d+)")
 
 "prefix \(.b) suffix"
 {"b":{"c":3}}
+
+# ---------- Issue #52: computed object key accepts non-string by stringification ----------
+
+{(null):1}
+null
+
+{(1):"x"}
+null
+
+{(true):1}
+null
+
+{(.k):1}
+null
+
+{(.k):1}
+{"k":"a"}

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -423,3 +423,17 @@ unique_by(.)
 
 unique_by(.a)
 [{"a":1,"b":1},{"a":2,"b":2},{"a":1,"b":3}]
+
+# ---------- Issue #55: capture(regex; "g") must yield every match ----------
+
+[capture("(?<n>\\d+)"; "g")]
+"a1 b2 c3"
+
+[capture("(?<n>\\d+)"; "g")]
+"1,2,3"
+
+capture("(?<n>\\d+)"; "g")
+"1 2 3"
+
+capture("(?<n>\\d+)")
+"1,2,3"

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -406,3 +406,20 @@ split("a"; "gi")
 
 [splits(","; "g")]
 "a,b,c"
+
+# ---------- Issue #41: unique_by(f) must sort by f ----------
+
+unique_by(.)
+[3,1,2]
+
+unique_by(.)
+[1,2,3,null]
+
+unique_by(tostring)
+[null,1,2,3]
+
+unique_by(.)
+[1,"a",null,2]
+
+unique_by(.a)
+[{"a":1,"b":1},{"a":2,"b":2},{"a":1,"b":3}]

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -661,3 +661,34 @@ capture("(?<n>\\d+)")
 "\(.b)"
 {"b":"hi"}
 "hi"
+
+# Issue #52: computed object key `{(expr): val}` must error on non-strings
+
+# Null computed key errors
+{(null):1}
+null
+
+# Number computed key errors
+{(1):"x"}
+null
+
+# Boolean computed key errors
+{(true):1}
+null
+
+# Array computed key errors
+{([1]):1}
+null
+
+# Object computed key errors
+{({}):1}
+null
+
+# Null field as computed key errors
+{(.k):1}
+null
+
+# String computed key still succeeds
+{(.k):1}
+{"k":"a"}
+{"a":1}

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -692,3 +692,30 @@ null
 {(.k):1}
 {"k":"a"}
 {"a":1}
+
+# Issue #53: computed key ordering + dedup across static/dynamic keys
+
+# Static `a:1` must come first, then dynamic `(.k):2` at its source position
+{a:1, (.k):2}
+{"k":"b"}
+{"a":1,"b":2}
+
+# Dynamic-key slot preserved in the middle of a three-pair object
+{a:1, (.k):2, c:3}
+{"k":"z"}
+{"a":1,"z":2,"c":3}
+
+# Dynamic key collides with earlier static key — first position, last value wins
+{a:1, (.k):2}
+{"k":"a"}
+{"a":2}
+
+# Dynamic key colliding with static key in a longer object still dedupes
+{a:1, (.k):2, c:3}
+{"k":"a"}
+{"a":2,"c":3}
+
+# Dynamic key first, static key after with same name — first position holds last value
+{(.k):2, a:1}
+{"k":"a"}
+{"a":1}

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -627,3 +627,20 @@ unique_by(.)
 unique_by(.a)
 [{"a":1,"b":1},{"a":2,"b":2},{"a":1,"b":3}]
 [{"a":1,"b":1},{"a":2,"b":2}]
+
+# Issue #55: capture(regex; "g") must iterate over every match
+
+# capture with global flag yields one object per match
+[capture("(?<n>\\d+)"; "g")]
+"a1 b2 c3"
+[{"n":"1"},{"n":"2"},{"n":"3"}]
+
+# capture with global flag on comma-delimited digits
+[capture("(?<n>\\d+)"; "g")]
+"1,2,3"
+[{"n":"1"},{"n":"2"},{"n":"3"}]
+
+# capture without global returns only the first match
+capture("(?<n>\\d+)")
+"1,2,3"
+{"n":"1"}

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -600,3 +600,30 @@ split("a"; "gi")
 [splits(","; "g")]
 "a,b,c"
 ["a","b","c"]
+
+# Issue #41: unique_by(f) must sort by f — not just dedupe in input order
+
+# unique_by(.) on integers sorts ascending
+unique_by(.)
+[3,1,2]
+[1,2,3]
+
+# unique_by(.) places null before numbers per jq's cross-type order
+unique_by(.)
+[1,2,3,null]
+[null,1,2,3]
+
+# unique_by(tostring) sorts by stringified key with ASCII ordering
+unique_by(tostring)
+[null,1,2,3]
+[1,2,3,null]
+
+# unique_by(.) across mixed types respects null < number < string
+unique_by(.)
+[1,"a",null,2]
+[null,1,2,"a"]
+
+# unique_by(.a) on objects picks the first per distinct key, in sorted order
+unique_by(.a)
+[{"a":1,"b":1},{"a":2,"b":2},{"a":1,"b":3}]
+[{"a":1,"b":1},{"a":2,"b":2}]

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -644,3 +644,20 @@ unique_by(.a)
 capture("(?<n>\\d+)")
 "1,2,3"
 {"n":"1"}
+
+# Issue #45: string interpolation of field-accessed container must JSON-escape
+
+# Object container: inner quotes become \"
+"\(.b)"
+{"b":{"c":3}}
+"{\"c\":3}"
+
+# Array container: elements re-escaped
+"\(.x)"
+{"x":["a","b"]}
+"[\"a\",\"b\"]"
+
+# Scalar string is unchanged (identity into interpolation)
+"\(.b)"
+{"b":"hi"}
+"hi"


### PR DESCRIPTION
Batch 2 of jq 1.8.1 compatibility fixes. One commit per issue.

## Summary

- Closes #41 — `unique_by(f)` now sorts by key before deduping (jq's `group_by | map(.[0])` semantics)
- Closes #55 — `capture(regex; "g")` iterates every match via the new `rt_capture_global` helper
- Closes #45 — String interpolation of field-accessed container values re-escapes the inner JSON so the output stays valid
- Closes #52 — Computed object key `{(expr): v}` errors on non-string values (both eval and JIT paths)
- Closes #53 — Objects with mixed static and computed keys preserve source order and apply duplicate-key dedup

## Test plan
- [x] `cargo build --release` — zero warnings
- [x] `cargo test --release` — all three suites (official jq, regression, differential) green
- [x] Manual repro of each issue vs jq 1.8.1 — output matches