### PR TITLE
fix: jq 1.8.1 compat — //, negative index, path(f), (expr)?, del

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -7572,9 +7572,16 @@ fn real_main() {
                         Ok(())
                     })
                 } else if let Some((ref alt_field, ref fallback_bytes)) = field_alt {
-                    // .field // literal: extract field, output raw or fallback if null/false
+                    // .field // literal. `//` must not swallow type errors, so
+                    // route non-object, non-null inputs through the eval path
+                    // where `.field` raises "Cannot index ... with string".
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
+                        if raw.is_empty() || (raw[0] != b'{' && raw != b"null") {
+                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                            return Ok(());
+                        }
                         if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, alt_field) {
                             let val = &raw[vs..ve];
                             if val == b"null" || val == b"false" {
@@ -15070,6 +15077,11 @@ fn real_main() {
                 let content_bytes = content.as_bytes();
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
+                    if raw.is_empty() || (raw[0] != b'{' && raw != b"null") {
+                        let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                        process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                        return Ok(());
+                    }
                     if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, alt_field) {
                         let val = &raw[vs..ve];
                         if val == b"null" || val == b"false" {

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3814,9 +3814,28 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
         Expr::Input => cb(Value::Arr(Rc::new(vec![]))),
         Expr::Index { expr: be, key: ke } => {
             let cb_called = std::cell::Cell::new(false);
+            let input_for_check = input.clone();
             let result = eval_path(be, input.clone(), env, &mut |bp| {
                 cb_called.set(true);
                 eval(ke, input.clone(), env, &mut |key| {
+                    // jq errors `path(.field)` when the base value at the
+                    // current path can't accept the key type (issue #46).
+                    // Only objects (with string keys), arrays (with number
+                    // keys), and null (a no-op) are valid bases.
+                    let base_val = crate::runtime::rt_getpath(&input_for_check, &bp).unwrap_or(Value::Null);
+                    match (&base_val, &key) {
+                        (Value::Obj(_), Value::Str(_)) => {}
+                        (Value::Arr(_), Value::Num(_, _)) => {}
+                        (Value::Null, _) => {}
+                        _ => {
+                            let key_desc = match &key {
+                                Value::Str(s) => format!("string \"{}\"", s),
+                                Value::Num(n, _) => format!("number ({})", crate::value::format_jq_number(*n)),
+                                other => format!("{} ({})", other.type_name(), crate::value::value_to_json(other)),
+                            };
+                            bail!("Cannot index {} with {}", base_val.type_name(), key_desc);
+                        }
+                    }
                     let mut p = match &bp { Value::Arr(a) => a.as_ref().clone(), _ => vec![] };
                     p.push(key); cb(Value::Arr(Rc::new(p)))
                 })

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -2249,6 +2249,9 @@ pub fn eval(
         }
 
         Expr::Alternative { primary, fallback } => {
+            // `A // B`: yield each truthy value from A; fall back to B only when
+            // A emits nothing non-false/non-null. Errors must propagate — use
+            // `f?` or `try f catch g` to suppress them, per jq semantics.
             let mut has_output = false;
             let result = eval(primary, input.clone(), env, &mut |val| {
                 if val.is_truthy() { has_output = true; cb(val) } else { Ok(true) }
@@ -2256,7 +2259,7 @@ pub fn eval(
             match result {
                 Ok(_) if !has_output => eval(fallback, input, env, cb),
                 Ok(cont) => Ok(cont),
-                Err(_) => eval(fallback, input, env, cb),
+                Err(e) => Err(e),
             }
         }
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3866,7 +3866,12 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
                 match &base {
                     Value::Arr(a) => { for i in 0..a.len() { let mut p = match &bp { Value::Arr(a)=>a.as_ref().clone(), _=>vec![] }; p.push(Value::Num(i as f64, None)); if !cb(Value::Arr(Rc::new(p)))? { return Ok(false); } } Ok(true) }
                     Value::Obj(o) => { for k in o.keys() { let mut p = match &bp { Value::Arr(a)=>a.as_ref().clone(), _=>vec![] }; p.push(Value::from_str(k)); if !cb(Value::Arr(Rc::new(p)))? { return Ok(false); } } Ok(true) }
-                    _ => Ok(true),
+                    _ => {
+                        // jq errors `del(.[])` etc. when the current path
+                        // points at a non-iterable (issue #54). Silent
+                        // "no paths" turned type errors into no-ops.
+                        bail!("Cannot iterate over {} ({})", base.type_name(), crate::value::value_to_json(&base))
+                    }
                 }
             });
             match result {

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1889,25 +1889,20 @@ fn push_const_comma_list(expr: &crate::ir::Expr, buf: &mut Vec<u8>, first: bool)
 }
 
 impl Filter {
-    /// Get the inner expression for pattern detection, unwrapping top-level
-    /// `try EXPR` (TryCatch with Empty catch) since the raw byte fast paths
-    /// handle missing fields gracefully (return null/nothing).
+    /// Get the inner expression for pattern detection.
+    ///
+    /// Previously this stripped top-level `try EXPR` (TryCatch with Empty
+    /// catch) on the assumption that the raw byte fast paths handled missing
+    /// fields gracefully. They don't: `(.a)?` on a non-object needs to emit
+    /// nothing (the error is caught), while the fast path emitted `null`.
+    /// Leave TryCatch visible so the fast paths that can't honour `?`
+    /// semantics simply don't match, and eval handles it correctly (see
+    /// issue #50).
     fn detect_expr(&self) -> Option<&crate::ir::Expr> {
-        // Use simplified expression (identity pipes stripped) for pattern detection
         if let Some(ref simplified) = self.simplified {
-            if let crate::ir::Expr::TryCatch { try_expr, catch_expr } = simplified {
-                if matches!(catch_expr.as_ref(), crate::ir::Expr::Empty) {
-                    return Some(try_expr);
-                }
-            }
             return Some(simplified);
         }
         let (ref expr, _) = self.parsed.as_ref()?;
-        if let crate::ir::Expr::TryCatch { try_expr, catch_expr } = expr {
-            if matches!(catch_expr.as_ref(), crate::ir::Expr::Empty) {
-                return Some(try_expr);
-            }
-        }
         Some(expr)
     }
 

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -967,11 +967,21 @@ fn simplify_expr(expr: &crate::ir::Expr) -> crate::ir::Expr {
                             }
                             let mut elems = Vec::new();
                             collect_comma_for_idx(lg, &mut elems);
-                            let actual = if idx >= 0 { idx as usize } else {
-                                (elems.len() as i64 + idx).max(0) as usize
+                            // Only constant-fold when the negative index
+                            // actually lands inside the array. Previously the
+                            // negative branch clamped to 0 via `.max(0)`,
+                            // returning the first element for any out-of-range
+                            // negative index (issue #42). Falling through for
+                            // the out-of-range cases lets the runtime emit the
+                            // correct null result.
+                            let effective: Option<usize> = if idx >= 0 {
+                                if (idx as usize) < elems.len() { Some(idx as usize) } else { None }
+                            } else {
+                                let v = elems.len() as i64 + idx;
+                                if v >= 0 && (v as usize) < elems.len() { Some(v as usize) } else { None }
                             };
-                            if actual < elems.len() {
-                                return elems.swap_remove(actual);
+                            if let Some(i) = effective {
+                                return elems.swap_remove(i);
                             }
                             }
                         }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1712,15 +1712,10 @@ fn simplify_expr(expr: &crate::ir::Expr) -> crate::ir::Expr {
         }
         Expr::PathExpr { expr: pe } => {
             let sp = simplify_expr(pe);
-            // path(.field) → ["field"]
-            if let Expr::Index { expr: base, key } = &sp {
-                if matches!(base.as_ref(), Expr::Input) {
-                    if let Expr::Literal(lit) = key.as_ref() {
-                        return Expr::Collect { generator: Box::new(Expr::Literal(lit.clone())) };
-                    }
-                }
-            }
-            // path(.a, .b) → (["a"], ["b"])
+            // Note: `path(.field)` cannot be folded to `["field"]` at
+            // compile time — jq errors when the input type is not
+            // indexable, so the type check must happen at runtime
+            // (issue #46). Only comma distributivity is safe to fold.
             if let Expr::Comma { left, right } = &sp {
                 let lp = simplify_expr(&Expr::PathExpr { expr: left.clone() });
                 let rp = simplify_expr(&Expr::PathExpr { expr: right.clone() });

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -529,3 +529,20 @@ path(.a.b)
 
 path(.a,.b)
 1
+
+# ---------- Issue #50: (expr)? emits null instead of nothing on errors ----------
+
+(.a)?
+true
+
+(.a)?
+1
+
+(.a)?
+"x"
+
+(.a)?
+{}
+
+(.a)?
+{"a":5}

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -546,3 +546,26 @@ true
 
 (.a)?
 {"a":5}
+
+# ---------- Issue #54: del(path) errors on type-incompatible input ----------
+
+del(.a)
+1
+
+del(.a)
+[1,2]
+
+del(.[0])
+{}
+
+del(.[])
+1
+
+del(.[])
+null
+
+del(.a)
+{"a":1,"b":2}
+
+del(.[0])
+[1,2,3]

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -482,3 +482,22 @@ null
 
 {(.k):2, a:1}
 {"k":"a"}
+# ---------- Issue #40: // propagates errors from the LHS ----------
+
+.x // 0
+1
+
+.x // 0
+true
+
+.x // 0
+"s"
+
+.x // 0
+[1]
+
+tonumber // 99
+"x"
+
+sort_by(.x // 0)
+[1,2,3]

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -515,3 +515,17 @@ null
 
 ["a","b"] | .[-3]
 null
+
+# ---------- Issue #46: path(f) errors on type-incompatible input ----------
+
+path(.a)
+1
+
+path(.[0])
+{}
+
+path(.a.b)
+1
+
+path(.a,.b)
+1

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -501,3 +501,17 @@ tonumber // 99
 
 sort_by(.x // 0)
 [1,2,3]
+
+# ---------- Issue #42: literal array negative index out-of-range ----------
+
+[1,2,3] | .[-4]
+null
+
+[1,2,3] | .[-100]
+null
+
+[10,20,30,40] | .[-5]
+null
+
+["a","b"] | .[-3]
+null

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -757,3 +757,35 @@ null
 .x // 0
 {"a":1}
 0
+
+# Issue #42: literal array piped into negative-index returns null when out of range
+
+# Negative overshoot by one — should be null, not elems[0]
+[1,2,3] | .[-4]
+null
+null
+
+# Large negative overshoot
+[1,2,3] | .[-100]
+null
+null
+
+# Four-element array, overshoot by one
+[10,20,30,40] | .[-5]
+null
+null
+
+# String array overshoot
+["a","b"] | .[-3]
+null
+null
+
+# Bound negative index still works
+[1,2,3] | .[-1]
+null
+3
+
+# Positive overshoot still returns null at runtime
+[1,2,3] | .[10]
+null
+null

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -845,3 +845,35 @@ null
 (.a)?
 {"a":5}
 5
+
+# Issue #54: del(path) errors on type-incompatible input
+
+# del(.a) on number errors
+del(.a)
+1
+
+# del(.a) on array errors (wrong key type for array)
+del(.a)
+[1,2]
+
+# del(.[0]) on object errors
+del(.[0])
+{}
+
+# del(.[]) on number errors (cannot iterate)
+del(.[])
+1
+
+# del(.[]) on null errors — jq treats null as non-iterable here
+del(.[])
+null
+
+# del still works on valid input
+del(.a)
+{"a":1,"b":2}
+{"b":2}
+
+# del on an array index removes that element
+del(.[0])
+[1,2,3]
+[2,3]

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -719,3 +719,41 @@ null
 {(.k):2, a:1}
 {"k":"a"}
 {"a":1}
+# Issue #40: `//` must propagate errors from the LHS
+
+# .x on a non-object must error, not silently fall through to the RHS
+.x // 0
+1
+
+# Non-object inputs of other types all error the same way
+.x // 0
+true
+
+.x // 0
+"s"
+
+.x // 0
+[1]
+
+# tonumber failure bubbles through //
+tonumber // 99
+"x"
+
+# sort_by propagates the per-element error from .x on a number input
+sort_by(.x // 0)
+[1,2,3]
+
+# null input to .field // fb is still null → fallback; no error
+.x // 0
+null
+0
+
+# Object with the key null is still null → fallback; no error
+.x // 0
+{"x":null}
+0
+
+# Object without the key → fallback (no error)
+.x // 0
+{"a":1}
+0

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -789,3 +789,35 @@ null
 [1,2,3] | .[10]
 null
 null
+
+# Issue #46: path(f) errors on type-incompatible input, like the bare access
+
+# path(.a) on a number errors
+path(.a)
+1
+
+# path(.a) on a boolean errors
+path(.a)
+true
+
+# path(.[0]) on an object errors (wrong key type for that base)
+path(.[0])
+{}
+
+# Nested path walk surfaces the same error when the initial step is invalid
+path(.a.b)
+1
+
+# path(.a,.b) errors on the first branch when the base is not indexable
+path(.a,.b)
+1
+
+# Valid paths still succeed
+path(.a)
+{"a":1}
+["a"]
+
+# path on null is a no-op (empty check happens naturally)
+path(.a)
+null
+["a"]

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -821,3 +821,27 @@ path(.a)
 path(.a)
 null
 ["a"]
+
+# Issue #50: (expr)? emits null instead of nothing when expr errors
+
+# Parenthesised field access with ? emits nothing on boolean input
+(.a)?
+true
+
+# Same behaviour on a number
+(.a)?
+1
+
+# Same behaviour on a string
+(.a)?
+"x"
+
+# Missing field on an object still returns null (no error to catch)
+(.a)?
+{}
+null
+
+# Field present still returns the value
+(.a)?
+{"a":5}
+5


### PR DESCRIPTION
Batch 3 of jq 1.8.1 compatibility fixes. One commit per issue.

## Summary

- Closes #40 — `//` propagates LHS errors instead of swallowing them
- Closes #42 — Literal-array negative-index overshoot returns null, not `elems[0]`
- Closes #46 — `path(f)` errors on type-incompatible input (no silent static-path folding)
- Closes #50 — `(expr)?` emits nothing, not `null`, when `expr` errors
- Closes #54 — `del(path)` errors on non-iterable / non-indexable input

## Test plan
- [x] `cargo build --release` — zero warnings
- [x] `cargo test --release` — all three suites green
- [x] Manual repro of each issue vs jq 1.8.1 — output matches