### PR TITLE
fix: from_entries on {} returns {} instead of erroring

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1369,6 +1369,9 @@ fn rt_from_entries(v: &Value) -> Result<Value> {
             }
             Ok(Value::Obj(Rc::new(obj)))
         }
+        // jq's from_entries desugars to `map(...) | add + {}`. On {} the map yields [],
+        // add yields null, and null + {} is {} — so empty objects round-trip to {}.
+        Value::Obj(o) if o.is_empty() => Ok(Value::Obj(Rc::new(new_objmap()))),
         _ => bail!("{} cannot be converted from entries", v.type_name()),
     }
 }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -938,3 +938,8 @@ until(. > 2; . + 10)
 until(. > 2; . + 10)
 5
 5
+
+# Issue #71: from_entries on {} round-trips to {} (follow-up to #44)
+from_entries
+{}
+{}


### PR DESCRIPTION
## Summary

- `{} | from_entries` now returns `{}`, matching jq 1.8.1
- Non-empty object inputs still error (matching jq, which errors from the `.key`/`.value` indexing inside the builtin's desugar)
- Regression test added for the empty-object branch

## Why

Follow-up to #44. jq's `from_entries` desugars to `map(...) | add + {}`. On `{}`:
- `.[]` yields no values, so `map(...)` yields `[]`
- `[] | add` yields `null`
- `null + {}` yields `{}`

So `{}` is a valid identity case, just like `[]`. The #44 fix installed a blanket "only arrays" gate that over-shot this case.

## Test plan

- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (509 official + regression all pass)
- [x] `./bench/comprehensive.sh --quick` — no regression vs v1.1.0
- [x] Manual: `echo '{}' | jq-jit -c 'from_entries'` → `{}`; `{"a":1}` still errors

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)