### PR TITLE
Release v1.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,7 +417,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jq-jit"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jq-jit"
-version = "1.2.1"
+version = "1.3.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A JIT-compiling implementation of jq using Cranelift"


### PR DESCRIPTION
## Summary

Version bump for v1.3.0. Headline change: libjq / libonig system dependency removed (#63 parent, shipped across #64–#68). jq-jit now builds and ships as pure Rust — `cargo install jq-jit` requires no system libraries.

## Release notes (draft)

### Highlights

- **No more libjq / libonig system dependency.** Earlier versions linked against both; jq-jit 1.3.0 runs parser / eval / JIT entirely in Rust. This simplifies installation (no more `brew install jq oniguruma` / Linux source-build dance).

### Bug fixes surfaced along the way

- Native `fromjson` parser with error messages byte-identical to jq 1.8.1 — no more divergences in `try fromjson catch .` usage (#64).
- User-defined functions now correctly shadow same-named builtins. `def add(x): x + .; add(10)` used to discard input by hitting the 1-arg `add` builtin alias (#65).
- Unbound `\$x` is a parse-time error, matching jq's "`\$x` is not defined" (#65).
- Number literals like `.5` and `1e2` now always emit valid JSON (`0.5`, `1E+2`) instead of source-form text that some consumers rejected (#65).
- `from_entries` on `{}` returns `{}` instead of erroring (#72).
- Chained unary minus (`- -1`, `- - -1`) now parses (#66).

### Known limitations

- `tostream` / `fromstream` / `truncate_stream` are not yet implemented natively — they were previously handled by the libjq fallback. Tracked in #89.

## Test plan

- [x] `cargo build --release` — zero warnings
- [x] `cargo test --release` — full suite green (no more `--test-threads=1`)
- [x] `otool -L target/release/jq-jit` — no libjq / libonig linkage
- [x] `./bench/comprehensive.sh --quick` — no regression vs 1.2.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)