### PR TITLE
test: add property-based differential fuzzer (#81)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,10 +54,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bumpalo"
@@ -343,6 +364,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
 name = "gimli"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -435,6 +468,7 @@ dependencies = [
  "memchr",
  "memmap2",
  "mimalloc",
+ "proptest",
  "regex",
  "ryu",
  "serde_json",
@@ -537,12 +571,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.11.1",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "unarray",
 ]
 
 [[package]]
@@ -562,6 +622,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -613,7 +717,7 @@ version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6b6ebd13bc009aef9cd476c1310d49ac354d36e240cf1bd753290f3dc7199a7"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "libc",
  "mach2",
  "windows-sys 0.52.0",
@@ -734,10 +838,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -955,6 +1074,32 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,9 @@ stacker = "0.1"
 csv = "1"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 
+[dev-dependencies]
+proptest = { version = "1", default-features = false, features = ["std", "bit-set"] }
+
 [profile.release]
 lto = "thin"
 

--- a/tests/differential_proptest.rs
+++ b/tests/differential_proptest.rs
@@ -1,0 +1,447 @@
+//! Property-based differential fuzzer: generate random `(filter, input)` pairs
+//! and run both `jq-jit` and reference `jq 1.8.x`. Any value-level divergence
+//! is a failure; both-error agreement is tolerated.
+//!
+//! Sized to finish within a ~60s CI budget. Override via env vars:
+//!   `JQJIT_PROPTEST_CASES` (default 500)
+//!   `JQJIT_PROPTEST_TIMEOUT_SECS` (per-subprocess cap, default 3)
+//!
+//! The reference `jq` binary is resolved the same way as the hand-curated
+//! differential harness (`$JQ_BIN` → Homebrew → `$PATH`). If no jq-1.8.x is
+//! available the test is skipped with a diagnostic.
+//!
+//! ## Running
+//!
+//! The test is marked `#[ignore]`: it exists to surface the entire class of
+//! fast-path type-dispatch divergences (`.a` on a non-object, etc.) on
+//! demand. Those divergences are structural and will keep falling out of
+//! random generation until the fast-path contract (issue #83) and the
+//! normalize-by-default constructors (issue #84) land. Running it in the
+//! default CI matrix would block every PR on the same known bug class.
+//!
+//! Run it explicitly:
+//!
+//! ```bash
+//! cargo test --release --test differential_proptest -- --ignored --nocapture
+//! # longer run:
+//! JQJIT_PROPTEST_CASES=5000 cargo test --release --test differential_proptest -- --ignored --nocapture
+//! ```
+//!
+//! Shrinker output reports a minimal `(FilterExpr, JsonShape)` pair; paste it
+//! into `tests/regression.test` once the underlying bug is fixed.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::Duration;
+
+use proptest::prelude::*;
+
+const IDENT_POOL: &[&str] = &["a", "b", "c", "k", "v", "x", "y"];
+const BUILTIN_UNARY_VALUE: &[&str] = &[
+    "length", "keys", "keys_unsorted", "values", "type",
+    "tostring", "tonumber", "add", "to_entries", "from_entries",
+    "reverse", "sort", "unique", "min", "max", "floor", "ceil", "fabs",
+    "not", "empty", "any", "all",
+];
+
+#[derive(Debug, Clone)]
+enum FilterExpr {
+    Identity,
+    Recurse,
+    Field(String),
+    Index(i32),
+    Slice(Option<i32>, Option<i32>),
+    ArrayConstruct(Vec<FilterExpr>),
+    ObjectConstruct(Vec<(String, FilterExpr)>),
+    Pipe(Box<FilterExpr>, Box<FilterExpr>),
+    Comma(Box<FilterExpr>, Box<FilterExpr>),
+    If(Box<FilterExpr>, Box<FilterExpr>, Box<FilterExpr>),
+    Slash(Box<FilterExpr>, Box<FilterExpr>),
+    TryCatch(Box<FilterExpr>, Box<FilterExpr>),
+    Optional(Box<FilterExpr>),
+    Limit(u32, Box<FilterExpr>),
+    Map(Box<FilterExpr>),
+    Select(Box<FilterExpr>),
+    UnaryBuiltin(&'static str),
+    Reduce(Box<FilterExpr>),   // reduce .[] as $x (0; . + $x)
+    Foreach(Box<FilterExpr>),  // foreach .[] as $x (0; . + $x; .)
+    RangeN(u32),
+    IntLiteral(i32),
+}
+
+fn render(expr: &FilterExpr) -> String {
+    match expr {
+        FilterExpr::Identity => ".".into(),
+        FilterExpr::Recurse => "..".into(),
+        FilterExpr::Field(name) => format!(".{}", name),
+        FilterExpr::Index(n) => format!(".[{}]", n),
+        FilterExpr::Slice(a, b) => {
+            let lo = a.map(|v| v.to_string()).unwrap_or_default();
+            let hi = b.map(|v| v.to_string()).unwrap_or_default();
+            format!(".[{}:{}]", lo, hi)
+        }
+        FilterExpr::ArrayConstruct(items) => {
+            if items.is_empty() { return "[]".into(); }
+            let parts: Vec<String> = items.iter().map(render).collect();
+            format!("[{}]", parts.join(","))
+        }
+        FilterExpr::ObjectConstruct(pairs) => {
+            if pairs.is_empty() { return "{}".into(); }
+            let parts: Vec<String> = pairs
+                .iter()
+                .map(|(k, v)| format!("{}: ({})", k, render(v)))
+                .collect();
+            format!("{{{}}}", parts.join(", "))
+        }
+        FilterExpr::Pipe(a, b) => format!("({}) | ({})", render(a), render(b)),
+        FilterExpr::Comma(a, b) => format!("({}), ({})", render(a), render(b)),
+        FilterExpr::If(c, t, e) => {
+            format!("if ({}) then ({}) else ({}) end", render(c), render(t), render(e))
+        }
+        FilterExpr::Slash(a, b) => format!("({}) // ({})", render(a), render(b)),
+        FilterExpr::TryCatch(a, b) => format!("try ({}) catch ({})", render(a), render(b)),
+        FilterExpr::Optional(a) => format!("({})?", render(a)),
+        FilterExpr::Limit(n, g) => format!("limit({}; {})", n, render(g)),
+        FilterExpr::Map(f) => format!("map({})", render(f)),
+        FilterExpr::Select(f) => format!("select({})", render(f)),
+        FilterExpr::UnaryBuiltin(name) => (*name).to_string(),
+        FilterExpr::Reduce(gen) => format!("reduce ({}) as $x (0; . + ($x | tonumber? // 0))", render(gen)),
+        FilterExpr::Foreach(gen) => format!("foreach ({}) as $x (0; . + ($x | tonumber? // 0); .)", render(gen)),
+        FilterExpr::RangeN(n) => format!("range({})", n),
+        FilterExpr::IntLiteral(n) => n.to_string(),
+    }
+}
+
+fn ident_strategy() -> impl Strategy<Value = String> {
+    prop::sample::select(IDENT_POOL).prop_map(|s| s.to_string())
+}
+
+fn leaf_strategy() -> impl Strategy<Value = FilterExpr> {
+    prop_oneof![
+        Just(FilterExpr::Identity),
+        Just(FilterExpr::Recurse),
+        ident_strategy().prop_map(FilterExpr::Field),
+        (-3i32..=3).prop_map(FilterExpr::Index),
+        prop::sample::select(BUILTIN_UNARY_VALUE).prop_map(FilterExpr::UnaryBuiltin),
+        (0u32..5).prop_map(FilterExpr::RangeN),
+        (-3i32..=3).prop_map(FilterExpr::IntLiteral),
+        prop::option::of(-3i32..=3)
+            .prop_flat_map(|a| prop::option::of(-3i32..=3).prop_map(move |b| FilterExpr::Slice(a, b))),
+    ]
+}
+
+fn filter_strategy() -> impl Strategy<Value = FilterExpr> {
+    leaf_strategy().prop_recursive(
+        4,   // depth
+        40,  // total size budget
+        6,   // max items per collection / branches
+        |inner| {
+            prop_oneof![
+                // Array construct (0-3 items)
+                prop::collection::vec(inner.clone(), 0..=3).prop_map(FilterExpr::ArrayConstruct),
+                // Object construct (0-3 pairs) with keys from pool
+                prop::collection::vec(
+                    (ident_strategy(), inner.clone()),
+                    0..=3,
+                ).prop_map(FilterExpr::ObjectConstruct),
+                (inner.clone(), inner.clone()).prop_map(|(a, b)| FilterExpr::Pipe(Box::new(a), Box::new(b))),
+                (inner.clone(), inner.clone()).prop_map(|(a, b)| FilterExpr::Comma(Box::new(a), Box::new(b))),
+                (inner.clone(), inner.clone(), inner.clone()).prop_map(|(a, b, c)| {
+                    FilterExpr::If(Box::new(a), Box::new(b), Box::new(c))
+                }),
+                (inner.clone(), inner.clone()).prop_map(|(a, b)| FilterExpr::Slash(Box::new(a), Box::new(b))),
+                (inner.clone(), inner.clone()).prop_map(|(a, b)| FilterExpr::TryCatch(Box::new(a), Box::new(b))),
+                inner.clone().prop_map(|a| FilterExpr::Optional(Box::new(a))),
+                (1u32..=4, inner.clone()).prop_map(|(n, g)| FilterExpr::Limit(n, Box::new(g))),
+                inner.clone().prop_map(|f| FilterExpr::Map(Box::new(f))),
+                inner.clone().prop_map(|f| FilterExpr::Select(Box::new(f))),
+                inner.clone().prop_map(|g| FilterExpr::Reduce(Box::new(g))),
+                inner.clone().prop_map(|g| FilterExpr::Foreach(Box::new(g))),
+            ]
+        },
+    )
+}
+
+#[derive(Debug, Clone)]
+enum JsonShape {
+    Null,
+    Bool(bool),
+    IntN(i32),
+    FloatN(f64),
+    Str(String),
+    Arr(Vec<JsonShape>),
+    Obj(Vec<(String, JsonShape)>),
+}
+
+fn render_json(v: &JsonShape) -> String {
+    match v {
+        JsonShape::Null => "null".into(),
+        JsonShape::Bool(b) => b.to_string(),
+        JsonShape::IntN(n) => n.to_string(),
+        JsonShape::FloatN(f) => {
+            if f.is_finite() {
+                // Use ryu-style formatting; fall back to a sane default.
+                let mut s = format!("{}", f);
+                if !s.contains('.') && !s.contains('e') && !s.contains('E') {
+                    s.push_str(".0");
+                }
+                s
+            } else {
+                "0".into()
+            }
+        }
+        JsonShape::Str(s) => serde_json::to_string(s).unwrap(),
+        JsonShape::Arr(items) => {
+            let parts: Vec<String> = items.iter().map(render_json).collect();
+            format!("[{}]", parts.join(","))
+        }
+        JsonShape::Obj(pairs) => {
+            let parts: Vec<String> = pairs
+                .iter()
+                .map(|(k, v)| format!("{}:{}", serde_json::to_string(k).unwrap(), render_json(v)))
+                .collect();
+            format!("{{{}}}", parts.join(","))
+        }
+    }
+}
+
+fn json_leaf() -> impl Strategy<Value = JsonShape> {
+    prop_oneof![
+        Just(JsonShape::Null),
+        any::<bool>().prop_map(JsonShape::Bool),
+        (-5i32..=5).prop_map(JsonShape::IntN),
+        prop_oneof![
+            Just(0.5f64), Just(-0.5), Just(1.5), Just(2.5), Just(-1.5),
+        ].prop_map(JsonShape::FloatN),
+        prop::sample::select(vec!["", "a", "ab", "hello", "0"]).prop_map(|s| JsonShape::Str(s.to_string())),
+    ]
+}
+
+fn json_strategy() -> impl Strategy<Value = JsonShape> {
+    json_leaf().prop_recursive(3, 16, 4, |inner| {
+        prop_oneof![
+            prop::collection::vec(inner.clone(), 0..=3).prop_map(JsonShape::Arr),
+            prop::collection::vec((ident_strategy(), inner.clone()), 0..=3).prop_map(JsonShape::Obj),
+        ]
+    })
+}
+
+struct RunOutput {
+    stdout: String,
+    is_error: bool,
+}
+
+fn run_once(bin: &str, filter: &str, input: &str, timeout: Duration) -> Option<RunOutput> {
+    let mut cmd = Command::new(bin);
+    cmd.arg("-c").arg(filter);
+    cmd.stdin(std::process::Stdio::piped());
+    cmd.stdout(std::process::Stdio::piped());
+    cmd.stderr(std::process::Stdio::piped());
+    let mut child = cmd.spawn().ok()?;
+    {
+        use std::io::Write;
+        let mut stdin = child.stdin.take()?;
+        let _ = stdin.write_all(input.as_bytes());
+        let _ = stdin.write_all(b"\n");
+    }
+    let start = std::time::Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                let out = child.wait_with_output().ok()?;
+                let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+                let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+                #[cfg(unix)]
+                {
+                    use std::os::unix::process::ExitStatusExt;
+                    if let Some(sig) = status.signal() {
+                        return Some(RunOutput {
+                            stdout: format!("<killed by signal {}> stderr: {}", sig, stderr.trim()),
+                            is_error: true,
+                        });
+                    }
+                }
+                return Some(RunOutput { stdout, is_error: !status.success() });
+            }
+            Ok(None) => {
+                if start.elapsed() > timeout {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return Some(RunOutput { stdout: "<timeout>".to_string(), is_error: true });
+                }
+                std::thread::sleep(Duration::from_millis(5));
+            }
+            Err(_) => return None,
+        }
+    }
+}
+
+fn normalize(output: &str) -> Result<String, String> {
+    let mut lines = Vec::new();
+    for line in output.lines() {
+        let t = line.trim();
+        if t.is_empty() { continue; }
+        let v: serde_json::Value = serde_json::from_str(t)
+            .map_err(|e| format!("non-JSON `{}`: {}", t, e))?;
+        lines.push(serialize_sorted(&normalize_value(v)));
+    }
+    Ok(lines.join("\n"))
+}
+
+fn normalize_value(val: serde_json::Value) -> serde_json::Value {
+    use serde_json::Value;
+    match val {
+        Value::Number(n) => {
+            if let Some(f) = n.as_f64() {
+                if f.is_finite() && f == (f as i64) as f64 && f.abs() < (1i64 << 53) as f64 {
+                    return Value::Number(serde_json::Number::from(f as i64));
+                }
+            }
+            Value::Number(n)
+        }
+        Value::Array(a) => Value::Array(a.into_iter().map(normalize_value).collect()),
+        Value::Object(m) => Value::Object(m.into_iter().map(|(k, v)| (k, normalize_value(v))).collect()),
+        other => other,
+    }
+}
+
+fn serialize_sorted(val: &serde_json::Value) -> String {
+    use serde_json::Value;
+    match val {
+        Value::Null => "null".into(),
+        Value::Bool(b) => b.to_string(),
+        Value::Number(n) => n.to_string(),
+        Value::String(s) => serde_json::to_string(s).unwrap(),
+        Value::Array(a) => {
+            let items: Vec<String> = a.iter().map(serialize_sorted).collect();
+            format!("[{}]", items.join(","))
+        }
+        Value::Object(m) => {
+            let mut entries: Vec<(&String, &Value)> = m.iter().collect();
+            entries.sort_by_key(|(k, _)| *k);
+            let items: Vec<String> = entries
+                .iter()
+                .map(|(k, v)| format!("{}:{}", serde_json::to_string(k).unwrap(), serialize_sorted(v)))
+                .collect();
+            format!("{{{}}}", items.join(","))
+        }
+    }
+}
+
+fn resolve_jq() -> Option<String> {
+    let candidates: Vec<String> = std::env::var("JQ_BIN")
+        .ok()
+        .into_iter()
+        .chain(std::iter::once("/opt/homebrew/opt/jq/bin/jq".to_string()))
+        .chain(std::iter::once("jq".to_string()))
+        .collect();
+    for cand in &candidates {
+        let Ok(out) = Command::new(cand).arg("--version").output() else { continue };
+        if !out.status.success() { continue; }
+        let ver = String::from_utf8_lossy(&out.stdout);
+        if ver.trim().starts_with("jq-1.8.") { return Some(cand.clone()); }
+    }
+    None
+}
+
+#[test]
+#[ignore = "opt-in: surfaces known fast-path type-dispatch divergences; run with --ignored"]
+fn differential_proptest_against_jq_1_8() {
+    let Some(jq) = resolve_jq() else {
+        let msg = "no jq-1.8.x binary found. Set JQ_BIN to a jq-1.8.x binary.";
+        if std::env::var_os("CI").is_some() {
+            panic!("differential_proptest: {}", msg);
+        }
+        eprintln!("SKIP differential_proptest: {}", msg);
+        return;
+    };
+    let jq_jit: PathBuf = env!("CARGO_BIN_EXE_jq-jit").into();
+    let jq_jit = jq_jit.to_string_lossy().into_owned();
+
+    let cases: u32 = std::env::var("JQJIT_PROPTEST_CASES")
+        .ok().and_then(|s| s.parse().ok()).unwrap_or(500);
+    let timeout_secs: u64 = std::env::var("JQJIT_PROPTEST_TIMEOUT_SECS")
+        .ok().and_then(|s| s.parse().ok()).unwrap_or(3);
+    let timeout = Duration::from_secs(timeout_secs);
+
+    // Track how many proptest iterations ran meaningful jq/jit comparisons,
+    // and how many fell into "both errored" skips (counted as pass).
+    let compared = std::sync::atomic::AtomicUsize::new(0);
+    let both_error = std::sync::atomic::AtomicUsize::new(0);
+
+    let cfg = ProptestConfig {
+        cases,
+        failure_persistence: None,
+        max_shrink_time: 15_000,
+        ..ProptestConfig::default()
+    };
+
+    let mut runner = proptest::test_runner::TestRunner::new(cfg);
+    let strategy = (filter_strategy(), json_strategy());
+
+    let result = runner.run(&strategy, |(expr, input_shape)| {
+        let filter = render(&expr);
+        let input = render_json(&input_shape);
+
+        let Some(r_jq) = run_once(&jq, &filter, &input, timeout) else {
+            // Spawn failure — skip, do not fail the property.
+            return Ok(());
+        };
+        let Some(r_jit) = run_once(&jq_jit, &filter, &input, timeout) else {
+            return Ok(());
+        };
+
+        // Crash markers from jq-jit are hard failures.
+        let crash_markers = ["panicked", "SIGSEGV", "Assertion failed", "stack overflow", "RUST_BACKTRACE"];
+        if crash_markers.iter().any(|m| r_jit.stdout.contains(m)) {
+            return Err(TestCaseError::fail(format!(
+                "jq-jit crashed\n  filter: {}\n  input:  {}\n  stderr: {}",
+                filter, input, r_jit.stdout.trim()
+            )));
+        }
+
+        if r_jq.is_error && r_jit.is_error {
+            both_error.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            return Ok(());
+        }
+        if r_jq.is_error != r_jit.is_error {
+            return Err(TestCaseError::fail(format!(
+                "error mismatch (jq error={}, jit error={})\n  filter: {}\n  input:  {}\n  jq:  {}\n  jit: {}",
+                r_jq.is_error, r_jit.is_error, filter, input,
+                r_jq.stdout.trim(), r_jit.stdout.trim()
+            )));
+        }
+
+        let a_norm = match normalize(&r_jq.stdout) {
+            Ok(s) => s,
+            Err(_) => return Ok(()),  // jq produced non-JSON line (shouldn't happen; skip rather than fail)
+        };
+        let b_norm = match normalize(&r_jit.stdout) {
+            Ok(s) => s,
+            Err(e) => return Err(TestCaseError::fail(format!(
+                "jq-jit emitted non-JSON\n  filter: {}\n  input:  {}\n  err: {}\n  jit: {}",
+                filter, input, e, r_jit.stdout.trim()
+            ))),
+        };
+
+        compared.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        if a_norm != b_norm {
+            return Err(TestCaseError::fail(format!(
+                "value mismatch\n  filter: {}\n  input:  {}\n  jq:  {}\n  jit: {}",
+                filter, input, a_norm, b_norm
+            )));
+        }
+        Ok(())
+    });
+
+    eprintln!(
+        "=== Proptest differential (vs {}) ===\n  compared: {}\n  both_errored: {}",
+        jq,
+        compared.load(std::sync::atomic::Ordering::Relaxed),
+        both_error.load(std::sync::atomic::Ordering::Relaxed),
+    );
+
+    if let Err(e) = result {
+        panic!("proptest differential failed:\n{}", e);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a property-based differential test (`tests/differential_proptest.rs`) that generates random `(FilterExpr, JsonShape)` pairs and runs them through both `jq-jit` and reference `jq 1.8.x`, failing on any value-level divergence, error-polarity mismatch, or jq-jit crash marker.
- Generator covers the constructs named in the scope of #81: `Identity`, `Recurse`, `Field`, `Index`, `Slice`, `ArrayConstruct`, `ObjectConstruct`, `Pipe`, `Comma`, `If`, `Slash`, `TryCatch`, `Optional`, `Limit`, `Reduce`, `Foreach`, `map`, `select`, plus ~20 unary builtins. JSON inputs recurse up to depth 3.
- Default: 500 cases with a 3s per-subprocess timeout, tunable via `JQJIT_PROPTEST_CASES` / `JQJIT_PROPTEST_TIMEOUT_SECS`.
- Adds `proptest` as a dev-dependency (default-features off, `std` + `bit-set`).

## Why `#[ignore]` for now
A single random sweep already surfaces the open fast-path type-dispatch bug class (e.g. `.a` on `false` returns `null` instead of erroring) that #83 (fast-path contract) and #84 (normalize-by-default constructors) are designed to end. Running this in the default CI matrix would block every PR on the same bug class. The test is marked `#[ignore]` so it stays runnable as an opt-in tool:

```
cargo test --release --test differential_proptest -- --ignored --nocapture
JQJIT_PROPTEST_CASES=5000 cargo test --release --test differential_proptest -- --ignored --nocapture
```

Flip the `#[ignore]` off once #83 / #84 land.

## Test plan
- [x] `cargo build --release` — zero warnings
- [x] `cargo test --release` — 3 existing tests pass, proptest reported as ignored
- [x] `cargo test --release --test differential_proptest -- --ignored` — runs the generator and (expected) reports minimal shrink of the current fast-path divergence
- [ ] CI completes green (auto-merge on pass)

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)