### PR TITLE
refactor: Value constructor opt-out factories (#84)

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -101,20 +101,26 @@ JIT にまで降りる filter はここ。`flatten_scalar` / `flatten_gen` の m
 
 ### オブジェクト重複キーの dedup
 
-jq は `{a:1, a:2}` → `{"a":2}`（後勝ち、最初の位置を保持）。構築系 fast path すべてで
-`interpreter.rs` の `normalize_object_pairs<K, V>` ヘルパを通して守る:
+jq は `{a:1, a:2}` → `{"a":2}`（後勝ち、最初の位置を保持）。
 
-| 場所 | 関数 |
+**canonical な作り方**: `Value::Obj` を直接作らず、`src/value.rs` の
+ファクトリを通す。dedup 不変性は関数シグネチャで強制される（"opt-out" 方式、#84）:
+
+| 目的 | API |
 |---|---|
-| `interpreter.rs` | `const_expr_to_json`（ObjectConstruct 分岐） |
-| `interpreter.rs` | `push_const_json`（`detect_literal_output` 経由） |
-| `interpreter.rs` | `simplify_expr` の `{pairs} | length` 畳み込み |
-| `interpreter.rs` | `detect_field_remap`（戻り値 dedup） |
-| `interpreter.rs` | `detect_computed_remap`（戻り値 dedup） |
+| pair list から構築（dedup） | `Value::object_from_pairs(pairs)` |
+| dedup 済みと分かっている場合 | `Value::object_from_normalized_pairs(pairs)` （debug_assert で重複検知） |
+| `ObjMap` を insert/push_unique 経由で組み立て済み | `Value::object_from_map(map)` |
 
-新しい object 構築 fast path を足す時は、`(key, value)` ペアのリストを組み立てた後に
-`normalize_object_pairs` を必ず通す（キー型は `PartialEq` でよい）。`| length` 系の
-個数だけ欲しい場合も `.len()` を取れば jq と一致する。
+`Value::Obj(Rc::new(..))` を直書きすると
+`tests/value_factory_enforcement.rs` が旧サイト以外で検知して fail する
+（旧サイトの count は `tests/value_factory_enforcement.allowlist` に記録、
+削減方向にしか更新できない）。
+
+pair list を他形式（JSON バイト、Vec<(String, RemapExpr)> など）に変換する前に
+dedup だけしたい場合は従来の `interpreter.rs::normalize_object_pairs<K, V>`
+を使う（キー型は `PartialEq` でよい）。`| length` 系で個数だけ欲しい場合は
+dedup 後の `.len()` を取れば jq と一致する。
 
 invariant 回帰は `tests/regression.test` の "Issue #30" ブロックと
 `tests/differential/corpus.test` の "duplicate-key collapse" ブロックで監視している。

--- a/src/value.rs
+++ b/src/value.rs
@@ -437,6 +437,78 @@ impl Value {
         Value::Obj(Rc::new(pairs.into_iter().map(|(k, v)| (KeyStr::from(k), v)).collect()))
     }
 
+    /// Canonical object factory: dedupes duplicate keys (last value wins,
+    /// earliest position preserved) to match jq's `{a:1, a:2}` → `{"a":2}`
+    /// object-literal semantics. Every Obj construction that builds a pair
+    /// list from user-controlled / fast-path sources should route through
+    /// this function so the dedup invariant is enforced structurally instead
+    /// of by a per-site "remember to call the helper" convention. See
+    /// `docs/maintenance.md` §3.
+    pub fn object_from_pairs<K, I>(pairs: I) -> Self
+    where
+        K: Into<KeyStr>,
+        I: IntoIterator<Item = (K, Value)>,
+    {
+        let iter = pairs.into_iter();
+        let (lo, _) = iter.size_hint();
+        let mut map = ObjMap::with_capacity(lo);
+        for (k, v) in iter {
+            map.insert(k.into(), v);
+        }
+        Value::Obj(Rc::new(map))
+    }
+
+    /// Bypass variant of [`Value::object_from_pairs`]: trusts the caller to
+    /// provide an already-normalized pair list (no duplicate keys, order
+    /// reflects insertion order). Prefer the normalizing variant unless the
+    /// source is provably unique — parser output, a clone of an existing
+    /// `Rc<ObjMap>`, or a rebuild of a structure that went through dedup
+    /// earlier in the same pipeline. In debug builds this asserts the
+    /// caller's contract.
+    pub fn object_from_normalized_pairs<K, I>(pairs: I) -> Self
+    where
+        K: Into<KeyStr>,
+        I: IntoIterator<Item = (K, Value)>,
+    {
+        let iter = pairs.into_iter();
+        let (lo, _) = iter.size_hint();
+        let mut map = ObjMap::with_capacity(lo);
+        for (k, v) in iter {
+            let key: KeyStr = k.into();
+            debug_assert!(
+                !map.contains_key(key.as_str()),
+                "object_from_normalized_pairs: duplicate key `{}`", key
+            );
+            map.push_unique(key, v);
+        }
+        Value::Obj(Rc::new(map))
+    }
+
+    /// Wrap an existing `ObjMap` that was built with invariant-preserving
+    /// operations (`insert` / `push_unique` / JSON parsing). Reuses the
+    /// caller's allocation — does not dedupe.
+    pub fn object_from_map(map: ObjMap) -> Self {
+        Value::Obj(Rc::new(map))
+    }
+
+    /// Numeric factory that drops the repr annotation. Equivalent to
+    /// [`Value::from_f64`], named consistently with [`Value::object_from_pairs`].
+    #[inline]
+    pub fn number(n: f64) -> Self {
+        Value::Num(n, None)
+    }
+
+    /// Numeric factory that preserves the original textual representation.
+    /// Callers that read a number from source (parser, literal fold,
+    /// identity-preserving round-trips) should prefer this so `1.0` stays
+    /// `1.0` and `-1.0` stays `-1.0`. Operations that produce a fresh number
+    /// value (arithmetic, length, etc.) should use [`Value::number`] so the
+    /// repr does not carry over misleadingly.
+    #[inline]
+    pub fn number_with_repr(n: f64, repr: Rc<str>) -> Self {
+        Value::Num(n, Some(repr))
+    }
+
     pub fn is_true(&self) -> bool {
         !matches!(self, Value::Null | Value::False)
     }

--- a/tests/value_factories.rs
+++ b/tests/value_factories.rs
@@ -1,0 +1,61 @@
+//! Unit coverage for the Value factories introduced alongside #84.
+
+use jq_jit::value::Value;
+
+#[test]
+fn object_from_pairs_dedupes_last_wins_first_position() {
+    // { a: 1, b: 2, a: 3 } → { a: 3, b: 2 } with `a` kept at position 0.
+    let obj = Value::object_from_pairs(vec![
+        ("a", Value::number(1.0)),
+        ("b", Value::number(2.0)),
+        ("a", Value::number(3.0)),
+    ]);
+    let Value::Obj(rc) = obj else { panic!("expected Obj") };
+    let keys: Vec<&str> = rc.iter().map(|(k, _)| k.as_str()).collect();
+    assert_eq!(keys, vec!["a", "b"]);
+    let (_, a_val) = rc.iter().find(|(k, _)| k.as_str() == "a").unwrap();
+    let Value::Num(n, _) = a_val else { panic!("expected Num") };
+    assert_eq!(*n, 3.0);
+}
+
+#[test]
+fn object_from_pairs_empty() {
+    let obj = Value::object_from_pairs::<&str, _>(Vec::<(&str, Value)>::new());
+    let Value::Obj(rc) = obj else { panic!("expected Obj") };
+    assert_eq!(rc.len(), 0);
+}
+
+#[test]
+fn object_from_normalized_pairs_trusts_caller() {
+    let obj = Value::object_from_normalized_pairs(vec![
+        ("x", Value::number(1.0)),
+        ("y", Value::number(2.0)),
+    ]);
+    let Value::Obj(rc) = obj else { panic!("expected Obj") };
+    assert_eq!(rc.len(), 2);
+}
+
+#[test]
+fn number_factory_drops_repr() {
+    let n = Value::number(1.0);
+    match n {
+        Value::Num(v, repr) => {
+            assert_eq!(v, 1.0);
+            assert!(repr.is_none(), "bare number should have no repr");
+        }
+        _ => panic!("expected Num"),
+    }
+}
+
+#[test]
+fn number_with_repr_factory_preserves_repr() {
+    let raw: std::rc::Rc<str> = std::rc::Rc::from("1.0");
+    let n = Value::number_with_repr(1.0, raw.clone());
+    match n {
+        Value::Num(v, repr) => {
+            assert_eq!(v, 1.0);
+            assert_eq!(repr.as_deref(), Some("1.0"));
+        }
+        _ => panic!("expected Num"),
+    }
+}

--- a/tests/value_factory_enforcement.allowlist
+++ b/tests/value_factory_enforcement.allowlist
@@ -1,0 +1,33 @@
+# Grandfathered direct `Value::Obj(Rc::new(…))` construction sites.
+# Format: `<path>  <count>` — one file per line.
+# Blank lines and `#`-prefixed comments are ignored.
+#
+# The test in tests/value_factory_enforcement.rs enforces both an upper
+# and lower bound: the count is the exact number of raw construction
+# sites tolerated in each file. Adding a new site without bumping the
+# count fails the test; reducing the count (by migrating to a factory)
+# without editing the allowlist also fails the test, so the numbers
+# stay in sync with reality.
+#
+# Shrink-only policy: when migrating a site to a factory, lower the
+# count here. When the count reaches zero, remove the line. The goal
+# is an empty allowlist — every Value::Obj construction routed through
+# Value::object_from_pairs / object_from_normalized_pairs / object_from_map.
+#
+# Rationale for each currently-allowed file is below; each entry should
+# eventually be zeroed out:
+#
+# - src/value.rs: the factories themselves live here; also JSON parser
+#   construction where keys come pre-deduped by the parser's lookahead.
+# - src/module.rs: module-loader fixed maps with compile-time-known
+#   unique keys.
+# - src/runtime.rs / src/eval.rs / src/jit.rs: execution-path sites
+#   that currently rebuild objects after dedup helpers or from
+#   insert-based maps. Converting these to `object_from_map(map)` is
+#   mechanical but noisy; do it in follow-up PRs.
+
+src/value.rs      8
+src/module.rs     4
+src/eval.rs       9
+src/jit.rs        6
+src/runtime.rs    24

--- a/tests/value_factory_enforcement.rs
+++ b/tests/value_factory_enforcement.rs
@@ -1,0 +1,161 @@
+//! Enforce that new code routes `Value::Obj` construction through the
+//! `Value::object_from_pairs` / `Value::object_from_normalized_pairs` /
+//! `Value::object_from_map` factories in `src/value.rs`.
+//!
+//! Direct `Value::Obj(Rc::new(…))` construction is the failure mode behind
+//! #52 / #53 / #73 / #75: each site has to remember to run the pair list
+//! through `normalize_object_pairs` before constructing the Value, and any
+//! site that forgets silently ships duplicate-key output. The factories
+//! fold dedup into the construction call, so "the only way to build an
+//! object Value routes through normalize".
+//!
+//! Since migrating the ~50 existing call sites is its own refactor, this
+//! test grandfathers each current site into
+//! `tests/value_factory_enforcement.allowlist` (file + line-count).
+//! The allowlist is unidirectional:
+//!
+//!   - New `Value::Obj(Rc::new(…))` site not in allowlist  →  FAIL
+//!   - Existing file grew above its grandfathered count    →  FAIL
+//!   - Existing file shrank below its grandfathered count  →  FAIL (update the count)
+//!   - File in allowlist no longer exists / has zero hits  →  FAIL
+//!
+//! To add a legitimate new construction site: prefer one of the factories.
+//! If you genuinely need raw `Value::Obj(Rc::new(…))` — e.g. inside
+//! `src/value.rs` where the factory itself lives — update the allowlist.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+const GUARDED_PATTERN: &str = "Value::Obj(Rc::new";
+
+fn scan_src() -> BTreeMap<String, usize> {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut counts: BTreeMap<String, usize> = BTreeMap::new();
+    walk(&root, &root, &mut counts);
+    counts
+}
+
+fn walk(base: &PathBuf, dir: &PathBuf, counts: &mut BTreeMap<String, usize>) {
+    let Ok(entries) = std::fs::read_dir(dir) else { return };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            walk(base, &path, counts);
+            continue;
+        }
+        if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+            continue;
+        }
+        let Ok(content) = std::fs::read_to_string(&path) else { continue };
+        let hits = content.matches(GUARDED_PATTERN).count();
+        if hits == 0 { continue; }
+        let rel = path.strip_prefix(base).unwrap_or(&path).to_string_lossy().into_owned();
+        counts.insert(format!("src/{}", rel), hits);
+    }
+}
+
+fn load_allowlist() -> BTreeMap<String, usize> {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/value_factory_enforcement.allowlist");
+    let Ok(content) = std::fs::read_to_string(&path) else {
+        return BTreeMap::new();
+    };
+    let mut out: BTreeMap<String, usize> = BTreeMap::new();
+    for (n, raw) in content.lines().enumerate() {
+        let line = raw.trim();
+        if line.is_empty() || line.starts_with('#') { continue; }
+        let Some((file, count_str)) = line.rsplit_once(char::is_whitespace) else {
+            panic!(
+                "allowlist line {}: expected `<path>  <count>` (got: `{}`)",
+                n + 1, raw,
+            );
+        };
+        let count: usize = count_str.trim().parse().unwrap_or_else(|_| {
+            panic!(
+                "allowlist line {}: `{}` is not a valid count",
+                n + 1, count_str,
+            )
+        });
+        out.insert(file.trim().to_string(), count);
+    }
+    out
+}
+
+#[test]
+fn value_obj_construction_goes_through_factories() {
+    let actual = scan_src();
+    let allowed = load_allowlist();
+
+    let mut new_hits: Vec<(String, usize)> = Vec::new();
+    let mut grew: Vec<(String, usize, usize)> = Vec::new();
+    let mut shrank: Vec<(String, usize, usize)> = Vec::new();
+    let mut stale: Vec<String> = Vec::new();
+
+    for (file, hits) in &actual {
+        match allowed.get(file) {
+            None => new_hits.push((file.clone(), *hits)),
+            Some(limit) if hits > limit => grew.push((file.clone(), *limit, *hits)),
+            Some(limit) if hits < limit => shrank.push((file.clone(), *limit, *hits)),
+            _ => {}
+        }
+    }
+    for file in allowed.keys() {
+        if !actual.contains_key(file) {
+            stale.push(file.clone());
+        }
+    }
+
+    eprintln!();
+    eprintln!("=== Value::Obj(Rc::new(…)) enforcement ===");
+    eprintln!("pattern:       {}", GUARDED_PATTERN);
+    eprintln!("allowlisted:   {} files, {} hits total",
+        allowed.len(), allowed.values().sum::<usize>());
+    eprintln!("actual:        {} files, {} hits total",
+        actual.len(), actual.values().sum::<usize>());
+
+    if !new_hits.is_empty() {
+        eprintln!();
+        eprintln!("=== New files with direct Value::Obj construction ===");
+        for (file, hits) in &new_hits {
+            eprintln!("  {}  (+{} hits)", file, hits);
+        }
+        eprintln!("\nRoute through one of:");
+        eprintln!("  Value::object_from_pairs(pairs)             // dedupes duplicate keys");
+        eprintln!("  Value::object_from_normalized_pairs(pairs)  // asserts pre-deduped");
+        eprintln!("  Value::object_from_map(map)                 // reuse an ObjMap built via insert/push_unique");
+        eprintln!("\nIf a raw construction is genuinely necessary (e.g. inside value.rs");
+        eprintln!("itself), add the file to tests/value_factory_enforcement.allowlist.");
+    }
+    if !grew.is_empty() {
+        eprintln!();
+        eprintln!("=== Files that grew past their grandfathered count ===");
+        for (file, limit, now) in &grew {
+            eprintln!("  {}  was {}, now {}", file, limit, now);
+        }
+        eprintln!("\nNew raw construction sites were added to an existing file. Either");
+        eprintln!("route them through a factory or bump the allowlist count with a");
+        eprintln!("justifying comment.");
+    }
+    if !shrank.is_empty() {
+        eprintln!();
+        eprintln!("=== Files with fewer hits than allowlisted ===");
+        for (file, limit, now) in &shrank {
+            eprintln!("  {}  was {}, now {}  — update the allowlist", file, limit, now);
+        }
+    }
+    if !stale.is_empty() {
+        eprintln!();
+        eprintln!("=== Stale allowlist entries ===");
+        for file in &stale {
+            eprintln!("  {}", file);
+        }
+        eprintln!("\nThese files are in the allowlist but no longer contain any direct");
+        eprintln!("construction. Remove them.");
+    }
+
+    assert!(
+        new_hits.is_empty() && grew.is_empty() && shrank.is_empty() && stale.is_empty(),
+        "value-factory enforcement: {} new, {} grew, {} shrank, {} stale",
+        new_hits.len(), grew.len(), shrank.len(), stale.len(),
+    );
+}


### PR DESCRIPTION
## Summary
Partial implementation of #84: adds the opt-out factories so new code cannot forget the dedup invariant, and freezes the existing direct-construction sites behind a shrink-only allowlist. Full variant-private migration of the remaining ~51 sites is deferred to follow-ups.

### New in \`src/value.rs\`
- \`Value::object_from_pairs(pairs)\` — dedupes via \`ObjMap::insert\` (last-write-wins, first-position preserved)
- \`Value::object_from_normalized_pairs(pairs)\` — trusts the caller, debug_asserts uniqueness
- \`Value::object_from_map(map)\` — wraps a pre-built \`ObjMap\` without re-deduping
- \`Value::number(n)\` / \`Value::number_with_repr(n, repr)\` — matching split for numeric construction so repr preservation is an explicit choice

### Enforcement
- \`tests/value_factory_enforcement.rs\` greps \`src/**/*.rs\` for the \`Value::Obj(Rc::new(…))\` literal and compares against \`tests/value_factory_enforcement.allowlist\` (file → exact hit count). The test fails on new files, growth, shrinkage, and stale entries, so the allowlist can only shrink toward empty as migration proceeds.
- \`tests/value_factories.rs\` adds unit coverage for dedup semantics and repr preservation.

### Docs
- \`docs/maintenance.md\` §3 points at the factories as the canonical construction path; the old \"remember to call \`normalize_object_pairs\`\" phrasing is replaced with the factory API table.

## Migration status

| file           | grandfathered hits |
|---|---:|
| src/value.rs   | 8 |
| src/module.rs  | 4 |
| src/eval.rs    | 9 |
| src/jit.rs     | 6 |
| src/runtime.rs | 24 |
| **total**      | **51** |

Each follow-up PR that touches one of these files should lower its count by the number of sites it migrates.

## Test plan
- [x] \`cargo build --release\` — zero warnings
- [x] \`cargo test --release\` — all tests pass (3 unit + 1 differential + 2 official + 1 coverage-enforcement + 5 factory unit = 12 tests)
- [ ] CI completes green (auto-merge on pass)

Refs #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)