### PR TITLE
refactor: FastPath trait contract with pilot (#83)

### DIFF
--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -1,0 +1,110 @@
+//! Structural contract for fast paths — a staged replacement for the
+//! "match-and-commit" pattern in `bin/jq-jit.rs::detect_*` dispatch.
+//!
+//! # Background
+//!
+//! Today every raw-byte fast path in `bin/jq-jit.rs` and every rewrite
+//! in `simplify_expr` (inside [`crate::interpreter`]) commits once the
+//! filter shape matches: it must produce the jq-compatible answer for
+//! every possible input, or the user sees garbage. There is no "give
+//! up" exit. When a matcher forgets to check an input type (#50), an
+//! error-propagation boundary (#43, #48), or a number-repr invariant
+//! (#75), the unhandled case surfaces as a silent compat bug in
+//! release.
+//!
+//! # The contract
+//!
+//! A [`FastPath`] is a concrete optimisation that runs on a
+//! [`crate::value::Value`] input and returns one of three verdicts:
+//!
+//! | return            | meaning                                         |
+//! |-------------------|-------------------------------------------------|
+//! | `Some(Ok(v))`     | success — `v` is the jq-compatible output value |
+//! | `Some(Err(e))`    | the same error jq would raise on this input     |
+//! | `None`            | "not my problem, run the generic path"          |
+//!
+//! The generic path ([`crate::eval`] / [`crate::jit`]) is authoritative,
+//! so returning `None` is always safe. The review signal is at the
+//! trait boundary: *any* fast path that `Some(Ok(_))`'s an input it
+//! shouldn't handle is visibly wrong.
+//!
+//! # Non-goals
+//!
+//! - Not removing the existing raw-byte fast paths: they stay, because
+//!   materialising a [`Value`] is strictly more expensive than copying
+//!   JSON bytes directly.
+//! - Not forcing every fast path to handle every input type: `None` is
+//!   always available and is what the type-guard pattern exists for.
+//!
+//! # Pilot: [`FieldAccessPath`]
+//!
+//! `.field` — the single-field access fast path exercised by
+//! `bin/jq-jit.rs::detect_field_access`. It has a clean type-check:
+//! object input succeeds, null input returns null (matching jq), every
+//! other input shape bails out with `None` for the generic path to
+//! raise `Cannot index <type> with "<field>"`.
+//!
+//! # Migration plan (for future PRs)
+//!
+//! 1. Wire [`Filter::try_typed_fast_path`] into the dispatch in
+//!    `bin/jq-jit.rs` *ahead of* the existing raw-byte detector cascade.
+//!    When the trait returns `None`, fall through to the existing
+//!    raw-byte path (unchanged behaviour). When the trait returns
+//!    `Some`, serialise the resulting `Value` and short-circuit the
+//!    remaining detectors.
+//! 2. Benchmark the pilot with `./bench/comprehensive.sh --quick`.
+//!    Document the cost of `Value` materialisation for the chosen path
+//!    so reviewers can weigh correctness-vs-perf on future migrations.
+//! 3. Port the next `detect_*` that is known to miss a type-dispatch
+//!    case (`detect_field_remap`, `detect_obj_merge_literal`, …).
+//!    Each port removes a compat-bug pattern structurally, not by yet
+//!    another defensive `match` added to the raw-byte emitter.
+
+use anyhow::Result;
+
+use crate::value::{KeyStr, Value};
+
+/// A fast path whose type-dispatch obligations are encoded in its
+/// `run` signature. See the module docs for the contract.
+pub trait FastPath {
+    /// Run this fast path on `input` and return its verdict.
+    ///
+    /// Implementations **must** return `None` (not `Some(Ok(Value::Null))`
+    /// or `Some(Err(_))`) for any input type they are not confident
+    /// they handle identically to the generic path. The generic path
+    /// is authoritative.
+    fn run(&self, input: &Value) -> Option<Result<Value>>;
+}
+
+/// Pilot fast path: single `.field` access on input.
+///
+/// * Object input — returns the field value or `null` if absent.
+/// * `null` input — returns `null` (jq semantics: `.x` on null is null).
+/// * Any other input — returns `None` so the generic path can raise the
+///   "Cannot index <type> with \"<field>\"" error jq does. This is the
+///   divergence #50 / the null-masking class would otherwise produce.
+pub struct FieldAccessPath {
+    pub field: KeyStr,
+}
+
+impl FieldAccessPath {
+    pub fn new(field: impl Into<KeyStr>) -> Self {
+        FieldAccessPath { field: field.into() }
+    }
+}
+
+impl FastPath for FieldAccessPath {
+    fn run(&self, input: &Value) -> Option<Result<Value>> {
+        match input {
+            Value::Null => Some(Ok(Value::Null)),
+            Value::Obj(obj) => {
+                let v = obj.get(self.field.as_str()).cloned().unwrap_or(Value::Null);
+                Some(Ok(v))
+            }
+            // Non-object, non-null input: bail to the generic path so it
+            // can raise the correct type-error. Returning `Some(Ok(Value::Null))`
+            // here would reintroduce the null-masking bug class (#50).
+            _ => None,
+        }
+    }
+}

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1939,6 +1939,30 @@ impl Filter {
         Some(&self.simplified)
     }
 
+    /// Probe the [`crate::fast_path::FastPath`]-shaped (typed) dispatch
+    /// table for this filter. See `src/fast_path.rs` for the contract.
+    ///
+    /// Returns the fast path's verdict:
+    ///
+    /// - `Some(Ok(v))`  — the typed fast path produced `v`.
+    /// - `Some(Err(e))` — the typed fast path detected the same error
+    ///   jq would raise on this input.
+    /// - `None`         — no typed fast path matched this filter shape,
+    ///   or the fast path declined to handle this input type. The caller
+    ///   should run the generic eval / jit path (authoritative).
+    ///
+    /// Currently wired paths: [`crate::fast_path::FieldAccessPath`]
+    /// (single `.field` access). More paths migrate in follow-up PRs —
+    /// each migration replaces a raw-byte detector whose type-dispatch
+    /// obligations have historically leaked (see issue #83).
+    pub fn try_typed_fast_path(&self, input: &Value) -> Option<Result<Value>> {
+        use crate::fast_path::{FastPath, FieldAccessPath};
+        if let Some(field) = self.detect_field_access() {
+            return FieldAccessPath::new(field).run(input);
+        }
+        None
+    }
+
     pub fn new(program: &str) -> Result<Self> {
         Self::with_options(program, &[], true)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,3 +6,4 @@ pub mod parser;
 pub mod eval;
 pub mod module;
 pub mod jit;
+pub mod fast_path;

--- a/tests/fast_path_contract.rs
+++ b/tests/fast_path_contract.rs
@@ -1,0 +1,99 @@
+//! Coverage for the [`jq_jit::fast_path::FastPath`] contract introduced
+//! in #83. Verifies that:
+//!
+//! - the pilot `FieldAccessPath` succeeds on object and null inputs,
+//! - the pilot bails with `None` on every other input type (so the
+//!   generic path can raise the jq-compatible "Cannot index …" error
+//!   instead of leaking null-masking divergence #50),
+//! - `Filter::try_typed_fast_path` routes `.field` filters through the
+//!   pilot and returns `None` for filters that aren't yet migrated.
+
+use jq_jit::fast_path::{FastPath, FieldAccessPath};
+use jq_jit::interpreter::Filter;
+use jq_jit::value::Value;
+
+#[test]
+fn field_access_on_object_hits() {
+    let path = FieldAccessPath::new("x");
+    let obj = Value::from_pairs(vec![
+        ("x".to_string(), Value::from_f64(42.0)),
+        ("y".to_string(), Value::from_f64(7.0)),
+    ]);
+    let out = path.run(&obj).expect("must produce a verdict").expect("ok");
+    match out {
+        Value::Num(n, _) => assert_eq!(n, 42.0),
+        _ => panic!("expected Num, got {:?}", out),
+    }
+}
+
+#[test]
+fn field_access_on_object_missing_key_returns_null() {
+    let path = FieldAccessPath::new("absent");
+    let obj = Value::from_pairs(vec![("present".to_string(), Value::from_f64(1.0))]);
+    let out = path.run(&obj).expect("must produce a verdict").expect("ok");
+    assert!(matches!(out, Value::Null), "expected null, got {:?}", out);
+}
+
+#[test]
+fn field_access_on_null_returns_null() {
+    // jq semantics: `.x` on null is null.
+    let path = FieldAccessPath::new("x");
+    let out = path.run(&Value::Null).expect("must produce a verdict").expect("ok");
+    assert!(matches!(out, Value::Null), "expected null, got {:?}", out);
+}
+
+#[test]
+fn field_access_on_non_object_bails_to_generic() {
+    // Every non-object non-null input must return None so the generic
+    // path can raise the correct type-error. This is the #50 /
+    // null-masking divergence the typed contract exists to prevent.
+    for input in [
+        Value::from_bool(true),
+        Value::from_bool(false),
+        Value::from_f64(1.0),
+        Value::from_str("hello"),
+        Value::Arr(std::rc::Rc::new(vec![Value::from_f64(1.0)])),
+    ] {
+        let path = FieldAccessPath::new("x");
+        let verdict = path.run(&input);
+        assert!(
+            verdict.is_none(),
+            "FieldAccessPath must bail on non-object non-null input, got {:?} for input {:?}",
+            verdict, input,
+        );
+    }
+}
+
+#[test]
+fn filter_try_typed_fast_path_routes_field_access() {
+    let f = Filter::new(".x").expect("parse");
+    let obj = Value::from_pairs(vec![("x".to_string(), Value::from_f64(99.0))]);
+    let verdict = f.try_typed_fast_path(&obj).expect("must route");
+    let v = verdict.expect("ok");
+    match v {
+        Value::Num(n, _) => assert_eq!(n, 99.0),
+        _ => panic!("expected Num, got {:?}", v),
+    }
+}
+
+#[test]
+fn filter_try_typed_fast_path_bails_on_non_object() {
+    // `.x` on a non-object non-null input must not short-circuit — the
+    // contract defers to the generic path which raises the correct error.
+    let f = Filter::new(".x").expect("parse");
+    let verdict = f.try_typed_fast_path(&Value::from_bool(true));
+    assert!(verdict.is_none(), "expected bail to generic, got {:?}", verdict);
+}
+
+#[test]
+fn filter_try_typed_fast_path_returns_none_for_unmigrated_filter() {
+    // A filter shape that the pilot doesn't recognise must return None
+    // so the existing raw-byte / eval / jit dispatch stays in charge.
+    let f = Filter::new("[.x, .y] | add").expect("parse");
+    let obj = Value::from_pairs(vec![
+        ("x".to_string(), Value::from_f64(1.0)),
+        ("y".to_string(), Value::from_f64(2.0)),
+    ]);
+    let verdict = f.try_typed_fast_path(&obj);
+    assert!(verdict.is_none(), "pilot should decline unmigrated shapes, got {:?}", verdict);
+}


### PR DESCRIPTION
## Summary
Partial #83: lands the `FastPath` trait contract plus a pilot implementation for `.field` access, and exposes `Filter::try_typed_fast_path(input)` as the dispatch entry point. The pilot is not yet wired into the default runtime dispatch — that step is staged for follow-ups so the perf cost of `Value` materialisation is measured per migrated path.

### The contract (`src/fast_path.rs`)
```rust
pub trait FastPath {
    fn run(&self, input: &Value) -> Option<Result<Value>>;
}
```
- `Some(Ok(v))` — jq-compatible output
- `Some(Err(e))` — same error jq would raise
- `None` — bail; the generic path (eval / jit) is authoritative

Any fast path that produces `Some(Ok(_))` for an input it shouldn't handle is visibly wrong at review — the trait signature announces the "committing to jq semantics here" step that the current `detect_*` bodies hide.

### Pilot: `FieldAccessPath`
`.field` access — object input returns the value (or null), `null` input returns null (jq's `.x` on null), every other input bails out with `None`. This is exactly the #50 pattern; the current raw-byte path returns null for non-object input and that null leaks through `(.x)?`.

### Routing helper
`Filter::try_typed_fast_path(input)` checks the typed dispatch table. Currently only `FieldAccessPath` is wired; unmigrated filter shapes return `None` so the existing raw-byte / eval / JIT dispatch stays authoritative.

### Tests
- `tests/fast_path_contract.rs` — 7 cases covering success paths, null passthrough, non-object bail, filter routing, and decline-on-unmigrated-shape.

### Migration plan
See the module-level docs in `src/fast_path.rs` for the ordered migration plan:

1. Wire `try_typed_fast_path` in ahead of the existing detector cascade.
2. Benchmark the pilot via `./bench/comprehensive.sh --quick`.
3. Port the next `detect_*` with known type-dispatch leaks (`detect_field_remap`, `detect_obj_merge_literal`, …).

## Test plan
- [x] `cargo build --release` — zero warnings
- [x] `cargo test --release` — all tests pass (3 unit + 1 differential + 2 official + 7 fast_path_contract = 13 tests)
- [ ] CI completes green (auto-merge on pass)

Refs #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)