### PR TITLE
refactor: wire typed fast path into Filter::execute (#83)

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -10783,6 +10783,14 @@ impl Filter {
 
     /// Execute the filter against an input value, collecting all results.
     pub fn execute(&self, input: &Value) -> Result<Vec<Value>> {
+        // Typed fast path (issue #83): probed ahead of JIT / eval. Only
+        // migrated filter shapes return `Some`; every other shape or
+        // unhandled input type returns `None` and falls through to the
+        // authoritative generic path below.
+        if let Some(verdict) = self.try_typed_fast_path(input) {
+            return verdict.map(|v| vec![v]);
+        }
+
         // Try JIT execution first
         if let Some(jit_fn) = self.jit_fn {
             return crate::jit::execute_jit(jit_fn, input);
@@ -10795,6 +10803,15 @@ impl Filter {
     /// Execute the filter with a callback for each result (avoids Vec allocation).
     /// Returns Ok(true) if all values were processed, Ok(false) if stopped early.
     pub fn execute_cb(&self, input: &Value, cb: &mut dyn FnMut(&Value) -> Result<bool>) -> Result<bool> {
+        // Typed fast path (issue #83) — see `execute` for rationale. The
+        // current pilot emits a single value, so hitting it closes out the
+        // generator: we invoke `cb` once with the verdict and return its
+        // continue/stop decision to the caller.
+        if let Some(verdict) = self.try_typed_fast_path(input) {
+            let val = verdict?;
+            return cb(&val);
+        }
+
         if let Some(jit_fn) = self.jit_fn {
             return crate::jit::execute_jit_cb(jit_fn, input, cb);
         }

--- a/tests/fast_path_contract.rs
+++ b/tests/fast_path_contract.rs
@@ -97,3 +97,60 @@ fn filter_try_typed_fast_path_returns_none_for_unmigrated_filter() {
     let verdict = f.try_typed_fast_path(&obj);
     assert!(verdict.is_none(), "pilot should decline unmigrated shapes, got {:?}", verdict);
 }
+
+// ---------------------------------------------------------------------------
+// Integration coverage — `Filter::execute` / `execute_cb` routing.
+//
+// The tests above pin the pilot's verdict surface in isolation. These ones
+// close the loop: the typed fast path is only useful once it actually fires
+// from the public dispatch. If `execute` is ever refactored and forgets to
+// probe `try_typed_fast_path`, these break before a compat bug ships.
+
+#[test]
+fn execute_field_access_on_object_returns_value() {
+    let f = Filter::new(".x").expect("parse");
+    let obj = Value::from_pairs(vec![("x".to_string(), Value::from_f64(99.0))]);
+    let out = f.execute(&obj).expect("ok");
+    assert_eq!(out.len(), 1, "expected single value, got {:?}", out);
+    match &out[0] {
+        Value::Num(n, _) => assert_eq!(*n, 99.0),
+        v => panic!("expected Num, got {:?}", v),
+    }
+}
+
+#[test]
+fn execute_field_access_on_null_returns_null() {
+    let f = Filter::new(".x").expect("parse");
+    let out = f.execute(&Value::Null).expect("ok");
+    assert_eq!(out, vec![Value::Null]);
+}
+
+#[test]
+fn execute_field_access_on_non_object_falls_through_to_generic() {
+    // The typed fast path bails with `None` on boolean input, which is its
+    // contract: it MUST NOT short-circuit with `Some(Ok(Value::Null))` or it
+    // re-introduces the null-masking bug class (#50). Here we only confirm
+    // that `execute` does not panic or return the typed verdict directly —
+    // the generic eval / jit path takes over. The generic path's compat with
+    // jq (whether it raises "Cannot index ...") is tracked separately as
+    // part of #83's broader migration and is not asserted here.
+    let f = Filter::new(".x").expect("parse");
+    let _ = f.execute(&Value::from_bool(true));
+}
+
+#[test]
+fn execute_cb_field_access_invokes_callback_once() {
+    let f = Filter::new(".x").expect("parse");
+    let obj = Value::from_pairs(vec![("x".to_string(), Value::from_f64(7.0))]);
+    let mut seen: Vec<Value> = Vec::new();
+    let all = f.execute_cb(&obj, &mut |v| {
+        seen.push(v.clone());
+        Ok(true)
+    }).expect("ok");
+    assert!(all, "callback must report full completion");
+    assert_eq!(seen.len(), 1, "typed path should emit exactly one value");
+    match &seen[0] {
+        Value::Num(n, _) => assert_eq!(*n, 7.0),
+        v => panic!("expected Num, got {:?}", v),
+    }
+}


### PR DESCRIPTION
## Summary

- Completes step 1 of the migration plan in `src/fast_path.rs`: wire the pilot `FieldAccessPath` into the generic dispatch via `Filter::execute` / `execute_cb`.
- `try_typed_fast_path` is probed ahead of JIT / eval. `Some(Ok(v))` short-circuits, `Some(Err(e))` propagates, `None` falls through unchanged — raw-byte cascade in `bin/jq-jit.rs` is untouched.
- Adds integration tests that drive the pilot through the public `execute` / `execute_cb` surface, so a future refactor that forgets the probe fails loudly.

This PR does not port additional `detect_*` to the typed contract — that's follow-up work tracked by the same issue.

## Verification

- `cargo build --release` — zero warnings.
- `cargo test --release` — 509 official + regression + all `tests/*` pass; new typed-path integration tests pass.
- `./bench/comprehensive.sh --quick` — no regression vs `docs/benchmark-history.md` v1.1.0 (`field access .name` 0.068s vs 0.066s, within noise; `nested .x,.y,.name` 0.099s vs 0.096s; all other NDJSON workloads unchanged). Raw-byte path still hits `detect_field_access` for `-c .name`, so typed path only runs in fall-through scenarios.

Refs #83