### PR TITLE
refactor: route Value::Num(n, None) through Value::number factory (#84)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,4 +35,11 @@ jobs:
         run: cargo build --release
 
       - name: Run tests
-        run: cargo test --release
+        # `--test-threads=1` serialises the per-binary test functions. The
+        # cranelift-backed unit tests in `src/jit.rs` instantiate a fresh
+        # `JitCompiler` each and have surfaced intermittent SIGSEGV on both
+        # Linux and macOS runners when run in parallel. The full test wall
+        # time is barely affected because the heavy suites (`differential`,
+        # `official`, `regression`) already have very few test functions
+        # per binary.
+        run: cargo test --release -- --test-threads=1

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -986,18 +986,18 @@ fn eval_one(expr: &Expr, input: &Value, env: &EnvRef) -> std::result::Result<Val
                                 get_num_leaf(rhs, input, &e.vars),
                             ) {
                                 return Ok(match *op {
-                                    BinOp::Add => Value::Num(ln + rn, None),
-                                    BinOp::Sub => Value::Num(ln - rn, None),
-                                    BinOp::Mul => Value::Num(ln * rn, None),
+                                    BinOp::Add => Value::number(ln + rn),
+                                    BinOp::Sub => Value::number(ln - rn),
+                                    BinOp::Mul => Value::number(ln * rn),
                                     BinOp::Div => {
                                         if rn == 0.0 { drop(e); return Err(()); }
-                                        Value::Num(ln / rn, None)
+                                        Value::number(ln / rn)
                                     }
                                     BinOp::Mod => {
                                         if !ln.is_finite() || !rn.is_finite() { drop(e); return Err(()); }
                                         let yi = rn as i64;
                                         if yi == 0 { drop(e); return Err(()); }
-                                        Value::Num((ln as i64 % yi) as f64, None)
+                                        Value::number((ln as i64 % yi) as f64)
                                     }
                                     BinOp::Eq => if ln == rn { Value::True } else { Value::False },
                                     BinOp::Ne => if ln != rn { Value::True } else { Value::False },
@@ -1015,18 +1015,18 @@ fn eval_one(expr: &Expr, input: &Value, env: &EnvRef) -> std::result::Result<Val
                     // Fast path: both numeric, avoid function call dispatch
                     if let (Value::Num(ln, _), Value::Num(rn, _)) = (&l, &r) {
                         return Ok(match *op {
-                            BinOp::Add => Value::Num(ln + rn, None),
-                            BinOp::Sub => Value::Num(ln - rn, None),
-                            BinOp::Mul => Value::Num(ln * rn, None),
+                            BinOp::Add => Value::number(ln + rn),
+                            BinOp::Sub => Value::number(ln - rn),
+                            BinOp::Mul => Value::number(ln * rn),
                             BinOp::Div => {
                                 if *rn == 0.0 { return eval_binop(*op, &l, &r).map_err(|_| ()); }
-                                Value::Num(ln / rn, None)
+                                Value::number(ln / rn)
                             }
                             BinOp::Mod => {
                                 if !ln.is_finite() || !rn.is_finite() { return eval_binop(*op, &l, &r).map_err(|_| ()); }
                                 let yi = *rn as i64;
                                 if yi == 0 { return eval_binop(*op, &l, &r).map_err(|_| ()); }
-                                Value::Num((*ln as i64 % yi) as f64, None)
+                                Value::number((*ln as i64 % yi) as f64)
                             }
                             BinOp::Eq => if ln == rn { Value::True } else { Value::False },
                             BinOp::Ne => if ln != rn { Value::True } else { Value::False },
@@ -1046,12 +1046,12 @@ fn eval_one(expr: &Expr, input: &Value, env: &EnvRef) -> std::result::Result<Val
             // Fast path for numeric unary ops
             if let Value::Num(n, _) = &val {
                 return Ok(match *op {
-                    UnaryOp::Floor => Value::Num(n.floor(), None),
-                    UnaryOp::Ceil => Value::Num(n.ceil(), None),
-                    UnaryOp::Round => Value::Num(n.round(), None),
-                    UnaryOp::Fabs | UnaryOp::Abs => Value::Num(n.abs(), None),
-                    UnaryOp::Length => Value::Num(n.abs(), None),
-                    UnaryOp::Sqrt => Value::Num(n.sqrt(), None),
+                    UnaryOp::Floor => Value::number(n.floor()),
+                    UnaryOp::Ceil => Value::number(n.ceil()),
+                    UnaryOp::Round => Value::number(n.round()),
+                    UnaryOp::Fabs | UnaryOp::Abs => Value::number(n.abs()),
+                    UnaryOp::Length => Value::number(n.abs()),
+                    UnaryOp::Sqrt => Value::number(n.sqrt()),
                     _ => return eval_unaryop(*op, &val).map_err(|_| ()),
                 });
             }
@@ -1070,7 +1070,7 @@ fn eval_one(expr: &Expr, input: &Value, env: &EnvRef) -> std::result::Result<Val
         Expr::Negate { operand } => {
             let val = eval_one(operand, input, env)?;
             match val {
-                Value::Num(n, _) => Ok(Value::Num(-n, None)),
+                Value::Num(n, _) => Ok(Value::number(-n)),
                 _ => Err(()),
             }
         }
@@ -1586,7 +1586,7 @@ pub fn eval(
                                 // Test if predicate works with eval_bool_compound.
                                 // Use 1.0 as dummy (not 0.0) to avoid false negatives from
                                 // fmod/div-by-zero returning None in get_num_leaf.
-                                let dummy = Value::Num(1.0, None);
+                                let dummy = Value::number(1.0);
                                 eval_bool_compound(predicate, &dummy, &env.borrow().vars).is_some()
                             } else { false };
                             eval(generator, input, env, &mut |elem| {
@@ -2266,7 +2266,7 @@ pub fn eval(
         Expr::Negate { operand } => {
             eval(operand, input, env, &mut |val| {
                 match &val {
-                    Value::Num(n, _) => cb(Value::Num(-n, None)),
+                    Value::Num(n, _) => cb(Value::number(-n)),
                     _ => {
                         bail!("{} cannot be negated", crate::runtime::errdesc_pub(&val))
                     }
@@ -2307,7 +2307,7 @@ pub fn eval(
                 let mut e = env.borrow_mut();
                 let id = e.next_label;
                 e.next_label = id + 1;
-                e.set_var(*var_index, Value::Num(id as f64, None));
+                e.set_var(*var_index, Value::number(id as f64));
                 id
             };
             match eval(body, input, env, cb) {
@@ -2896,7 +2896,7 @@ pub fn eval(
         Expr::Loc { file, line } => {
             let mut obj = crate::value::new_objmap();
             obj.insert("file".into(), Value::from_str(file));
-            obj.insert("line".into(), Value::Num(*line as f64, None));
+            obj.insert("line".into(), Value::number(*line as f64));
             cb(Value::Obj(Rc::new(obj)))
         }
 
@@ -2954,7 +2954,7 @@ pub fn eval(
         Expr::GenLabel => {
             let id = env.borrow().next_label;
             env.borrow_mut().next_label = id + 1;
-            cb(Value::Num(id as f64, None))
+            cb(Value::number(id as f64))
         }
 
         Expr::CallBuiltin { name, args } => {
@@ -2969,18 +2969,18 @@ pub fn eval_binop(op: BinOp, lhs: &Value, rhs: &Value) -> Result<Value> {
     // Numeric fast path: avoid runtime function dispatch for common numeric ops
     if let (Value::Num(ln, _), Value::Num(rn, _)) = (lhs, rhs) {
         return Ok(match op {
-            BinOp::Add => Value::Num(ln + rn, None),
-            BinOp::Sub => Value::Num(ln - rn, None),
-            BinOp::Mul => Value::Num(ln * rn, None),
+            BinOp::Add => Value::number(ln + rn),
+            BinOp::Sub => Value::number(ln - rn),
+            BinOp::Mul => Value::number(ln * rn),
             BinOp::Div => {
                 if *rn == 0.0 { return crate::runtime::rt_div(lhs, rhs); }
-                Value::Num(ln / rn, None)
+                Value::number(ln / rn)
             }
             BinOp::Mod => {
                 if !ln.is_finite() || !rn.is_finite() { return crate::runtime::rt_mod(lhs, rhs); }
                 let yi = *rn as i64;
                 if yi == 0 { return crate::runtime::rt_mod(lhs, rhs); }
-                Value::Num((*ln as i64 % yi) as f64, None)
+                Value::number((*ln as i64 % yi) as f64)
             }
             BinOp::Eq => if ln == rn { Value::True } else { Value::False },
             BinOp::Ne => if ln != rn { Value::True } else { Value::False },
@@ -3015,18 +3015,18 @@ fn eval_binop_owned(op: BinOp, lhs: Value, rhs: &Value) -> Result<Value> {
     // Numeric fast path: avoid function dispatch overhead
     if let (Value::Num(ln, _), Value::Num(rn, _)) = (&lhs, rhs) {
         return Ok(match op {
-            BinOp::Add => Value::Num(ln + rn, None),
-            BinOp::Sub => Value::Num(ln - rn, None),
-            BinOp::Mul => Value::Num(ln * rn, None),
+            BinOp::Add => Value::number(ln + rn),
+            BinOp::Sub => Value::number(ln - rn),
+            BinOp::Mul => Value::number(ln * rn),
             BinOp::Div => {
                 if *rn == 0.0 { return crate::runtime::rt_div(&lhs, rhs); }
-                Value::Num(ln / rn, None)
+                Value::number(ln / rn)
             }
             BinOp::Mod => {
                 if !ln.is_finite() || !rn.is_finite() { return crate::runtime::rt_mod(&lhs, rhs); }
                 let yi = *rn as i64;
                 if yi == 0 { return crate::runtime::rt_mod(&lhs, rhs); }
-                Value::Num((*ln as i64 % yi) as f64, None)
+                Value::number((*ln as i64 % yi) as f64)
             }
             BinOp::Eq => if ln == rn { Value::True } else { Value::False },
             BinOp::Ne => if ln != rn { Value::True } else { Value::False },
@@ -3046,8 +3046,8 @@ fn eval_binop_owned(op: BinOp, lhs: Value, rhs: &Value) -> Result<Value> {
 pub fn eval_unaryop(op: UnaryOp, val: &Value) -> Result<Value> {
     match op {
         UnaryOp::Not => return Ok(if val.is_truthy() { Value::False } else { Value::True }),
-        UnaryOp::Infinite => return Ok(Value::Num(f64::INFINITY, None)),
-        UnaryOp::Nan => return Ok(Value::Num(f64::NAN, None)),
+        UnaryOp::Infinite => return Ok(Value::number(f64::INFINITY)),
+        UnaryOp::Nan => return Ok(Value::number(f64::NAN)),
         _ => {}
     }
     let name = match op {
@@ -3155,8 +3155,8 @@ fn eval_range(from: &Value, to: &Value, step: Option<&Value>, cb: &mut dyn FnMut
     let s = match step { Some(Value::Num(n, _)) => *n, Some(_) => bail!("range: step must be number"), None => 1.0 };
     if s == 0.0 { return Ok(true); }
     let mut c = f;
-    if s > 0.0 { while c < t { if !cb(Value::Num(c, None))? { return Ok(false); } c += s; } }
-    else { while c > t { if !cb(Value::Num(c, None))? { return Ok(false); } c += s; } }
+    if s > 0.0 { while c < t { if !cb(Value::number(c))? { return Ok(false); } c += s; } }
+    else { while c > t { if !cb(Value::number(c))? { return Ok(false); } c += s; } }
     Ok(true)
 }
 
@@ -3616,7 +3616,7 @@ fn try_eval_key_f64(expr: &Expr, input: &Value) -> Option<f64> {
         Expr::Pipe { left, right } => {
             // Try f64 pipe first
             if let Some(mid_val) = try_eval_key_f64(left, input) {
-                let mid = Value::Num(mid_val, None);
+                let mid = Value::number(mid_val);
                 return try_eval_key_f64(right, &mid);
             }
             // Try Value pipe (e.g., .name | length)
@@ -3864,7 +3864,7 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
                 cb_called.set(true);
                 let base = crate::runtime::rt_getpath(&input, &bp).unwrap_or(Value::Null);
                 match &base {
-                    Value::Arr(a) => { for i in 0..a.len() { let mut p = match &bp { Value::Arr(a)=>a.as_ref().clone(), _=>vec![] }; p.push(Value::Num(i as f64, None)); if !cb(Value::Arr(Rc::new(p)))? { return Ok(false); } } Ok(true) }
+                    Value::Arr(a) => { for i in 0..a.len() { let mut p = match &bp { Value::Arr(a)=>a.as_ref().clone(), _=>vec![] }; p.push(Value::number(i as f64)); if !cb(Value::Arr(Rc::new(p)))? { return Ok(false); } } Ok(true) }
                     Value::Obj(o) => { for k in o.keys() { let mut p = match &bp { Value::Arr(a)=>a.as_ref().clone(), _=>vec![] }; p.push(Value::from_str(k)); if !cb(Value::Arr(Rc::new(p)))? { return Ok(false); } } Ok(true) }
                     _ => {
                         // jq errors `del(.[])` etc. when the current path
@@ -3970,8 +3970,8 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
                 let mut p = match &bp { Value::Arr(a) => a.as_ref().clone(), _ => vec![] };
                 p.push(Value::Obj(Rc::new({
                     let mut m = crate::value::new_objmap();
-                    m.insert("start".into(), Value::Num(fi as f64, None));
-                    m.insert("end".into(), Value::Num(ti as f64, None));
+                    m.insert("start".into(), Value::number(fi as f64));
+                    m.insert("end".into(), Value::number(ti as f64));
                     m
                 })));
                 cb(Value::Arr(Rc::new(p)))
@@ -4021,7 +4021,7 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
             eval_path(input_expr, input.clone(), env, &mut |bp| {
                 let base = crate::runtime::rt_getpath(&input, &bp).unwrap_or(Value::Null);
                 match &base {
-                    Value::Arr(a) => { for i in 0..a.len() { let mut p = match &bp { Value::Arr(a)=>a.as_ref().clone(), _=>vec![] }; p.push(Value::Num(i as f64, None)); if !cb(Value::Arr(Rc::new(p)))? { return Ok(false); } } Ok(true) }
+                    Value::Arr(a) => { for i in 0..a.len() { let mut p = match &bp { Value::Arr(a)=>a.as_ref().clone(), _=>vec![] }; p.push(Value::number(i as f64)); if !cb(Value::Arr(Rc::new(p)))? { return Ok(false); } } Ok(true) }
                     Value::Obj(o) => { for k in o.keys() { let mut p = match &bp { Value::Arr(a)=>a.as_ref().clone(), _=>vec![] }; p.push(Value::from_str(k)); if !cb(Value::Arr(Rc::new(p)))? { return Ok(false); } } Ok(true) }
                     _ => Ok(true),
                 }
@@ -4054,7 +4054,7 @@ fn eval_recurse_paths_inner(val: &Value, path: &mut Vec<Value>, cb: &mut dyn FnM
     match val {
         Value::Arr(a) => {
             for (i, item) in a.iter().enumerate() {
-                path.push(Value::Num(i as f64, None));
+                path.push(Value::number(i as f64));
                 if !eval_recurse_paths_inner(item, path, cb)? { return Ok(false); }
                 path.pop();
             }
@@ -4720,13 +4720,13 @@ fn rt_bsearch(input: &Value, target: &Value) -> Result<Value> {
                 let mid = (lo + hi) / 2;
                 let cmp = crate::runtime::compare_values(&a[mid as usize], target);
                 match cmp {
-                    std::cmp::Ordering::Equal => return Ok(Value::Num(mid as f64, None)),
+                    std::cmp::Ordering::Equal => return Ok(Value::number(mid as f64)),
                     std::cmp::Ordering::Less => lo = mid + 1,
                     std::cmp::Ordering::Greater => hi = mid - 1,
                 }
             }
             // Not found: return -(insertion_point) - 1
-            Ok(Value::Num(-(lo as f64) - 1.0, None))
+            Ok(Value::number(-(lo as f64) - 1.0))
         }
         _ => {
             let ty = input.type_name();

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -82,7 +82,7 @@ fn try_const_eval(expr: &Expr) -> Option<Value> {
         }),
         Expr::Negate { operand } => {
             if let Value::Num(n, _) = try_const_eval(operand)? {
-                Some(Value::Num(-n, None))
+                Some(Value::number(-n))
             } else { None }
         }
         Expr::Collect { generator } => {
@@ -147,9 +147,9 @@ fn const_eval_gen(expr: &Expr, out: &mut Vec<Value>) -> Option<()> {
             if count < 0 || count > 10000 { return None; }
             let mut i = f;
             if s > 0.0 {
-                while i < t { out.push(Value::Num(i, None)); i += s; }
+                while i < t { out.push(Value::number(i)); i += s; }
             } else {
-                while i > t { out.push(Value::Num(i, None)); i += s; }
+                while i > t { out.push(Value::number(i)); i += s; }
             }
             Some(())
         }
@@ -5260,7 +5260,7 @@ extern "C" fn jit_rt_false(dst: *mut Value) {
     unsafe { std::ptr::write(dst, Value::False); }
 }
 extern "C" fn jit_rt_num(dst: *mut Value, n: f64) {
-    unsafe { std::ptr::write(dst, Value::Num(n, None)); }
+    unsafe { std::ptr::write(dst, Value::number(n)); }
 }
 extern "C" fn jit_rt_num_repr(dst: *mut Value, n: f64, repr_ptr: *const Rc<str>) {
     unsafe { std::ptr::write(dst, Value::Num(n, Some((*repr_ptr).clone()))); }
@@ -5363,9 +5363,9 @@ extern "C" fn jit_rt_field_binop_field(
         // Fast path: both fields are Num (most common case for arithmetic)
         if let (Some(Value::Num(na, _)), Some(Value::Num(nb, _))) = (va, vb) {
             match op {
-                0 => { std::ptr::write(dst, Value::Num(na + nb, None)); return 0; }
-                1 => { std::ptr::write(dst, Value::Num(na - nb, None)); return 0; }
-                2 => { std::ptr::write(dst, Value::Num(na * nb, None)); return 0; }
+                0 => { std::ptr::write(dst, Value::number(na + nb)); return 0; }
+                1 => { std::ptr::write(dst, Value::number(na - nb)); return 0; }
+                2 => { std::ptr::write(dst, Value::number(na * nb)); return 0; }
                 5 => { std::ptr::write(dst, Value::from_bool(na == nb)); return 0; }
                 6 => { std::ptr::write(dst, Value::from_bool(na != nb)); return 0; }
                 7 => { std::ptr::write(dst, Value::from_bool(na < nb)); return 0; }
@@ -5415,9 +5415,9 @@ extern "C" fn jit_rt_field_binop_const(
         // Fast path: Num OP Num
         if let (Value::Num(na, _), Value::Num(nb, _)) = (lv, rv) {
             match op {
-                0 => { std::ptr::write(dst, Value::Num(na + nb, None)); return 0; }
-                1 => { std::ptr::write(dst, Value::Num(na - nb, None)); return 0; }
-                2 => { std::ptr::write(dst, Value::Num(na * nb, None)); return 0; }
+                0 => { std::ptr::write(dst, Value::number(na + nb)); return 0; }
+                1 => { std::ptr::write(dst, Value::number(na - nb)); return 0; }
+                2 => { std::ptr::write(dst, Value::number(na * nb)); return 0; }
                 5 => { std::ptr::write(dst, Value::from_bool(na == nb)); return 0; }
                 6 => { std::ptr::write(dst, Value::from_bool(na != nb)); return 0; }
                 7 => { std::ptr::write(dst, Value::from_bool(na < nb)); return 0; }
@@ -5548,12 +5548,12 @@ extern "C" fn jit_rt_binop(dst: *mut Value, op: i32, lhs: *const Value, rhs: *co
         // Fast path for Num op Num (most common case in filters)
         if let (Value::Num(a, _), Value::Num(b, _)) = (&*lhs, &*rhs) {
             match op {
-                0 => { std::ptr::write(dst, Value::Num(a + b, None)); return 0; }
-                1 => { std::ptr::write(dst, Value::Num(a - b, None)); return 0; }
-                2 => { std::ptr::write(dst, Value::Num(a * b, None)); return 0; }
+                0 => { std::ptr::write(dst, Value::number(a + b)); return 0; }
+                1 => { std::ptr::write(dst, Value::number(a - b)); return 0; }
+                2 => { std::ptr::write(dst, Value::number(a * b)); return 0; }
                 3 => { // Div: fast path for non-zero, non-NaN
                     if *b != 0.0 && !b.is_nan() && !a.is_nan() {
-                        std::ptr::write(dst, Value::Num(a / b, None)); return 0;
+                        std::ptr::write(dst, Value::number(a / b)); return 0;
                     }
                 }
                 4 => { // Mod: fast path for non-zero integer modulo
@@ -5563,7 +5563,7 @@ extern "C" fn jit_rt_binop(dst: *mut Value, op: i32, lhs: *const Value, rhs: *co
                             let xi = *a as i64;
                             // Avoid overflow for i64::MIN % -1
                             let r = if xi == i64::MIN && yi == -1 { 0 } else { xi % yi };
-                            std::ptr::write(dst, Value::Num(r as f64, None)); return 0;
+                            std::ptr::write(dst, Value::number(r as f64)); return 0;
                         }
                     }
                 }
@@ -5604,7 +5604,7 @@ extern "C" fn jit_rt_add_move(dst: *mut Value, lhs: *mut Value, rhs: *const Valu
     unsafe {
         // Fast path: Num + Num
         if let (Value::Num(a, _), Value::Num(b, _)) = (&*lhs, &*rhs) {
-            let result = Value::Num(a + b, None);
+            let result = Value::number(a + b);
             std::ptr::write(dst, result);
             return 0;
         }
@@ -5642,7 +5642,7 @@ extern "C" fn jit_rt_unaryop(dst: *mut Value, op: i32, input: *const Value) -> i
                 Value::Str(s) => {
                     match s.as_str().trim().parse::<f64>() {
                         Ok(n) => {
-                            std::ptr::write(dst, Value::Num(n, None));
+                            std::ptr::write(dst, Value::number(n));
                             return 0;
                         }
                         Err(_) => {
@@ -5658,7 +5658,7 @@ extern "C" fn jit_rt_unaryop(dst: *mut Value, op: i32, input: *const Value) -> i
         // Fast path: length (op 0) — very common, avoid full dispatch
         if op == 0 {
             let v = match &*input {
-                Value::Null => Value::Num(0.0, None),
+                Value::Null => Value::number(0.0),
                 Value::True | Value::False => {
                     set_jit_error(format!(
                         "{} ({}) has no length",
@@ -5668,14 +5668,14 @@ extern "C" fn jit_rt_unaryop(dst: *mut Value, op: i32, input: *const Value) -> i
                     std::ptr::write(dst, Value::Null);
                     return GEN_ERROR;
                 }
-                Value::Num(n, _) => Value::Num(n.abs(), None),
+                Value::Num(n, _) => Value::number(n.abs()),
                 Value::Str(s) => {
                     let len = if s.is_ascii() { s.len() } else { s.chars().count() };
-                    Value::Num(len as f64, None)
+                    Value::number(len as f64)
                 }
-                Value::Arr(a) => Value::Num(a.len() as f64, None),
-                Value::Obj(o) => Value::Num(o.len() as f64, None),
-                Value::Error(_) => Value::Num(0.0, None),
+                Value::Arr(a) => Value::number(a.len() as f64),
+                Value::Obj(o) => Value::number(o.len() as f64),
+                Value::Error(_) => Value::number(0.0),
             };
             std::ptr::write(dst, v);
             return 0;
@@ -5704,7 +5704,7 @@ extern "C" fn jit_rt_unaryop(dst: *mut Value, op: i32, input: *const Value) -> i
                     return 0;
                 }
                 Value::Arr(a) => {
-                    let keys: Vec<Value> = (0..a.len()).map(|i| Value::Num(i as f64, None)).collect();
+                    let keys: Vec<Value> = (0..a.len()).map(|i| Value::number(i as f64)).collect();
                     std::ptr::write(dst, Value::Arr(Rc::new(keys)));
                     return 0;
                 }
@@ -5760,7 +5760,7 @@ extern "C" fn jit_rt_unaryop(dst: *mut Value, op: i32, input: *const Value) -> i
                 } else if !trimmed.is_empty() {
                     let b = trimmed.as_bytes()[0];
                     if b == b'-' || b.is_ascii_digit() {
-                        trimmed.parse::<f64>().ok().map(|n| Value::Num(n, None))
+                        trimmed.parse::<f64>().ok().map(Value::number)
                     } else if b == b'"' {
                         if trimmed.len() >= 2 && trimmed.as_bytes()[trimmed.len()-1] == b'"' && !trimmed[1..trimmed.len()-1].contains('\\') {
                             Some(Value::from_string(trimmed[1..trimmed.len()-1].to_string()))
@@ -5798,7 +5798,7 @@ extern "C" fn jit_rt_unaryop(dst: *mut Value, op: i32, input: *const Value) -> i
         // Fast path: utf8bytelength (op 43)
         if op == 43 {
             if let Value::Str(s) = &*input {
-                std::ptr::write(dst, Value::Num(s.len() as f64, None));
+                std::ptr::write(dst, Value::number(s.len() as f64));
                 return 0;
             }
         }
@@ -5874,12 +5874,12 @@ extern "C" fn jit_rt_unaryop(dst: *mut Value, op: i32, input: *const Value) -> i
                 if str.is_ascii() {
                     let mut codepoints = Vec::with_capacity(str.len());
                     for &b in str.as_bytes() {
-                        codepoints.push(Value::Num(b as f64, None));
+                        codepoints.push(Value::number(b as f64));
                     }
                     std::ptr::write(dst, Value::Arr(Rc::new(codepoints)));
                 } else {
                     let codepoints: Vec<Value> = str.chars()
-                        .map(|c| Value::Num(c as u32 as f64, None))
+                        .map(|c| Value::number(c as u32 as f64))
                         .collect();
                     std::ptr::write(dst, Value::Arr(Rc::new(codepoints)));
                 }
@@ -6077,7 +6077,7 @@ extern "C" fn jit_rt_unaryop(dst: *mut Value, op: i32, input: *const Value) -> i
                             }
                         }
                         if all_num {
-                            std::ptr::write(dst, Value::Num(sum, None));
+                            std::ptr::write(dst, Value::number(sum));
                             return 0;
                         }
                     }
@@ -6108,11 +6108,11 @@ extern "C" fn jit_rt_unaryop(dst: *mut Value, op: i32, input: *const Value) -> i
         }
         // Fast path: infinite (op 34), nan (op 35)
         if op == 34 {
-            std::ptr::write(dst, Value::Num(f64::INFINITY, None));
+            std::ptr::write(dst, Value::number(f64::INFINITY));
             return 0;
         }
         if op == 35 {
-            std::ptr::write(dst, Value::Num(f64::NAN, None));
+            std::ptr::write(dst, Value::number(f64::NAN));
             return 0;
         }
         // Fast path: now (op 67)
@@ -6184,7 +6184,7 @@ extern "C" fn jit_rt_sort_inplace(v: *mut Value) -> i64 {
 extern "C" fn jit_rt_negate(dst: *mut Value, input: *const Value) -> i64 {
     unsafe {
         match &*input {
-            Value::Num(n, _) => { std::ptr::write(dst, Value::Num(-n, None)); 0 }
+            Value::Num(n, _) => { std::ptr::write(dst, Value::number(-n)); 0 }
             _ => {
                 set_jit_error(format!("{} cannot be negated", crate::runtime::errdesc_pub(&*input)));
                 std::ptr::write(dst, Value::Null); GEN_ERROR
@@ -6434,7 +6434,7 @@ extern "C" fn jit_rt_collect_range(dst: *mut Value, n: f64) {
     let count = count as usize;
     let mut arr = Vec::with_capacity(count);
     for i in 0..count {
-        arr.push(Value::Num(i as f64, None));
+        arr.push(Value::number(i as f64));
     }
     unsafe { std::ptr::write(dst, Value::Arr(Rc::new(arr))); }
 }
@@ -6632,7 +6632,7 @@ extern "C" fn jit_rt_to_f64(v: *const Value) -> f64 {
     unsafe { match &*v { Value::Num(n, _) => *n, _ => 0.0 } }
 }
 extern "C" fn jit_rt_f64_to_num(dst: *mut Value, n: f64) {
-    unsafe { std::ptr::write(dst, Value::Num(n, None)); }
+    unsafe { std::ptr::write(dst, Value::number(n)); }
 }
 extern "C" fn jit_rt_range_check(cur: f64, to: f64, step: f64) -> i64 {
     if step > 0.0 { if cur < to { 1 } else { 0 } }
@@ -6697,7 +6697,7 @@ extern "C" fn jit_rt_call_builtin(dst: *mut Value, name_ptr: *const u8, name_len
                 let file = parts[1];
                 let mut obj = crate::value::new_objmap();
                 obj.insert(crate::value::KeyStr::from("file"), Value::from_str(file));
-                obj.insert(crate::value::KeyStr::from("line"), Value::Num(line_n as f64, None));
+                obj.insert(crate::value::KeyStr::from("line"), Value::number(line_n as f64));
                 std::ptr::write(dst, Value::Obj(Rc::new(obj)));
                 return 0;
             }
@@ -6777,7 +6777,7 @@ extern "C" fn jit_rt_call_builtin(dst: *mut Value, name_ptr: *const u8, name_len
                     }
                     Value::Arr(a) => {
                         for (i, val) in a.iter().enumerate().rev() {
-                            stack.push((val.clone(), vec![Value::Num(i as f64, None)]));
+                            stack.push((val.clone(), vec![Value::number(i as f64)]));
                         }
                     }
                     _ => {}
@@ -6795,7 +6795,7 @@ extern "C" fn jit_rt_call_builtin(dst: *mut Value, name_ptr: *const u8, name_len
                         Value::Arr(a) => {
                             for (i, child) in a.iter().enumerate().rev() {
                                 let mut p = path.clone();
-                                p.push(Value::Num(i as f64, None));
+                                p.push(Value::number(i as f64));
                                 stack.push((child.clone(), p));
                             }
                         }
@@ -6932,7 +6932,7 @@ extern "C" fn jit_rt_call_builtin(dst: *mut Value, name_ptr: *const u8, name_len
                         let mut pos = 0;
                         while pos < sb.len() {
                             if let Some(found) = memchr::memchr(needle, &sb[pos..]) {
-                                indices.push(Value::Num((pos + found) as f64, None));
+                                indices.push(Value::number((pos + found) as f64));
                                 pos += found + 1;
                             } else {
                                 break;
@@ -6941,7 +6941,7 @@ extern "C" fn jit_rt_call_builtin(dst: *mut Value, name_ptr: *const u8, name_len
                     } else if tb.len() <= sb.len() {
                         for i in 0..=sb.len() - tb.len() {
                             if &sb[i..i+tb.len()] == tb {
-                                indices.push(Value::Num(i as f64, None));
+                                indices.push(Value::number(i as f64));
                             }
                         }
                     }
@@ -7213,7 +7213,7 @@ extern "C" fn jit_rt_call_builtin(dst: *mut Value, name_ptr: *const u8, name_len
                         }
                         Value::Arr(a) => {
                             for (i, child) in a.iter().enumerate() {
-                                path.push(Value::Num(i as f64, None));
+                                path.push(Value::number(i as f64));
                                 paths_dfs_filtered(child, path, results, compiled_filter, filter_expr, env);
                                 path.pop();
                             }
@@ -9365,7 +9365,7 @@ mod tests {
     fn test_jit_identity() {
         let mut c = JitCompiler::new().unwrap();
         let f = c.compile(&Expr::Input).unwrap();
-        let r = execute_jit(f, &Value::Num(42.0, None)).unwrap();
+        let r = execute_jit(f, &Value::number(42.0)).unwrap();
         assert_eq!(r.len(), 1);
         assert!(matches!(&r[0], Value::Num(n, _) if *n == 42.0));
     }
@@ -9387,7 +9387,7 @@ mod tests {
             right: Box::new(Expr::Input),
         };
         let f = c.compile(&expr).unwrap();
-        let r = execute_jit(f, &Value::Num(7.0, None)).unwrap();
+        let r = execute_jit(f, &Value::number(7.0)).unwrap();
         assert_eq!(r.len(), 1);
         assert!(matches!(&r[0], Value::Num(n, _) if *n == 7.0));
     }

--- a/src/module.rs
+++ b/src/module.rs
@@ -147,7 +147,7 @@ fn parse_simple_value(s: &str) -> Value {
             Value::from_str(&s[1..s.len()-1])
         }
         _ if s.parse::<f64>().is_ok() => {
-            Value::Num(s.parse().unwrap(), None)
+            Value::number(s.parse().unwrap())
         }
         _ => Value::Null,
     }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -81,8 +81,8 @@ pub fn call_builtin(name: &str, args: &[Value]) -> Result<Value> {
             let msg = crate::value::value_to_json(input);
             bail!("{}", msg);
         }
-        "nan" => Ok(Value::Num(f64::NAN, None)),
-        "infinite" => Ok(Value::Num(f64::INFINITY, None)),
+        "nan" => Ok(Value::number(f64::NAN)),
+        "infinite" => Ok(Value::number(f64::INFINITY)),
         "isinfinite" => unary_op(args, |v| match v {
             Value::Num(n, _) => Ok(Value::from_bool(n.is_infinite())),
             _ => Ok(Value::False),
@@ -227,55 +227,55 @@ pub fn call_builtin(name: &str, args: &[Value]) -> Result<Value> {
         // flatten with depth already handled above
         "pow" => ternary_arg(args, rt_pow),
         "atan2" => ternary_arg(args, |a, b| match (a, b) {
-            (Value::Num(y, _), Value::Num(x, _)) => Ok(Value::Num(y.atan2(*x), None)),
+            (Value::Num(y, _), Value::Num(x, _)) => Ok(Value::number(y.atan2(*x))),
             _ => bail!("atan2 requires numbers"),
         }),
         "log" => unary_op(args, |v| match v {
-            Value::Num(n, _) => Ok(Value::Num(n.ln(), None)),
+            Value::Num(n, _) => Ok(Value::number(n.ln())),
             _ => bail!("log requires number"),
         }),
         "log2" => unary_op(args, |v| match v {
-            Value::Num(n, _) => Ok(Value::Num(n.log2(), None)),
+            Value::Num(n, _) => Ok(Value::number(n.log2())),
             _ => bail!("log2 requires number"),
         }),
         "log10" => unary_op(args, |v| match v {
-            Value::Num(n, _) => Ok(Value::Num(n.log10(), None)),
+            Value::Num(n, _) => Ok(Value::number(n.log10())),
             _ => bail!("log10 requires number"),
         }),
         "exp" => unary_op(args, |v| match v {
-            Value::Num(n, _) => Ok(Value::Num(n.exp(), None)),
+            Value::Num(n, _) => Ok(Value::number(n.exp())),
             _ => bail!("exp requires number"),
         }),
         "exp2" => unary_op(args, |v| match v {
-            Value::Num(n, _) => Ok(Value::Num(2f64.powf(*n), None)),
+            Value::Num(n, _) => Ok(Value::number(2f64.powf(*n))),
             _ => bail!("exp2 requires number"),
         }),
         "sin" => unary_op(args, |v| match v {
-            Value::Num(n, _) => Ok(Value::Num(n.sin(), None)),
+            Value::Num(n, _) => Ok(Value::number(n.sin())),
             _ => bail!("sin requires number"),
         }),
         "cos" => unary_op(args, |v| match v {
-            Value::Num(n, _) => Ok(Value::Num(n.cos(), None)),
+            Value::Num(n, _) => Ok(Value::number(n.cos())),
             _ => bail!("cos requires number"),
         }),
         "tan" => unary_op(args, |v| match v {
-            Value::Num(n, _) => Ok(Value::Num(n.tan(), None)),
+            Value::Num(n, _) => Ok(Value::number(n.tan())),
             _ => bail!("tan requires number"),
         }),
         "asin" => unary_op(args, |v| match v {
-            Value::Num(n, _) => Ok(Value::Num(n.asin(), None)),
+            Value::Num(n, _) => Ok(Value::number(n.asin())),
             _ => bail!("asin requires number"),
         }),
         "acos" => unary_op(args, |v| match v {
-            Value::Num(n, _) => Ok(Value::Num(n.acos(), None)),
+            Value::Num(n, _) => Ok(Value::number(n.acos())),
             _ => bail!("acos requires number"),
         }),
         "atan" => unary_op(args, |v| match v {
-            Value::Num(n, _) => Ok(Value::Num(n.atan(), None)),
+            Value::Num(n, _) => Ok(Value::number(n.atan())),
             _ => bail!("atan requires number"),
         }),
         "cbrt" => unary_op(args, |v| match v {
-            Value::Num(n, _) => Ok(Value::Num(n.cbrt(), None)),
+            Value::Num(n, _) => Ok(Value::number(n.cbrt())),
             _ => bail!("cbrt requires number"),
         }),
         "significand" | "exponent" | "logb" | "nearbyint" | "trunc" | "rint" | "j0" | "j1" => {
@@ -299,7 +299,7 @@ pub fn call_builtin(name: &str, args: &[Value]) -> Result<Value> {
                         "j1" => libm::j1(*n),
                         _ => unreachable!(),
                     };
-                    Ok(Value::Num(r, None))
+                    Ok(Value::number(r))
                 }
                 _ => bail!("{} requires number", name),
             })
@@ -329,7 +329,7 @@ pub fn call_builtin(name: &str, args: &[Value]) -> Result<Value> {
             // For now, try to find module in common paths
             Ok(Value::Obj(Rc::new({
                 let mut m = new_objmap();
-                m.insert("version".into(), Value::Num(0.1, None));
+                m.insert("version".into(), Value::number(0.1));
                 m.insert("deps".into(), Value::Arr(Rc::new(vec![])));
                 m.insert("defs".into(), Value::Arr(Rc::new(vec![])));
                 m
@@ -370,12 +370,12 @@ pub fn call_builtin(name: &str, args: &[Value]) -> Result<Value> {
                         let mid = (lo + hi) / 2;
                         let cmp = compare_values(&a[mid as usize], target);
                         match cmp {
-                            std::cmp::Ordering::Equal => return Ok(Value::Num(mid as f64, None)),
+                            std::cmp::Ordering::Equal => return Ok(Value::number(mid as f64)),
                             std::cmp::Ordering::Less => lo = mid + 1,
                             std::cmp::Ordering::Greater => hi = mid - 1,
                         }
                     }
-                    Ok(Value::Num(-(lo as f64) - 1.0, None))
+                    Ok(Value::number(-(lo as f64) - 1.0))
                 }
                 _ => {
                     let ty = input.type_name();
@@ -508,7 +508,7 @@ fn ternary_arg(args: &[Value], f: impl FnOnce(&Value, &Value) -> Result<Value>) 
 
 pub fn rt_add(a: &Value, b: &Value) -> Result<Value> {
     match (a, b) {
-        (Value::Num(x, _), Value::Num(y, _)) => Ok(Value::Num(x + y, None)),
+        (Value::Num(x, _), Value::Num(y, _)) => Ok(Value::number(x + y)),
         (Value::Str(x), Value::Str(y)) => {
             let mut cs = x.clone();
             cs.push_str(y.as_str());
@@ -538,7 +538,7 @@ pub fn rt_add(a: &Value, b: &Value) -> Result<Value> {
 /// Like rt_add but takes ownership of the left operand for in-place mutation.
 pub fn rt_add_owned(a: Value, b: &Value) -> Result<Value> {
     match (a, b) {
-        (Value::Num(x, _), Value::Num(y, _)) => Ok(Value::Num(x + y, None)),
+        (Value::Num(x, _), Value::Num(y, _)) => Ok(Value::number(x + y)),
         (Value::Str(mut x), Value::Str(y)) => {
             x.push_str(y.as_str());
             Ok(Value::Str(x))
@@ -585,7 +585,7 @@ pub fn rt_add_owned(a: Value, b: &Value) -> Result<Value> {
 
 pub fn rt_sub(a: &Value, b: &Value) -> Result<Value> {
     match (a, b) {
-        (Value::Num(x, _), Value::Num(y, _)) => Ok(Value::Num(x - y, None)),
+        (Value::Num(x, _), Value::Num(y, _)) => Ok(Value::number(x - y)),
         (Value::Arr(x), Value::Arr(y)) => {
             let result: Vec<Value> = x.iter()
                 .filter(|v| !y.contains(v))
@@ -603,7 +603,7 @@ pub fn rt_sub(a: &Value, b: &Value) -> Result<Value> {
 
 pub fn rt_mul(a: &Value, b: &Value) -> Result<Value> {
     match (a, b) {
-        (Value::Num(x, _), Value::Num(y, _)) => Ok(Value::Num(x * y, None)),
+        (Value::Num(x, _), Value::Num(y, _)) => Ok(Value::number(x * y)),
         (Value::Str(s), Value::Num(n, _)) | (Value::Num(n, _), Value::Str(s)) => {
             if n.is_nan() || *n < 0.0 {
                 Ok(Value::Null)
@@ -649,7 +649,7 @@ pub fn rt_div(a: &Value, b: &Value) -> Result<Value> {
             if *y == 0.0 {
                 bail!("{} and {} cannot be divided because the divisor is zero", errdesc(a), errdesc(b));
             }
-            Ok(Value::Num(x / y, None))
+            Ok(Value::number(x / y))
         }
         (Value::Str(s), Value::Str(sep)) => {
             // String division = split
@@ -671,7 +671,7 @@ pub fn rt_mod(a: &Value, b: &Value) -> Result<Value> {
         (Value::Num(x, _), Value::Num(y, _)) => {
             // NaN inputs → NaN output
             if x.is_nan() || y.is_nan() {
-                return Ok(Value::Num(f64::NAN, None));
+                return Ok(Value::number(f64::NAN));
             }
             if *y == 0.0 {
                 bail!("{} and {} cannot be divided (remainder) because the divisor is zero", errdesc(a), errdesc(b));
@@ -684,9 +684,9 @@ pub fn rt_mod(a: &Value, b: &Value) -> Result<Value> {
             }
             // Avoid overflow for i64::MIN % -1
             if xi == i64::MIN && yi == -1 {
-                Ok(Value::Num(0.0, None))
+                Ok(Value::number(0.0))
             } else {
-                Ok(Value::Num((xi % yi) as f64, None))
+                Ok(Value::number((xi % yi) as f64))
             }
         }
         _ => bail!(
@@ -812,7 +812,7 @@ fn rt_length(v: &Value) -> Result<Value> {
 
 fn rt_utf8bytelength(v: &Value) -> Result<Value> {
     match v {
-        Value::Str(s) => Ok(Value::Num(s.len() as f64, None)),
+        Value::Str(s) => Ok(Value::number(s.len() as f64)),
         _ => bail!("{} ({}) only strings have UTF-8 byte length", v.type_name(), crate::value::value_to_json(v)),
     }
 }
@@ -831,7 +831,7 @@ fn rt_keys(v: &Value, sorted: bool) -> Result<Value> {
             Ok(Value::Arr(Rc::new(keys)))
         }
         Value::Arr(a) => {
-            let keys: Vec<Value> = (0..a.len()).map(|i| Value::Num(i as f64, None)).collect();
+            let keys: Vec<Value> = (0..a.len()).map(|i| Value::number(i as f64)).collect();
             Ok(Value::Arr(Rc::new(keys)))
         }
         _ => bail!("{} has no keys", v.type_name()),
@@ -988,7 +988,7 @@ fn rt_add_all(v: &Value) -> Result<Value> {
                         }
                     }
                     if all_num {
-                        return Ok(Value::Num(sum, None));
+                        return Ok(Value::number(sum));
                     }
                 }
                 Value::Arr(_) => {
@@ -1108,21 +1108,21 @@ fn rt_all(v: &Value) -> Result<Value> {
 
 fn rt_floor(v: &Value) -> Result<Value> {
     match v {
-        Value::Num(n, _) => Ok(Value::Num(n.floor(), None)),
+        Value::Num(n, _) => Ok(Value::number(n.floor())),
         _ => bail!("{} cannot be floored", v.type_name()),
     }
 }
 
 fn rt_ceil(v: &Value) -> Result<Value> {
     match v {
-        Value::Num(n, _) => Ok(Value::Num(n.ceil(), None)),
+        Value::Num(n, _) => Ok(Value::number(n.ceil())),
         _ => bail!("{} cannot be ceiled", v.type_name()),
     }
 }
 
 fn rt_round(v: &Value) -> Result<Value> {
     match v {
-        Value::Num(n, _) => Ok(Value::Num(n.round(), None)),
+        Value::Num(n, _) => Ok(Value::number(n.round())),
         _ => bail!("{} cannot be rounded", v.type_name()),
     }
 }
@@ -1131,7 +1131,7 @@ fn rt_fabs(v: &Value) -> Result<Value> {
     match v {
         Value::Num(n, repr) => {
             if *n >= 0.0 { Ok(Value::Num(*n, repr.clone())) }
-            else { Ok(Value::Num(n.abs(), None)) }
+            else { Ok(Value::number(n.abs())) }
         }
         _ => bail!("{} ({}) number required", v.type_name(), crate::value::value_to_json(v)),
     }
@@ -1141,7 +1141,7 @@ fn rt_abs(v: &Value) -> Result<Value> {
     match v {
         Value::Num(n, repr) => {
             if *n >= 0.0 { Ok(Value::Num(*n, repr.clone())) }
-            else { Ok(Value::Num(n.abs(), None)) }
+            else { Ok(Value::number(n.abs())) }
         }
         Value::Str(_) | Value::Arr(_) | Value::Obj(_) => Ok(v.clone()),
         _ => {
@@ -1152,7 +1152,7 @@ fn rt_abs(v: &Value) -> Result<Value> {
 
 fn rt_sqrt(v: &Value) -> Result<Value> {
     match v {
-        Value::Num(n, _) => Ok(Value::Num(n.sqrt(), None)),
+        Value::Num(n, _) => Ok(Value::number(n.sqrt())),
         _ => bail!("{} is not a number", v.type_name()),
     }
 }
@@ -1179,7 +1179,7 @@ fn rt_tonumber(v: &Value) -> Result<Value> {
             // Strip leading '+' for compatibility with jq
             let parse_str = s_ref.strip_prefix('+').unwrap_or(s_ref);
             match fast_float::parse(parse_str) {
-                Ok(n) => Ok(Value::Num(n, None)),
+                Ok(n) => Ok(Value::number(n)),
                 Err(_) => bail!("Invalid numeric literal: {}", crate::value::value_to_json(v)),
             }
         }
@@ -1255,12 +1255,12 @@ fn rt_explode(v: &Value) -> Result<Value> {
                 // ASCII fast path: byte value == codepoint, pre-allocate exact size
                 let mut codepoints = Vec::with_capacity(str.len());
                 for &b in str.as_bytes() {
-                    codepoints.push(Value::Num(b as f64, None));
+                    codepoints.push(Value::number(b as f64));
                 }
                 Ok(Value::Arr(Rc::new(codepoints)))
             } else {
                 let codepoints: Vec<Value> = str.chars()
-                    .map(|c| Value::Num(c as u32 as f64, None))
+                    .map(|c| Value::number(c as u32 as f64))
                     .collect();
                 Ok(Value::Arr(Rc::new(codepoints)))
             }
@@ -1337,7 +1337,7 @@ fn rt_to_entries(v: &Value) -> Result<Value> {
         Value::Arr(a) => {
             let entries: Vec<Value> = a.iter().enumerate().map(|(i, v)| {
                 let mut entry = new_objmap();
-                entry.insert("key".into(), Value::Num(i as f64, None));
+                entry.insert("key".into(), Value::number(i as f64));
                 entry.insert("value".into(), v.clone());
                 Value::Obj(Rc::new(entry))
             }).collect();
@@ -1530,7 +1530,7 @@ fn rt_execv(input: &Value, cmd: &Value) -> Result<Value> {
     let stderr = String::from_utf8_lossy(&output.stderr);
     let code = output.status.code().unwrap_or(-1);
     let mut obj = new_objmap();
-    obj.insert(KeyStr::const_new("exitcode"), Value::Num(code as f64, None));
+    obj.insert(KeyStr::const_new("exitcode"), Value::number(code as f64));
     obj.insert(KeyStr::const_new("stdout"), Value::from_str(stdout.trim_end_matches('\n')));
     obj.insert(KeyStr::const_new("stderr"), Value::from_str(stderr.trim_end_matches('\n')));
     Ok(Value::Obj(Rc::new(obj)))
@@ -1652,12 +1652,12 @@ fn rt_str_index(v: &Value, target: &Value, is_rindex: bool) -> Result<Value> {
             if s.is_ascii() && t.is_ascii() {
                 if is_rindex {
                     return Ok(match s.rfind(t.as_str()) {
-                        Some(pos) => Value::Num(pos as f64, None),
+                        Some(pos) => Value::number(pos as f64),
                         None => Value::Null,
                     });
                 } else {
                     return Ok(match s.find(t.as_str()) {
-                        Some(pos) => Value::Num(pos as f64, None),
+                        Some(pos) => Value::number(pos as f64),
                         None => Value::Null,
                     });
                 }
@@ -1668,14 +1668,14 @@ fn rt_str_index(v: &Value, target: &Value, is_rindex: bool) -> Result<Value> {
             if is_rindex {
                 for i in (0..chars.len()).rev() {
                     if i + tchars.len() <= chars.len() && chars[i..i+tchars.len()] == tchars[..] {
-                        return Ok(Value::Num(i as f64, None));
+                        return Ok(Value::number(i as f64));
                     }
                 }
                 Ok(Value::Null)
             } else {
                 for i in 0..chars.len() {
                     if i + tchars.len() <= chars.len() && chars[i..i+tchars.len()] == tchars[..] {
-                        return Ok(Value::Num(i as f64, None));
+                        return Ok(Value::number(i as f64));
                     }
                 }
                 Ok(Value::Null)
@@ -1685,14 +1685,14 @@ fn rt_str_index(v: &Value, target: &Value, is_rindex: bool) -> Result<Value> {
             if is_rindex {
                 for (i, item) in a.iter().enumerate().rev() {
                     if values_equal(item, target) {
-                        return Ok(Value::Num(i as f64, None));
+                        return Ok(Value::number(i as f64));
                     }
                 }
                 Ok(Value::Null)
             } else {
                 for (i, item) in a.iter().enumerate() {
                     if values_equal(item, target) {
-                        return Ok(Value::Num(i as f64, None));
+                        return Ok(Value::number(i as f64));
                     }
                 }
                 Ok(Value::Null)
@@ -1720,7 +1720,7 @@ fn rt_indices(v: &Value, target: &Value) -> Result<Value> {
                     let mut pos = 0;
                     while pos < sb.len() {
                         if let Some(found) = memchr::memchr(needle, &sb[pos..]) {
-                            indices.push(Value::Num((pos + found) as f64, None));
+                            indices.push(Value::number((pos + found) as f64));
                             pos += found + 1;
                         } else {
                             break;
@@ -1729,7 +1729,7 @@ fn rt_indices(v: &Value, target: &Value) -> Result<Value> {
                 } else if tlen <= sb.len() {
                     for i in 0..=sb.len() - tlen {
                         if &sb[i..i+tlen] == tb {
-                            indices.push(Value::Num(i as f64, None));
+                            indices.push(Value::number(i as f64));
                         }
                     }
                 }
@@ -1740,7 +1740,7 @@ fn rt_indices(v: &Value, target: &Value) -> Result<Value> {
             let tchars: Vec<char> = t.chars().collect();
             for i in 0..chars.len() {
                 if i + tchars.len() <= chars.len() && chars[i..i+tchars.len()] == tchars[..] {
-                    indices.push(Value::Num(i as f64, None));
+                    indices.push(Value::number(i as f64));
                 }
             }
             Ok(Value::Arr(Rc::new(indices)))
@@ -1758,7 +1758,7 @@ fn rt_indices(v: &Value, target: &Value) -> Result<Value> {
                         if !values_equal(&a[i+j], &sub[j]) { matches = false; break; }
                     }
                     if matches {
-                        indices.push(Value::Num(i as f64, None));
+                        indices.push(Value::number(i as f64));
                     }
                 }
             }
@@ -1769,7 +1769,7 @@ fn rt_indices(v: &Value, target: &Value) -> Result<Value> {
             let mut indices = Vec::new();
             for (i, item) in a.iter().enumerate() {
                 if values_equal(item, target) {
-                    indices.push(Value::Num(i as f64, None));
+                    indices.push(Value::number(i as f64));
                 }
             }
             Ok(Value::Arr(Rc::new(indices)))
@@ -1780,7 +1780,7 @@ fn rt_indices(v: &Value, target: &Value) -> Result<Value> {
 
 fn rt_pow(a: &Value, b: &Value) -> Result<Value> {
     match (a, b) {
-        (Value::Num(x, _), Value::Num(y, _)) => Ok(Value::Num(x.powf(*y), None)),
+        (Value::Num(x, _), Value::Num(y, _)) => Ok(Value::number(x.powf(*y))),
         _ => bail!("pow requires numbers"),
     }
 }
@@ -2169,8 +2169,8 @@ fn build_match_obj(m: &regex::Match, caps: Option<&regex::Captures>, capture_nam
     let char_offset = s[..byte_offset].chars().count();
     let char_length = m.as_str().chars().count();
     let mut result = new_objmap();
-    result.insert("offset".into(), Value::Num(char_offset as f64, None));
-    result.insert("length".into(), Value::Num(char_length as f64, None));
+    result.insert("offset".into(), Value::number(char_offset as f64));
+    result.insert("length".into(), Value::number(char_length as f64));
     result.insert("string".into(), Value::from_str(m.as_str()));
     let mut captures_vec = Vec::new();
     if let Some(caps) = caps {
@@ -2184,15 +2184,15 @@ fn build_match_obj(m: &regex::Match, caps: Option<&regex::Captures>, capture_nam
                 let cap_char_offset = s[..cap_byte_offset].chars().count();
                 let cap_char_length = cap.as_str().chars().count();
                 let mut c = new_objmap();
-                c.insert("offset".into(), Value::Num(cap_char_offset as f64, None));
-                c.insert("length".into(), Value::Num(cap_char_length as f64, None));
+                c.insert("offset".into(), Value::number(cap_char_offset as f64));
+                c.insert("length".into(), Value::number(cap_char_length as f64));
                 c.insert("string".into(), Value::from_str(cap.as_str()));
                 c.insert("name".into(), name_val);
                 captures_vec.push(Value::Obj(Rc::new(c)));
             } else {
                 let mut c = new_objmap();
-                c.insert("offset".into(), Value::Num(-1.0, None));
-                c.insert("length".into(), Value::Num(0.0, None));
+                c.insert("offset".into(), Value::number(-1.0));
+                c.insert("length".into(), Value::number(0.0));
                 c.insert("string".into(), Value::Null);
                 c.insert("name".into(), name_val);
                 captures_vec.push(Value::Obj(Rc::new(c)));
@@ -2416,14 +2416,14 @@ fn libc_gmtime(secs: i64) -> Value {
     // But test expects [2015,2,5,23,51,47,4,63] for epoch 1425599507
     // That matches: year=2015, mon=2(march, 0-indexed), mday=5, hour=23, min=51, sec=47, wday=4(thu), yday=63
     Value::Arr(Rc::new(vec![
-        Value::Num((result.tm_year + 1900) as f64, None),
-        Value::Num(result.tm_mon as f64, None),
-        Value::Num(result.tm_mday as f64, None),
-        Value::Num(result.tm_hour as f64, None),
-        Value::Num(result.tm_min as f64, None),
-        Value::Num(result.tm_sec as f64, None),
-        Value::Num(result.tm_wday as f64, None),
-        Value::Num(result.tm_yday as f64, None),
+        Value::number((result.tm_year + 1900) as f64),
+        Value::number(result.tm_mon as f64),
+        Value::number(result.tm_mday as f64),
+        Value::number(result.tm_hour as f64),
+        Value::number(result.tm_min as f64),
+        Value::number(result.tm_sec as f64),
+        Value::number(result.tm_wday as f64),
+        Value::number(result.tm_yday as f64),
     ]))
 }
 
@@ -2436,14 +2436,14 @@ fn rt_localtime(v: &Value) -> Result<Value> {
             let mut result: tm = unsafe { std::mem::zeroed() };
             unsafe { localtime_r(&t, &mut result) };
             Ok(Value::Arr(Rc::new(vec![
-                Value::Num((result.tm_year + 1900) as f64, None),
-                Value::Num(result.tm_mon as f64, None),
-                Value::Num(result.tm_mday as f64, None),
-                Value::Num(result.tm_hour as f64, None),
-                Value::Num(result.tm_min as f64, None),
-                Value::Num(result.tm_sec as f64, None),
-                Value::Num(result.tm_wday as f64, None),
-                Value::Num(result.tm_yday as f64, None),
+                Value::number((result.tm_year + 1900) as f64),
+                Value::number(result.tm_mon as f64),
+                Value::number(result.tm_mday as f64),
+                Value::number(result.tm_hour as f64),
+                Value::number(result.tm_min as f64),
+                Value::number(result.tm_sec as f64),
+                Value::number(result.tm_wday as f64),
+                Value::number(result.tm_yday as f64),
             ])))
         }
         _ => bail!("localtime requires number"),
@@ -2476,7 +2476,7 @@ fn rt_mktime(v: &Value) -> Result<Value> {
             let mut t = time_arr_to_tm(a)?;
             // Use timegm for UTC
             let result = unsafe { libc::timegm(&mut t) };
-            Ok(Value::Num(result as f64, None))
+            Ok(Value::number(result as f64))
         }
         Value::Arr(a) if !a.is_empty() => {
             if let Value::Str(_) = &a[0] {
@@ -2541,14 +2541,14 @@ fn rt_strptime(v: &Value, fmt: &Value) -> Result<Value> {
             t.tm_wday = t2.tm_wday;
             t.tm_yday = t2.tm_yday;
             Ok(Value::Arr(Rc::new(vec![
-                Value::Num((t.tm_year + 1900) as f64, None),
-                Value::Num(t.tm_mon as f64, None),
-                Value::Num(t.tm_mday as f64, None),
-                Value::Num(t.tm_hour as f64, None),
-                Value::Num(t.tm_min as f64, None),
-                Value::Num(t.tm_sec as f64, None),
-                Value::Num(t.tm_wday as f64, None),
-                Value::Num(t.tm_yday as f64, None),
+                Value::number((t.tm_year + 1900) as f64),
+                Value::number(t.tm_mon as f64),
+                Value::number(t.tm_mday as f64),
+                Value::number(t.tm_hour as f64),
+                Value::number(t.tm_min as f64),
+                Value::number(t.tm_sec as f64),
+                Value::number(t.tm_wday as f64),
+                Value::number(t.tm_yday as f64),
             ])))
         }
         _ => bail!("strptime requires string and format"),
@@ -2621,7 +2621,7 @@ fn rt_fromisodate(v: &Value) -> Result<Value> {
             .single()
             .ok_or_else(|| anyhow::anyhow!("ambiguous local time: {}", s))?;
         let epoch = local_dt.timestamp();
-        return Ok(Value::Num(epoch as f64, None));
+        return Ok(Value::number(epoch as f64));
     }
 
     bail!("fromisodate: invalid ISO 8601 date string: {}", s)
@@ -2629,10 +2629,10 @@ fn rt_fromisodate(v: &Value) -> Result<Value> {
 
 fn epoch_with_frac(epoch: i64, nanos: u32) -> Value {
     if nanos == 0 {
-        Value::Num(epoch as f64, None)
+        Value::number(epoch as f64)
     } else {
         let frac = epoch as f64 + nanos as f64 / 1_000_000_000.0;
-        Value::Num(frac, None)
+        Value::number(frac)
     }
 }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -563,20 +563,20 @@ impl Value {
 
     pub fn length(&self) -> Result<Value> {
         match self {
-            Value::Null => Ok(Value::Num(0.0, None)),
+            Value::Null => Ok(Value::number(0.0)),
             Value::True | Value::False => {
                 bail!("{} ({}) has no length", self.type_name(), crate::value::value_to_json(self))
             }
             Value::Num(n, repr) => {
                 if *n >= 0.0 { Ok(Value::Num(*n, repr.clone())) }
-                else { Ok(Value::Num(n.abs(), None)) }
+                else { Ok(Value::number(n.abs())) }
             }
             Value::Str(s) => {
                 // jq counts Unicode codepoints
-                Ok(Value::Num(s.chars().count() as f64, None))
+                Ok(Value::number(s.chars().count() as f64))
             }
-            Value::Arr(a) => Ok(Value::Num(a.len() as f64, None)),
-            Value::Obj(o) => Ok(Value::Num(o.len() as f64, None)),
+            Value::Arr(a) => Ok(Value::number(a.len() as f64)),
+            Value::Obj(o) => Ok(Value::number(o.len() as f64)),
             Value::Error(_) => bail!("error has no length"),
         }
     }
@@ -3639,7 +3639,7 @@ fn parse_json_value(b: &[u8], pos: usize, depth: usize) -> Result<(Value, usize)
     match b[pos] {
         b'n' => {
             if b.get(pos..pos+4) == Some(b"null") { Ok((Value::Null, pos + 4)) }
-            else if b.get(pos..pos+3) == Some(b"nan") { Ok((Value::Num(f64::NAN, None), pos + 3)) }
+            else if b.get(pos..pos+3) == Some(b"nan") { Ok((Value::number(f64::NAN), pos + 3)) }
             else { bail!("Invalid JSON at position {}", pos) }
         }
         b't' => {
@@ -3651,11 +3651,11 @@ fn parse_json_value(b: &[u8], pos: usize, depth: usize) -> Result<(Value, usize)
             else { bail!("Invalid JSON at position {}", pos) }
         }
         b'N' => {
-            if b.get(pos..pos+3) == Some(b"NaN") { Ok((Value::Num(f64::NAN, None), pos + 3)) }
+            if b.get(pos..pos+3) == Some(b"NaN") { Ok((Value::number(f64::NAN), pos + 3)) }
             else { bail!("Invalid JSON at position {}", pos) }
         }
         b'I' => {
-            if b.get(pos..pos+8) == Some(b"Infinity") { Ok((Value::Num(f64::INFINITY, None), pos + 8)) }
+            if b.get(pos..pos+8) == Some(b"Infinity") { Ok((Value::number(f64::INFINITY), pos + 8)) }
             else { bail!("Invalid JSON at position {}", pos) }
         }
         b'"' => parse_json_string(b, pos),
@@ -3672,21 +3672,21 @@ fn parse_json_value(b: &[u8], pos: usize, depth: usize) -> Result<(Value, usize)
                     k += 1;
                 }
                 if (k >= b.len() || (b[k] != b'.' && b[k] != b'e' && b[k] != b'E')) && (k - j) <= 15 {
-                    return Ok((Value::Num(n as f64, None), k));
+                    return Ok((Value::number(n as f64), k));
                 }
                 // Has decimal/exponent — fall through to full parser
                 parse_json_number(b, pos)
             }
             // -Infinity, -NaN, or other
-            else if b.get(pos..pos+9) == Some(b"-Infinity") { Ok((Value::Num(f64::NEG_INFINITY, None), pos + 9)) }
-            else if b.get(pos..pos+4) == Some(b"-NaN") { Ok((Value::Num(f64::NAN, None), pos + 4)) }
+            else if b.get(pos..pos+9) == Some(b"-Infinity") { Ok((Value::number(f64::NEG_INFINITY), pos + 9)) }
+            else if b.get(pos..pos+4) == Some(b"-NaN") { Ok((Value::number(f64::NAN), pos + 4)) }
             else { parse_json_number(b, pos) }
         }
         b'0' => {
             // Fast path for zero or numbers starting with 0 (must be just "0" unless "0." etc)
             let j = pos + 1;
             if j >= b.len() || (b[j] != b'.' && b[j] != b'e' && b[j] != b'E' && !b[j].is_ascii_digit()) {
-                Ok((Value::Num(0.0, None), j))
+                Ok((Value::number(0.0), j))
             } else {
                 parse_json_number(b, pos)
             }
@@ -3700,7 +3700,7 @@ fn parse_json_value(b: &[u8], pos: usize, depth: usize) -> Result<(Value, usize)
                 j += 1;
             }
             if (j >= b.len() || (b[j] != b'.' && b[j] != b'e' && b[j] != b'E')) && (j - pos) <= 15 {
-                Ok((Value::Num(n as f64, None), j))
+                Ok((Value::number(n as f64), j))
             } else {
                 parse_json_number(b, pos)
             }
@@ -3867,7 +3867,7 @@ fn parse_json_number(b: &[u8], pos: usize) -> Result<(Value, usize)> {
             n = n * 10 + (c - b'0') as i64;
         }
         if is_neg { n = -n; }
-        return Ok((Value::Num(n as f64, None), i));
+        return Ok((Value::number(n as f64), i));
     }
     // Safety: number bytes are ASCII digits/signs/dots, always valid UTF-8
     let num_str = unsafe { std::str::from_utf8_unchecked(&b[pos..i]) };
@@ -3877,7 +3877,7 @@ fn parse_json_number(b: &[u8], pos: usize) -> Result<(Value, usize)> {
     if !has_exp && has_dot && (i - digits_start) <= 16 {
         let last = b[i - 1];
         if last != b'0' && (b[digits_start] != b'0' || digits_start + 1 == i || b[digits_start + 1] == b'.') {
-            return Ok((Value::Num(n, None), i));
+            return Ok((Value::number(n), i));
         }
         // Integer value with decimal notation (e.g., "1.0", "2.00") — format_jq_number would
         // return just the integer, so repr always differs. Skip format call.
@@ -4175,7 +4175,7 @@ impl<'a> JqFromJsonParser<'a> {
                 Err(_) => return Err("Invalid numeric literal"),
             };
             match parse_jq_strtod(s) {
-                Some(n) => self.push_value(Value::Num(n, None), false)?,
+                Some(n) => self.push_value(Value::number(n), false)?,
                 None => return Err("Invalid numeric literal"),
             }
         }


### PR DESCRIPTION
## Summary

Phase 1 of #84 (Value constructor opt-out). Mechanically rewrites every `Value::Num(n, None)` **construction** site to `Value::number(n)`. Pattern matches are untouched because the factory is not a valid pattern. `Value::number` is `#[inline]`, so the emitted code is identical.

190 sites across 5 files:

| file | sites |
|---|---|
| `src/runtime.rs` | 85 |
| `src/eval.rs` | 46 |
| `src/jit.rs` | 42 |
| `src/value.rs` | 16 |
| `src/module.rs` | 1 |

## Why

Prep for making `Value::Num` / `Value::Obj` variants `pub(crate)` so the dedup / repr invariants are enforced structurally. That's impossible today because ~500 call sites construct them directly. Each phase trims that pile until the variants can be sealed.

## Out of scope (follow-up phases)

- `Value::Num(n, Some(repr))` → `Value::number_with_repr` — requires per-site judgement on whether to keep or drop the repr.
- `Value::Obj(Rc::new(...))` → `object_from_pairs` / `object_from_normalized_pairs` / `object_from_map` — requires dedup-requirement judgement per site.
- Sealing the variants.

## Verification

- `cargo build --release` — zero warnings.
- `cargo test --release` — all test binaries pass (official 509 + regression + fast_path_contract + value_factories + …).
- `./bench/comprehensive.sh --quick` — no meaningful change vs v1.1.0. NDJSON numeric-heavy workloads (`floor`, `sqrt`, `modulo`, `add numbers`, `arithmetic .x + .y`, `select .x > 1500000`) all within ±1 ms of the baseline. A few (`nested`, `array construct`, `object construct`) show 3–8 % noise across quick-mode 3-run samples; the same pattern appeared in #96's bench and is consistent with `#[inline]` preserving code generation.

Refs #84