### PR TITLE
refactor: route Value::Num(n, repr) through factories (#84 Phase 2)

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -930,7 +930,7 @@ fn eval_one(expr: &Expr, input: &Value, env: &EnvRef) -> std::result::Result<Val
             Literal::Null => Value::Null,
             Literal::True => Value::True,
             Literal::False => Value::False,
-            Literal::Num(n, repr) => Value::Num(*n, repr.clone()),
+            Literal::Num(n, repr) => Value::number_opt(*n, repr.clone()),
             Literal::Str(s) => Value::from_str(s),
         }),
         Expr::LoadVar { var_index } => {
@@ -1321,7 +1321,7 @@ pub fn eval(
             Literal::Null => Value::Null,
             Literal::True => Value::True,
             Literal::False => Value::False,
-            Literal::Num(n, repr) => Value::Num(*n, repr.clone()),
+            Literal::Num(n, repr) => Value::number_opt(*n, repr.clone()),
             Literal::Str(s) => Value::from_str(s),
         }),
 

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -77,7 +77,7 @@ fn try_const_eval(expr: &Expr) -> Option<Value> {
             Literal::Null => Value::Null,
             Literal::True => Value::True,
             Literal::False => Value::False,
-            Literal::Num(n, repr) => Value::Num(*n, repr.clone()),
+            Literal::Num(n, repr) => Value::number_opt(*n, repr.clone()),
             Literal::Str(s) => Value::from_str(s),
         }),
         Expr::Negate { operand } => {
@@ -508,7 +508,7 @@ impl Flattener {
             Literal::Null => Value::Null,
             Literal::True => Value::True,
             Literal::False => Value::False,
-            Literal::Num(n, repr) => Value::Num(*n, repr.clone()),
+            Literal::Num(n, repr) => Value::number_opt(*n, repr.clone()),
             Literal::Str(s) => Value::Str(crate::value::KeyStr::from(s.as_str())),
         };
         self.hoist_value(val)
@@ -5263,7 +5263,7 @@ extern "C" fn jit_rt_num(dst: *mut Value, n: f64) {
     unsafe { std::ptr::write(dst, Value::number(n)); }
 }
 extern "C" fn jit_rt_num_repr(dst: *mut Value, n: f64, repr_ptr: *const Rc<str>) {
-    unsafe { std::ptr::write(dst, Value::Num(n, Some((*repr_ptr).clone()))); }
+    unsafe { std::ptr::write(dst, Value::number_with_repr(n, (*repr_ptr).clone())); }
 }
 extern "C" fn jit_rt_str(dst: *mut Value, ptr: *const u8, len: usize) {
     unsafe {
@@ -5968,7 +5968,7 @@ extern "C" fn jit_rt_unaryop(dst: *mut Value, op: i32, input: *const Value) -> i
             if let Some(r) = result {
                 // Preserve repr if result equals the original value
                 let keep_repr = repr.is_some() && r == n;
-                std::ptr::write(dst, Value::Num(r, if keep_repr { repr.clone() } else { None }));
+                std::ptr::write(dst, Value::number_opt(r, if keep_repr { repr.clone() } else { None }));
                 return 0;
             }
         }
@@ -6117,8 +6117,8 @@ extern "C" fn jit_rt_unaryop(dst: *mut Value, op: i32, input: *const Value) -> i
         }
         // Fast path: now (op 67)
         if op == 67 {
-            std::ptr::write(dst, Value::Num(std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH).unwrap().as_secs_f64(), None));
+            std::ptr::write(dst, Value::number(std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH).unwrap().as_secs_f64()));
             return 0;
         }
         // Fast path: ltrimstr/rtrimstr/trim (op 40/41/42) — null-arg form trims whitespace

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -114,10 +114,10 @@ pub fn call_builtin(name: &str, args: &[Value]) -> Result<Value> {
             // These need special handling with the input source
             Ok(Value::Null)
         }
-        "now" => Ok(Value::Num(std::time::SystemTime::now()
+        "now" => Ok(Value::number(std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
-            .as_secs_f64(), None)),
+            .as_secs_f64())),
         "path" => {
             // path() needs special handling
             Ok(Value::Arr(Rc::new(vec![])))
@@ -1130,7 +1130,7 @@ fn rt_round(v: &Value) -> Result<Value> {
 fn rt_fabs(v: &Value) -> Result<Value> {
     match v {
         Value::Num(n, repr) => {
-            if *n >= 0.0 { Ok(Value::Num(*n, repr.clone())) }
+            if *n >= 0.0 { Ok(Value::number_opt(*n, repr.clone())) }
             else { Ok(Value::number(n.abs())) }
         }
         _ => bail!("{} ({}) number required", v.type_name(), crate::value::value_to_json(v)),
@@ -1140,7 +1140,7 @@ fn rt_fabs(v: &Value) -> Result<Value> {
 fn rt_abs(v: &Value) -> Result<Value> {
     match v {
         Value::Num(n, repr) => {
-            if *n >= 0.0 { Ok(Value::Num(*n, repr.clone())) }
+            if *n >= 0.0 { Ok(Value::number_opt(*n, repr.clone())) }
             else { Ok(Value::number(n.abs())) }
         }
         Value::Str(_) | Value::Arr(_) | Value::Obj(_) => Ok(v.clone()),

--- a/src/value.rs
+++ b/src/value.rs
@@ -391,7 +391,7 @@ impl Clone for Value {
             Value::Null => Value::Null,
             Value::False => Value::False,
             Value::True => Value::True,
-            Value::Num(n, repr) => Value::Num(*n, repr.clone()),
+            Value::Num(n, repr) => Value::number_opt(*n, repr.clone()),
             Value::Str(s) => Value::Str(s.clone()),
             Value::Arr(a) => Value::Arr(Rc::clone(a)),
             Value::Obj(o) => Value::Obj(Rc::clone(o)),
@@ -509,6 +509,16 @@ impl Value {
         Value::Num(n, Some(repr))
     }
 
+    /// Numeric factory that takes an already-built repr option. Convenience
+    /// wrapper for sites that hold a `Option<Rc<str>>` (cloned from another
+    /// number, carried through a pipeline) and want to avoid pattern-matching
+    /// on the option before dispatching to [`Value::number`] or
+    /// [`Value::number_with_repr`].
+    #[inline]
+    pub fn number_opt(n: f64, repr: Option<Rc<str>>) -> Self {
+        Value::Num(n, repr)
+    }
+
     pub fn is_true(&self) -> bool {
         !matches!(self, Value::Null | Value::False)
     }
@@ -568,7 +578,7 @@ impl Value {
                 bail!("{} ({}) has no length", self.type_name(), crate::value::value_to_json(self))
             }
             Value::Num(n, repr) => {
-                if *n >= 0.0 { Ok(Value::Num(*n, repr.clone())) }
+                if *n >= 0.0 { Ok(Value::number_opt(*n, repr.clone())) }
                 else { Ok(Value::number(n.abs())) }
             }
             Value::Str(s) => {
@@ -3884,13 +3894,13 @@ fn parse_json_number(b: &[u8], pos: usize) -> Result<(Value, usize)> {
         if n == n.trunc() && n.abs() < 1e16 {
             let iv = n as i64;
             if iv as f64 == n {
-                return Ok((Value::Num(n, Some(Rc::from(num_str))), i));
+                return Ok((Value::number_with_repr(n, Rc::from(num_str)), i));
             }
         }
     }
     let f64_repr = format_jq_number(n);
     let repr = if f64_repr == num_str { None } else { Some(Rc::from(num_str)) };
-    Ok((Value::Num(n, repr), i))
+    Ok((Value::number_opt(n, repr), i))
 }
 
 fn parse_json_array(b: &[u8], pos: usize, depth: usize) -> Result<(Value, usize)> {


### PR DESCRIPTION
## Summary

Phase 2 of #84. Remaining `Value::Num(_, repr)` construction sites are routed through factories. No semantic change — repr is preserved or dropped at exactly the sites it was before.

| factory | call sites | usage |
|---|---|---|
| `number_with_repr(n, Rc<str>)` | 2 | caller holds a bare `Rc<str>` to attach |
| `number_opt(n, Option<Rc<str>>)` *(new)* | 9 | caller holds an `Option<Rc<str>>` — clone-through, pipeline carry |
| `number(n)` | 2 | Phase 1 leftovers (`now` fast paths in `jit.rs:6120`, `runtime.rs:117-120`) |

13 construction sites across `src/value.rs`, `src/eval.rs`, `src/jit.rs`, `src/runtime.rs`.

## Why `number_opt`

Many sites carry an `Option<Rc<str>>` through pipelines (e.g. `Value::Num(*n, repr.clone())` in `Clone::clone`). Without `number_opt` those either have to `match` and dispatch between the two existing factories, or bypass them. A thin wrapper keeps the call-site a one-liner.

## Out of scope

- The repr-drop bug class (#75 — unary minus loses the repr, some arithmetic paths too). Fixing it requires per-site audit of "should this drop or preserve"; this PR preserves whatever the current behaviour is. Planned as Phase 2b.
- `Value::Obj(Rc::new(...))` constructions (Phase 3).
- Sealing the variants (Phase 4).

## Verification

- `cargo build --release` — zero warnings.
- `cargo test --release` — all test binaries pass.
- `./bench/comprehensive.sh --quick` — same noise envelope as #97 (NDJSON workloads within ±5% of v1.1.0 over quick-mode 3-run samples). All factories are `#[inline]` so codegen is identical to direct construction.

Refs #84