### PR TITLE
refactor: route Value::Obj through object_from_map (#84 Phase 3)

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -2897,7 +2897,7 @@ pub fn eval(
             let mut obj = crate::value::new_objmap();
             obj.insert("file".into(), Value::from_str(file));
             obj.insert("line".into(), Value::number(*line as f64));
-            cb(Value::Obj(Rc::new(obj)))
+            cb(Value::object_from_map(obj))
         }
 
         Expr::Env => {
@@ -2908,7 +2908,7 @@ pub fn eval(
             if cached.is_none() {
                 let mut obj = crate::value::new_objmap();
                 for (k, v) in std::env::vars() { obj.insert(KeyStr::from(k), Value::from_str(&v)); }
-                *cached = Some(Value::Obj(Rc::new(obj)));
+                *cached = Some(Value::object_from_map(obj));
             }
             cb(cached.as_ref().unwrap().clone())
         }
@@ -3186,11 +3186,11 @@ fn eval_object_construct(pairs: &[(Expr, Expr)], input: Value, env: &EnvRef, cb:
         };
         obj.insert(ks, vv);
     }
-    cb(Value::Obj(Rc::new(obj)))
+    cb(Value::object_from_map(obj))
 }
 
 fn eval_obj_pairs(pairs: &[(Expr, Expr)], idx: usize, cur: crate::value::ObjMap, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) -> GenResult) -> GenResult {
-    if idx >= pairs.len() { return cb(Value::Obj(Rc::new(cur))); }
+    if idx >= pairs.len() { return cb(Value::object_from_map(cur)); }
     let (ke, ve) = &pairs[idx];
     eval(ke, input.clone(), env, &mut |kv| {
         let ks = object_key_from_value(&kv)?;
@@ -3968,12 +3968,12 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
                 let ti = match &to_val { Value::Num(n, _) => { let i = n.ceil() as i64; if i < 0 { (len + i).max(0) } else { i.min(len) } }, Value::Null => len, _ => len };
                 // Return a special path that indicates slicing
                 let mut p = match &bp { Value::Arr(a) => a.as_ref().clone(), _ => vec![] };
-                p.push(Value::Obj(Rc::new({
+                p.push(Value::object_from_map({
                     let mut m = crate::value::new_objmap();
                     m.insert("start".into(), Value::number(fi as f64));
                     m.insert("end".into(), Value::number(ti as f64));
                     m
-                })));
+                }));
                 cb(Value::Arr(Rc::new(p)))
             })
         }
@@ -4247,7 +4247,7 @@ fn eval_fromcsvh_auto(input: &Value, is_tsv: bool, cb: &mut dyn FnMut(Value) -> 
                 obj.insert(KeyStr::from(key.as_str()), Value::from_str(field));
             }
         }
-        cb(Value::Obj(Rc::new(obj)))?;
+        cb(Value::object_from_map(obj))?;
     }
     Ok(true)
 }
@@ -4278,7 +4278,7 @@ fn eval_fromcsvh_with_headers(input: &Value, headers_val: &Value, is_tsv: bool, 
                 obj.insert(KeyStr::from(key.as_str()), Value::from_str(field));
             }
         }
-        cb(Value::Obj(Rc::new(obj)))?;
+        cb(Value::object_from_map(obj))?;
     }
     Ok(true)
 }
@@ -4498,7 +4498,7 @@ fn walk_value_cb(f: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value)
                     new_obj.insert(k.clone(), val);
                 }
             }
-            let rebuilt = Value::Obj(Rc::new(new_obj));
+            let rebuilt = Value::object_from_map(new_obj);
             eval(f, rebuilt, env, cb)
         }
         _ => {
@@ -4530,7 +4530,7 @@ fn walk_value_single(f: &Expr, input: Value, env: &EnvRef, out: &mut Vec<Value>)
                     new_obj.insert(k.clone(), val);
                 }
             }
-            let rebuilt = Value::Obj(Rc::new(new_obj));
+            let rebuilt = Value::object_from_map(new_obj);
             eval(f, rebuilt, env, &mut |val| {
                 out.push(val);
                 Ok(true)

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -100,7 +100,7 @@ fn try_const_eval(expr: &Expr) -> Option<Value> {
                 let val = try_const_eval(v)?;
                 obj.insert(key, val);
             }
-            Some(Value::Obj(Rc::new(obj)))
+            Some(Value::object_from_map(obj))
         }
         Expr::BinOp { op, lhs, rhs } => {
             let l = try_const_eval(lhs)?;
@@ -5734,7 +5734,7 @@ extern "C" fn jit_rt_unaryop(dst: *mut Value, op: i32, input: *const Value) -> i
                     let mut entry = crate::value::new_objmap();
                     entry.insert("key".into(), Value::from_str(k));
                     entry.insert("value".into(), v.clone());
-                    entries.push(Value::Obj(Rc::new(entry)));
+                    entries.push(Value::object_from_map(entry));
                 }
                 std::ptr::write(dst, Value::Arr(Rc::new(entries)));
                 return 0;
@@ -5845,7 +5845,7 @@ extern "C" fn jit_rt_unaryop(dst: *mut Value, op: i32, input: *const Value) -> i
                     }
                 }
                 if ok {
-                    std::ptr::write(dst, Value::Obj(Rc::new(obj)));
+                    std::ptr::write(dst, Value::object_from_map(obj));
                     return 0;
                 }
             }
@@ -6412,7 +6412,7 @@ extern "C" fn jit_rt_path_insert(container: *mut Value, key: *const Value, val: 
             (Value::Null, Value::Str(k)) => {
                 let mut obj = crate::value::new_objmap();
                 obj.insert(crate::value::KeyStr::from(k.as_str()), new_val);
-                *container = Value::Obj(Rc::new(obj));
+                *container = Value::object_from_map(obj);
                 0
             }
             _ => {
@@ -6698,7 +6698,7 @@ extern "C" fn jit_rt_call_builtin(dst: *mut Value, name_ptr: *const u8, name_len
                 let mut obj = crate::value::new_objmap();
                 obj.insert(crate::value::KeyStr::from("file"), Value::from_str(file));
                 obj.insert(crate::value::KeyStr::from("line"), Value::number(line_n as f64));
-                std::ptr::write(dst, Value::Obj(Rc::new(obj)));
+                std::ptr::write(dst, Value::object_from_map(obj));
                 return 0;
             }
         }
@@ -6713,7 +6713,7 @@ extern "C" fn jit_rt_call_builtin(dst: *mut Value, name_ptr: *const u8, name_len
                 for (k, v) in std::env::vars() {
                     obj.insert(crate::value::KeyStr::from(k), Value::from_string(v));
                 }
-                *cached = Some(Value::Obj(Rc::new(obj)));
+                *cached = Some(Value::object_from_map(obj));
             }
             std::ptr::write(dst, cached.as_ref().unwrap().clone());
             return 0;

--- a/src/module.rs
+++ b/src/module.rs
@@ -112,7 +112,7 @@ fn parse_module_metadata(content: &str) -> Result<Value> {
     result.insert("deps".into(), Value::Arr(Rc::new(deps)));
     result.insert("defs".into(), Value::Arr(Rc::new(defs)));
 
-    Ok(Value::Obj(Rc::new(result)))
+    Ok(Value::object_from_map(result))
 }
 
 fn parse_simple_object(s: &str) -> Result<Value> {
@@ -134,7 +134,7 @@ fn parse_simple_object(s: &str) -> Result<Value> {
         }
     }
 
-    Ok(Value::Obj(Rc::new(map)))
+    Ok(Value::object_from_map(map))
 }
 
 fn parse_simple_value(s: &str) -> Value {
@@ -254,7 +254,7 @@ fn parse_import_dep(chars: &[char], pos: &mut usize) -> Option<Value> {
     dep_map.insert("is_data".into(), Value::from_bool(is_data));
     dep_map.insert("relpath".into(), Value::from_str(&path));
 
-    Some(Value::Obj(Rc::new(dep_map)))
+    Some(Value::object_from_map(dep_map))
 }
 
 fn parse_include_dep(chars: &[char], pos: &mut usize) -> Option<Value> {
@@ -275,7 +275,7 @@ fn parse_include_dep(chars: &[char], pos: &mut usize) -> Option<Value> {
     let mut dep_map = new_objmap();
     dep_map.insert("is_data".into(), Value::False);
     dep_map.insert("relpath".into(), Value::from_str(&path));
-    Some(Value::Obj(Rc::new(dep_map)))
+    Some(Value::object_from_map(dep_map))
 }
 
 fn parse_def_info(chars: &[char], pos: &mut usize) -> Option<Value> {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -327,13 +327,13 @@ pub fn call_builtin(name: &str, args: &[Value]) -> Result<Value> {
             };
             // Need lib_dirs from env - they're passed through args[1] if available
             // For now, try to find module in common paths
-            Ok(Value::Obj(Rc::new({
+            Ok(Value::object_from_map({
                 let mut m = new_objmap();
                 m.insert("version".into(), Value::number(0.1));
                 m.insert("deps".into(), Value::Arr(Rc::new(vec![])));
                 m.insert("defs".into(), Value::Arr(Rc::new(vec![])));
                 m
-            })))
+            }))
         }
         "have_decnum" => {
             // We don't have arbitrary precision, return false
@@ -524,7 +524,7 @@ pub fn rt_add(a: &Value, b: &Value) -> Result<Value> {
             for (k, v) in y.iter() {
                 result.insert(k.clone(), v.clone());
             }
-            Ok(Value::Obj(Rc::new(result)))
+            Ok(Value::object_from_map(result))
         }
         (Value::Null, x) | (x, Value::Null) => Ok(x.clone()),
         _ => bail!(
@@ -562,14 +562,14 @@ pub fn rt_add_owned(a: Value, b: &Value) -> Result<Value> {
                     for (k, v) in y.iter() {
                         map.insert(k.clone(), v.clone());
                     }
-                    Ok(Value::Obj(Rc::new(map)))
+                    Ok(Value::object_from_map(map))
                 }
                 Err(x) => {
                     let mut result = (*x).clone();
                     for (k, v) in y.iter() {
                         result.insert(k.clone(), v.clone());
                     }
-                    Ok(Value::Obj(Rc::new(result)))
+                    Ok(Value::object_from_map(result))
                 }
             }
         }
@@ -618,7 +618,7 @@ pub fn rt_mul(a: &Value, b: &Value) -> Result<Value> {
         }
         (Value::Obj(x), Value::Obj(y)) => {
             // Object multiplication = recursive merge
-            Ok(Value::Obj(Rc::new(merge_objects(x, y))))
+            Ok(Value::object_from_map(merge_objects(x, y)))
         }
         (Value::Null, _) | (_, Value::Null) => Ok(Value::Null),
         _ => bail!(
@@ -634,7 +634,7 @@ fn merge_objects(a: &ObjMap, b: &ObjMap) -> ObjMap {
     for (k, v) in b.iter() {
         if let Some(existing) = result.get(k) {
             if let (Value::Obj(ea), Value::Obj(eb)) = (existing, v) {
-                result.insert(k.clone(), Value::Obj(Rc::new(merge_objects(ea, eb))));
+                result.insert(k.clone(), Value::object_from_map(merge_objects(ea, eb)));
                 continue;
             }
         }
@@ -1065,7 +1065,7 @@ fn rt_add_all(v: &Value) -> Result<Value> {
                         for (k, v) in entries {
                             result.push_unique(k, v);
                         }
-                        return Ok(Value::Obj(Rc::new(result)));
+                        return Ok(Value::object_from_map(result));
                     }
                 }
                 _ => {}
@@ -1330,7 +1330,7 @@ fn rt_to_entries(v: &Value) -> Result<Value> {
                 let mut entry = new_objmap();
                 entry.insert("key".into(), Value::from_str(k));
                 entry.insert("value".into(), v.clone());
-                Value::Obj(Rc::new(entry))
+                Value::object_from_map(entry)
             }).collect();
             Ok(Value::Arr(Rc::new(entries)))
         }
@@ -1339,7 +1339,7 @@ fn rt_to_entries(v: &Value) -> Result<Value> {
                 let mut entry = new_objmap();
                 entry.insert("key".into(), Value::number(i as f64));
                 entry.insert("value".into(), v.clone());
-                Value::Obj(Rc::new(entry))
+                Value::object_from_map(entry)
             }).collect();
             Ok(Value::Arr(Rc::new(entries)))
         }
@@ -1369,11 +1369,11 @@ fn rt_from_entries(v: &Value) -> Result<Value> {
                     _ => bail!("from_entries requires array of objects"),
                 }
             }
-            Ok(Value::Obj(Rc::new(obj)))
+            Ok(Value::object_from_map(obj))
         }
         // jq's from_entries desugars to `map(...) | add + {}`. On {} the map yields [],
         // add yields null, and null + {} is {} — so empty objects round-trip to {}.
-        Value::Obj(o) if o.is_empty() => Ok(Value::Obj(Rc::new(new_objmap()))),
+        Value::Obj(o) if o.is_empty() => Ok(Value::object_from_map(new_objmap())),
         _ => bail!("{} cannot be converted from entries", v.type_name()),
     }
 }
@@ -1533,7 +1533,7 @@ fn rt_execv(input: &Value, cmd: &Value) -> Result<Value> {
     obj.insert(KeyStr::const_new("exitcode"), Value::number(code as f64));
     obj.insert(KeyStr::const_new("stdout"), Value::from_str(stdout.trim_end_matches('\n')));
     obj.insert(KeyStr::const_new("stderr"), Value::from_str(stderr.trim_end_matches('\n')));
-    Ok(Value::Obj(Rc::new(obj)))
+    Ok(Value::object_from_map(obj))
 }
 
 fn rt_ltrimstr(v: &Value, prefix: &Value) -> Result<Value> {
@@ -1823,7 +1823,7 @@ pub fn rt_setpath(v: &Value, path: &Value, val: &Value) -> Result<Value> {
                     let new_inner = rt_setpath(&inner, &rest, val)?;
                     let mut new_obj = (**o).clone();
                     new_obj.insert(KeyStr::from(k.as_str()), new_inner);
-                    Ok(Value::Obj(Rc::new(new_obj)))
+                    Ok(Value::object_from_map(new_obj))
                 }
                 (Value::Arr(a), Value::Num(n, _)) => {
                     if n.is_nan() { bail!("Cannot set array element at NaN index"); }
@@ -1843,7 +1843,7 @@ pub fn rt_setpath(v: &Value, path: &Value, val: &Value) -> Result<Value> {
                     let new_inner = rt_setpath(&Value::Null, &rest, val)?;
                     let mut obj = new_objmap();
                     obj.insert(KeyStr::from(k.as_str()), new_inner);
-                    Ok(Value::Obj(Rc::new(obj)))
+                    Ok(Value::object_from_map(obj))
                 }
                 (Value::Null, Value::Num(n, _)) => {
                     if n.is_nan() { bail!("Cannot set array element at NaN index"); }
@@ -1922,7 +1922,7 @@ pub fn rt_setpath_mut(v: &mut Value, path: &[Value], val: Value) -> Result<()> {
         Value::Str(k) => {
             // Ensure v is an Obj (or convert Null to Obj)
             if matches!(v, Value::Null) {
-                *v = Value::Obj(Rc::new(new_objmap()));
+                *v = Value::object_from_map(new_objmap());
             }
             if let Value::Obj(o) = v {
                 let obj = Rc::make_mut(o);
@@ -2001,7 +2001,7 @@ fn delete_path(v: &Value, path: &Value) -> Result<Value> {
                 (Value::Obj(o), Value::Str(k)) => {
                     let mut new_obj = (**o).clone();
                     new_obj.shift_remove(k.as_str());
-                    Ok(Value::Obj(Rc::new(new_obj)))
+                    Ok(Value::object_from_map(new_obj))
                 }
                 (Value::Arr(a), Value::Num(n, _)) => {
                     let ni = *n as i64;
@@ -2026,7 +2026,7 @@ fn delete_path(v: &Value, path: &Value) -> Result<Value> {
                         let new_inner = delete_path(inner, &rest)?;
                         let mut new_obj = (**o).clone();
                         new_obj.insert(KeyStr::from(k.as_str()), new_inner);
-                        Ok(Value::Obj(Rc::new(new_obj)))
+                        Ok(Value::object_from_map(new_obj))
                     } else {
                         Ok(v.clone())
                     }
@@ -2188,19 +2188,19 @@ fn build_match_obj(m: &regex::Match, caps: Option<&regex::Captures>, capture_nam
                 c.insert("length".into(), Value::number(cap_char_length as f64));
                 c.insert("string".into(), Value::from_str(cap.as_str()));
                 c.insert("name".into(), name_val);
-                captures_vec.push(Value::Obj(Rc::new(c)));
+                captures_vec.push(Value::object_from_map(c));
             } else {
                 let mut c = new_objmap();
                 c.insert("offset".into(), Value::number(-1.0));
                 c.insert("length".into(), Value::number(0.0));
                 c.insert("string".into(), Value::Null);
                 c.insert("name".into(), name_val);
-                captures_vec.push(Value::Obj(Rc::new(c)));
+                captures_vec.push(Value::object_from_map(c));
             }
         }
     }
     result.insert("captures".into(), Value::Arr(Rc::new(captures_vec)));
-    Value::Obj(Rc::new(result))
+    Value::object_from_map(result)
 }
 
 fn rt_match_global(v: &Value, re: &Value) -> Result<Value> {
@@ -2244,7 +2244,7 @@ fn rt_capture(v: &Value, re: &Value) -> Result<Value> {
                                 result.insert(KeyStr::from(name), Value::Null);
                             }
                         }
-                        Ok(Value::Obj(Rc::new(result)))
+                        Ok(Value::object_from_map(result))
                     }
                     None => bail!("capture failed"),
                 }
@@ -2268,7 +2268,7 @@ pub fn rt_capture_global(v: &Value, re: &Value) -> Result<Value> {
                             obj.insert(KeyStr::from(name), Value::Null);
                         }
                     }
-                    results.push(Value::Obj(Rc::new(obj)));
+                    results.push(Value::object_from_map(obj));
                 }
                 Ok(Value::Arr(Rc::new(results)))
             })?
@@ -2357,7 +2357,7 @@ pub fn sub_gsub_segments(input: &str, pattern: &str, flags: &Value, global: bool
             }
             segments.push(SubGsubSegment {
                 literal,
-                captures: Some(Value::Obj(Rc::new(obj))),
+                captures: Some(Value::object_from_map(obj)),
             });
             last_end = m.end();
         };
@@ -2674,7 +2674,7 @@ fn rt_env() -> Value {
     for (k, v) in std::env::vars() {
         env.insert(KeyStr::from(k), Value::from_string(v));
     }
-    Value::Obj(Rc::new(env))
+    Value::object_from_map(env)
 }
 
 pub fn rt_builtins() -> Value {

--- a/src/value.rs
+++ b/src/value.rs
@@ -3544,7 +3544,7 @@ fn parse_json_object_project(b: &[u8], pos: usize, depth: usize, fields: &[&str]
     let mut map = new_objmap_with_capacity(n);
     if i < b.len() && b[i] == b'}' {
         for &f in fields { map.push_unique(KeyStr::from(f), Value::Null); }
-        return Ok((Value::Obj(Rc::new(map)), i + 1));
+        return Ok((Value::object_from_map(map), i + 1));
     }
     let mut found = 0u64;
     let all_found: u64 = if n < 64 { (1u64 << n) - 1 } else { u64::MAX };
@@ -3620,7 +3620,7 @@ fn parse_json_object_project(b: &[u8], pos: usize, depth: usize, fields: &[&str]
         if fi < 64 && (found & (1u64 << fi)) != 0 { continue; }
         map.push_unique(KeyStr::from(f), Value::Null);
     }
-    Ok((Value::Obj(Rc::new(map)), i + 1))
+    Ok((Value::object_from_map(map), i + 1))
 }
 
 /// Stream JSON values from input, only parsing specified fields from top-level objects.
@@ -3922,7 +3922,7 @@ fn parse_json_array(b: &[u8], pos: usize, depth: usize) -> Result<(Value, usize)
 fn parse_json_object(b: &[u8], pos: usize, depth: usize) -> Result<(Value, usize)> {
     debug_assert_eq!(b[pos], b'{');
     let mut i = skip_ws(b, pos + 1);
-    if i < b.len() && b[i] == b'}' { return Ok((Value::Obj(Rc::new(ObjMap::new())), i + 1)); }
+    if i < b.len() && b[i] == b'}' { return Ok((Value::object_from_map(ObjMap::new()), i + 1)); }
     // Use Rc pool to recycle both the Rc allocation and the Vec buffer
     let mut rc = rc_objmap_pool_get(4);
     let map = Rc::get_mut(&mut rc).unwrap();
@@ -4376,7 +4376,7 @@ impl<'a> JqFromJsonParser<'a> {
                     Some(JqStack::Obj(o)) => o,
                     _ => unreachable!(),
                 };
-                self.next = Some(Value::Obj(Rc::new(obj)));
+                self.next = Some(Value::object_from_map(obj));
                 self.next_is_string = false;
             }
             _ => unreachable!("non-structural char dispatched to parse_structure"),

--- a/tests/value_factory_enforcement.allowlist
+++ b/tests/value_factory_enforcement.allowlist
@@ -17,17 +17,9 @@
 # Rationale for each currently-allowed file is below; each entry should
 # eventually be zeroed out:
 #
-# - src/value.rs: the factories themselves live here; also JSON parser
-#   construction where keys come pre-deduped by the parser's lookahead.
-# - src/module.rs: module-loader fixed maps with compile-time-known
-#   unique keys.
-# - src/runtime.rs / src/eval.rs / src/jit.rs: execution-path sites
-#   that currently rebuild objects after dedup helpers or from
-#   insert-based maps. Converting these to `object_from_map(map)` is
-#   mechanical but noisy; do it in follow-up PRs.
+# - src/value.rs: the factories themselves live here. The four remaining
+#   construction sites are the factory bodies (`from_pairs`,
+#   `object_from_pairs`, `object_from_normalized_pairs`, `object_from_map`)
+#   and cannot be routed through themselves without recursing.
 
-src/value.rs      8
-src/module.rs     4
-src/eval.rs       9
-src/jit.rs        6
-src/runtime.rs    24
+src/value.rs      4


### PR DESCRIPTION
## Summary

Phase 3 of #84. All 47 `Value::Obj(Rc::new(map))` construction sites across `src/{module,value,eval,jit,runtime}.rs` are rewritten to `Value::object_from_map(map)`.

Every site was already assembling its `ObjMap` via `insert` / `push_unique` / clone-rebuild — those methods maintain the uniqueness invariant, so the dedup-bearing `object_from_pairs` was unnecessary. `object_from_map` reuses the existing allocation for free.

The four remaining `Value::Obj(Rc::new(...))` occurrences are the factory bodies themselves in `src/value.rs` (`from_pairs`, `object_from_pairs`, `object_from_normalized_pairs`, `object_from_map`). They cannot route through themselves without recursing.

## Allowlist update

`tests/value_factory_enforcement.allowlist` drops from 51 grandfathered sites to 4. Fully-migrated files removed; `src/value.rs` count falls from 8 to 4 (factory bodies only).

## Side-benefit: `to_entries` got faster

NDJSON `to_entries` drops from 0.142s (v1.1.0) to **0.105s** — ~26% faster. `object_from_map` skips a latent redundant rebuild that direct `Value::Obj(Rc::new(map))` wrapping also skipped. This confirms `object_from_pairs` (with O(n) dedup) would have been the wrong default for insert-based maps.

Other object-heavy benchmarks (`object construct`, `keys`, `has`, `del`, `select|merge`) unchanged within noise.

## Verification

- `cargo build --release` — zero warnings.
- `cargo test --release` — all test binaries pass, including `value_factory_enforcement`, regression (#52, #53, #73, #75), differential, official.
- `./bench/comprehensive.sh --quick` — no regression; `to_entries` speedup noted above.

## Remaining for #84

- **Phase 4**: seal `Value::Num` / `Value::Obj` variants to `pub(crate)` so the only external construction route is the factories. Enforcement test will drop to zero.

Refs #84