### PR TITLE
fix: sweep of 6 jq compatibility bugs (#73 #75 #76 #77 #78 #79)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -2884,15 +2884,22 @@ fn real_main() {
                         let raw = &input_bytes[start..end];
                         if json_object_get_fields_raw_buf(raw, 0, &aff_refs, &mut ranges_buf) {
                             // Check all string fields for escape sequences — fall back if any
+                            // Also bail out when any value is a nested array/object —
+                            // jq rejects those in a csv/tsv row (issue #79).
                             let mut has_escapes = false;
+                            let mut has_container = false;
                             for (vs, ve) in &ranges_buf {
                                 let val = &raw[*vs..*ve];
                                 if val[0] == b'"' && val[1..val.len()-1].contains(&b'\\') {
                                     has_escapes = true;
                                     break;
                                 }
+                                if val[0] == b'[' || val[0] == b'{' {
+                                    has_container = true;
+                                    break;
+                                }
                             }
-                            if has_escapes {
+                            if has_escapes || has_container {
                                 let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                                 process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                             } else {
@@ -2944,6 +2951,21 @@ fn real_main() {
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
                         if json_object_get_fields_raw_buf(raw, 0, &rcf_refs, &mut ranges_buf) {
+                            // Bail to the generic path if any field is a nested array/object —
+                            // jq rejects those in a csv/tsv row (issue #79).
+                            let has_container = ranges_buf.iter().any(|(vs, ve)| {
+                                let val = &raw[*vs..*ve];
+                                !val.is_empty() && (val[0] == b'[' || val[0] == b'{')
+                            });
+                            if has_container {
+                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                                if compact_buf.len() >= 1 << 17 {
+                                    let _ = out.write_all(&compact_buf);
+                                    compact_buf.clear();
+                                }
+                                return Ok(());
+                            }
                             for (i, (vs, ve)) in ranges_buf.iter().enumerate() {
                                 if i > 0 { compact_buf.push(sep); }
                                 let val = &raw[*vs..*ve];
@@ -12410,14 +12432,19 @@ fn real_main() {
                     let raw = &content_bytes[start..end];
                     if json_object_get_fields_raw_buf(raw, 0, &aff_refs, &mut ranges_buf) {
                         let mut has_escapes = false;
+                        let mut has_container = false;
                         for (vs, ve) in &ranges_buf {
                             let val = &raw[*vs..*ve];
                             if val[0] == b'"' && val[1..val.len()-1].contains(&b'\\') {
                                 has_escapes = true;
                                 break;
                             }
+                            if val[0] == b'[' || val[0] == b'{' {
+                                has_container = true;
+                                break;
+                            }
                         }
-                        if has_escapes {
+                        if has_escapes || has_container {
                             let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                             process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         } else {
@@ -12465,6 +12492,21 @@ fn real_main() {
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
                     if json_object_get_fields_raw_buf(raw, 0, &rcf_refs, &mut ranges_buf) {
+                        // Bail to the generic path if any field is a nested array/object —
+                        // jq rejects those in a csv/tsv row (issue #79).
+                        let has_container = ranges_buf.iter().any(|(vs, ve)| {
+                            let val = &raw[*vs..*ve];
+                            !val.is_empty() && (val[0] == b'[' || val[0] == b'{')
+                        });
+                        if has_container {
+                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                            if compact_buf.len() >= 1 << 17 {
+                                let _ = out.write_all(&compact_buf);
+                                compact_buf.clear();
+                            }
+                            return Ok(());
+                        }
                         for (i, (vs, ve)) in ranges_buf.iter().enumerate() {
                             if i > 0 { compact_buf.push(sep); }
                             let val = &raw[*vs..*ve];

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1070,7 +1070,7 @@ fn eval_one(expr: &Expr, input: &Value, env: &EnvRef) -> std::result::Result<Val
         Expr::Negate { operand } => {
             let val = eval_one(operand, input, env)?;
             match val {
-                Value::Num(n, _) => Ok(Value::number(-n)),
+                Value::Num(n, repr) => Ok(Value::number_opt(-n, crate::value::Value::negate_repr(repr))),
                 _ => Err(()),
             }
         }
@@ -2266,7 +2266,7 @@ pub fn eval(
         Expr::Negate { operand } => {
             eval(operand, input, env, &mut |val| {
                 match &val {
-                    Value::Num(n, _) => cb(Value::number(-n)),
+                    Value::Num(n, repr) => cb(Value::number_opt(-n, crate::value::Value::negate_repr(repr.clone()))),
                     _ => {
                         bail!("{} cannot be negated", crate::runtime::errdesc_pub(&val))
                     }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3244,6 +3244,12 @@ pub fn eval_format(name: &str, val: &Value) -> Result<String> {
                     Value::Num(n, _) => {
                         crate::value::push_jq_number_str(&mut buf, *n);
                     }
+                    // jq rejects arrays/objects as row elements (issue #79).
+                    Value::Arr(_) | Value::Obj(_) => bail!(
+                        "{} ({}) is not valid in a csv row",
+                        v.type_name(),
+                        crate::value::value_to_json(v),
+                    ),
                     _ => buf.push_str(&crate::value::value_to_json(v)),
                 }
             }
@@ -3270,6 +3276,12 @@ pub fn eval_format(name: &str, val: &Value) -> Result<String> {
                     Value::True => buf.push_str("true"),
                     Value::False => buf.push_str("false"),
                     Value::Num(n, _) => crate::value::push_jq_number_str(&mut buf, *n),
+                    // jq uses the same "csv row" wording for @tsv (issue #79).
+                    Value::Arr(_) | Value::Obj(_) => bail!(
+                        "{} ({}) is not valid in a csv row",
+                        v.type_name(),
+                        crate::value::value_to_json(v),
+                    ),
                     _ => buf.push_str(&crate::value::value_to_json(v)),
                 }
             }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1585,8 +1585,9 @@ fn simplify_expr(expr: &crate::ir::Expr) -> crate::ir::Expr {
         }
         Expr::Negate { operand } => {
             let s = simplify_expr(operand);
-            if let Expr::Literal(Literal::Num(n, _)) = &s {
-                Expr::Literal(Literal::Num(-n, None))
+            if let Expr::Literal(Literal::Num(n, repr)) = &s {
+                let new_repr = crate::value::Value::negate_repr(repr.clone());
+                Expr::Literal(Literal::Num(-n, new_repr))
             } else {
                 Expr::Negate { operand: Box::new(s) }
             }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -992,8 +992,41 @@ fn simplify_expr(expr: &crate::ir::Expr) -> crate::ir::Expr {
                                     other => out.push(other.clone()),
                                 }
                             }
+                            // Only constant-fold when every element yields
+                            // exactly one value — otherwise the rewrite promotes
+                            // a generator (range/recurse/.[] /limit/...) to the
+                            // top level and streams every element instead of
+                            // returning the indexed one (issue #78).
+                            fn is_single_valued_idx(e: &Expr) -> bool {
+                                match e {
+                                    Expr::Empty => false,
+                                    Expr::Each { .. } | Expr::EachOpt { .. }
+                                    | Expr::Comma { .. } | Expr::Recurse { .. }
+                                    | Expr::Range { .. } | Expr::Limit { .. }
+                                    | Expr::RegexMatch { .. } | Expr::RegexScan { .. }
+                                    | Expr::RegexCapture { .. } => false,
+                                    Expr::Pipe { left, right } => is_single_valued_idx(left) && is_single_valued_idx(right),
+                                    Expr::IfThenElse { cond, then_branch, else_branch } =>
+                                        is_single_valued_idx(cond) && is_single_valued_idx(then_branch) && is_single_valued_idx(else_branch),
+                                    Expr::TryCatch { try_expr, catch_expr } =>
+                                        is_single_valued_idx(try_expr) && is_single_valued_idx(catch_expr),
+                                    Expr::Alternative { primary, fallback } =>
+                                        is_single_valued_idx(primary) && is_single_valued_idx(fallback),
+                                    Expr::LetBinding { value, body, .. } =>
+                                        is_single_valued_idx(value) && is_single_valued_idx(body),
+                                    Expr::Collect { .. } => true,
+                                    Expr::Input | Expr::Literal(_) | Expr::LoadVar { .. }
+                                    | Expr::Not | Expr::Negate { .. }
+                                    | Expr::Index { .. } | Expr::IndexOpt { .. }
+                                    | Expr::Slice { .. } | Expr::UnaryOp { .. } | Expr::BinOp { .. }
+                                    | Expr::StringInterpolation { .. } | Expr::ObjectConstruct { .. }
+                                    | Expr::RegexTest { .. } | Expr::RegexSub { .. } | Expr::RegexGsub { .. } => true,
+                                    _ => false,
+                                }
+                            }
                             let mut elems = Vec::new();
                             collect_comma_for_idx(lg, &mut elems);
+                            let all_single = elems.iter().all(is_single_valued_idx);
                             // Only constant-fold when the negative index
                             // actually lands inside the array. Previously the
                             // negative branch clamped to 0 via `.max(0)`,
@@ -1007,8 +1040,10 @@ fn simplify_expr(expr: &crate::ir::Expr) -> crate::ir::Expr {
                                 let v = elems.len() as i64 + idx;
                                 if v >= 0 && (v as usize) < elems.len() { Some(v as usize) } else { None }
                             };
-                            if let Some(i) = effective {
-                                return elems.swap_remove(i);
+                            if all_single {
+                                if let Some(i) = effective {
+                                    return elems.swap_remove(i);
+                                }
                             }
                             }
                         }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -495,12 +495,9 @@ fn simplify_expr(expr: &crate::ir::Expr) -> crate::ir::Expr {
                     });
                 }
             }
-            // Semantic: to_entries | from_entries → identity
-            if matches!(&sl, Expr::UnaryOp { op: UnaryOp::ToEntries, .. })
-                && matches!(&sr, Expr::UnaryOp { op: UnaryOp::FromEntries, operand } if matches!(operand.as_ref(), Expr::Input))
-            {
-                return Expr::Input;
-            }
+            // NOTE: `to_entries | from_entries` is NOT identity. It's identity only
+            // for string-keyed objects; arrays and other inputs must flow through
+            // `from_entries`'s type check (issue #73). Do not rewrite.
             // NOTE: tojson | fromjson is NOT identity — tojson normalizes nan/inf to null.
             // E.g., {a:nan} | tojson | fromjson → {a:null}. Do not simplify.
             // Semantic: to_entries | map(.key) → keys_unsorted
@@ -2146,16 +2143,17 @@ impl Filter {
     }
 
     fn expr_is_identity(expr: &crate::ir::Expr) -> bool {
-        use crate::ir::{Expr, UnaryOp};
+        use crate::ir::Expr;
         match expr {
             Expr::Input => true,
             Expr::Pipe { left, right } => {
                 // . | X → X, X | . → X (recursive identity simplification)
                 if Self::expr_is_identity(left) { return Self::expr_is_identity(right); }
                 if Self::expr_is_identity(right) { return Self::expr_is_identity(left); }
-                // to_entries | from_entries → identity
-                matches!(left.as_ref(), Expr::UnaryOp { op: UnaryOp::ToEntries, operand } if matches!(operand.as_ref(), Expr::Input))
-                && matches!(right.as_ref(), Expr::UnaryOp { op: UnaryOp::FromEntries, operand } if matches!(operand.as_ref(), Expr::Input))
+                // NOTE: `to_entries | from_entries` is NOT universal identity — it's
+                // identity only for string-keyed objects. Arrays get a type error
+                // on numeric keys, and `[]` round-trips to `{}` (issue #73).
+                false
             }
             _ => false,
         }

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -442,6 +442,11 @@ enum JitOp {
     /// If so, write the error value to error_dst and jump to catch_label.
     CheckError { error_dst: SlotId, catch_label: LabelId },
 
+    /// Like `CheckError` but does *not* drain the pending error. Used on the
+    /// outside-try-catch propagation path so `ReturnError` / `propagate_error`
+    /// can still read `JIT_LAST_ERROR` and transfer it to `env.error_msg`.
+    JumpIfError { label: LabelId },
+
     // Error throwing
     ThrowError { msg: SlotId },
 
@@ -569,10 +574,9 @@ impl Flattener {
                 }
                 // Semantic optimizations for to_entries pipelines (must run before beta-reduction)
                 if let Expr::UnaryOp { op: UnaryOp::ToEntries, .. } = new_left.as_ref() {
-                    // to_entries | from_entries → identity
-                    if matches!(new_right.as_ref(), Expr::UnaryOp { op: UnaryOp::FromEntries, operand } if matches!(operand.as_ref(), Expr::Input)) {
-                        return Expr::Input;
-                    }
+                    // NOTE: `to_entries | from_entries` is NOT universal identity — arrays
+                    // must surface the numeric-key type error and `[]` round-trips to `{}`
+                    // (issue #73). Do not rewrite.
                     // to_entries | map(.value) → [.[]]
                     // to_entries | map(.key) → keys_unsorted
                     if let Expr::Collect { generator } = new_right.as_ref() {
@@ -861,14 +865,14 @@ impl Flattener {
             if let Some((catch_label, error_slot)) = self.try_catch_target {
                 self.ops.push(JitOp::CheckError { error_dst: error_slot, catch_label });
             } else {
-                // Propagate errors even outside try-catch blocks
-                let error_slot = self.alloc_slot();
+                // Outside a try-catch: branch to ReturnError without draining the
+                // pending error, so `propagate_error` can still hand it off to
+                // `env.error_msg` (fixes generic "JIT execution error" messages).
                 let error_label = self.alloc_label();
                 let ok_label = self.alloc_label();
-                self.ops.push(JitOp::CheckError { error_dst: error_slot, catch_label: error_label });
+                self.ops.push(JitOp::JumpIfError { label: error_label });
                 self.ops.push(JitOp::Jump { label: ok_label });
                 self.ops.push(JitOp::Label { id: error_label });
-                self.ops.push(JitOp::Drop { slot: error_slot });
                 self.ops.push(JitOp::ReturnError);
                 self.ops.push(JitOp::Label { id: ok_label });
             }
@@ -881,13 +885,11 @@ impl Flattener {
         if let Some((catch_label, error_slot)) = self.try_catch_target {
             self.ops.push(JitOp::CheckError { error_dst: error_slot, catch_label });
         } else {
-            let error_slot = self.alloc_slot();
             let error_label = self.alloc_label();
             let ok_label = self.alloc_label();
-            self.ops.push(JitOp::CheckError { error_dst: error_slot, catch_label: error_label });
+            self.ops.push(JitOp::JumpIfError { label: error_label });
             self.ops.push(JitOp::Jump { label: ok_label });
             self.ops.push(JitOp::Label { id: error_label });
-            self.ops.push(JitOp::Drop { slot: error_slot });
             self.ops.push(JitOp::ReturnError);
             self.ops.push(JitOp::Label { id: ok_label });
         }
@@ -5821,7 +5823,8 @@ extern "C" fn jit_rt_unaryop(dst: *mut Value, op: i32, input: *const Value) -> i
                 return 0;
             }
         }
-        // Fast path: from_entries (op 28)
+        // Fast path: from_entries (op 28). Bail to the generic builtin path when the
+        // key resolves to a non-string so the eval path emits jq's type error (issue #73).
         if op == 28 {
             if let Value::Arr(a) = &*input {
                 let mut obj = crate::value::new_objmap();
@@ -5829,15 +5832,24 @@ extern "C" fn jit_rt_unaryop(dst: *mut Value, op: i32, input: *const Value) -> i
                 for entry in a.iter() {
                     match entry {
                         Value::Obj(o) => {
-                            let key = o.get("key").or_else(|| o.get("Key"))
-                                .or_else(|| o.get("name")).or_else(|| o.get("Name"))
-                                .cloned().unwrap_or(Value::Null);
+                            let pick_truthy = |name: &str| -> Option<&Value> {
+                                match o.get(name) {
+                                    Some(v) if !matches!(v, Value::Null | Value::False) => Some(v),
+                                    _ => None,
+                                }
+                            };
+                            let key = pick_truthy("key")
+                                .or_else(|| pick_truthy("key_"))
+                                .or_else(|| pick_truthy("Key"))
+                                .or_else(|| pick_truthy("name"))
+                                .or_else(|| pick_truthy("Name"))
+                                .cloned()
+                                .unwrap_or(Value::Null);
                             let val = o.get("value").or_else(|| o.get("Value"))
                                 .cloned().unwrap_or(Value::Null);
                             let key_str = match &key {
                                 Value::Str(s) => crate::value::KeyStr::from(s.as_str()),
-                                Value::Num(n, _) => crate::value::KeyStr::from(crate::value::format_jq_number(*n)),
-                                _ => crate::value::KeyStr::from(crate::value::value_to_json(&key)),
+                                _ => { ok = false; break; }
                             };
                             obj.insert(key_str, val);
                         }
@@ -7340,6 +7352,9 @@ extern "C" fn jit_rt_try_end(env: *mut JitEnv) {
 
 /// Transfer error from JIT_LAST_ERROR to env.error_msg for propagation.
 extern "C" fn jit_rt_propagate_error(env: *mut JitEnv) {
+    // Always clear the flag — the error is either consumed here or already
+    // drained by CheckError::get_error.
+    unsafe { *JIT_ERROR_FLAG.0.get() = 0; }
     // Check for direct Value from `error` builtin (deferred serialization)
     if let Some(val) = take_jit_error_value() {
         let _ = take_jit_error(); // clear the marker
@@ -9012,6 +9027,17 @@ impl JitCompiler {
                         b.ins().call(rt["get_error"], &[d]);
                         b.ins().jump(label_blocks[*catch_label as usize], &[]);
                         // OK path: continue
+                        b.switch_to_block(ok_blk);
+                        b.seal_block(ok_blk);
+                    }
+                    JitOp::JumpIfError { label } => {
+                        // Branch on JIT_ERROR_FLAG without draining the pending error.
+                        let flag_addr = b.ins().iconst(ptr_ty, JIT_ERROR_FLAG.0.get() as i64);
+                        let flag_val = b.ins().load(types::I64, cranelift_codegen::ir::MemFlags::new(), flag_addr, 0);
+                        let zero = b.ins().iconst(types::I64, 0);
+                        let is_err = b.ins().icmp(cranelift_codegen::ir::condcodes::IntCC::NotEqual, flag_val, zero);
+                        let ok_blk = b.create_block();
+                        b.ins().brif(is_err, label_blocks[*label as usize], &[], ok_blk, &[]);
                         b.switch_to_block(ok_blk);
                         b.seal_block(ok_blk);
                     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3150,19 +3150,11 @@ impl Parser {
             }
             ("getpath", 1) => {
                 let path = args.into_iter().next().unwrap();
-                // Optimize getpath(["key1","key2",...]) → .key1.key2...
-                if let Some(keys) = extract_literal_str_array(&path) {
-                    if !keys.is_empty() {
-                        let mut expr = Expr::Input;
-                        for key in keys {
-                            expr = Expr::Index {
-                                expr: Box::new(expr),
-                                key: Box::new(Expr::Literal(Literal::Str(key))),
-                            };
-                        }
-                        return Ok(expr);
-                    }
-                }
+                // Don't rewrite `getpath([...keys])` → `.key.key.key`: the
+                // chained-Index path inherits a pre-existing divergence where
+                // `.a` on a non-indexable (number/string/boolean) yields null
+                // instead of erroring, which hides the type error `getpath`
+                // must raise (issue #77). `rt_getpath` surfaces the error.
                 Ok(Expr::GetPath { path: Box::new(path) })
             }
             ("setpath", 2) => {
@@ -3944,30 +3936,6 @@ fn name_to_unary_op(name: &str) -> Result<UnaryOp> {
         "isfinite" => Ok(UnaryOp::IsFinite),
         "ascii" => Ok(UnaryOp::Ascii),
         _ => bail!("unknown unary operation: {}", name),
-    }
-}
-
-/// Extract a literal string array from an expression like `Collect(Comma("a", "b", ...))`.
-/// Returns None if the expression isn't a constant string array.
-fn extract_literal_str_array(expr: &Expr) -> Option<Vec<String>> {
-    use crate::ir::Literal;
-    match expr {
-        Expr::Collect { generator } => {
-            let mut keys = Vec::new();
-            fn collect_strings(e: &Expr, out: &mut Vec<String>) -> bool {
-                match e {
-                    Expr::Literal(Literal::Str(s)) => { out.push(s.clone()); true }
-                    Expr::Comma { left, right } => collect_strings(left, out) && collect_strings(right, out),
-                    _ => false,
-                }
-            }
-            if collect_strings(generator, &mut keys) {
-                Some(keys)
-            } else {
-                None
-            }
-        }
-        _ => None,
     }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1181,18 +1181,24 @@ impl Parser {
         self.expect(&Token::Pipe)?;
         let body = self.parse_pipe()?;
 
-        // Build: try (bind pattern1 | body) catch try (bind pattern2 | body) catch ... catch empty
+        // Build: try (bind pattern1 | body) catch try (bind pattern2 | body) catch ... bind patternN | body
+        // The last alternative runs WITHOUT a try-catch so its error propagates —
+        // per the jq spec, "if they all fail, then an error is emitted" (issue #76).
         let tmp_idx = self.scope.alloc_var("__altdestruct_tmp__");
         let tmp_ref = Expr::LoadVar { var_index: tmp_idx };
 
-        let mut result = Expr::Empty; // final fallback: empty
+        let mut result: Option<Expr> = None;
         for pattern in alt_patterns.into_iter().rev() {
             let binding = self.build_binding_with_varmap(tmp_ref.clone(), &pattern, &var_map, body.clone())?;
-            result = Expr::TryCatch {
-                try_expr: Box::new(binding),
-                catch_expr: Box::new(result),
-            };
+            result = Some(match result {
+                None => binding,
+                Some(prev) => Expr::TryCatch {
+                    try_expr: Box::new(binding),
+                    catch_expr: Box::new(prev),
+                },
+            });
         }
+        let result = result.expect("alt_patterns has at least two entries here");
 
         Ok(Expr::LetBinding {
             var_index: tmp_idx,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1305,7 +1305,11 @@ fn rt_implode(v: &Value) -> Result<Value> {
 }
 
 fn rt_tojson(v: &Value) -> Result<Value> {
-    Ok(Value::from_string(crate::value::value_to_json(v)))
+    // Preserve the lexical form of numbers so `1.0 | tojson` yields `"1.0"`
+    // (not `"1"`). jq 1.8.1 does the same via decnum; jq-jit has only f64, so
+    // reprs carrying more precision than f64 can hold (or overflowing to ±inf)
+    // fall back to the f64-formatted form inside `value_to_json_tojson`.
+    Ok(Value::from_string(crate::value::value_to_json_tojson(v)))
 }
 
 fn rt_fromjson(v: &Value) -> Result<Value> {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1358,15 +1358,31 @@ fn rt_from_entries(v: &Value) -> Result<Value> {
             for entry in a.iter() {
                 match entry {
                     Value::Obj(o) => {
-                        let key = o.get("key").or_else(|| o.get("Key"))
-                            .or_else(|| o.get("name")).or_else(|| o.get("Name"))
-                            .cloned().unwrap_or(Value::Null);
+                        // jq resolves the key via `.key // .key_ // .Key // .name // .Name`
+                        // — `//` skips null/false — and errors when the resolved key is
+                        // not a string. Matches jq 1.8.1 wording.
+                        let pick_truthy = |name: &str| -> Option<&Value> {
+                            match o.get(name) {
+                                Some(v) if !matches!(v, Value::Null | Value::False) => Some(v),
+                                _ => None,
+                            }
+                        };
+                        let key = pick_truthy("key")
+                            .or_else(|| pick_truthy("key_"))
+                            .or_else(|| pick_truthy("Key"))
+                            .or_else(|| pick_truthy("name"))
+                            .or_else(|| pick_truthy("Name"))
+                            .cloned()
+                            .unwrap_or(Value::Null);
                         let val = o.get("value").or_else(|| o.get("Value"))
                             .cloned().unwrap_or(Value::Null);
                         let key_str = match &key {
                             Value::Str(s) => s.to_string(),
-                            Value::Num(n, _) => crate::value::format_jq_number(*n),
-                            _ => crate::value::value_to_json(&key),
+                            other => bail!(
+                                "Cannot use {} ({}) as object key",
+                                other.type_name(),
+                                crate::value::value_to_json(other),
+                            ),
                         };
                         obj.insert(KeyStr::from(key_str), val);
                     }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1819,15 +1819,36 @@ pub fn rt_getpath(v: &Value, path: &Value) -> Result<Value> {
                         let actual = if idx < 0 { (a.len() as i64 + idx) as usize } else { idx as usize };
                         current = a.get(actual).cloned().unwrap_or(Value::Null);
                     }
-                    (Value::Null, _) => {
+                    // jq allows string or number keys through null (yielding null) but
+                    // still errors on other key types — matches `.[null]` on null.
+                    (Value::Null, Value::Str(_)) | (Value::Null, Value::Num(_, _)) => {
                         current = Value::Null;
                     }
-                    _ => return Ok(Value::Null),
+                    // jq errors on type-incompatible path elements (issue #77).
+                    (_, _) => bail!(
+                        "Cannot index {} with {}",
+                        current.type_name(),
+                        index_err_desc(key),
+                    ),
                 }
             }
             Ok(current)
         }
         _ => bail!("getpath requires array path"),
+    }
+}
+
+/// Match jq 1.8.1's "Cannot index X with Y" wording for the Y side.
+/// Numbers omit the value; strings keep the quoted content; others show the type name.
+fn index_err_desc(key: &Value) -> String {
+    match key {
+        Value::Str(s) => format!("string \"{}\"", s),
+        Value::Num(_, _) => "number".to_string(),
+        Value::Null => "null".to_string(),
+        Value::True | Value::False => "boolean".to_string(),
+        Value::Arr(_) => "array".to_string(),
+        Value::Obj(_) => "object".to_string(),
+        Value::Error(_) => "error".to_string(),
     }
 }
 
@@ -1848,7 +1869,13 @@ pub fn rt_setpath(v: &Value, path: &Value, val: &Value) -> Result<Value> {
                 (Value::Arr(a), Value::Num(n, _)) => {
                     if n.is_nan() { bail!("Cannot set array element at NaN index"); }
                     let idx = *n as i64;
-                    let actual = if idx < 0 { (a.len() as i64 + idx) as usize } else { idx as usize };
+                    let actual = if idx < 0 {
+                        // Out-of-range negative indices must error — clamping silently
+                        // rewrote the first element, see issue #77.
+                        let adj = a.len() as i64 + idx;
+                        if adj < 0 { bail!("Out of bounds negative array index"); }
+                        adj as usize
+                    } else { idx as usize };
                     if actual > 536870911 { bail!("Array index too large"); }
                     let inner = a.get(actual).cloned().unwrap_or(Value::Null);
                     let new_inner = rt_setpath(&inner, &rest, val)?;
@@ -1975,7 +2002,13 @@ pub fn rt_setpath_mut(v: &mut Value, path: &[Value], val: Value) -> Result<()> {
             }
             if let Value::Arr(a) = v {
                 let arr = Rc::make_mut(a);
-                let actual = if idx < 0 { (arr.len() as i64 + idx).max(0) as usize } else { idx as usize };
+                let actual = if idx < 0 {
+                    // Out-of-range negative indices error — the previous `.max(0)`
+                    // clamp silently rewrote the first element (issue #77).
+                    let adj = arr.len() as i64 + idx;
+                    if adj < 0 { bail!("Out of bounds negative array index"); }
+                    adj as usize
+                } else { idx as usize };
                 if actual > 536870911 { bail!("Array index too large"); }
                 while arr.len() <= actual {
                     arr.push(Value::Null);
@@ -2018,6 +2051,7 @@ fn delete_path(v: &Value, path: &Value) -> Result<Value> {
         Value::Arr(p) if p.is_empty() => Ok(Value::Null),
         Value::Arr(p) if p.len() == 1 => {
             match (v, &p[0]) {
+                (Value::Null, _) => Ok(Value::Null),
                 (Value::Obj(o), Value::Str(k)) => {
                     let mut new_obj = (**o).clone();
                     new_obj.shift_remove(k.as_str());
@@ -2034,13 +2068,17 @@ fn delete_path(v: &Value, path: &Value) -> Result<Value> {
                         Ok(v.clone())
                     }
                 }
-                _ => Ok(v.clone()),
+                // Match jq 1.8.1's error wording for type-incompatible paths (issue #77).
+                (Value::Obj(_), key) => bail!("Cannot delete {} field of object", index_err_desc(key)),
+                (Value::Arr(_), key) => bail!("Cannot delete {} element of array", index_err_desc(key)),
+                (other, _) => bail!("Cannot delete fields from {}", other.type_name()),
             }
         }
         Value::Arr(p) => {
             let key = &p[0];
             let rest = Value::Arr(Rc::new(p[1..].to_vec()));
             match (v, key) {
+                (Value::Null, _) => Ok(Value::Null),
                 (Value::Obj(o), Value::Str(k)) => {
                     if let Some(inner) = o.get(k.as_str()) {
                         let new_inner = delete_path(inner, &rest)?;
@@ -2065,7 +2103,9 @@ fn delete_path(v: &Value, path: &Value) -> Result<Value> {
                         Ok(v.clone())
                     }
                 }
-                _ => Ok(v.clone()),
+                (Value::Obj(_), key) => bail!("Cannot delete {} field of object", index_err_desc(key)),
+                (Value::Arr(_), key) => bail!("Cannot delete {} element of array", index_err_desc(key)),
+                (other, _) => bail!("Cannot delete fields from {}", other.type_name()),
             }
         }
         _ => Ok(v.clone()),

--- a/src/value.rs
+++ b/src/value.rs
@@ -519,6 +519,24 @@ impl Value {
         Value::Num(n, repr)
     }
 
+    /// Flip the sign of a numeric repr, preserving the original textual form
+    /// (so `1.0` ↔ `-1.0`, `1e10` ↔ `-1e10`). Returns `None` if the input is
+    /// `None` or if the repr is not a JSON-valid number.
+    #[inline]
+    pub fn negate_repr(repr: Option<Rc<str>>) -> Option<Rc<str>> {
+        let r = repr?;
+        if !is_valid_json_number(&r) { return None; }
+        let s: &str = &r;
+        if let Some(rest) = s.strip_prefix('-') {
+            Some(Rc::from(rest))
+        } else {
+            let mut out = String::with_capacity(s.len() + 1);
+            out.push('-');
+            out.push_str(s);
+            Some(Rc::from(out.as_str()))
+        }
+    }
+
     pub fn is_true(&self) -> bool {
         !matches!(self, Value::Null | Value::False)
     }
@@ -4609,6 +4627,90 @@ pub fn value_to_json(v: &Value) -> String {
 /// Convert Value to compact JSON string, using precise repr when available.
 pub fn value_to_json_precise(v: &Value) -> String {
     value_to_json_depth(v, 0, true)
+}
+
+/// Convert Value to compact JSON string for `tojson`. Uses the repr when it
+/// exactly represents the stored f64, otherwise falls back to the f64 form.
+/// jq 1.8.1 decnum preserves all reprs; without decnum we can only honor the
+/// ones f64 can hold exactly (so `1.0` stays `"1.0"` but `13911860366432393`
+/// renders as the rounded `"13911860366432392"`).
+pub fn value_to_json_tojson(v: &Value) -> String {
+    let mut out = String::new();
+    push_value_tojson(v, &mut out, 0);
+    out
+}
+
+fn push_value_tojson(v: &Value, out: &mut String, depth: usize) {
+    if depth > MAX_JSON_DEPTH {
+        out.push_str("\"<skipped: too deep>\"");
+        return;
+    }
+    match v {
+        Value::Null => out.push_str("null"),
+        Value::False => out.push_str("false"),
+        Value::True => out.push_str("true"),
+        Value::Num(n, repr) => {
+            if let Some(r) = repr.as_ref().filter(|r| is_valid_json_number(r) && repr_is_exact_for_f64(r, *n)) {
+                out.push_str(r);
+            } else {
+                push_jq_number_str(out, *n);
+            }
+        }
+        Value::Str(s) => push_json_string(out, s),
+        Value::Arr(a) => {
+            out.push('[');
+            for (i, item) in a.iter().enumerate() {
+                if i > 0 { out.push(','); }
+                push_value_tojson(item, out, depth + 1);
+            }
+            out.push(']');
+        }
+        Value::Obj(o) => {
+            out.push('{');
+            for (i, (k, v)) in o.iter().enumerate() {
+                if i > 0 { out.push(','); }
+                push_json_string(out, k);
+                out.push(':');
+                push_value_tojson(v, out, depth + 1);
+            }
+            out.push('}');
+        }
+        Value::Error(e) => push_json_string(out, e),
+    }
+}
+
+/// True iff `repr` (a JSON-valid decimal literal) represents a value that f64
+/// can hold exactly. Rejects mantissas with more than 15 significant decimal
+/// digits and exponents outside f64's dynamic range.
+fn repr_is_exact_for_f64(repr: &str, n: f64) -> bool {
+    if !n.is_finite() { return false; }
+    let bytes = repr.as_bytes();
+    let mut i = 0;
+    if matches!(bytes.first(), Some(b'-') | Some(b'+')) { i += 1; }
+    let mut sig_digits = 0u32;
+    let mut started = false;
+    while i < bytes.len() && bytes[i] != b'e' && bytes[i] != b'E' {
+        let c = bytes[i];
+        if c == b'.' { i += 1; continue; }
+        if !c.is_ascii_digit() { return false; }
+        if c != b'0' { started = true; }
+        if started { sig_digits += 1; }
+        i += 1;
+    }
+    let mut exp_val: i32 = 0;
+    if i < bytes.len() {
+        i += 1;
+        let mut exp_neg = false;
+        if matches!(bytes.get(i), Some(b'-')) { exp_neg = true; i += 1; }
+        else if matches!(bytes.get(i), Some(b'+')) { i += 1; }
+        while i < bytes.len() && bytes[i].is_ascii_digit() {
+            exp_val = exp_val.saturating_mul(10).saturating_add((bytes[i] - b'0') as i32);
+            i += 1;
+        }
+        if exp_neg { exp_val = -exp_val; }
+    }
+    if exp_val > 308 || exp_val < -323 { return false; }
+    sig_digits <= 15
 }
 
 fn value_to_json_depth(v: &Value, depth: usize, precise: bool) -> String {

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -3372,3 +3372,23 @@ true
 
 . as [$a] ?// {b: $a} ?// {c: $a} | $a
 {"c":5}
+
+# ---------- #78: [gen] | .[N] fast path only for single-valued elements ----------
+
+[range(3)] | .[0]
+null
+
+[range(3)] | .[-1]
+null
+
+[range(100)] | .[-1]
+null
+
+[range(3)] | (.[0])
+null
+
+[range(3)] | .[3]
+null
+
+[.[], .[]] | .[0]
+[1,2,3]

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -3392,3 +3392,32 @@ null
 
 [.[], .[]] | .[0]
 [1,2,3]
+
+# ---------- #79: @csv/@tsv reject nested array/object row elements ----------
+
+@csv
+[[1,2]]
+
+@csv
+[[1,2],3]
+
+@csv
+[{"a":1}]
+
+@tsv
+[[1,2]]
+
+@csv
+[1,2,3]
+
+@csv
+[null,true,1.5,"x"]
+
+[.a,.b] | @csv
+{"a":[1,2],"b":3}
+
+[.a,.b] | @csv
+{"a":1,"b":2}
+
+[.a,.b] | @tsv
+{"a":{"x":1},"b":2}

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -3314,3 +3314,38 @@ null
 "\"" | @html
 null
 
+
+# ---------- #73: from_entries type check ----------
+
+from_entries
+[{"key":0,"value":"x"}]
+
+from_entries
+[{"key":0,"value":1},{"key":1,"value":2}]
+
+to_entries | from_entries
+[1,2,3]
+
+to_entries | from_entries
+[]
+
+to_entries | from_entries
+["a","b"]
+
+to_entries | from_entries
+{"a":1,"b":2}
+
+to_entries | map(.value *= 10) | from_entries
+[1,2,3]
+
+from_entries
+[{"key":null,"value":1}]
+
+from_entries
+[{"key":true,"value":1}]
+
+from_entries
+[{"name":"foo","value":1}]
+
+with_entries(.value += 10)
+{"a":1,"b":2}

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -3349,3 +3349,26 @@ from_entries
 
 with_entries(.value += 10)
 {"a":1,"b":2}
+
+# ---------- #76: ?// destructure propagates last error ----------
+
+. as [$a] ?// {b: $a} | $a
+"x"
+
+. as [$a] ?// {b: $a} | $a
+1
+
+. as [$a] ?// {b: $a} | $a
+true
+
+. as [$a] ?// {b: $a} | $a
+[1,2]
+
+. as [$a] ?// {b: $a} | $a
+{"b":9}
+
+. as [$a] ?// {b: $a} ?// {c: $a} | $a
+"x"
+
+. as [$a] ?// {b: $a} ?// {c: $a} | $a
+{"c":5}

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -3421,3 +3421,56 @@ null
 
 [.a,.b] | @tsv
 {"a":{"x":1},"b":2}
+
+# ---------- #77: getpath / setpath / delpaths type + OOB checks ----------
+
+getpath([0,1])
+1
+
+getpath(["a",0])
+1
+
+getpath(["a","b","c"])
+"x"
+
+getpath([null])
+null
+
+getpath(["a","b","c"])
+{"a":1}
+
+getpath([null])
+[1]
+
+getpath([true])
+[1]
+
+setpath([-5]; "x")
+[1,2,3]
+
+setpath([-3]; "x")
+[1,2,3]
+
+setpath([-1]; "x")
+[1,2,3]
+
+setpath([-10]; "x")
+[1,2,3]
+
+delpaths([["a"]])
+1
+
+delpaths([[0]])
+"x"
+
+delpaths([[0],[2]])
+{}
+
+delpaths([["a","b"]])
+{"a":"x"}
+
+delpaths([[0]])
+{}
+
+delpaths([])
+null

--- a/tests/fast_path_coverage.allowlist
+++ b/tests/fast_path_coverage.allowlist
@@ -17,7 +17,6 @@
 detect_arith_chain_cmp
 detect_arith_cmp_branch_literals
 detect_array_field_access
-detect_array_fields_format
 detect_array_join
 detect_cmp_branch_literals
 detect_cmp_branch_merge

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -1003,3 +1003,23 @@ with_entries(.value += 10)
 . as [$a] ?// {b: $a} | $a
 {"b":9}
 9
+
+# Issue #78: [range(N)] | .[0] returns indexed element, not the generator
+[range(3)] | .[0]
+null
+0
+
+# Issue #78: [range(N)] | .[-1] returns the last element
+[range(3)] | .[-1]
+null
+2
+
+# Issue #78: parenthesized index also works
+[range(3)] | (.[0])
+null
+0
+
+# Issue #78: larger range returns correct endpoint
+[range(100)] | .[-1]
+null
+99

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -993,3 +993,13 @@ from_entries
 with_entries(.value += 10)
 {"a":1}
 {"a":11}
+
+# Issue #76: all-fail destructure alt raises last attempt's error
+. as [$a] ?// {b: $a} | $a
+[1,2]
+1
+
+# Issue #76: pattern succeeds on object matching destructure
+. as [$a] ?// {b: $a} | $a
+{"b":9}
+9

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -968,3 +968,28 @@ null
 [-1.0, -2.0]
 null
 [-1.0,-2.0]
+
+# Issue #73: to_entries | from_entries is identity on objects (not arrays)
+to_entries | from_entries
+{"a":1,"b":2}
+{"a":1,"b":2}
+
+# Issue #73: [] round-trips to {} (empty array picks up object type)
+to_entries | from_entries
+[]
+{}
+
+# Issue #73: from_entries on empty array returns {}
+from_entries
+[]
+{}
+
+# Issue #73: name fallback still works when key is missing
+from_entries
+[{"name":"foo","value":1}]
+{"foo":1}
+
+# Issue #73: with_entries on object preserves through round-trip
+with_entries(.value += 10)
+{"a":1}
+{"a":11}

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -1023,3 +1023,13 @@ null
 [range(100)] | .[-1]
 null
 99
+
+# Issue #79: scalar-only row still works for @csv
+@csv
+[1,2,3]
+"1,2,3"
+
+# Issue #79: scalar-only row still works for @tsv (tab separator)
+[.a,.b] | @csv
+{"a":1,"b":2}
+"1,2"

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -943,3 +943,28 @@ until(. > 2; . + 10)
 from_entries
 {}
 {}
+
+# Issue #75: unary minus preserves literal repr (".0" survives)
+-1.0
+null
+-1.0
+
+# Issue #75: tojson on literal preserves repr
+1.0 | tojson
+null
+"1.0"
+
+# Issue #75: tojson on scientific literal preserves normalized form
+1e10 | tojson
+null
+"1E+10"
+
+# Issue #75: tojson on 0.0 preserves repr
+0.0 | tojson
+null
+"0.0"
+
+# Issue #75: negated literal inside array keeps repr
+[-1.0, -2.0]
+null
+[-1.0,-2.0]

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -1033,3 +1033,28 @@ null
 [.a,.b] | @csv
 {"a":1,"b":2}
 "1,2"
+
+# Issue #77: getpath still works for nested objects
+getpath(["a","b"])
+{"a":{"b":5}}
+5
+
+# Issue #77: getpath on null with string/number key yields null
+getpath(["a"])
+null
+null
+
+# Issue #77: delpaths on missing keys is no-op (does not error)
+delpaths([["b"]])
+{"a":1}
+{"a":1}
+
+# Issue #77: setpath with negative-in-range stays correct
+setpath([-3]; "x")
+[1,2,3]
+["x",2,3]
+
+# Issue #77: delpaths with empty path list is identity
+delpaths([])
+{"a":1,"b":2}
+{"a":1,"b":2}


### PR DESCRIPTION
## Summary

Bug sweep across six reported jq 1.8.1 compat divergences. One commit per issue, each bundled with regression + differential corpus coverage.

| # | Area | Fix |
|---|---|---|
| #75 | number repr | Preserve repr through unary minus (`-1.0` stays `-1.0`) and through `tojson`; fallback to f64 form when repr exceeds 15 significant digits so the 4 `have_decnum`-conditional tests still match the no-decnum branch |
| #73 | `from_entries` | Reject non-string keys with `Cannot use <type> (<value>) as object key`; drop the over-eager `to_entries \| from_entries → Input` rewrite in all three places (simplify_expr, is_identity, jit rewriter); fix a pre-existing JIT error-propagation bug exposed by (1) via a new `JumpIfError` op |
| #76 | `as ?// alt` | Stop wrapping the last alternative in a try-catch whose final catch was `Empty`; the last pattern's error now propagates per the jq spec |
| #78 | `[gen] \| .[N]` | Gate the `[e0, e1, ...] \| .[N] → eN` fold on `is_single_valued` so `[range(3)] \| .[0]` returns `0` instead of streaming every value |
| #79 | `@csv` / `@tsv` | Error on nested arrays/objects with jq's `array/object (...) is not valid in a csv row` wording; also bail from the `detect_array_fields_format` raw-byte fast paths when any field starts with `[` or `{` |
| #77 | `getpath` / `setpath` / `delpaths` | Surface jq's type / OOB errors instead of returning null / clamping / no-oping; drop the parse-time `getpath([…keys]) → .key.key.key` rewrite (it inherited a pre-existing `.a`-on-non-object divergence) |

## Test plan

- [x] `cargo test --release` — 509 official + 538 regression + 11 fast-path coverage + differential suite all pass with zero warnings
- [x] `./bench/comprehensive.sh --quick` — no regression vs v1.1.0 baseline in docs/benchmark-history.md
- [x] Manual diff against jq 1.8.1 for each issue's repro cases
- [ ] CI green before merge

Closes #73
Closes #75
Closes #76
Closes #77
Closes #78
Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)