### PR TITLE
fix: bug sweep #102-108 (7 jq compat divergences)

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3202,18 +3202,31 @@ fn eval_obj_pairs(pairs: &[(Expr, Expr)], idx: usize, cur: crate::value::ObjMap,
     })
 }
 
-fn format_sh(val: &Value) -> String {
+fn format_sh_scalar(val: &Value) -> Result<String> {
     match val {
-        Value::Str(s) => format!("'{}'", s.replace('\'', "'\\''")),
-        Value::Null => "null".to_string(),
-        Value::True => "true".to_string(),
-        Value::False => "false".to_string(),
-        Value::Num(n, _) => crate::value::format_jq_number(*n),
+        Value::Str(s) => Ok(format!("'{}'", s.replace('\'', "'\\''"))),
+        Value::Null => Ok("null".to_string()),
+        Value::True => Ok("true".to_string()),
+        Value::False => Ok("false".to_string()),
+        Value::Num(n, _) => Ok(crate::value::format_jq_number(*n)),
+        _ => bail!(
+            "{} ({}) can not be escaped for shell",
+            val.type_name(),
+            crate::value::value_to_json(val),
+        ),
+    }
+}
+
+fn format_sh(val: &Value) -> Result<String> {
+    match val {
         Value::Arr(a) => {
-            let parts: Vec<String> = a.iter().map(|v| format_sh(v)).collect();
-            parts.join(" ")
+            let mut parts: Vec<String> = Vec::with_capacity(a.len());
+            for v in a.iter() {
+                parts.push(format_sh_scalar(v)?);
+            }
+            Ok(parts.join(" "))
         }
-        _ => format!("'{}'", crate::value::value_to_json(val).replace('\'', "'\\''")),
+        _ => format_sh_scalar(val),
     }
 }
 
@@ -3339,7 +3352,7 @@ pub fn eval_format(name: &str, val: &Value) -> Result<String> {
             }
             Ok(String::from_utf8_lossy(&decoded).into_owned())
         }
-        "sh" => Ok(format_sh(val)),
+        "sh" => format_sh(val),
         "base64" => {
             const C: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
             let d = s.as_bytes(); let mut r = String::new();

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1763,7 +1763,6 @@ pub fn eval(
                         }
                         Ok(true)
                     }
-                    Value::Null => Ok(true),
                     _ => bail!("Cannot iterate over {} ({})",
                         container.type_name(), crate::value::value_to_json(&container)),
                 }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -906,10 +906,19 @@ fn simplify_expr(expr: &crate::ir::Expr) -> crate::ir::Expr {
                                 is_single_valued(value) && is_single_valued(body)
                             }
                             Expr::Collect { .. } => true,
+                            // Compound nodes can hide generators in their operands
+                            // (e.g. simplify_expr beta-reduces `gen | .*k` into
+                            // `BinOp(gen, k)` — issue #102). Recurse so the fold
+                            // doesn't promote that buried generator.
+                            Expr::BinOp { lhs, rhs, .. } => is_single_valued(lhs) && is_single_valued(rhs),
+                            Expr::UnaryOp { operand, .. } => is_single_valued(operand),
+                            Expr::Negate { operand } => is_single_valued(operand),
+                            Expr::Index { expr, key } | Expr::IndexOpt { expr, key } => {
+                                is_single_valued(expr) && is_single_valued(key)
+                            }
                             Expr::Input | Expr::Literal(_) | Expr::LoadVar { .. }
-                            | Expr::Not | Expr::Negate { .. }
-                            | Expr::Index { .. } | Expr::IndexOpt { .. }
-                            | Expr::Slice { .. } | Expr::UnaryOp { .. } | Expr::BinOp { .. }
+                            | Expr::Not
+                            | Expr::Slice { .. }
                             | Expr::StringInterpolation { .. } | Expr::ObjectConstruct { .. }
                             | Expr::RegexTest { .. } | Expr::RegexSub { .. } | Expr::RegexGsub { .. } => true,
                             _ => false,
@@ -1015,10 +1024,19 @@ fn simplify_expr(expr: &crate::ir::Expr) -> crate::ir::Expr {
                                     Expr::LetBinding { value, body, .. } =>
                                         is_single_valued_idx(value) && is_single_valued_idx(body),
                                     Expr::Collect { .. } => true,
+                                    // Compound nodes can hide generators in their
+                                    // operands (e.g. simplify_expr beta-reduces
+                                    // `gen | .*k` into `BinOp(gen, k)` — issue #102).
+                                    // Recurse so the fold doesn't promote it.
+                                    Expr::BinOp { lhs, rhs, .. } => is_single_valued_idx(lhs) && is_single_valued_idx(rhs),
+                                    Expr::UnaryOp { operand, .. } => is_single_valued_idx(operand),
+                                    Expr::Negate { operand } => is_single_valued_idx(operand),
+                                    Expr::Index { expr, key } | Expr::IndexOpt { expr, key } => {
+                                        is_single_valued_idx(expr) && is_single_valued_idx(key)
+                                    }
                                     Expr::Input | Expr::Literal(_) | Expr::LoadVar { .. }
-                                    | Expr::Not | Expr::Negate { .. }
-                                    | Expr::Index { .. } | Expr::IndexOpt { .. }
-                                    | Expr::Slice { .. } | Expr::UnaryOp { .. } | Expr::BinOp { .. }
+                                    | Expr::Not
+                                    | Expr::Slice { .. }
                                     | Expr::StringInterpolation { .. } | Expr::ObjectConstruct { .. }
                                     | Expr::RegexTest { .. } | Expr::RegexSub { .. } | Expr::RegexGsub { .. } => true,
                                     _ => false,

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -3922,7 +3922,22 @@ impl Flattener {
         self.emit(JitOp::Jump { label: done_lbl });
 
         self.emit(JitOp::Label { id: other_lbl });
-        if !is_opt { self.emit(JitOp::ReturnError); }
+        if !is_opt {
+            // Set "Cannot iterate over TYPE (VALUE)" before returning the error;
+            // bare ReturnError leaves the error message blank (issue #107).
+            let err_slot = self.alloc_slot();
+            self.emit(JitOp::CallBuiltin {
+                dst: err_slot,
+                name: "__each_error__".to_string(),
+                args: vec![container],
+            });
+            self.emit(JitOp::Drop { slot: err_slot });
+            if let Some((catch_label, error_slot)) = self.try_catch_target {
+                self.emit(JitOp::CheckError { error_dst: error_slot, catch_label });
+            } else {
+                self.emit(JitOp::ReturnError);
+            }
+        }
         self.emit(JitOp::Label { id: done_lbl });
         true
     }
@@ -4813,7 +4828,22 @@ impl Flattener {
         self.emit(JitOp::Jump { label: done_lbl });
 
         self.emit(JitOp::Label { id: other_lbl });
-        if !is_opt { self.emit(JitOp::ReturnError); }
+        if !is_opt {
+            // Set "Cannot iterate over TYPE (VALUE)" before returning the error;
+            // bare ReturnError leaves the error message blank (issue #107).
+            let err_slot = self.alloc_slot();
+            self.emit(JitOp::CallBuiltin {
+                dst: err_slot,
+                name: "__each_error__".to_string(),
+                args: vec![container],
+            });
+            self.emit(JitOp::Drop { slot: err_slot });
+            if let Some((catch_label, error_slot)) = self.try_catch_target {
+                self.emit(JitOp::CheckError { error_dst: error_slot, catch_label });
+            } else {
+                self.emit(JitOp::ReturnError);
+            }
+        }
         self.emit(JitOp::Label { id: done_lbl });
     }
 

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -5968,7 +5968,9 @@ extern "C" fn jit_rt_unaryop(dst: *mut Value, op: i32, input: *const Value) -> i
                     36 => n.is_infinite(),
                     37 => n.is_nan(),
                     38 => n.is_normal(),
-                    39 => n.is_finite(),
+                    // isfinite: jq's def is `type == "number" and (isinfinite | not)`,
+                    // so NaN counts as finite (issue #108).
+                    39 => !n.is_infinite(),
                     _ => unreachable!(),
                 }
             } else {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -620,7 +620,6 @@ pub fn rt_mul(a: &Value, b: &Value) -> Result<Value> {
             // Object multiplication = recursive merge
             Ok(Value::object_from_map(merge_objects(x, y)))
         }
-        (Value::Null, _) | (_, Value::Null) => Ok(Value::Null),
         _ => bail!(
             "{} and {} cannot be multiplied",
             errdesc(a),

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1740,7 +1740,35 @@ fn rt_str_index(v: &Value, target: &Value, is_rindex: bool) -> Result<Value> {
                 Ok(Value::Null)
             }
         }
-        _ => bail!("index/rindex requires string or array"),
+        // jq's def is `index(x): indices(x) | .[0]` (and `rindex(x): ... | .[-1:][0]`),
+        // so non-string/array input falls through to `.[target]`-style indexing.
+        _ => {
+            let inner = rt_indices_dot_fallback(v, target)?;
+            match &inner {
+                Value::Null => Ok(Value::Null),
+                _ => {
+                    // Scalar from object lookup: jq's `.[0]` / `.[-1:][0]` on a
+                    // scalar errors with these specific wordings.
+                    if is_rindex {
+                        bail!("Cannot index {} with object", inner.type_name())
+                    } else {
+                        bail!("Cannot index {} with number", inner.type_name())
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Mimic jq's `.[target]` semantics used when indices/index/rindex fall through
+/// to builtin.jq's `.[$i]` branch on non-string/array input.
+fn rt_indices_dot_fallback(v: &Value, target: &Value) -> Result<Value> {
+    match (v, target) {
+        (Value::Null, Value::Str(_)) => Ok(Value::Null),
+        (Value::Null, Value::Num(_, _)) => Ok(Value::Null),
+        (Value::Null, Value::Obj(_)) => Ok(Value::Null),
+        (Value::Obj(o), Value::Str(k)) => Ok(o.get(k.as_str()).cloned().unwrap_or(Value::Null)),
+        _ => bail!("Cannot index {} with {}", v.type_name(), index_err_desc(target)),
     }
 }
 
@@ -1816,7 +1844,10 @@ fn rt_indices(v: &Value, target: &Value) -> Result<Value> {
             }
             Ok(Value::Arr(Rc::new(indices)))
         }
-        _ => bail!("indices requires string or array"),
+        // jq's `def indices($i)` falls through to `.[$i]` for non-string/array
+        // input, so the result here can be a scalar (object value) or null —
+        // not an array.
+        _ => rt_indices_dot_fallback(v, target),
     }
 }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1468,7 +1468,30 @@ fn rt_in(v: &Value, container: &Value) -> Result<Value> {
 }
 
 fn rt_contains(a: &Value, b: &Value) -> Result<Value> {
+    // jq treats true/false as distinct kinds at the top level: contains
+    // requires both operands to share a kind, otherwise it errors. Nested
+    // comparisons (inside arrays/objects) silently fall back to false.
+    if jq_kind_tag(a) != jq_kind_tag(b) {
+        bail!(
+            "{} and {} cannot have their containment checked",
+            errdesc(a),
+            errdesc(b)
+        );
+    }
     Ok(Value::from_bool(value_contains(a, b)))
+}
+
+fn jq_kind_tag(v: &Value) -> u8 {
+    match v {
+        Value::Null => 0,
+        Value::False => 1,
+        Value::True => 2,
+        Value::Num(_, _) => 3,
+        Value::Str(_) => 4,
+        Value::Arr(_) => 5,
+        Value::Obj(_) => 6,
+        Value::Error(_) => 7,
+    }
 }
 
 fn value_contains(a: &Value, b: &Value) -> bool {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -96,7 +96,9 @@ pub fn call_builtin(name: &str, args: &[Value]) -> Result<Value> {
             _ => Ok(Value::False),
         }),
         "isfinite" => unary_op(args, |v| match v {
-            Value::Num(n, _) => Ok(Value::from_bool(n.is_finite())),
+            // jq's isfinite is `type == "number" and (isinfinite | not)`,
+            // so NaN counts as finite (issue #108).
+            Value::Num(n, _) => Ok(Value::from_bool(!n.is_infinite())),
             _ => Ok(Value::False),
         }),
         "ascii" => unary_op(args, rt_ascii),

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -3474,3 +3474,14 @@ delpaths([[0]])
 
 delpaths([])
 null
+
+# ---------- Issue #103: null * n must error ----------
+
+null * 2
+null
+
+1 * null
+null
+
+null * null
+null

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -3513,3 +3513,20 @@ true
 
 @sh
 [1,[2]]
+
+# ---------- Issue #106: indices/index/rindex on null/object ----------
+
+indices("a")
+null
+
+index("a")
+{}
+
+rindex("a")
+null
+
+indices(0)
+null
+
+index("missing")
+{"a":1}

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -3530,3 +3530,17 @@ null
 
 index("missing")
 {"a":1}
+
+# ---------- Issue #107: .[] on null errors ----------
+
+.[]
+null
+
+reduce .[] as $x (0; . + $x)
+null
+
+[foreach .[] as $x (0; . + $x)]
+null
+
+[.[]?]
+null

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -3544,3 +3544,17 @@ null
 
 [.[]?]
 null
+
+# ---------- Issue #108: isfinite of NaN is true ----------
+
+nan | isfinite
+null
+
+infinite | isfinite
+null
+
+1 | isfinite
+null
+
+"x" | isfinite
+null

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -3558,3 +3558,17 @@ null
 
 "x" | isfinite
 null
+
+# ---------- Issue #102: gen|.*k inside [...] | .[N] ----------
+
+[range(5) | . * 2] | .[0]
+null
+
+[range(5) | . + 1] | .[-1]
+null
+
+[1,2,3 | . * 2] | .[0]
+null
+
+[range(5) | . + 1] | .[0]
+null

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -3499,3 +3499,17 @@ inside("hello")
 
 contains(false)
 true
+
+# ---------- Issue #105: @sh on object errors ----------
+
+@sh
+{}
+
+@sh
+{"a":1}
+
+@sh
+[1,{}]
+
+@sh
+[1,[2]]

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -3485,3 +3485,17 @@ null
 
 null * null
 null
+
+# ---------- Issue #104: contains/inside type-mismatch error ----------
+
+contains(1)
+"hello"
+
+contains({})
+[]
+
+inside("hello")
+1
+
+contains(false)
+true

--- a/tests/fast_path_coverage.allowlist
+++ b/tests/fast_path_coverage.allowlist
@@ -165,7 +165,6 @@ detect_with_entries_del_keys
 detect_with_entries_select_key_str
 detect_with_entries_select_value_cmp
 detect_with_entries_select_value_type
-is_each
 is_empty
 is_sort_keys
 is_with_entries_tostring

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -1159,3 +1159,23 @@ true
 "x" | isfinite
 null
 false
+
+# Issue #102: gen body with compound arithmetic must not collapse the array
+[range(5) | . * 2] | .[0]
+null
+0
+
+# Issue #102: negative endpoint with arithmetic body
+[range(5) | . + 1] | .[-1]
+null
+5
+
+# Issue #102: comma generator with arithmetic body
+[1,2,3 | . * 2] | .[0]
+null
+2
+
+# Issue #102: arithmetic body with addition still selects index 0
+[range(5) | . + 1] | .[0]
+null
+1

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -1102,3 +1102,23 @@ true
 # Issue #105: nested array inside array errors
 @sh
 [1,[2]]
+
+# Issue #106: indices on null returns null
+indices("a")
+null
+null
+
+# Issue #106: index on object with missing string key returns null
+index("a")
+{}
+null
+
+# Issue #106: rindex on null returns null
+rindex("a")
+null
+null
+
+# Issue #106: indices on null with number target also returns null
+indices(0)
+null
+null

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -1070,3 +1070,19 @@ null
 # Issue #103: null * null errors
 null * null
 null
+
+# Issue #104: contains with type mismatch errors instead of returning false
+contains(1)
+"hello"
+
+# Issue #104: contains with array vs object errors
+contains({})
+[]
+
+# Issue #104: inside with type mismatch errors (inside is contains with operands swapped)
+inside("hello")
+1
+
+# Issue #104: contains across boolean kinds errors (true vs false are distinct)
+contains(false)
+true

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -1058,3 +1058,15 @@ setpath([-3]; "x")
 delpaths([])
 {"a":1,"b":2}
 {"a":1,"b":2}
+
+# Issue #103: null * n errors instead of returning null
+null * 2
+null
+
+# Issue #103: n * null errors instead of returning null
+1 * null
+null
+
+# Issue #103: null * null errors
+null * null
+null

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -1122,3 +1122,20 @@ null
 indices(0)
 null
 null
+
+# Issue #107: .[] on null errors instead of yielding nothing
+.[]
+null
+
+# Issue #107: reduce over .[] on null errors
+reduce .[] as $x (0; . + $x)
+null
+
+# Issue #107: foreach over .[] on null errors
+[foreach .[] as $x (0; . + $x)]
+null
+
+# Issue #107: optional .[]? on null still yields nothing
+[.[]?]
+null
+[]

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -1139,3 +1139,23 @@ null
 [.[]?]
 null
 []
+
+# Issue #108: isfinite of NaN is true (jq def: type=="number" and (isinfinite|not))
+nan | isfinite
+null
+true
+
+# Issue #108: isfinite of infinity is false
+infinite | isfinite
+null
+false
+
+# Issue #108: isfinite of regular number is true
+1 | isfinite
+null
+true
+
+# Issue #108: isfinite of non-number is false
+"x" | isfinite
+null
+false

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -1086,3 +1086,19 @@ inside("hello")
 # Issue #104: contains across boolean kinds errors (true vs false are distinct)
 contains(false)
 true
+
+# Issue #105: @sh on object errors
+@sh
+{}
+
+# Issue #105: @sh on populated object errors
+@sh
+{"a":1}
+
+# Issue #105: nested object inside array errors too
+@sh
+[1,{}]
+
+# Issue #105: nested array inside array errors
+@sh
+[1,[2]]


### PR DESCRIPTION
## Summary

Fixes the 7 open compat-bug issues filed in this session. One commit per issue, kept on a single branch as requested.

- **#102** `[gen | . op k] | .[N]` collapsed to a 5-stream because the single-valued helper treated `BinOp/UnaryOp/Index` as unconditionally single-valued. Recurse into operands so the fold rejects buried generators.
- **#103** `null * n` and `n * null` silently returned null. Removed the catch-all null arm in `rt_mul`.
- **#104** `contains(b)` / `inside(b)` returned false on type mismatch instead of erroring. Added a kind-tag gate that mirrors jq's JV_KIND distinction (true and false count as different kinds).
- **#105** `@sh` shell-quoted JSON for objects (and nested arrays/objects inside array elements). Split `format_sh` into a scalar formatter that bails on objects/arrays and a wrapper that joins array elements.
- **#106** `indices/index/rindex` errored with a generic message on null/object input. Mirror jq's builtin.jq fall-through to `.[$i]` semantics.
- **#107** `.[]` on null silently yielded nothing. Removed the Null arm in eval's Each handler; also routed JIT each-with-body / each-with-action error paths through `__each_error__` to populate the message instead of bare `ReturnError`.
- **#108** `nan | isfinite` returned false; jq's def is `type == "number" and (isinfinite | not)` so NaN counts as finite. Replaced `is_finite()` with `!is_infinite()` in both runtime and the JIT op-39 fast path.

## Test plan

- [x] `cargo build --release` — zero warnings
- [x] `cargo test --release` — all suites pass (regression 225, differential 1079, official jq, fast-path coverage)
- [x] Removed `is_each` from `tests/fast_path_coverage.allowlist` (now covered by new corpus probes)
- [x] Reproduction commands from each issue verified against jq 1.8.1
- [x] `./bench/comprehensive.sh --quick` shows no regressions (all timings within prior ranges)

Closes #102
Closes #103
Closes #104
Closes #105
Closes #106
Closes #107
Closes #108