### PR TITLE
fix(date): add canonical todateiso8601 / fromdateiso8601 builtins (#116)

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2641,7 +2641,7 @@ impl Parser {
             | "toboolean" | "walk" | "pick" | "bsearch" | "skip" | "del"
             | "IN" | "INDEX" | "JOIN" | "strflocaltime"
             | "fromcsv" | "fromtsv" | "fromcsvh" | "fromtsvh"
-            | "fromisodate" | "toisodate"
+            | "fromdateiso8601" | "todateiso8601" | "fromisodate" | "toisodate"
             | "input_line_number"
             if !matches!(self.current(), Token::LParen) => {
                 self.compile_builtin_noargs(name)
@@ -2885,7 +2885,7 @@ impl Parser {
             "fromcsv" | "fromtsv" | "fromcsvh" | "fromtsvh" => {
                 Ok(Expr::CallBuiltin { name: name.to_string(), args: vec![] })
             }
-            "fromisodate" | "toisodate" => {
+            "fromdateiso8601" | "todateiso8601" | "fromisodate" | "toisodate" => {
                 Ok(Expr::CallBuiltin { name: name.to_string(), args: vec![] })
             }
             _ => {
@@ -3495,11 +3495,14 @@ impl Parser {
                 let headers = args.into_iter().next().unwrap();
                 Ok(Expr::CallBuiltin { name: "fromtsvh".to_string(), args: vec![headers] })
             }
-            // fromisodate/0, toisodate/0: ISO 8601 date conversion
-            ("fromisodate", 0) => {
+            // fromdateiso8601/0, todateiso8601/0 (canonical jq names)
+            // plus fromisodate/0, toisodate/0 aliases kept for
+            // backward compatibility: all four route to the same
+            // runtime impl.
+            ("fromdateiso8601", 0) | ("fromisodate", 0) => {
                 Ok(Expr::CallBuiltin { name: "fromisodate".to_string(), args: vec![] })
             }
-            ("toisodate", 0) => {
+            ("todateiso8601", 0) | ("toisodate", 0) => {
                 Ok(Expr::CallBuiltin { name: "toisodate".to_string(), args: vec![] })
             }
             // IN/1: IN(s) = any(. == s; .)... actually IN(s) = . as $x | first(s | if . == $x then true else empty end) // false

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -335,8 +335,12 @@ pub fn call_builtin(name: &str, args: &[Value]) -> Result<Value> {
         "todate" => unary_op(args, |v| rt_strftime(v, &Value::from_str("%Y-%m-%dT%H:%M:%SZ"))),
         "fromdate" => unary_op(args, |v| rt_strptime(v, &Value::from_str("%Y-%m-%dT%H:%M:%SZ"))),
         "date" => unary_op(args, |v| rt_strftime(v, &Value::from_str("%Y-%m-%dT%H:%M:%SZ"))),
-        "fromisodate" => unary_op(args, rt_fromisodate),
-        "toisodate" => unary_op(args, rt_toisodate),
+        // Canonical jq names per the docs at
+        // https://jqlang.github.io/jq/manual/#Dates. Keep the
+        // non-standard `fromisodate` / `toisodate` aliases for backward
+        // compatibility with callers that adopted them before #116.
+        "fromdateiso8601" | "fromisodate" => unary_op(args, rt_fromisodate),
+        "todateiso8601"   | "toisodate"   => unary_op(args, rt_toisodate),
         "trimstr" => binary_arg(args, |a, b| {
             let v = rt_ltrimstr(a, b)?;
             rt_rtrimstr(&v, b)
@@ -2820,6 +2824,7 @@ pub fn rt_builtins() -> Value {
         "strflocaltime/1",
         "fromcsv/0", "fromtsv/0", "fromcsvh/0", "fromcsvh/1", "fromtsvh/0", "fromtsvh/1",
         "toboolean/0",
+        "fromdateiso8601/0", "todateiso8601/0",
         "fromisodate/0", "toisodate/0",
     ];
     let arr: Vec<Value> = builtins.iter()


### PR DESCRIPTION
## Summary

jq-jit only recognised the non-standard `toisodate` / `fromisodate` names. Any filter written against canonical jq (which documents `todateiso8601` / `fromdateiso8601` in the [manual](https://jqlang.github.io/jq/manual/#Dates)) failed with `unknown unary operation: todateiso8601`.

## Fix

Route all four names — `todateiso8601`, `fromdateiso8601`, `toisodate`, `fromisodate` — to the existing runtime impl at four sites:

- `runtime.rs` dispatch (`rt_fromisodate` / `rt_toisodate` alias groups)
- `parser.rs` no-args dispatch list
- `parser.rs` `compile_builtin_noargs` arm
- `parser.rs` function-call-with-args arm

Also expose the canonical names in `builtins/0` so `jq --builtins` and scripted discovery return them. The non-standard aliases stay in place for backward compatibility.

Fixes #116

## Test plan

- [x] `cargo build --release`
- [x] `echo '0' | ./target/release/jq-jit -c 'todateiso8601'` → `"1970-01-01T00:00:00Z"` ✅
- [x] `echo '"1970-01-01T00:00:00Z"' | ./target/release/jq-jit -c 'fromdateiso8601'` → `0` ✅
- [x] `echo '0' | ./target/release/jq-jit -c 'toisodate'` still works (backward-compat) ✅