### PR TITLE
fix: bug sweep #115 #123 #126

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -1759,6 +1759,8 @@ fn real_main() {
     let mut sort_keys = false;
     let mut exit_status = false;
     let mut color_output = false;
+    let mut unbuffered = false;
+    let mut seq = false;
     let mut arg_vars: Vec<(String, Value)> = Vec::new();
     let mut argjson_vars: Vec<(String, Value)> = Vec::new();
     let mut lib_dirs: Vec<String> = Vec::new();
@@ -1791,6 +1793,21 @@ fn real_main() {
             "-e" | "--exit-status" => exit_status = true,
             "-C" | "--color-output" => color_output = true,
             "-M" | "--monochrome-output" => color_output = false,
+            "--unbuffered" => unbuffered = true,
+            "--seq" => seq = true,
+            "-a" | "--ascii-output" => {
+                // Recognised but not yet implemented (#126). Emit a
+                // clear error instead of falling through to the filter
+                // tokenizer (which would raise "unknown unary operation: a").
+                eprintln!("jq: --ascii-output (-a) is not yet implemented in jq-jit");
+                process::exit(2);
+            }
+            "--stream" => {
+                // Stream mode requires a substantial transform of every
+                // input into path-value tuples; deferred (#126).
+                eprintln!("jq: --stream is not yet implemented in jq-jit");
+                process::exit(2);
+            }
             "--tab" => tab = true,
             "--indent" => {
                 i += 1;
@@ -2033,6 +2050,14 @@ fn real_main() {
     let stdin_data: Option<String> = if !null_input && files.is_empty() && !raw_input {
         let mut s = String::new();
         io::stdin().lock().read_to_string(&mut s).unwrap_or(0);
+        if seq {
+            // RFC 7464 input: strip the RS (0x1e) record separators
+            // before they reach the JSON parser. RS is a control char
+            // that would otherwise be illegal mid-input; valid JSON
+            // strings cannot contain it unescaped, so removing every
+            // 0x1e byte is safe and matches jq's --seq input handling.
+            s.retain(|c| c != '\u{1e}');
+        }
         Some(s)
     } else {
         None
@@ -2706,6 +2731,16 @@ fn real_main() {
             if exit_status && !result.is_true() {
                 *any_false = true;
             }
+            // RFC 7464 JSON Text Sequences: every output value is preceded
+            // by an RS (0x1e) byte. The trailing LF is already produced by
+            // each emitter below.
+            if seq {
+                if use_compact_buf || use_pretty_buf {
+                    cbuf.push(0x1e);
+                } else {
+                    let _ = out.write_all(&[0x1e]);
+                }
+            }
             if use_compact_buf {
                 if !color_output {
                     // Raw passthrough: if result is the unmodified input and bytes are compact,
@@ -2756,6 +2791,16 @@ fn real_main() {
             }
             Ok(true)
         });
+        // --unbuffered: flush after every input so consumers get
+        // results as they're produced rather than waiting for the
+        // 64KB BufWriter to fill.
+        if unbuffered {
+            if !cbuf.is_empty() {
+                let _ = out.write_all(cbuf);
+                cbuf.clear();
+            }
+            let _ = out.flush();
+        }
         if let Err(e) = result {
             let msg = format!("{}", e);
             if let Some(code_str) = msg.strip_prefix("__halt__:") {
@@ -5072,8 +5117,10 @@ fn real_main() {
                         }
                         Ok(())
                     })
-                } else if filter.is_identity() && use_compact_buf && !color_output && !exit_status {
-                    // Fast path: if the entire file is compact NDJSON, write it in one shot
+                } else if filter.is_identity() && use_compact_buf && !color_output && !exit_status && !seq {
+                    // Fast path: if the entire file is compact NDJSON, write it in one shot.
+                    // Skip the fast path under --seq so the per-output RS prefix gets
+                    // applied through the regular process_input route.
                     let ib = input_bytes;
                     let mut bom_skip = 0usize;
                     if ib.len() >= 3 && ib[0] == 0xEF && ib[1] == 0xBB && ib[2] == 0xBF { bom_skip = 3; }
@@ -5126,7 +5173,7 @@ fn real_main() {
                             Ok(())
                         })
                     }
-                } else if filter.is_identity() && use_pretty_buf && !color_output && !exit_status {
+                } else if filter.is_identity() && use_pretty_buf && !color_output && !exit_status && !seq {
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
                         push_json_pretty_raw(&mut compact_buf, raw, indent_n, tab);
@@ -21629,9 +21676,11 @@ fn real_main() {
                     }
                     Ok(())
                 })
-            } else if filter.is_identity() && use_compact_buf && !color_output && !exit_status {
+            } else if filter.is_identity() && use_compact_buf && !color_output && !exit_status && !seq {
                 // Identity fast path: skip JSON parsing entirely, just validate structure
                 // and copy raw bytes directly. Falls back to parse+serialize for non-compact input.
+                // Skipped under --seq so the per-output RS prefix gets applied through
+                // the regular process_input route.
                 let content_bytes = content.as_bytes();
                 // Whole-file passthrough for compact NDJSON — sample multiple lines
                 let mut bom_skip2 = 0usize;
@@ -21682,7 +21731,7 @@ fn real_main() {
                         Ok(())
                     })
                 }
-            } else if filter.is_identity() && use_pretty_buf && !color_output && !exit_status {
+            } else if filter.is_identity() && use_pretty_buf && !color_output && !exit_status && !seq {
                 let content_bytes = content.as_bytes();
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1001,10 +1001,10 @@ fn eval_one(expr: &Expr, input: &Value, env: &EnvRef) -> std::result::Result<Val
                                     }
                                     BinOp::Eq => if ln == rn { Value::True } else { Value::False },
                                     BinOp::Ne => if ln != rn { Value::True } else { Value::False },
-                                    BinOp::Lt => if ln < rn { Value::True } else { Value::False },
-                                    BinOp::Gt => if ln > rn { Value::True } else { Value::False },
-                                    BinOp::Le => if ln <= rn { Value::True } else { Value::False },
-                                    BinOp::Ge => if ln >= rn { Value::True } else { Value::False },
+                                    BinOp::Lt => if jq_num_lt(ln, rn) { Value::True } else { Value::False },
+                                    BinOp::Gt => if jq_num_gt(ln, rn) { Value::True } else { Value::False },
+                                    BinOp::Le => if jq_num_le(ln, rn) { Value::True } else { Value::False },
+                                    BinOp::Ge => if jq_num_ge(ln, rn) { Value::True } else { Value::False },
                                     _ => { drop(e); return Err(()); }
                                 });
                             }
@@ -1030,10 +1030,10 @@ fn eval_one(expr: &Expr, input: &Value, env: &EnvRef) -> std::result::Result<Val
                             }
                             BinOp::Eq => if ln == rn { Value::True } else { Value::False },
                             BinOp::Ne => if ln != rn { Value::True } else { Value::False },
-                            BinOp::Lt => if ln < rn { Value::True } else { Value::False },
-                            BinOp::Gt => if ln > rn { Value::True } else { Value::False },
-                            BinOp::Le => if ln <= rn { Value::True } else { Value::False },
-                            BinOp::Ge => if ln >= rn { Value::True } else { Value::False },
+                            BinOp::Lt => if jq_num_lt(*ln, *rn) { Value::True } else { Value::False },
+                            BinOp::Gt => if jq_num_gt(*ln, *rn) { Value::True } else { Value::False },
+                            BinOp::Le => if jq_num_le(*ln, *rn) { Value::True } else { Value::False },
+                            BinOp::Ge => if jq_num_ge(*ln, *rn) { Value::True } else { Value::False },
                             _ => return eval_binop(*op, &l, &r).map_err(|_| ()),
                         });
                     }
@@ -2962,6 +2962,29 @@ pub fn eval(
     }
 }
 
+// jq treats NaN as less than every number (including itself, reflexively
+// via `<`) so the ordering operators stay total over numeric inputs and
+// `sort` is stable in the presence of NaN. IEEE 754's "all comparisons
+// false" leaves NaNs scattered, so each numeric fast path routes through
+// these helpers instead of `<`/`>` directly. (`==` / `!=` keep IEEE 754
+// inequality semantics — `nan == nan` is still false.)
+#[inline]
+pub fn jq_num_lt(ln: f64, rn: f64) -> bool {
+    if ln.is_nan() { true }
+    else if rn.is_nan() { false }
+    else { ln < rn }
+}
+#[inline]
+pub fn jq_num_gt(ln: f64, rn: f64) -> bool {
+    if rn.is_nan() && !ln.is_nan() { true }
+    else if ln.is_nan() { false }
+    else { ln > rn }
+}
+#[inline]
+pub fn jq_num_le(ln: f64, rn: f64) -> bool { !jq_num_gt(ln, rn) }
+#[inline]
+pub fn jq_num_ge(ln: f64, rn: f64) -> bool { !jq_num_lt(ln, rn) }
+
 // ---------------------------------------------------------------------------
 #[inline]
 pub fn eval_binop(op: BinOp, lhs: &Value, rhs: &Value) -> Result<Value> {
@@ -2983,10 +3006,10 @@ pub fn eval_binop(op: BinOp, lhs: &Value, rhs: &Value) -> Result<Value> {
             }
             BinOp::Eq => if ln == rn { Value::True } else { Value::False },
             BinOp::Ne => if ln != rn { Value::True } else { Value::False },
-            BinOp::Lt => if ln < rn { Value::True } else { Value::False },
-            BinOp::Gt => if ln > rn { Value::True } else { Value::False },
-            BinOp::Le => if ln <= rn { Value::True } else { Value::False },
-            BinOp::Ge => if ln >= rn { Value::True } else { Value::False },
+            BinOp::Lt => if jq_num_lt(*ln, *rn) { Value::True } else { Value::False },
+            BinOp::Gt => if jq_num_gt(*ln, *rn) { Value::True } else { Value::False },
+            BinOp::Le => if jq_num_le(*ln, *rn) { Value::True } else { Value::False },
+            BinOp::Ge => if jq_num_ge(*ln, *rn) { Value::True } else { Value::False },
             BinOp::And => if lhs.is_truthy() && rhs.is_truthy() { Value::True } else { Value::False },
             BinOp::Or => if lhs.is_truthy() || rhs.is_truthy() { Value::True } else { Value::False },
         });
@@ -3029,10 +3052,10 @@ fn eval_binop_owned(op: BinOp, lhs: Value, rhs: &Value) -> Result<Value> {
             }
             BinOp::Eq => if ln == rn { Value::True } else { Value::False },
             BinOp::Ne => if ln != rn { Value::True } else { Value::False },
-            BinOp::Lt => if ln < rn { Value::True } else { Value::False },
-            BinOp::Gt => if ln > rn { Value::True } else { Value::False },
-            BinOp::Le => if ln <= rn { Value::True } else { Value::False },
-            BinOp::Ge => if ln >= rn { Value::True } else { Value::False },
+            BinOp::Lt => if jq_num_lt(*ln, *rn) { Value::True } else { Value::False },
+            BinOp::Gt => if jq_num_gt(*ln, *rn) { Value::True } else { Value::False },
+            BinOp::Le => if jq_num_le(*ln, *rn) { Value::True } else { Value::False },
+            BinOp::Ge => if jq_num_ge(*ln, *rn) { Value::True } else { Value::False },
             BinOp::And | BinOp::Or => return eval_binop(op, &lhs, rhs),
         });
     }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1529,14 +1529,18 @@ fn simplify_expr(expr: &crate::ir::Expr) -> crate::ir::Expr {
                 if let Some(r) = result {
                     return Expr::Literal(Literal::Num(r, None));
                 }
-                // Comparison ops
+                // Comparison ops. jq treats NaN as below every number
+                // (#115) so ordering folds must mirror runtime semantics
+                // — IEEE 754's "all false" would have NaN sort scattered
+                // and `nan < nan` come out false. `==`/`!=` keep IEEE 754
+                // inequality (`nan == nan` is still false).
                 let cmp_result = match op {
                     crate::ir::BinOp::Eq => Some(*a == *b),
                     crate::ir::BinOp::Ne => Some(*a != *b),
-                    crate::ir::BinOp::Lt => Some(*a < *b),
-                    crate::ir::BinOp::Gt => Some(*a > *b),
-                    crate::ir::BinOp::Le => Some(*a <= *b),
-                    crate::ir::BinOp::Ge => Some(*a >= *b),
+                    crate::ir::BinOp::Lt => Some(crate::eval::jq_num_lt(*a, *b)),
+                    crate::ir::BinOp::Gt => Some(crate::eval::jq_num_gt(*a, *b)),
+                    crate::ir::BinOp::Le => Some(crate::eval::jq_num_le(*a, *b)),
+                    crate::ir::BinOp::Ge => Some(crate::eval::jq_num_ge(*a, *b)),
                     _ => None,
                 };
                 if let Some(r) = cmp_result {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2096,6 +2096,9 @@ impl Parser {
                         let (key_expr, val_expr) = self.parse_object_pair()?;
                         pairs.push((key_expr, val_expr));
                         if !self.eat(&Token::Comma) { break; }
+                        // Allow a trailing comma (`{a:1,}`, `{a,}`, etc.)
+                        // to match jq 1.8.1's parser.
+                        if self.at(&Token::RBrace) { break; }
                     }
                 }
                 self.scope.restore_func_scope(saved);

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -771,6 +771,22 @@ pub fn values_equal(a: &Value, b: &Value) -> bool {
     }
 }
 
+/// jq 1.8.1 puts NaN below every number (and reflexively below itself)
+/// so `sort`, `unique`, `min`/`max`, and the `<`/`>` operators stay
+/// total over numeric inputs. IEEE 754's "all comparisons false" would
+/// leave NaNs scattered. (`==` keeps IEEE 754 inequality so
+/// `nan == nan` is still false.)
+#[inline]
+pub fn cmp_num_jq(x: f64, y: f64) -> std::cmp::Ordering {
+    use std::cmp::Ordering;
+    match (x.is_nan(), y.is_nan()) {
+        (true, true) => Ordering::Less,
+        (true, false) => Ordering::Less,
+        (false, true) => Ordering::Greater,
+        (false, false) => x.partial_cmp(&y).unwrap_or(Ordering::Equal),
+    }
+}
+
 #[inline]
 pub fn compare_values(a: &Value, b: &Value) -> std::cmp::Ordering {
     use std::cmp::Ordering;
@@ -795,7 +811,7 @@ pub fn compare_values(a: &Value, b: &Value) -> std::cmp::Ordering {
     }
 
     match (a, b) {
-        (Value::Num(x, _), Value::Num(y, _)) => x.partial_cmp(y).unwrap_or(Ordering::Equal),
+        (Value::Num(x, _), Value::Num(y, _)) => cmp_num_jq(*x, *y),
         (Value::Str(x), Value::Str(y)) => x.cmp(y),
         (Value::Arr(x), Value::Arr(y)) => {
             for (a, b) in x.iter().zip(y.iter()) {
@@ -894,10 +910,12 @@ fn sort_values(sorted: &mut [Value]) {
     // Check first element type to select fast comparator
     match &sorted[0] {
         Value::Num(..) => {
-            // Optimistic: try numeric sort, fall back if mixed types
+            // Optimistic: try numeric sort, fall back if mixed types.
+            // NaN must rank below every number (jq's total order, #115);
+            // partial_cmp would scatter NaNs as Equal-ish.
             sorted.sort_by(|a, b| {
                 if let (Value::Num(x, _), Value::Num(y, _)) = (a, b) {
-                    x.partial_cmp(y).unwrap_or(std::cmp::Ordering::Equal)
+                    cmp_num_jq(*x, *y)
                 } else {
                     compare_values(a, b)
                 }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -1453,3 +1453,18 @@ modf
 input_filename
 1
 "<stdin>"
+
+# Issue #123: object literal trailing comma is allowed
+{a:1,}
+null
+{"a":1}
+
+# Issue #123: shorthand object literal with trailing comma
+{a,}
+{"a":10}
+{"a":10}
+
+# Issue #123: multi-pair object literal with trailing comma
+{a: 1, b: 2,}
+null
+{"a":1,"b":2}

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -1468,3 +1468,23 @@ null
 {a: 1, b: 2,}
 null
 {"a":1,"b":2}
+
+# Issue #115: nan ranks below every number in the total order
+nan < nan
+null
+true
+
+# Issue #115: 1 > nan because nan is below 1
+1 > nan
+null
+true
+
+# Issue #115: nan is not equal to nan (IEEE 754 inequality preserved)
+nan == nan
+null
+false
+
+# Issue #115: sort of array with NaN places NaN first (rendered as null in -c)
+[1, nan, 2, nan] | sort
+null
+[null,null,1,2]


### PR DESCRIPTION
## Summary

Three more jq 1.8.1 compatibility fixes, one commit per issue on a shared branch.

- **#123** — `{a:1,}`, `{a,}`, and `{a:1, b:2,}` were rejected with "expected object key, got RBrace". Allow a single trailing comma in object construction syntax (jq 1.8.1 accepts it). Array literals (`[1,2,3,]`) still error in both implementations.
- **#115** — `nan < nan` was false, `1 > nan` was false, `[1, nan, 2, nan] | sort` left NaNs scattered. Centralize jq's "NaN below every number" total order in `runtime::cmp_num_jq` and `eval::jq_num_lt/gt/le/ge`, route the four numeric fast-path BinOp call sites and the constant-folding pass through them. `==`/`!=` keep IEEE 754 inequality so `nan == nan` is still false.
- **#126** — `--seq` and `--unbuffered` are now recognized; `-a`/`--ascii-output` and `--stream` get a clear "not yet implemented" diagnostic instead of falling through to the filter tokenizer (which raised "unknown unary operation: a").
  - `--seq` is implemented end-to-end (RFC 7464): strip RS bytes from stdin, emit RS before each output value. Identity fast paths skipped under `--seq` so the per-output prefix gets applied through the regular write route.
  - `--unbuffered` flushes the BufWriter after every input.

## Out of scope (deferred)

- `-a` / `--ascii-output` (#126) — needs a parameterized JSON string serializer; tracked in #126.
- `--stream` (#126) — needs the full path-value transform; tracked in #126.
- #117 `input_line_number` — tracked separately.

## Test plan

- [x] `cargo build --release` — zero warnings
- [x] `cargo test --release` — 509 official + 291 regression + all unit suites green (added 7 regression cases)
- [x] `./bench/comprehensive.sh --quick` — within noise of v1.1.0 baseline
- [x] `--seq` output diffed byte-for-byte against `jq --seq` for both identity and non-identity filters

🤖 Generated with [Claude Code](https://claude.com/claude-code)