### PR TITLE
Release v1.3.1: add homebrew-tap auto-bump to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,4 +68,42 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
-        run: gh release create ${{ github.ref_name }} --generate-notes jq-jit-*.tar.gz
+        run: gh release create "${{ github.ref_name }}" --generate-notes jq-jit-*.tar.gz
+
+      - name: Checkout homebrew-tap
+        uses: actions/checkout@v6
+        with:
+          repository: m5d215/homebrew-tap
+          token: ${{ secrets.TAP_PUSH_TOKEN }}
+          path: homebrew-tap
+
+      - name: Bump formula
+        working-directory: homebrew-tap
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          version="${TAG#v}"
+          formula="Formula/jq-jit.rb"
+
+          sed -i -E "s|version \"[^\"]+\"|version \"${version}\"|" "$formula"
+
+          # 各プラットフォームの url 行と直後の sha256 行をペアで更新。
+          # sed の N で次行を pattern space に追加してから一括置換する。
+          for target in macos-arm64 linux-x86_64; do
+            sha=$(shasum -a 256 "../jq-jit-${target}.tar.gz" | cut -d' ' -f1)
+            sed -i -E "/-${target}\.tar\.gz\"$/{
+              N
+              s|download/v[0-9.]+/|download/${TAG}/|
+              s|sha256 \"[a-f0-9]+\"|sha256 \"${sha}\"|
+            }" "$formula"
+          done
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add "$formula"
+          if git diff --cached --quiet; then
+            echo "formula already at ${TAG}; skipping commit"
+            exit 0
+          fi
+          git commit -m "jq-jit: bump to ${TAG}"
+          git push

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,7 +450,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jq-jit"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jq-jit"
-version = "1.3.0"
+version = "1.3.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A JIT-compiling implementation of jq using Cranelift"


### PR DESCRIPTION
## Summary

- Extend release workflow with homebrew-tap formula auto-update (version + per-platform url + per-platform sha256)
- Bump Cargo.toml to 1.3.1 in prep for the tag

## Test plan

- [ ] CI passes
- [ ] After merge, `git tag v1.3.1 && git push --tags` triggers the workflow
- [ ] GitHub Release v1.3.1 created with tar.gz assets
- [ ] `m5d215/homebrew-tap` receives a commit bumping `Formula/jq-jit.rb` to 1.3.1 with matching sha256s

🤖 Generated with [Claude Code](https://claude.com/claude-code)