### PR TITLE
ci: serialize release tests and bump to 1.3.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,11 @@ jobs:
         run: cargo build --release
 
       - name: Run tests
-        run: cargo test --release
+        # `--test-threads=1` serialises the per-binary test functions. The
+        # cranelift-backed unit tests in `src/jit.rs` instantiate a fresh
+        # `JitCompiler` each and have surfaced intermittent SIGSEGV on both
+        # Linux and macOS runners when run in parallel. Mirrors ci.yml.
+        run: cargo test --release -- --test-threads=1
 
       - name: Package
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,7 +450,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jq-jit"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jq-jit"
-version = "1.3.1"
+version = "1.3.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A JIT-compiling implementation of jq using Cranelift"


### PR DESCRIPTION
## Summary
- Mirror `ci.yml`'s `--test-threads=1` into `release.yml` to stop the cranelift `JitCompiler` unit tests from SIGSEGVing on tagged builds.
- Bump to 1.3.2 so a fresh tag re-exercises the release workflow (v1.3.1 tag build [run 24897701830](https://github.com/m5d215/jq-jit/actions/runs/24897701830) failed on the Ubuntu `Run tests` step; no GitHub Release / tap bump produced).

## Root cause
`src/jit.rs`'s tests each instantiate a fresh `JitCompiler`. Running them in parallel intermittently segfaults — `ci.yml` documents this and serializes tests; `release.yml` did not. Same commit (7cc4a02) passed CI but failed Release.

## Test plan
- [x] `cargo build --release`
- [x] `cargo test --release -- --test-threads=1` (local)
- [ ] Release workflow succeeds when v1.3.2 tag is pushed post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)