### PR TITLE
feat: restore exec/execv jqx extensions, bump to 1.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,7 +450,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jq-jit"
-version = "1.3.2"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jq-jit"
-version = "1.3.2"
+version = "1.4.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A JIT-compiling implementation of jq using Cranelift"

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -4191,6 +4191,10 @@ fn eval_call_builtin(name: &str, args: &[Expr], input: Value, env: &EnvRef, cb: 
             // del(f) = delpaths([path(f)])
             return eval_del(&args[0], input, env, cb);
         }
+        ("exec", 2) => {
+            // exec(generator; "cmd"): spawn cmd once, pipe generator outputs to stdin, yield stdout lines
+            return eval_exec_pipe(&args[0], &args[1], input, env, cb);
+        }
         ("fromcsv", 0) | ("fromtsv", 0) => {
             return eval_fromcsv(&input, name == "fromtsv", cb);
         }
@@ -4310,6 +4314,60 @@ fn halt_error_write(input: &Value) {
             let _ = stderr.write_all(json.as_bytes());
         }
     }
+}
+
+fn eval_exec_pipe(gen_expr: &Expr, cmd_expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) -> GenResult) -> GenResult {
+    use std::io::Write;
+    // Evaluate the command string first
+    let mut cmd_str = None;
+    eval(cmd_expr, input.clone(), env, &mut |cmd_val| {
+        match &cmd_val {
+            Value::Str(s) => { cmd_str = Some(s.as_str().to_string()); }
+            _ => { return Err(anyhow::anyhow!("exec: command must be a string")); }
+        }
+        Ok(true)
+    })?;
+    let cmd_str = cmd_str.ok_or_else(|| anyhow::anyhow!("exec: command produced no value"))?;
+
+    // Spawn the process once
+    let mut child = std::process::Command::new("sh")
+        .args(["-c", &cmd_str])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .map_err(|e| anyhow::anyhow!("exec: failed to spawn: {}", e))?;
+
+    // Pipe generator outputs to stdin
+    {
+        let mut stdin = child.stdin.take().unwrap();
+        eval(gen_expr, input, env, &mut |val| {
+            let line = match &val {
+                Value::Str(s) => s.as_str().to_string(),
+                other => crate::value::value_to_json(other),
+            };
+            writeln!(stdin, "{}", line)
+                .map_err(|e| anyhow::anyhow!("exec: write to stdin failed: {}", e))?;
+            Ok(true)
+        })?;
+        // stdin is dropped here, signaling EOF
+    }
+
+    let output = child.wait_with_output()
+        .map_err(|e| anyhow::anyhow!("exec: failed to wait: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let code = output.status.code().unwrap_or(-1);
+        bail!("exec: command exited with code {}: {}", code, stderr.trim_end());
+    }
+
+    // Yield each line of stdout as a separate value
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for line in stdout.as_ref().lines() {
+        cb(Value::from_str(line))?;
+    }
+    Ok(true)
 }
 
 fn eval_fromcsv(input: &Value, is_tsv: bool, cb: &mut dyn FnMut(Value) -> GenResult) -> GenResult {

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -229,7 +229,7 @@ fn is_scalar(expr: &Expr) -> bool {
         Expr::CallBuiltin { name, args } => {
             // Filter-argument builtins can't be treated as scalar
             match (name.as_str(), args.len()) {
-                ("walk", _) | ("pick", _) | ("skip", _) | ("del", _)
+                ("walk", _) | ("pick", _) | ("skip", _) | ("del", _) | ("exec", 2)
                 | ("fromcsv", _) | ("fromtsv", _) | ("fromcsvh", _) | ("fromtsvh", _) => false,
                 ("add", 1) => false,
                 _ => args.iter().all(is_scalar),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3501,6 +3501,23 @@ impl Parser {
                 let f = args.into_iter().next().unwrap();
                 Ok(Expr::CallBuiltin { name: "walk".to_string(), args: vec![f] })
             }
+            // exec/1: execute shell command and return stdout
+            ("exec", 1) => {
+                let cmd = args.into_iter().next().unwrap();
+                Ok(Expr::CallBuiltin { name: "exec".to_string(), args: vec![cmd] })
+            }
+            // execv/1: execute shell command, return {exitcode, stdout, stderr}
+            ("execv", 1) => {
+                let cmd = args.into_iter().next().unwrap();
+                Ok(Expr::CallBuiltin { name: "execv".to_string(), args: vec![cmd] })
+            }
+            // exec/2: pipe generator output to shell command, yield stdout lines
+            ("exec", 2) => {
+                let mut args = args.into_iter();
+                let gen = args.next().unwrap();
+                let cmd = args.next().unwrap();
+                Ok(Expr::CallBuiltin { name: "exec".to_string(), args: vec![gen, cmd] })
+            }
             // fromcsv/0, fromtsv/0: parse CSV/TSV string, yield arrays per row
             ("fromcsv", 0) => {
                 Ok(Expr::CallBuiltin { name: "fromcsv".to_string(), args: vec![] })

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -131,6 +131,8 @@ pub fn call_builtin(name: &str, args: &[Value]) -> Result<Value> {
         "inside" => binary_arg(args, |a, b| rt_contains(b, a)),
         "startswith" => binary_arg(args, rt_startswith),
         "endswith" => binary_arg(args, rt_endswith),
+        "exec" => binary_arg(args, rt_exec),
+        "execv" => binary_arg(args, rt_execv),
         "ltrimstr" => binary_arg(args, rt_ltrimstr),
         "rtrimstr" => binary_arg(args, rt_rtrimstr),
         "split" if args.len() <= 2 => binary_arg(args, rt_split),
@@ -1562,6 +1564,61 @@ fn rt_endswith(v: &Value, suffix: &Value) -> Result<Value> {
     }
 }
 
+fn exec_spawn(input: &Value, cmd: &Value) -> Result<std::process::Output> {
+    let cmd_str = match cmd {
+        Value::Str(s) => s.as_str().to_string(),
+        _ => bail!("exec requires a string command"),
+    };
+    let stdin_data = match input {
+        Value::Null => None,
+        Value::Str(s) => Some(s.as_str().to_string()),
+        other => Some(crate::value::value_to_json(other)),
+    };
+    let mut child = std::process::Command::new("sh")
+        .args(["-c", &cmd_str])
+        .stdin(if stdin_data.is_some() {
+            std::process::Stdio::piped()
+        } else {
+            std::process::Stdio::null()
+        })
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .map_err(|e| anyhow::anyhow!("exec: failed to spawn: {}", e))?;
+    if let Some(data) = stdin_data {
+        use std::io::Write;
+        if let Some(ref mut stdin) = child.stdin {
+            let _ = stdin.write_all(data.as_bytes());
+        }
+    }
+    child.wait_with_output()
+        .map_err(|e| anyhow::anyhow!("exec: failed to wait: {}", e))
+}
+
+fn rt_exec(input: &Value, cmd: &Value) -> Result<Value> {
+    let output = exec_spawn(input, cmd)?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let code = output.status.code().unwrap_or(-1);
+        bail!("exec: command exited with code {}: {}", code, stderr.trim_end());
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let trimmed = stdout.trim_end_matches('\n');
+    Ok(Value::from_str(trimmed))
+}
+
+fn rt_execv(input: &Value, cmd: &Value) -> Result<Value> {
+    let output = exec_spawn(input, cmd)?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let code = output.status.code().unwrap_or(-1);
+    let mut obj = new_objmap();
+    obj.insert(KeyStr::const_new("exitcode"), Value::number(code as f64));
+    obj.insert(KeyStr::const_new("stdout"), Value::from_str(stdout.trim_end_matches('\n')));
+    obj.insert(KeyStr::const_new("stderr"), Value::from_str(stderr.trim_end_matches('\n')));
+    Ok(Value::object_from_map(obj))
+}
+
 fn rt_ltrimstr(v: &Value, prefix: &Value) -> Result<Value> {
     match (v, prefix) {
         (Value::Str(s), Value::Str(p)) => {
@@ -2862,6 +2919,7 @@ pub fn rt_builtins() -> Value {
         "have_decnum/0", "have_sql/0", "have_bom/0",
         "@base64/0", "@base64d/0", "@uri/0", "@csv/0", "@tsv/0",
         "@html/0", "@json/0", "@text/0", "@sh/0",
+        "exec/1", "exec/2", "execv/1",
         "fromcsv/0", "fromtsv/0", "fromcsvh/0", "fromcsvh/1", "fromtsvh/0", "fromtsvh/1",
         "toboolean/0",
         "format/1",

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -1270,11 +1270,6 @@ null
 null
 6
 
-# Issue #121: exec/1, exec/2, execv/1 must not be registered (not in jq 1.8.1)
-[builtins[] | select(. | startswith("exec"))]
-null
-[]
-
 # Issue #127: .a on a number errors instead of returning null
 .a
 1
@@ -1563,3 +1558,18 @@ try error catch . | tostring
 getpath([]) | tostring
 -0
 "-0"
+
+# Restore #121: exec/1 executes shell command and returns stdout
+exec("printf hello")
+null
+"hello"
+
+# Restore #121: execv/1 returns {exitcode, stdout, stderr}
+execv("printf hi") | .stdout
+null
+"hi"
+
+# Restore #121: exec/1, exec/2, execv/1 are advertised in builtins (jqx extension)
+[builtins[] | select(. == "exec/1" or . == "exec/2" or . == "execv/1")] | sort
+null
+["exec/1","exec/2","execv/1"]


### PR DESCRIPTION
## Summary

- Restores the `exec/1`, `exec/2`, and `execv/1` builtins that #121 removed in the 1.3.x line. The README already documents them under **Extensions (jqx)** and user code was relying on them.
- Bumps the crate version to `1.4.0` — minor bump for the restored user-facing feature.

## Why revert #121?

#121 was motivated by jq 1.8.1 compatibility. That reasoning is real but the trade-off was too aggressive: these builtins are deliberately out-of-spec `jqx` extensions, and pulling them broke anything relying on shell-out from filters. Restore them and continue treating them as extensions rather than compat-mode features.

## Test plan

- [x] `cargo build --release` — zero warnings
- [x] `cargo test --release -- --test-threads=1` — all tests pass (official 509 + regression + differential + fast-path)
- [x] `./bench/comprehensive.sh --quick` — no hot-path touched, numbers unchanged
- [x] Smoke checks:
  - `exec("printf hello")` → `"hello"`
  - `execv("printf hi") | .stdout` → `"hi"`
  - `[1,2,3] | exec(.[]; "tr a-z A-Z")` → yields per-line
  - `builtins | index("exec/1")` → non-null

After merge: tag `v1.4.0` on `main` to trigger the release workflow and homebrew-tap auto-bump.