### PR TITLE
ci: auto-add new issues/PRs to m5d215 Project v2

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,18 @@
+name: Add to project
+
+on:
+  issues:
+    types: [opened, reopened, transferred]
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions: {}
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1
+        with:
+          project-url: https://github.com/users/m5d215/projects/1
+          github-token: ${{ secrets.PROJECT_PAT }}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/add-to-project.yml` that funnels new and reopened issues plus opened/reopened `pull_request_target` events into [@m5d215's Issues](https://github.com/users/m5d215/projects/1) Project v2
- Uses `actions/add-to-project@v1` with the `PROJECT_PAT` classic PAT (managed externally)
- Sister change rolls out to other m5d215 public repos for unified issue tracking

## Test plan

- [ ] PR merge → CI passes (this workflow itself doesn't run on push, only on issue/PR events)
- [ ] Open a throwaway issue after merge → workflow run succeeds → issue appears in the Project

🤖 Generated with [Claude Code](https://claude.com/claude-code)
