### PR TITLE
ci: pin actions/add-to-project to v1.0.2

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -12,7 +12,7 @@ jobs:
   add-to-project:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v1
+      - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/users/m5d215/projects/1
           github-token: ${{ secrets.PROJECT_PAT }}


### PR DESCRIPTION
## Summary

Followup to #148. The `@v1` major tag for `actions/add-to-project` does not exist (only specific `v1.0.0/.1/.2` tags are published), so the workflow run on issue #149 failed with `Unable to resolve action actions/add-to-project@v1`. Pin to the current latest `v1.0.2`.

## Test plan

- [ ] CI passes
- [ ] After merge, reopen #149 — workflow fires successfully and the issue appears in the Project

🤖 Generated with [Claude Code](https://claude.com/claude-code)