### PR TITLE
chore: bump to 1.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,7 +450,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jq-jit"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jq-jit"
-version = "1.4.0"
+version = "1.4.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A JIT-compiling implementation of jq using Cranelift"


### PR DESCRIPTION
## Summary

Version bump to 1.4.1 for the #161 compound cmp-branch fast-path fix
shipped via #170.

## Test plan

- [x] cargo build --release (zero warnings)
- [x] cargo test --release — all green on prior commit