### PR TITLE
fix: serialise JIT path and thread-localise pools so tests can run in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,11 +35,4 @@ jobs:
         run: cargo build --release
 
       - name: Run tests
-        # `--test-threads=1` serialises the per-binary test functions. The
-        # cranelift-backed unit tests in `src/jit.rs` instantiate a fresh
-        # `JitCompiler` each and have surfaced intermittent SIGSEGV on both
-        # Linux and macOS runners when run in parallel. The full test wall
-        # time is barely affected because the heavy suites (`differential`,
-        # `official`, `regression`) already have very few test functions
-        # per binary.
-        run: cargo test --release -- --test-threads=1
+        run: cargo test --release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,11 +40,7 @@ jobs:
         run: cargo build --release
 
       - name: Run tests
-        # `--test-threads=1` serialises the per-binary test functions. The
-        # cranelift-backed unit tests in `src/jit.rs` instantiate a fresh
-        # `JitCompiler` each and have surfaced intermittent SIGSEGV on both
-        # Linux and macOS runners when run in parallel. Mirrors ci.yml.
-        run: cargo test --release -- --test-threads=1
+        run: cargo test --release
 
       - name: Package
         run: |

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -17,54 +17,51 @@ use crate::value::{Value, KeyStr};
 type GenResult = Result<bool>;
 pub type EnvRef = Rc<RefCell<Env>>;
 
-/// Global inputs queue for `input`/`inputs` builtins.
-/// Pre-populated by CLI before eval/JIT execution.
-/// SAFETY: jq-jit is single-threaded — no concurrent access.
-struct InputsCell(std::cell::UnsafeCell<(Vec<Value>, usize)>);
-unsafe impl Sync for InputsCell {}
-static INPUTS_STATE: InputsCell = InputsCell(std::cell::UnsafeCell::new((Vec::new(), 0)));
+// Per-thread inputs queue for `input`/`inputs` builtins.
+// Pre-populated by CLI before eval/JIT execution. Per-thread to keep
+// `cargo test` parallel runs honest — see `value::OBJMAP_POOL`.
+thread_local! {
+    static INPUTS_STATE: RefCell<(Vec<Value>, usize)> = const { RefCell::new((Vec::new(), 0)) };
+}
 
-/// Current input's 1-indexed line number for `input_line_number`.
-/// The CLI updates this before executing the filter on each input; jq defines
-/// it as the count of `\n` bytes consumed at the point the value was emitted
-/// (not where the value started), which for multi-value lines means every
-/// value on that line sees the same number.
-struct InputLineCell(std::cell::UnsafeCell<u64>);
-unsafe impl Sync for InputLineCell {}
-static INPUT_LINE_STATE: InputLineCell = InputLineCell(std::cell::UnsafeCell::new(0));
+// Per-thread 1-indexed line number for `input_line_number`. The CLI updates
+// it before executing the filter on each input; jq defines it as the count
+// of `\n` bytes consumed at the point the value was emitted (not where the
+// value started), which for multi-value lines means every value on that
+// line sees the same number.
+thread_local! {
+    static INPUT_LINE_STATE: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+}
 
 /// Set the line number reported by `input_line_number` for the current input.
 pub fn set_input_line_number(n: u64) {
-    unsafe { *INPUT_LINE_STATE.0.get() = n; }
+    INPUT_LINE_STATE.with(|c| c.set(n));
 }
 
 /// Read the current line number reported by `input_line_number`.
 pub fn get_input_line_number() -> u64 {
-    unsafe { *INPUT_LINE_STATE.0.get() }
+    INPUT_LINE_STATE.with(|c| c.get())
 }
 
 /// Set the inputs queue for `input`/`inputs` builtins.
 pub fn set_inputs_queue(values: Vec<Value>) {
-    unsafe {
-        let state = &mut *INPUTS_STATE.0.get();
+    INPUTS_STATE.with_borrow_mut(|state| {
         state.0 = values;
         state.1 = 0;
-    }
+    });
 }
 
 /// Clear the inputs queue.
 pub fn clear_inputs_queue() {
-    unsafe {
-        let state = &mut *INPUTS_STATE.0.get();
+    INPUTS_STATE.with_borrow_mut(|state| {
         state.0.clear();
         state.1 = 0;
-    }
+    });
 }
 
 /// Read the next input value. Returns None if exhausted.
 pub fn read_next_input() -> Option<Value> {
-    unsafe {
-        let state = &mut *INPUTS_STATE.0.get();
+    INPUTS_STATE.with_borrow_mut(|state| {
         if state.1 < state.0.len() {
             let idx = state.1;
             state.1 += 1;
@@ -72,7 +69,7 @@ pub fn read_next_input() -> Option<Value> {
         } else {
             None
         }
-    }
+    })
 }
 
 /// Typed error for label/break to avoid string formatting/parsing overhead.
@@ -2946,16 +2943,18 @@ pub fn eval(
         }
 
         Expr::Env => {
-            struct EnvCache(std::cell::UnsafeCell<Option<Value>>);
-            unsafe impl Sync for EnvCache {}
-            static ENV_CACHE: EnvCache = EnvCache(std::cell::UnsafeCell::new(None));
-            let cached = unsafe { &mut *ENV_CACHE.0.get() };
-            if cached.is_none() {
-                let mut obj = crate::value::new_objmap();
-                for (k, v) in std::env::vars() { obj.insert(KeyStr::from(k), Value::from_str(&v)); }
-                *cached = Some(Value::object_from_map(obj));
+            thread_local! {
+                static ENV_CACHE: RefCell<Option<Value>> = const { RefCell::new(None) };
             }
-            cb(cached.as_ref().unwrap().clone())
+            let env_value = ENV_CACHE.with_borrow_mut(|cached| {
+                if cached.is_none() {
+                    let mut obj = crate::value::new_objmap();
+                    for (k, v) in std::env::vars() { obj.insert(KeyStr::from(k), Value::from_str(&v)); }
+                    *cached = Some(Value::object_from_map(obj));
+                }
+                cached.as_ref().unwrap().clone()
+            });
+            cb(env_value)
         }
 
         Expr::Builtins => cb(crate::runtime::rt_builtins()),

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -11,13 +11,39 @@
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
+use std::sync::{Mutex, MutexGuard};
 
 use anyhow::{Result, bail};
+
+// Process-wide lock guarding the entire JIT path (compile + execute).
+//
+// jq-jit's JIT layer carries non-trivial mutable global state — the error
+// flag/value/message slots, the closure-ops vector, and the reusable JitEnv —
+// none of which are thread-safe. The codegen side embeds the address of
+// `JIT_ERROR_FLAG` directly into JIT'd machine code, so making these
+// thread-locals would require non-trivial codegen changes. Instead, every
+// `JitCompiler` instance acquires this lock for its full lifetime, which
+// transitively covers any `execute_jit*` call routed through that compiler.
+// Two threads that both want to JIT will serialize at `JitCompiler::new`.
+//
+// This is what previously hid behind `--test-threads=1` in CI: parallel test
+// runs were instantiating multiple `JitCompiler`s and racing on the globals,
+// which surfaced as intermittent SIGSEGVs. With the lock held the globals
+// behave as if jq-jit were truly single-threaded, regardless of how many
+// threads `cargo test` spawns.
+static JIT_GLOBAL_LOCK: Mutex<()> = Mutex::new(());
+
+fn jit_global_lock() -> MutexGuard<'static, ()> {
+    // Poison cannot corrupt JIT-allocated memory we care about: a panic
+    // mid-compile leaves the globals in a transient state that the next
+    // compiler reinitialises. Recover the guard rather than aborting.
+    JIT_GLOBAL_LOCK.lock().unwrap_or_else(|p| p.into_inner())
+}
 
 // Thread-local error storage for JIT runtime functions.
 // When a fallible runtime function encounters an error, it stores the error
 // message here. The CheckError JitOp checks this and branches to catch handlers.
-// Global statics — safe because jq-jit is single-threaded (uses Rc, not Arc).
+// Access is serialised by `JIT_GLOBAL_LOCK` (held by the live `JitCompiler`).
 struct GlobalCell<T>(std::cell::UnsafeCell<T>);
 unsafe impl<T> Sync for GlobalCell<T> {}
 
@@ -6755,19 +6781,21 @@ extern "C" fn jit_rt_call_builtin(dst: *mut Value, name_ptr: *const u8, name_len
             return 0;
         }
         if name == "__env__" {
-            // Cache env object — environment is constant during execution
-            struct EnvCache(std::cell::UnsafeCell<Option<Value>>);
-            unsafe impl Sync for EnvCache {}
-            static ENV_CACHE: EnvCache = EnvCache(std::cell::UnsafeCell::new(None));
-            let cached = &mut *ENV_CACHE.0.get();
-            if cached.is_none() {
-                let mut obj = crate::value::new_objmap();
-                for (k, v) in std::env::vars() {
-                    obj.insert(crate::value::KeyStr::from(k), Value::from_string(v));
-                }
-                *cached = Some(Value::object_from_map(obj));
+            // Cache env object — environment is constant during execution.
+            thread_local! {
+                static ENV_CACHE: RefCell<Option<Value>> = const { RefCell::new(None) };
             }
-            std::ptr::write(dst, cached.as_ref().unwrap().clone());
+            let env_value = ENV_CACHE.with_borrow_mut(|cached| {
+                if cached.is_none() {
+                    let mut obj = crate::value::new_objmap();
+                    for (k, v) in std::env::vars() {
+                        obj.insert(crate::value::KeyStr::from(k), Value::from_string(v));
+                    }
+                    *cached = Some(Value::object_from_map(obj));
+                }
+                cached.as_ref().unwrap().clone()
+            });
+            std::ptr::write(dst, env_value);
             return 0;
         }
         if name == "__each_error__" {
@@ -7804,6 +7832,13 @@ fn optimize_clone_yield(mut ops: Vec<JitOp>) -> Vec<JitOp> {
 }
 
 pub struct JitCompiler {
+    /// Held for the entire lifetime of this compiler so concurrent threads
+    /// cannot trample the JIT globals (`JIT_ERROR_FLAG`, `JIT_CLOSURE_OPS`,
+    /// `REUSABLE_ENV`, ...). Dropped automatically when the compiler is
+    /// dropped, after every JIT'd function pointer it owns has been
+    /// invalidated. Field order matters — `_lock` is first so it is released
+    /// last, after `module` has freed its mmap'd code pages.
+    _lock: MutexGuard<'static, ()>,
     module: JITModule,
     ctx: cranelift_codegen::Context,
     func_ctx: FunctionBuilderContext,
@@ -7821,6 +7856,9 @@ pub struct JitCompiler {
 
 impl JitCompiler {
     pub fn new() -> Result<Self> {
+        // Acquire the global lock before touching any cranelift or
+        // jq-jit JIT state. See `JIT_GLOBAL_LOCK` for rationale.
+        let _lock = jit_global_lock();
         let mut flag_builder = settings::builder();
         flag_builder.set("opt_level", "speed")?;
         let isa_builder = cranelift_native::builder().map_err(|e| anyhow::anyhow!("{}", e))?;
@@ -7914,6 +7952,7 @@ impl JitCompiler {
         declare_rt_funcs(&mut module, &mut rt_funcs)?;
 
         Ok(JitCompiler {
+            _lock,
             module, ctx: cranelift_codegen::Context::new(),
             func_ctx: FunctionBuilderContext::new(), rt_funcs,
             _string_constants: Vec::new(), _repr_constants: Vec::new(),

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2329,16 +2329,19 @@ impl RegexCache {
     }
 }
 
-// Global regex cache (safe: single-threaded)
-struct GlobalRegexCache(std::cell::UnsafeCell<Option<RegexCache>>);
-unsafe impl Sync for GlobalRegexCache {}
-static REGEX_CACHE: GlobalRegexCache = GlobalRegexCache(std::cell::UnsafeCell::new(None));
+// Per-thread regex cache. Each `cargo test` worker keeps its own cache so
+// parallel test runs cannot trample the LRU; the previous global cache was
+// the kind of thing `--test-threads=1` was hiding.
+thread_local! {
+    static REGEX_CACHE: std::cell::RefCell<Option<RegexCache>> = const { std::cell::RefCell::new(None) };
+}
 
 fn with_regex<R>(pattern: &str, f: impl FnOnce(&regex::Regex) -> R) -> Result<R> {
-    let cache = unsafe { &mut *REGEX_CACHE.0.get() };
-    let cache = cache.get_or_insert_with(RegexCache::new);
-    let re = cache.get(pattern)?;
-    Ok(f(re))
+    REGEX_CACHE.with_borrow_mut(|cache| {
+        let cache = cache.get_or_insert_with(RegexCache::new);
+        let re = cache.get(pattern)?;
+        Ok(f(re))
+    })
 }
 
 /// Iterate matches with jq/Oniguruma-style global semantics: after a

--- a/src/value.rs
+++ b/src/value.rs
@@ -2,6 +2,7 @@
 //!
 //! Uses Vec-backed ordered map for objects (optimal for typical small JSON objects).
 
+use std::cell::{RefCell, UnsafeCell};
 use std::fmt;
 use std::rc::Rc;
 
@@ -10,30 +11,39 @@ use anyhow::{Result, bail};
 /// Inline-optimized string for object keys (≤24 bytes stored on stack, no heap alloc).
 pub type KeyStr = compact_str::CompactString;
 
-// Global pool of Vec buffers for ObjMap reuse.
-// Safe because jq-jit is single-threaded (uses Rc, not Arc).
-struct ObjMapPool(std::cell::UnsafeCell<Vec<Vec<(KeyStr, Value)>>>);
-unsafe impl Sync for ObjMapPool {}
-
-static OBJMAP_POOL: ObjMapPool = ObjMapPool(std::cell::UnsafeCell::new(Vec::new()));
+// Per-thread pool of Vec buffers for ObjMap reuse. Each thread keeps its own
+// pool — `cargo test` may run multiple test threads concurrently, and a shared
+// global pool was racy (the previous implementation hid this behind
+// `--test-threads=1` in CI). Thread-locality also matches the runtime's
+// `Rc` / `!Send` discipline.
+//
+// The bare `UnsafeCell` (vs `RefCell`) is a deliberate hot-path optimisation:
+// pool ops are millions-per-bench and `RefCell::borrow_mut`'s flag check
+// shows up as a measurable regression on `field_access` / `array construct`.
+// Safety: each thread has its own cell, and the access patterns inside
+// `pool_get` / `pool_return` / `rc_objmap_pool_*` never re-enter the same
+// pool while a `&mut` is live (drops in `pool_return` only touch the
+// `RC_OBJMAP_POOL` via `pool_value`, which is a different cell).
+thread_local! {
+    static OBJMAP_POOL: UnsafeCell<Vec<Vec<(KeyStr, Value)>>> = const { UnsafeCell::new(Vec::new()) };
+}
 
 const OBJMAP_POOL_MAX: usize = 64;
 
-// Global pool of Rc<ObjMap> to avoid repeated Rc alloc/dealloc.
+// Per-thread pool of Rc<ObjMap> to avoid repeated Rc alloc/dealloc.
 // When an Rc<ObjMap> with refcount=1 is dropped, we clear entries and pool the Rc.
 // On next alloc, we reuse the Rc memory instead of calling malloc.
-struct RcObjMapPool(std::cell::UnsafeCell<Vec<*const ObjMap>>);
-unsafe impl Sync for RcObjMapPool {}
-
-static RC_OBJMAP_POOL: RcObjMapPool = RcObjMapPool(std::cell::UnsafeCell::new(Vec::new()));
+thread_local! {
+    static RC_OBJMAP_POOL: UnsafeCell<Vec<*const ObjMap>> = const { UnsafeCell::new(Vec::new()) };
+}
 
 const RC_OBJMAP_POOL_MAX: usize = 32;
 
 /// Try to recycle an Rc<ObjMap> instead of allocating a new one.
 #[inline]
 pub fn rc_objmap_pool_get(cap: usize) -> Rc<ObjMap> {
-    let pool = unsafe { &mut *RC_OBJMAP_POOL.0.get() };
-    if let Some(raw) = pool.pop() {
+    let popped = RC_OBJMAP_POOL.with(|cell| unsafe { (*cell.get()).pop() });
+    if let Some(raw) = popped {
         // Safety: raw was produced by Rc::into_raw and has refcount=1
         let mut rc = unsafe { Rc::from_raw(raw) };
         let map = Rc::get_mut(&mut rc).unwrap();
@@ -52,8 +62,7 @@ pub fn rc_objmap_pool_return(mut rc: Rc<ObjMap>) -> bool {
     if Rc::strong_count(&rc) != 1 {
         return false;
     }
-    let pool = unsafe { &mut *RC_OBJMAP_POOL.0.get() };
-    if pool.len() >= RC_OBJMAP_POOL_MAX {
+    if RC_OBJMAP_POOL.with(|cell| unsafe { (*cell.get()).len() }) >= RC_OBJMAP_POOL_MAX {
         return false;
     }
     // Clear entries and pool the Vec buffer
@@ -62,19 +71,21 @@ pub fn rc_objmap_pool_return(mut rc: Rc<ObjMap>) -> bool {
     pool_return(old_entries);
     // Pool the Rc itself (prevents deallocation)
     let raw = Rc::into_raw(rc);
-    pool.push(raw);
+    RC_OBJMAP_POOL.with(|cell| unsafe { (*cell.get()).push(raw) });
     true
 }
 
 #[inline]
 fn pool_get(cap: usize) -> Vec<(KeyStr, Value)> {
-    let pool = unsafe { &mut *OBJMAP_POOL.0.get() };
-    if let Some(v) = pool.pop() {
-        if v.capacity() >= cap {
-            return v;
+    OBJMAP_POOL.with(|cell| {
+        let pool = unsafe { &mut *cell.get() };
+        if let Some(v) = pool.pop() {
+            if v.capacity() >= cap {
+                return v;
+            }
         }
-    }
-    Vec::with_capacity(cap)
+        Vec::with_capacity(cap)
+    })
 }
 
 #[inline]
@@ -94,10 +105,12 @@ fn pool_return(mut v: Vec<(KeyStr, Value)>) {
     } else {
         v.clear();
     }
-    let pool = unsafe { &mut *OBJMAP_POOL.0.get() };
-    if pool.len() < OBJMAP_POOL_MAX {
-        pool.push(v);
-    }
+    OBJMAP_POOL.with(|cell| {
+        let pool = unsafe { &mut *cell.get() };
+        if pool.len() < OBJMAP_POOL_MAX {
+            pool.push(v);
+        }
+    });
 }
 
 /// Recycle Rc<ObjMap> from a consumed Value to avoid repeated alloc/dealloc.
@@ -5222,10 +5235,11 @@ fn write_jq_number(w: &mut dyn io::Write, n: f64) -> io::Result<()> {
     write!(w, "{}", n)
 }
 
-// Reusable String buffer for pretty-print output.
-struct PrettyBuf(std::cell::UnsafeCell<String>);
-unsafe impl Sync for PrettyBuf {}
-static PRETTY_BUF: PrettyBuf = PrettyBuf(std::cell::UnsafeCell::new(String::new()));
+// Reusable String buffer for pretty-print output. Per-thread to keep
+// `cargo test` parallel runs honest — see OBJMAP_POOL.
+thread_local! {
+    static PRETTY_BUF: RefCell<String> = const { RefCell::new(String::new()) };
+}
 
 /// Write a Value as pretty JSON + newline, directly to writer.
 /// For scalar values and small containers, uses stack buffer to avoid String allocation.
@@ -5252,12 +5266,13 @@ pub fn write_value_pretty_line_color(w: &mut dyn io::Write, v: &Value, indent: u
             _ => {}
         }
     }
-    // Reuse a global String buffer to avoid per-value allocation
-    let out = unsafe { &mut *PRETTY_BUF.0.get() };
-    out.clear();
-    write_pretty_to_string(out, v, 0, indent, use_tab, sort_keys, color);
-    w.write_all(out.as_bytes())?;
-    w.write_all(b"\n")
+    // Reuse a per-thread String buffer to avoid per-value allocation
+    PRETTY_BUF.with_borrow_mut(|out| {
+        out.clear();
+        write_pretty_to_string(out, v, 0, indent, use_tab, sort_keys, color);
+        w.write_all(out.as_bytes())?;
+        w.write_all(b"\n")
+    })
 }
 
 /// Write a Value as compact JSON directly to an io::Write, using precise repr when available.


### PR DESCRIPTION
## Summary

- `JitCompiler` now holds a process-wide `Mutex<()>` for its full lifetime, serialising every call into the JIT-specific globals (`JIT_ERROR_FLAG`, `JIT_CLOSURE_OPS`, `REUSABLE_ENV`, the JIT error slots) without changing cranelift codegen.
- The non-JIT mutable globals (`OBJMAP_POOL`, `RC_OBJMAP_POOL`, `PRETTY_BUF`, `REGEX_CACHE`, the `inputs` queue, `input_line_number`, the `env` cache) move to `thread_local!`. The hot pools keep a bare `UnsafeCell` discipline (per-thread cell) so `RefCell::borrow_mut`'s flag check doesn't show up on `field_access` / `array construct` benches.
- Both CI workflows drop `--test-threads=1` since the underlying race is gone.

## Why

`--test-threads=1` was hiding intermittent SIGSEGVs: parallel test workers were instantiating multiple `JitCompiler`s and racing on the JIT globals (and several non-JIT pools), which manifested on macOS as exit code 133 (`EXC_BAD_ACCESS` / SIGTRAP). The "safe because jq-jit is single-threaded" comment was true for the CLI but never true for `cargo test`'s default thread pool.

## Test plan

- [x] `cargo build --release` — zero warnings
- [x] `cargo test --release` (no thread cap) — passes 3/3 runs
- [x] `tests/fast_path_contract.rs --test-threads=11` — 0/100 failures (was ~3/30 before)
- [x] lib unit tests `--test-threads=3` — 0/50 failures
- [x] `bench/comprehensive.sh --quick` deltas vs. main are within noise (~±5%), no systematic regression

## Follow-up

A cleaner alternative — moving `JIT_ERROR_FLAG` into `JitEnv` so cranelift codegen reads via `env_ptr + offset` instead of the embedded static address, then converting the remaining JIT globals to `thread_local!` and dropping the `JitCompiler` mutex — is tracked separately. The current change is intentionally minimal so the diff stays focused on unblocking parallel test runs.

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)