### PR TITLE
fix: bug sweep continuation (12 fixes)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -866,7 +866,7 @@ fn emit_remap_value(
             let idx = field_idx[f.as_str()];
             let (vs, ve) = ranges[idx];
             if let Some(a) = parse_json_num(&raw[vs..ve]) {
-                let r = match op { BinOp::Add => a + n, BinOp::Sub => a - n, BinOp::Mul => a * n, BinOp::Div => a / n, BinOp::Mod => a % n, _ => unreachable!() };
+                let r = match op { BinOp::Add => a + n, BinOp::Sub => a - n, BinOp::Mul => a * n, BinOp::Div => a / n, BinOp::Mod => jq_jit::runtime::jq_mod_f64(a, n).unwrap_or(f64::NAN), _ => unreachable!() };
                 push_jq_number_bytes(buf, r);
             } else { buf.extend_from_slice(b"null"); }
         }
@@ -876,7 +876,7 @@ fn emit_remap_value(
             let (vs1, ve1) = ranges[idx1];
             let (vs2, ve2) = ranges[idx2];
             if let (Some(a), Some(b)) = (parse_json_num(&raw[vs1..ve1]), parse_json_num(&raw[vs2..ve2])) {
-                let r = match op { BinOp::Add => a + b, BinOp::Sub => a - b, BinOp::Mul => a * b, BinOp::Div => a / b, BinOp::Mod => a % b, _ => unreachable!() };
+                let r = match op { BinOp::Add => a + b, BinOp::Sub => a - b, BinOp::Mul => a * b, BinOp::Div => a / b, BinOp::Mod => jq_jit::runtime::jq_mod_f64(a, b).unwrap_or(f64::NAN), _ => unreachable!() };
                 push_jq_number_bytes(buf, r);
             } else if matches!(op, BinOp::Add) && raw[vs1] == b'"' && raw[vs2] == b'"' {
                 // String concatenation: "hello" + "world" → "helloworld"
@@ -890,7 +890,7 @@ fn emit_remap_value(
             let idx = field_idx[f.as_str()];
             let (vs, ve) = ranges[idx];
             if let Some(b) = parse_json_num(&raw[vs..ve]) {
-                let r = match op { BinOp::Add => n + b, BinOp::Sub => n - b, BinOp::Mul => n * b, BinOp::Div => n / b, BinOp::Mod => n % b, _ => unreachable!() };
+                let r = match op { BinOp::Add => n + b, BinOp::Sub => n - b, BinOp::Mul => n * b, BinOp::Div => n / b, BinOp::Mod => jq_jit::runtime::jq_mod_f64(n, b).unwrap_or(f64::NAN), _ => unreachable!() };
                 push_jq_number_bytes(buf, r);
             } else { buf.extend_from_slice(b"null"); }
         }
@@ -932,7 +932,7 @@ fn emit_remap_value(
             let idx = field_idx[f.as_str()];
             let (vs, ve) = ranges[idx];
             if let Some(a) = parse_json_num(&raw[vs..ve]) {
-                let r = match op { BinOp::Add => a + n, BinOp::Sub => a - n, BinOp::Mul => a * n, BinOp::Div => a / n, BinOp::Mod => a % n, _ => unreachable!() };
+                let r = match op { BinOp::Add => a + n, BinOp::Sub => a - n, BinOp::Mul => a * n, BinOp::Div => a / n, BinOp::Mod => jq_jit::runtime::jq_mod_f64(a, n).unwrap_or(f64::NAN), _ => unreachable!() };
                 buf.push(b'"');
                 push_jq_number_bytes(buf, r);
                 buf.push(b'"');
@@ -993,7 +993,7 @@ fn emit_remap_value(
             let (vs1, ve1) = ranges[idx1];
             let (vs2, ve2) = ranges[idx2];
             if let (Some(a), Some(b)) = (parse_json_num(&raw[vs1..ve1]), parse_json_num(&raw[vs2..ve2])) {
-                let r = match op { BinOp::Add => a + b, BinOp::Sub => a - b, BinOp::Mul => a * b, BinOp::Div => a / b, BinOp::Mod => a % b, _ => unreachable!() };
+                let r = match op { BinOp::Add => a + b, BinOp::Sub => a - b, BinOp::Mul => a * b, BinOp::Div => a / b, BinOp::Mod => jq_jit::runtime::jq_mod_f64(a, b).unwrap_or(f64::NAN), _ => unreachable!() };
                 buf.push(b'"');
                 push_jq_number_bytes(buf, r);
                 buf.push(b'"');
@@ -1093,7 +1093,7 @@ fn eval_arith_raw_unresolved(
                 BinOp::Sub => l - r,
                 BinOp::Mul => l * r,
                 BinOp::Div => l / r,
-                BinOp::Mod => l % r,
+                BinOp::Mod => jq_jit::runtime::jq_mod_f64(l, r).unwrap_or(f64::NAN),
                 _ => return None,
             })
         }
@@ -1189,7 +1189,7 @@ fn emit_resolved_value(
         ResolvedRemap::FieldOpConst(idx, ref op, n) => {
             let (vs, ve) = ranges[idx];
             if let Some(a) = parse_json_num(&raw[vs..ve]) {
-                let r = match op { BinOp::Add => a + n, BinOp::Sub => a - n, BinOp::Mul => a * n, BinOp::Div => a / n, BinOp::Mod => a % n, _ => unreachable!() };
+                let r = match op { BinOp::Add => a + n, BinOp::Sub => a - n, BinOp::Mul => a * n, BinOp::Div => a / n, BinOp::Mod => jq_jit::runtime::jq_mod_f64(a, n).unwrap_or(f64::NAN), _ => unreachable!() };
                 push_jq_number_bytes(buf, r);
             } else { buf.extend_from_slice(b"null"); }
         }
@@ -1197,7 +1197,7 @@ fn emit_resolved_value(
             let (vs1, ve1) = ranges[idx1];
             let (vs2, ve2) = ranges[idx2];
             if let (Some(a), Some(b)) = (parse_json_num(&raw[vs1..ve1]), parse_json_num(&raw[vs2..ve2])) {
-                let r = match op { BinOp::Add => a + b, BinOp::Sub => a - b, BinOp::Mul => a * b, BinOp::Div => a / b, BinOp::Mod => a % b, _ => unreachable!() };
+                let r = match op { BinOp::Add => a + b, BinOp::Sub => a - b, BinOp::Mul => a * b, BinOp::Div => a / b, BinOp::Mod => jq_jit::runtime::jq_mod_f64(a, b).unwrap_or(f64::NAN), _ => unreachable!() };
                 push_jq_number_bytes(buf, r);
             } else if matches!(op, BinOp::Add) && raw[vs1] == b'"' && raw[vs2] == b'"' {
                 buf.push(b'"');
@@ -1209,7 +1209,7 @@ fn emit_resolved_value(
         ResolvedRemap::ConstOpField(n, ref op, idx) => {
             let (vs, ve) = ranges[idx];
             if let Some(b) = parse_json_num(&raw[vs..ve]) {
-                let r = match op { BinOp::Add => n + b, BinOp::Sub => n - b, BinOp::Mul => n * b, BinOp::Div => n / b, BinOp::Mod => n % b, _ => unreachable!() };
+                let r = match op { BinOp::Add => n + b, BinOp::Sub => n - b, BinOp::Mul => n * b, BinOp::Div => n / b, BinOp::Mod => jq_jit::runtime::jq_mod_f64(n, b).unwrap_or(f64::NAN), _ => unreachable!() };
                 push_jq_number_bytes(buf, r);
             } else { buf.extend_from_slice(b"null"); }
         }
@@ -1244,7 +1244,7 @@ fn emit_resolved_value(
         ResolvedRemap::FieldOpConstToString(idx, ref op, n) => {
             let (vs, ve) = ranges[idx];
             if let Some(a) = parse_json_num(&raw[vs..ve]) {
-                let r = match op { BinOp::Add => a + n, BinOp::Sub => a - n, BinOp::Mul => a * n, BinOp::Div => a / n, BinOp::Mod => a % n, _ => unreachable!() };
+                let r = match op { BinOp::Add => a + n, BinOp::Sub => a - n, BinOp::Mul => a * n, BinOp::Div => a / n, BinOp::Mod => jq_jit::runtime::jq_mod_f64(a, n).unwrap_or(f64::NAN), _ => unreachable!() };
                 buf.push(b'"');
                 push_jq_number_bytes(buf, r);
                 buf.push(b'"');
@@ -1404,7 +1404,7 @@ fn emit_resolved_value(
                                     jq_jit::ir::BinOp::Sub => val - n,
                                     jq_jit::ir::BinOp::Mul => val * n,
                                     jq_jit::ir::BinOp::Div => val / n,
-                                    jq_jit::ir::BinOp::Mod => val % n,
+                                    jq_jit::ir::BinOp::Mod => jq_jit::runtime::jq_mod_f64(val, n).unwrap_or(f64::NAN),
                                     _ => val,
                                 };
                             }
@@ -1439,7 +1439,7 @@ fn emit_resolved_value(
                                         jq_jit::ir::BinOp::Sub => val - n,
                                         jq_jit::ir::BinOp::Mul => val * n,
                                         jq_jit::ir::BinOp::Div => val / n,
-                                        jq_jit::ir::BinOp::Mod => val % n,
+                                        jq_jit::ir::BinOp::Mod => jq_jit::runtime::jq_mod_f64(val, n).unwrap_or(f64::NAN),
                                         _ => val,
                                     };
                                 }
@@ -1618,7 +1618,7 @@ fn emit_resolved_value(
             let (vs1, ve1) = ranges[idx1];
             let (vs2, ve2) = ranges[idx2];
             if let (Some(a), Some(b)) = (parse_json_num(&raw[vs1..ve1]), parse_json_num(&raw[vs2..ve2])) {
-                let r = match op { BinOp::Add => a + b, BinOp::Sub => a - b, BinOp::Mul => a * b, BinOp::Div => a / b, BinOp::Mod => a % b, _ => unreachable!() };
+                let r = match op { BinOp::Add => a + b, BinOp::Sub => a - b, BinOp::Mul => a * b, BinOp::Div => a / b, BinOp::Mod => jq_jit::runtime::jq_mod_f64(a, b).unwrap_or(f64::NAN), _ => unreachable!() };
                 buf.push(b'"');
                 push_jq_number_bytes(buf, r);
                 buf.push(b'"');
@@ -1765,7 +1765,7 @@ fn emit_resolved_value(
                                     jq_jit::ir::BinOp::Sub => v - n,
                                     jq_jit::ir::BinOp::Mul => v * n,
                                     jq_jit::ir::BinOp::Div => v / n,
-                                    jq_jit::ir::BinOp::Mod => { let r = v % n; if r.is_finite() { r } else { f64::NAN } },
+                                    jq_jit::ir::BinOp::Mod => jq_jit::runtime::jq_mod_f64(v, n).unwrap_or(f64::NAN),
                                     _ => v,
                                 };
                             }
@@ -1846,7 +1846,7 @@ fn eval_arith_raw(
                 BinOp::Sub => l - r,
                 BinOp::Mul => l * r,
                 BinOp::Div => l / r,
-                BinOp::Mod => l % r,
+                BinOp::Mod => jq_jit::runtime::jq_mod_f64(l, r).unwrap_or(f64::NAN),
                 _ => return None,
             })
         }
@@ -4144,7 +4144,7 @@ fn real_main() {
                                         v = match aop {
                                             BinOp::Add => v + n, BinOp::Sub => v - n,
                                             BinOp::Mul => v * n, BinOp::Div => v / n,
-                                            BinOp::Mod => { let r = v % n; if r.is_finite() { r } else { v } },
+                                            BinOp::Mod => jq_jit::runtime::jq_mod_f64(v, n).unwrap_or(v),
                                             _ => v,
                                         };
                                     }
@@ -5789,7 +5789,7 @@ fn real_main() {
                                 BinOp::Sub => a - b,
                                 BinOp::Mul => a * b,
                                 BinOp::Div => a / b,
-                                BinOp::Mod => a % b,
+                                BinOp::Mod => jq_jit::runtime::jq_mod_f64(a, b).unwrap_or(f64::NAN),
                                 _ => unreachable!(),
                             };
                             if result.is_finite() {
@@ -5818,13 +5818,13 @@ fn real_main() {
                             let inner = match op1 {
                                 BinOp::Add => a + b, BinOp::Sub => a - b,
                                 BinOp::Mul => a * b, BinOp::Div => a / b,
-                                BinOp::Mod => { let r = a % b; if r.is_finite() { r } else { f64::NAN } },
+                                BinOp::Mod => jq_jit::runtime::jq_mod_f64(a, b).unwrap_or(f64::NAN),
                                 _ => unreachable!(),
                             };
                             let result = match op2 {
                                 BinOp::Add => inner + const_val, BinOp::Sub => inner - const_val,
                                 BinOp::Mul => inner * const_val, BinOp::Div => inner / const_val,
-                                BinOp::Mod => { let r = inner % const_val; if r.is_finite() { r } else { f64::NAN } },
+                                BinOp::Mod => jq_jit::runtime::jq_mod_f64(inner, const_val).unwrap_or(f64::NAN),
                                 _ => unreachable!(),
                             };
                             if result.is_finite() {
@@ -5854,7 +5854,7 @@ fn real_main() {
                                 BinOp::Sub => a - b,
                                 BinOp::Mul => a * b,
                                 BinOp::Div => a / b,
-                                BinOp::Mod => a % b,
+                                BinOp::Mod => jq_jit::runtime::jq_mod_f64(a, b).unwrap_or(f64::NAN),
                                 _ => unreachable!(),
                             };
                             if result.is_finite() {
@@ -6079,7 +6079,7 @@ fn real_main() {
                                     BinOp::Sub => v - c,
                                     BinOp::Mul => v * c,
                                     BinOp::Div => v / c,
-                                    BinOp::Mod => { if c.is_finite() && *c != 0.0 { v % c } else { f64::NAN } }
+                                    BinOp::Mod => jq_jit::runtime::jq_mod_f64(v, *c).unwrap_or(f64::NAN),
                                     _ => v,
                                 };
                             }
@@ -6107,7 +6107,7 @@ fn real_main() {
                                 BinOp::Sub => a - b,
                                 BinOp::Mul => a * b,
                                 BinOp::Div => a / b,
-                                BinOp::Mod => a % b,
+                                BinOp::Mod => jq_jit::runtime::jq_mod_f64(a, b).unwrap_or(f64::NAN),
                                 _ => unreachable!(),
                             };
                             let result = if let Some(uop) = uop_opt {
@@ -6143,7 +6143,7 @@ fn real_main() {
                                     BinOp::Sub => result - c,
                                     BinOp::Mul => result * c,
                                     BinOp::Div => result / c,
-                                    BinOp::Mod => result % c,
+                                    BinOp::Mod => jq_jit::runtime::jq_mod_f64(result, c).unwrap_or(f64::NAN),
                                     _ => unreachable!(),
                                 };
                             }
@@ -6172,7 +6172,7 @@ fn real_main() {
                                     BinOp::Sub => result - c,
                                     BinOp::Mul => result * c,
                                     BinOp::Div => result / c,
-                                    BinOp::Mod => result % c,
+                                    BinOp::Mod => jq_jit::runtime::jq_mod_f64(result, c).unwrap_or(f64::NAN),
                                     _ => unreachable!(),
                                 };
                             }
@@ -7182,12 +7182,7 @@ fn real_main() {
                                             jq_jit::ir::BinOp::Sub => n - c,
                                             jq_jit::ir::BinOp::Mul => n * c,
                                             jq_jit::ir::BinOp::Div => n / c,
-                                            jq_jit::ir::BinOp::Mod => {
-                                                if n.fract() == 0.0 && c.fract() == 0.0 && *c != 0.0 {
-                                                    let a = n as i64; let b = *c as i64;
-                                                    if a == i64::MIN && b == -1 { 0.0 } else { (a % b) as f64 }
-                                                } else { n % c }
-                                            }
+                                            jq_jit::ir::BinOp::Mod => jq_jit::runtime::jq_mod_f64(n, *c).unwrap_or(f64::NAN),
                                             _ => n,
                                         };
                                     }
@@ -7540,7 +7535,7 @@ fn real_main() {
                                                         jq_jit::ir::BinOp::Sub => v - n,
                                                         jq_jit::ir::BinOp::Mul => v * n,
                                                         jq_jit::ir::BinOp::Div => v / n,
-                                                        jq_jit::ir::BinOp::Mod => { let r = v % n; if r.is_finite() { r } else { f64::NAN } },
+                                                        jq_jit::ir::BinOp::Mod => jq_jit::runtime::jq_mod_f64(v, n).unwrap_or(f64::NAN),
                                                         _ => v,
                                                     };
                                                 }
@@ -7635,7 +7630,7 @@ fn real_main() {
                                 val = match aop {
                                     BinOp::Add => val + n, BinOp::Sub => val - n,
                                     BinOp::Mul => val * n, BinOp::Div => val / n,
-                                    BinOp::Mod => val % n, _ => val,
+                                    BinOp::Mod => jq_jit::runtime::jq_mod_f64(val, n).unwrap_or(f64::NAN), _ => val,
                                 };
                             }
                             let pass = match cmp_op {
@@ -8498,7 +8493,7 @@ fn real_main() {
                                                 val = match aop {
                                                     BinOp::Add => val + n, BinOp::Sub => val - n,
                                                     BinOp::Mul => val * n, BinOp::Div => val / n,
-                                                    BinOp::Mod => val % n, _ => val,
+                                                    BinOp::Mod => jq_jit::runtime::jq_mod_f64(val, n).unwrap_or(f64::NAN), _ => val,
                                                 };
                                             }
                                             let rhs = match &br.cond_rhs { CondRhs::Const(n) => *n, _ => unreachable!() };
@@ -8525,7 +8520,7 @@ fn real_main() {
                                                 val = match aop {
                                                     BinOp::Add => val + n, BinOp::Sub => val - n,
                                                     BinOp::Mul => val * n, BinOp::Div => val / n,
-                                                    BinOp::Mod => val % n, _ => val,
+                                                    BinOp::Mod => jq_jit::runtime::jq_mod_f64(val, n).unwrap_or(f64::NAN), _ => val,
                                                 };
                                             }
                                             Some(match br.cond_op {
@@ -8649,7 +8644,7 @@ fn real_main() {
                                 val = match aop {
                                     BinOp::Add => val + n, BinOp::Sub => val - n,
                                     BinOp::Mul => val * n, BinOp::Div => val / n,
-                                    BinOp::Mod => val % n, _ => val,
+                                    BinOp::Mod => jq_jit::runtime::jq_mod_f64(val, n).unwrap_or(f64::NAN), _ => val,
                                 };
                             }
                             let pass = match cmp_op {
@@ -9897,7 +9892,7 @@ fn real_main() {
                                                     v = match op {
                                                         BinOp::Add => v + n, BinOp::Sub => v - n,
                                                         BinOp::Mul => v * n, BinOp::Div => v / n,
-                                                        BinOp::Mod => { let r = v % n; if r.is_finite() { r } else { f64::NAN } },
+                                                        BinOp::Mod => jq_jit::runtime::jq_mod_f64(v, n).unwrap_or(f64::NAN),
                                                         _ => v,
                                                     };
                                                 }
@@ -9971,7 +9966,7 @@ fn real_main() {
                                 val = match aop {
                                     BinOp::Add => val + n, BinOp::Sub => val - n,
                                     BinOp::Mul => val * n, BinOp::Div => val / n,
-                                    BinOp::Mod => val % n, _ => val,
+                                    BinOp::Mod => jq_jit::runtime::jq_mod_f64(val, n).unwrap_or(f64::NAN), _ => val,
                                 };
                             }
                             let pass = match cmp_op {
@@ -10403,7 +10398,7 @@ fn real_main() {
                                 val = match aop {
                                     BinOp::Add => val + n, BinOp::Sub => val - n,
                                     BinOp::Mul => val * n, BinOp::Div => val / n,
-                                    BinOp::Mod => if n.is_finite() && *n != 0.0 { val % n } else { val },
+                                    BinOp::Mod => jq_jit::runtime::jq_mod_f64(val, n).unwrap_or(val),
                                     _ => val,
                                 };
                             }
@@ -10479,7 +10474,7 @@ fn real_main() {
                                     };
                                     if pass {
                                         if let RemapExpr::FieldOpConst(_, op, n) = out_rexpr {
-                                            let r = match op { BinOp::Add => val + n, BinOp::Sub => val - n, BinOp::Mul => val * n, BinOp::Div => val / n, BinOp::Mod => val % n, _ => unreachable!() };
+                                            let r = match op { BinOp::Add => val + n, BinOp::Sub => val - n, BinOp::Mul => val * n, BinOp::Div => val / n, BinOp::Mod => jq_jit::runtime::jq_mod_f64(val, n).unwrap_or(f64::NAN), _ => unreachable!() };
                                             push_jq_number_bytes(&mut compact_buf, r);
                                         }
                                         compact_buf.push(b'\n');
@@ -10641,7 +10636,7 @@ fn real_main() {
                                                             jq_jit::ir::BinOp::Sub => v - n,
                                                             jq_jit::ir::BinOp::Mul => v * n,
                                                             jq_jit::ir::BinOp::Div => v / n,
-                                                            jq_jit::ir::BinOp::Mod => { let r = v % n; if r.is_finite() { r } else { f64::NAN } },
+                                                            jq_jit::ir::BinOp::Mod => jq_jit::runtime::jq_mod_f64(v, n).unwrap_or(f64::NAN),
                                                             _ => v,
                                                         };
                                                     }
@@ -11330,7 +11325,7 @@ fn real_main() {
                                                     v = match op {
                                                         jq_jit::ir::BinOp::Add => v + n, jq_jit::ir::BinOp::Sub => v - n,
                                                         jq_jit::ir::BinOp::Mul => v * n, jq_jit::ir::BinOp::Div => v / n,
-                                                        jq_jit::ir::BinOp::Mod => { let r = v % n; if r.is_finite() { r } else { f64::NAN } },
+                                                        jq_jit::ir::BinOp::Mod => jq_jit::runtime::jq_mod_f64(v, n).unwrap_or(f64::NAN),
                                                         _ => v,
                                                     };
                                                 }
@@ -12098,7 +12093,7 @@ fn real_main() {
                                     BinOp::Sub => v - arith_n,
                                     BinOp::Mul => v * arith_n,
                                     BinOp::Div => v / arith_n,
-                                    BinOp::Mod => { let r = v % arith_n; if r.is_finite() { r } else { all_ok = false; return; } },
+                                    BinOp::Mod => match jq_jit::runtime::jq_mod_f64(v, arith_n) { Some(r) => r, None => { all_ok = false; return; } },
                                     _ => { all_ok = false; return; }
                                 };
                                 if !first_elem { compact_buf.push(b','); }
@@ -13942,7 +13937,7 @@ fn real_main() {
                                     v = match aop {
                                         BinOp::Add => v + n, BinOp::Sub => v - n,
                                         BinOp::Mul => v * n, BinOp::Div => v / n,
-                                        BinOp::Mod => { let r = v % n; if r.is_finite() { r } else { v } },
+                                        BinOp::Mod => jq_jit::runtime::jq_mod_f64(v, n).unwrap_or(v),
                                         _ => v,
                                     };
                                 }
@@ -15398,7 +15393,7 @@ fn real_main() {
                             val = match aop {
                                 BinOp::Add => val + n, BinOp::Sub => val - n,
                                 BinOp::Mul => val * n, BinOp::Div => val / n,
-                                BinOp::Mod => val % n, _ => val,
+                                BinOp::Mod => jq_jit::runtime::jq_mod_f64(val, n).unwrap_or(f64::NAN), _ => val,
                             };
                         }
                         let pass = match cmp_op {
@@ -16185,7 +16180,7 @@ fn real_main() {
                                             val = match aop {
                                                 BinOp::Add => val + n, BinOp::Sub => val - n,
                                                 BinOp::Mul => val * n, BinOp::Div => val / n,
-                                                BinOp::Mod => val % n, _ => val,
+                                                BinOp::Mod => jq_jit::runtime::jq_mod_f64(val, n).unwrap_or(f64::NAN), _ => val,
                                             };
                                         }
                                         let rhs = match &br.cond_rhs { CondRhs::Const(n) => *n, _ => unreachable!() };
@@ -16212,7 +16207,7 @@ fn real_main() {
                                             val = match aop {
                                                 BinOp::Add => val + n, BinOp::Sub => val - n,
                                                 BinOp::Mul => val * n, BinOp::Div => val / n,
-                                                BinOp::Mod => val % n, _ => val,
+                                                BinOp::Mod => jq_jit::runtime::jq_mod_f64(val, n).unwrap_or(f64::NAN), _ => val,
                                             };
                                         }
                                         Some(match br.cond_op {
@@ -16332,7 +16327,7 @@ fn real_main() {
                             val = match aop {
                                 BinOp::Add => val + n, BinOp::Sub => val - n,
                                 BinOp::Mul => val * n, BinOp::Div => val / n,
-                                BinOp::Mod => val % n, _ => val,
+                                BinOp::Mod => jq_jit::runtime::jq_mod_f64(val, n).unwrap_or(f64::NAN), _ => val,
                             };
                         }
                         let pass = match cmp_op {
@@ -17539,7 +17534,7 @@ fn real_main() {
                                                 v = match op {
                                                     BinOp::Add => v + n, BinOp::Sub => v - n,
                                                     BinOp::Mul => v * n, BinOp::Div => v / n,
-                                                    BinOp::Mod => { let r = v % n; if r.is_finite() { r } else { f64::NAN } },
+                                                    BinOp::Mod => jq_jit::runtime::jq_mod_f64(v, n).unwrap_or(f64::NAN),
                                                     _ => v,
                                                 };
                                             }
@@ -17616,7 +17611,7 @@ fn real_main() {
                             val = match aop {
                                 BinOp::Add => val + n, BinOp::Sub => val - n,
                                 BinOp::Mul => val * n, BinOp::Div => val / n,
-                                BinOp::Mod => val % n, _ => val,
+                                BinOp::Mod => jq_jit::runtime::jq_mod_f64(val, n).unwrap_or(f64::NAN), _ => val,
                             };
                         }
                         let pass = match cmp_op {
@@ -18036,7 +18031,7 @@ fn real_main() {
                             val = match aop {
                                 BinOp::Add => val + n, BinOp::Sub => val - n,
                                 BinOp::Mul => val * n, BinOp::Div => val / n,
-                                BinOp::Mod => if n.is_finite() && *n != 0.0 { val % n } else { val },
+                                BinOp::Mod => jq_jit::runtime::jq_mod_f64(val, n).unwrap_or(val),
                                 _ => val,
                             };
                         }
@@ -18107,7 +18102,7 @@ fn real_main() {
                                 };
                                 if pass {
                                     if let RemapExpr::FieldOpConst(_, op, n) = out_rexpr {
-                                        let r = match op { BinOp::Add => val + n, BinOp::Sub => val - n, BinOp::Mul => val * n, BinOp::Div => val / n, BinOp::Mod => val % n, _ => unreachable!() };
+                                        let r = match op { BinOp::Add => val + n, BinOp::Sub => val - n, BinOp::Mul => val * n, BinOp::Div => val / n, BinOp::Mod => jq_jit::runtime::jq_mod_f64(val, n).unwrap_or(f64::NAN), _ => unreachable!() };
                                         push_jq_number_bytes(&mut compact_buf, r);
                                     }
                                     compact_buf.push(b'\n');
@@ -18262,7 +18257,7 @@ fn real_main() {
                                                         jq_jit::ir::BinOp::Sub => v - n,
                                                         jq_jit::ir::BinOp::Mul => v * n,
                                                         jq_jit::ir::BinOp::Div => v / n,
-                                                        jq_jit::ir::BinOp::Mod => { let r = v % n; if r.is_finite() { r } else { f64::NAN } },
+                                                        jq_jit::ir::BinOp::Mod => jq_jit::runtime::jq_mod_f64(v, n).unwrap_or(f64::NAN),
                                                         _ => v,
                                                     };
                                                 }
@@ -18930,7 +18925,7 @@ fn real_main() {
                                                 v = match op {
                                                     jq_jit::ir::BinOp::Add => v + n, jq_jit::ir::BinOp::Sub => v - n,
                                                     jq_jit::ir::BinOp::Mul => v * n, jq_jit::ir::BinOp::Div => v / n,
-                                                    jq_jit::ir::BinOp::Mod => { let r = v % n; if r.is_finite() { r } else { f64::NAN } },
+                                                    jq_jit::ir::BinOp::Mod => jq_jit::runtime::jq_mod_f64(v, n).unwrap_or(f64::NAN),
                                                     _ => v,
                                                 };
                                             }
@@ -19233,7 +19228,7 @@ fn real_main() {
                             BinOp::Sub => a - b,
                             BinOp::Mul => a * b,
                             BinOp::Div => if b == 0.0 { f64::NAN } else { a / b },
-                            BinOp::Mod => { let r = a % b; if r.is_finite() { r } else { f64::NAN } },
+                            BinOp::Mod => jq_jit::runtime::jq_mod_f64(a, b).unwrap_or(f64::NAN),
                             _ => unreachable!(),
                         };
                         if result.is_nan() {
@@ -19262,13 +19257,13 @@ fn real_main() {
                         let inner = match op1 {
                             BinOp::Add => a + b, BinOp::Sub => a - b,
                             BinOp::Mul => a * b, BinOp::Div => a / b,
-                            BinOp::Mod => { let r = a % b; if r.is_finite() { r } else { f64::NAN } },
+                            BinOp::Mod => jq_jit::runtime::jq_mod_f64(a, b).unwrap_or(f64::NAN),
                             _ => unreachable!(),
                         };
                         let result = match op2 {
                             BinOp::Add => inner + const_val, BinOp::Sub => inner - const_val,
                             BinOp::Mul => inner * const_val, BinOp::Div => inner / const_val,
-                            BinOp::Mod => { let r = inner % const_val; if r.is_finite() { r } else { f64::NAN } },
+                            BinOp::Mod => jq_jit::runtime::jq_mod_f64(inner, const_val).unwrap_or(f64::NAN),
                             _ => unreachable!(),
                         };
                         if result.is_finite() {
@@ -19298,7 +19293,7 @@ fn real_main() {
                             BinOp::Sub => a - b,
                             BinOp::Mul => a * b,
                             BinOp::Div => a / b,
-                            BinOp::Mod => a % b,
+                            BinOp::Mod => jq_jit::runtime::jq_mod_f64(a, b).unwrap_or(f64::NAN),
                             _ => unreachable!(),
                         };
                         if result.is_finite() {
@@ -19482,7 +19477,7 @@ fn real_main() {
                                 BinOp::Sub => v - c,
                                 BinOp::Mul => v * c,
                                 BinOp::Div => v / c,
-                                BinOp::Mod => { if c.is_finite() && *c != 0.0 { v % c } else { f64::NAN } }
+                                BinOp::Mod => jq_jit::runtime::jq_mod_f64(v, *c).unwrap_or(f64::NAN),
                                 _ => v,
                             };
                         }
@@ -19511,7 +19506,7 @@ fn real_main() {
                             BinOp::Sub => a - b,
                             BinOp::Mul => a * b,
                             BinOp::Div => a / b,
-                            BinOp::Mod => a % b,
+                            BinOp::Mod => jq_jit::runtime::jq_mod_f64(a, b).unwrap_or(f64::NAN),
                             _ => unreachable!(),
                         };
                         let result = if let Some(uop) = uop_opt {
@@ -19548,7 +19543,7 @@ fn real_main() {
                                 BinOp::Sub => result - c,
                                 BinOp::Mul => result * c,
                                 BinOp::Div => result / c,
-                                BinOp::Mod => result % c,
+                                BinOp::Mod => jq_jit::runtime::jq_mod_f64(result, c).unwrap_or(f64::NAN),
                                 _ => unreachable!(),
                             };
                         }
@@ -19578,7 +19573,7 @@ fn real_main() {
                                 BinOp::Sub => result - c,
                                 BinOp::Mul => result * c,
                                 BinOp::Div => result / c,
-                                BinOp::Mod => result % c,
+                                BinOp::Mod => jq_jit::runtime::jq_mod_f64(result, c).unwrap_or(f64::NAN),
                                 _ => unreachable!(),
                             };
                         }
@@ -20586,12 +20581,7 @@ fn real_main() {
                                         jq_jit::ir::BinOp::Sub => n - c,
                                         jq_jit::ir::BinOp::Mul => n * c,
                                         jq_jit::ir::BinOp::Div => n / c,
-                                        jq_jit::ir::BinOp::Mod => {
-                                            if n.fract() == 0.0 && c.fract() == 0.0 && *c != 0.0 {
-                                                let a = n as i64; let b = *c as i64;
-                                                if a == i64::MIN && b == -1 { 0.0 } else { (a % b) as f64 }
-                                            } else { n % c }
-                                        }
+                                        jq_jit::ir::BinOp::Mod => jq_jit::runtime::jq_mod_f64(n, *c).unwrap_or(f64::NAN),
                                         _ => n,
                                     };
                                 }
@@ -20927,7 +20917,7 @@ fn real_main() {
                                                     jq_jit::ir::BinOp::Sub => v - n,
                                                     jq_jit::ir::BinOp::Mul => v * n,
                                                     jq_jit::ir::BinOp::Div => v / n,
-                                                    jq_jit::ir::BinOp::Mod => { let r = v % n; if r.is_finite() { r } else { f64::NAN } },
+                                                    jq_jit::ir::BinOp::Mod => jq_jit::runtime::jq_mod_f64(v, n).unwrap_or(f64::NAN),
                                                     _ => v,
                                                 };
                                             }
@@ -21559,7 +21549,7 @@ fn real_main() {
                                 BinOp::Sub => v - arith_n,
                                 BinOp::Mul => v * arith_n,
                                 BinOp::Div => v / arith_n,
-                                BinOp::Mod => { let r = v % arith_n; if r.is_finite() { r } else { all_ok = false; return; } },
+                                BinOp::Mod => match jq_jit::runtime::jq_mod_f64(v, arith_n) { Some(r) => r, None => { all_ok = false; return; } },
                                 _ => { all_ok = false; return; }
                             };
                             if !first_elem { compact_buf.push(b','); }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3276,11 +3276,14 @@ fn eval_object_construct(pairs: &[(Expr, Expr)], input: Value, env: &EnvRef, cb:
             Ok(v) => v,
             Err(()) => return eval_obj_pairs(pairs, 0, crate::value::new_objmap_with_capacity(pairs.len()), input, env, cb),
         };
-        let ks = object_key_from_value(&kv)?;
+        // Defer validation: if the value generator turns out to be empty, jq
+        // short-circuits without complaining about the key (#201). Pull the
+        // value first; only then check the key type.
         let vv = match eval_one(ve, &input, env) {
             Ok(v) => v,
             Err(()) => return eval_obj_pairs(pairs, 0, crate::value::new_objmap_with_capacity(pairs.len()), input, env, cb),
         };
+        let ks = object_key_from_value(&kv)?;
         obj.insert(ks, vv);
     }
     cb(Value::object_from_map(obj))
@@ -3290,10 +3293,13 @@ fn eval_obj_pairs(pairs: &[(Expr, Expr)], idx: usize, cur: crate::value::ObjMap,
     if idx >= pairs.len() { return cb(Value::object_from_map(cur)); }
     let (ke, ve) = &pairs[idx];
     eval(ke, input.clone(), env, &mut |kv| {
-        let ks = object_key_from_value(&kv)?;
+        // Defer the key-type check until V yields at least one value: jq lets
+        // `{(non_string_key): empty}` short-circuit silently because no
+        // (key, value) pair actually materializes (#201).
         eval(ve, input.clone(), env, &mut |vv| {
+            let ks = object_key_from_value(&kv)?;
             let mut next = cur.clone();
-            next.insert(ks.clone(), vv);
+            next.insert(ks, vv);
             eval_obj_pairs(pairs, idx + 1, next, input.clone(), env, cb)
         })
     })

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -4172,6 +4172,23 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
                 }
             })
         }
+        Expr::Alternative { primary, fallback } => {
+            // `path(A // B)` — emit paths from A whose values are truthy;
+            // if none, fall through to paths from B.
+            let mut any_truthy = false;
+            let cont = eval_path(primary, input.clone(), env, &mut |bp| {
+                let v = crate::runtime::rt_getpath(&input, &bp).unwrap_or(Value::Null);
+                if v.is_truthy() {
+                    any_truthy = true;
+                    cb(bp)
+                } else {
+                    Ok(true)
+                }
+            })?;
+            if !cont { return Ok(false); }
+            if any_truthy { return Ok(true); }
+            eval_path(fallback, input, env, cb)
+        }
         _ => {
             // Non-path-safe expression: evaluate and report error
             let mut result_val = Value::Null;

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -4092,7 +4092,12 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
         }
         Expr::Slice { expr: base_expr, from, to } => {
             eval_path(base_expr, input.clone(), env, &mut |bp| {
+                // Type-check the receiver: jq errors on path slicing of non-array/string/null.
                 let base = crate::runtime::rt_getpath(&input, &bp).unwrap_or(Value::Null);
+                match &base {
+                    Value::Arr(_) | Value::Str(_) | Value::Null => {}
+                    other => bail!("Cannot index {} with object", other.type_name()),
+                }
                 let from_val = if let Some(f) = from {
                     let mut v = Value::Null;
                     eval(f, input.clone(), env, &mut |fv| { v = fv; Ok(true) })?; v
@@ -4101,19 +4106,13 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
                     let mut v = Value::Null;
                     eval(t, input.clone(), env, &mut |tv| { v = tv; Ok(true) })?; v
                 } else { Value::Null };
-                let len = match &base {
-                    Value::Arr(a) => a.len() as i64,
-                    Value::Str(s) => s.chars().count() as i64,
-                    _ => 0,
-                };
-                let fi = match &from_val { Value::Num(n, _) => { let i = n.floor() as i64; if i < 0 { (len + i).max(0) } else { i.min(len) } }, Value::Null => 0, _ => 0 };
-                let ti = match &to_val { Value::Num(n, _) => { let i = n.ceil() as i64; if i < 0 { (len + i).max(0) } else { i.min(len) } }, Value::Null => len, _ => len };
-                // Return a special path that indicates slicing
+                // jq preserves the literal slice expressions in path output without
+                // clamping to the receiver's actual length. Omitted bounds → null.
                 let mut p = match &bp { Value::Arr(a) => a.as_ref().clone(), _ => vec![] };
                 p.push(Value::object_from_map({
                     let mut m = crate::value::new_objmap();
-                    m.insert("start".into(), Value::number(fi as f64));
-                    m.insert("end".into(), Value::number(ti as f64));
+                    m.insert("start".into(), from_val);
+                    m.insert("end".into(), to_val);
                     m
                 }));
                 cb(Value::Arr(Rc::new(p)))

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -142,7 +142,7 @@ impl ArithExpr {
                     BinOp::Sub => l - r,
                     BinOp::Mul => l * r,
                     BinOp::Div => l / r,
-                    BinOp::Mod => l % r,
+                    BinOp::Mod => crate::runtime::jq_mod_f64(l, r).unwrap_or(f64::NAN),
                     _ => unreachable!(),
                 }
             }
@@ -1532,7 +1532,14 @@ fn simplify_expr(expr: &crate::ir::Expr) -> crate::ir::Expr {
                     crate::ir::BinOp::Sub => Some(a - b),
                     crate::ir::BinOp::Mul => Some(a * b),
                     crate::ir::BinOp::Div if *b != 0.0 => Some(a / b),
-                    crate::ir::BinOp::Mod if *b != 0.0 && b.is_finite() => Some(a % b),
+                    crate::ir::BinOp::Mod if a.is_finite() && b.is_finite() => {
+                        // jq truncates both operands to int before %, so 1 % 1.5 = 0.
+                        let yi = *b as i64;
+                        let xi = *a as i64;
+                        if yi == 0 { None }
+                        else if xi == i64::MIN && yi == -1 { Some(0.0) }
+                        else { Some((xi % yi) as f64) }
+                    }
                     _ => None,
                 };
                 if let Some(r) = result {

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -7153,7 +7153,9 @@ extern "C" fn jit_rt_call_builtin(dst: *mut Value, name_ptr: *const u8, name_len
                             let actual = if idx < 0 { (a.len() as i64 + idx) as usize } else { idx as usize };
                             current = a.get(actual).cloned().unwrap_or(Value::Null);
                         }
-                        (Value::Null, _) => { current = Value::Null; }
+                        (Value::Null, Value::Str(_)) | (Value::Null, Value::Num(_, _)) | (Value::Null, Value::Obj(_)) => {
+                            current = Value::Null;
+                        }
                         _ => { current = Value::Null; ok = false; break; }
                     }
                 }

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -9019,16 +9019,20 @@ impl JitCompiler {
                         b.def_var(vars[*dst_var as usize], bits);
                     }
                     JitOp::F64Rem { dst_var, a_var, b_var: bv } => {
-                        // Inline modulo: a - trunc(a / b) * b
-                        // Matches fmod semantics for non-zero b
+                        // jq's `%` truncates both operands toward zero before the
+                        // remainder, so 3.7 % 2 = 1 and 1 % 1.5 = 0 (#183). We
+                        // compute trunc(a) - trunc(trunc(a)/trunc(b)) * trunc(b)
+                        // to keep the result an integer with the dividend's sign.
                         let a_bits = b.use_var(vars[*a_var as usize]);
                         let b_bits = b.use_var(vars[*bv as usize]);
                         let a_f = b.ins().bitcast(types::F64, cranelift_codegen::ir::MemFlags::new(), a_bits);
                         let b_f = b.ins().bitcast(types::F64, cranelift_codegen::ir::MemFlags::new(), b_bits);
-                        let div = b.ins().fdiv(a_f, b_f);
-                        let trunc = b.ins().trunc(div);
-                        let prod = b.ins().fmul(trunc, b_f);
-                        let rem_f = b.ins().fsub(a_f, prod);
+                        let a_t = b.ins().trunc(a_f);
+                        let b_t = b.ins().trunc(b_f);
+                        let div = b.ins().fdiv(a_t, b_t);
+                        let q = b.ins().trunc(div);
+                        let prod = b.ins().fmul(q, b_t);
+                        let rem_f = b.ins().fsub(a_t, prod);
                         let bits = b.ins().bitcast(ptr_ty, cranelift_codegen::ir::MemFlags::new(), rem_f);
                         b.def_var(vars[*dst_var as usize], bits);
                     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1384,19 +1384,42 @@ impl Parser {
 
     /// Pre-allocate all variables from a pattern before parsing the body.
     fn alloc_pattern_vars(&mut self, pattern: &Pattern) -> Vec<u16> {
+        // For repeated names within a single pattern, share the same slot —
+        // necessary so object-pattern first-wins (#206) and array-pattern
+        // last-wins land on the right binding without false aliasing across
+        // separate names.
+        let mut seen: std::collections::HashMap<String, u16> = std::collections::HashMap::new();
+        self.alloc_pattern_vars_inner(pattern, &mut seen)
+    }
+
+    fn alloc_pattern_vars_inner(&mut self, pattern: &Pattern, seen: &mut std::collections::HashMap<String, u16>) -> Vec<u16> {
         match pattern {
             Pattern::Var(name) => {
-                vec![self.scope.alloc_var(name)]
+                let idx = if let Some(&existing) = seen.get(name) {
+                    existing
+                } else {
+                    let idx = self.scope.alloc_var(name);
+                    seen.insert(name.clone(), idx);
+                    idx
+                };
+                vec![idx]
             }
             Pattern::Array(pats) => {
-                pats.iter().flat_map(|p| self.alloc_pattern_vars(p)).collect()
+                pats.iter().flat_map(|p| self.alloc_pattern_vars_inner(p, seen)).collect()
             }
             Pattern::Object(pats) => {
-                pats.iter().flat_map(|(_, p)| self.alloc_pattern_vars(p)).collect()
+                pats.iter().flat_map(|(_, p)| self.alloc_pattern_vars_inner(p, seen)).collect()
             }
             Pattern::VarAndSub(name, sub) => {
-                let mut vars = vec![self.scope.alloc_var(name)];
-                vars.extend(self.alloc_pattern_vars(sub));
+                let head_idx = if let Some(&existing) = seen.get(name) {
+                    existing
+                } else {
+                    let idx = self.scope.alloc_var(name);
+                    seen.insert(name.clone(), idx);
+                    idx
+                };
+                let mut vars = vec![head_idx];
+                vars.extend(self.alloc_pattern_vars_inner(sub, seen));
                 vars
             }
         }
@@ -1504,16 +1527,44 @@ impl Parser {
     }
 
     fn build_object_destructure(&mut self, value: Expr, pats: &[(String, Pattern)], allocs: &[u16], body: Expr) -> Result<Expr> {
-        let mut result = body;
-        let mut alloc_idx = allocs.len();
-        for (key, pat) in pats.iter().rev() {
+        // jq's object-pattern destructure is first-wins for repeated variable
+        // names in the same pattern (#206). With slot dedup in
+        // `alloc_pattern_vars`, all references to `$a` map to one idx — so a
+        // later pair that only binds already-seen idx would shadow the first.
+        // Pre-scan source-order to mark pairs whose entire binding set is
+        // covered by an earlier pair, then drop them when emitting.
+        let mut pair_offsets: Vec<usize> = Vec::with_capacity(pats.len());
+        let mut acc = 0;
+        for (_, pat) in pats {
+            pair_offsets.push(acc);
+            acc += self.count_pattern_vars(pat);
+        }
+        let mut keep: Vec<bool> = vec![false; pats.len()];
+        let mut bound: std::collections::HashSet<u16> = std::collections::HashSet::new();
+        for (i, (_, pat)) in pats.iter().enumerate() {
             let count = self.count_pattern_vars(pat);
-            alloc_idx -= count;
+            let pair_allocs = &allocs[pair_offsets[i]..pair_offsets[i]+count];
+            if pair_allocs.is_empty() {
+                keep[i] = true;
+                continue;
+            }
+            let has_new = pair_allocs.iter().any(|idx| !bound.contains(idx));
+            if has_new {
+                keep[i] = true;
+                for &idx in pair_allocs { bound.insert(idx); }
+            }
+        }
+
+        let mut result = body;
+        for (i, (key, pat)) in pats.iter().enumerate().rev() {
+            if !keep[i] { continue; }
+            let count = self.count_pattern_vars(pat);
+            let pair_allocs = &allocs[pair_offsets[i]..pair_offsets[i]+count];
             let field_expr = Expr::Index {
                 expr: Box::new(value.clone()),
                 key: Box::new(Expr::Literal(Literal::Str(key.clone()))),
             };
-            result = self.build_pattern_binding(pat, field_expr, &allocs[alloc_idx..alloc_idx+count], result)?;
+            result = self.build_pattern_binding(pat, field_expr, pair_allocs, result)?;
         }
         Ok(result)
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2166,7 +2166,9 @@ impl Parser {
                 self.advance();
                 match self.advance() {
                     Token::Variable(name) => {
-                        let var_idx = self.scope.alloc_var(&name);
+                        // Register label-typed bindings under a sentinel prefix so they
+                        // can only be referenced via `break $name`, never as a bare $name.
+                        let var_idx = self.scope.alloc_var(&format!("\x00label:{}", name));
                         self.expect(&Token::Pipe)?;
                         let body = self.parse_pipe()?;
                         Ok(Expr::Label {
@@ -2182,8 +2184,8 @@ impl Parser {
                 self.advance();
                 match self.advance() {
                     Token::Variable(name) => {
-                        let var_idx = self.scope.lookup_var(&name)
-                            .ok_or_else(|| anyhow::anyhow!("undefined label variable ${}", name))?;
+                        let var_idx = self.scope.lookup_var(&format!("\x00label:{}", name))
+                            .ok_or_else(|| anyhow::anyhow!("${} is not defined", name))?;
                         Ok(Expr::Break {
                             var_index: var_idx,
                             value: Box::new(Expr::Input),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2508,12 +2508,15 @@ impl Parser {
                 Token::Variable(name) => name,
                 _ => unreachable!(),
             };
-            let var_idx = self.scope.alloc_var(&var_name);
-            let acc_idx = self.scope.alloc_var("__acc__");
 
+            // Parse INIT before binding $var: jq scopes the binding to UPDATE
+            // only, so a stray reference to $var inside INIT is a compile error
+            // (#202).
             self.expect(&Token::LParen)?;
             let init = self.parse_pipe()?;
             self.expect(&Token::Semicolon)?;
+            let var_idx = self.scope.alloc_var(&var_name);
+            let acc_idx = self.scope.alloc_var("__acc__");
             let update = self.parse_pipe()?;
             self.expect(&Token::RParen)?;
 
@@ -2525,15 +2528,18 @@ impl Parser {
                 update: Box::new(update),
             })
         } else {
-            // Destructuring pattern
+            // Destructuring pattern — parse INIT before allocating pattern vars
+            // for the same scoping reason as the simple case above. parse_pattern
+            // is purely syntactic (no var alloc), so we can run it now and
+            // defer alloc_pattern_vars until after INIT.
             let pattern = self.parse_pattern()?;
-            let allocs = self.alloc_pattern_vars(&pattern);
-            let tmp_var = self.scope.alloc_var("__reduce_item__");
-            let acc_idx = self.scope.alloc_var("__acc__");
 
             self.expect(&Token::LParen)?;
             let init = self.parse_pipe()?;
             self.expect(&Token::Semicolon)?;
+            let allocs = self.alloc_pattern_vars(&pattern);
+            let tmp_var = self.scope.alloc_var("__reduce_item__");
+            let acc_idx = self.scope.alloc_var("__acc__");
             let update_raw = self.parse_pipe()?;
             self.expect(&Token::RParen)?;
 
@@ -2566,12 +2572,13 @@ impl Parser {
                 Token::Variable(name) => name,
                 _ => unreachable!(),
             };
-            let var_idx = self.scope.alloc_var(&var_name);
-            let acc_idx = self.scope.alloc_var("__acc__");
 
+            // Parse INIT before binding $var (#202).
             self.expect(&Token::LParen)?;
             let init = self.parse_pipe()?;
             self.expect(&Token::Semicolon)?;
+            let var_idx = self.scope.alloc_var(&var_name);
+            let acc_idx = self.scope.alloc_var("__acc__");
             let update = self.parse_pipe()?;
             let extract = if self.eat(&Token::Semicolon) {
                 Some(Box::new(self.parse_pipe()?))
@@ -2589,15 +2596,15 @@ impl Parser {
                 extract,
             })
         } else {
-            // Destructuring pattern
+            // Destructuring pattern — same INIT-before-bind ordering.
             let pattern = self.parse_pattern()?;
-            let allocs = self.alloc_pattern_vars(&pattern);
-            let tmp_var = self.scope.alloc_var("__foreach_item__");
-            let acc_idx = self.scope.alloc_var("__acc__");
 
             self.expect(&Token::LParen)?;
             let init = self.parse_pipe()?;
             self.expect(&Token::Semicolon)?;
+            let allocs = self.alloc_pattern_vars(&pattern);
+            let tmp_var = self.scope.alloc_var("__foreach_item__");
+            let acc_idx = self.scope.alloc_var("__acc__");
             let update_raw = self.parse_pipe()?;
             let extract_raw = if self.eat(&Token::Semicolon) {
                 Some(self.parse_pipe()?)

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -775,6 +775,23 @@ pub fn rt_div(a: &Value, b: &Value) -> Result<Value> {
     }
 }
 
+/// jq's `%` semantics for f64 inputs: truncate both operands toward zero,
+/// then take the integer remainder. Returns None when either operand is
+/// non-finite or the divisor truncates to zero (caller decides the fallback).
+/// Generic over `f64` and `&f64` so call sites can pass through whatever
+/// shape they hold without per-site dereferencing.
+#[inline]
+pub fn jq_mod_f64<A: std::borrow::Borrow<f64>, B: std::borrow::Borrow<f64>>(a: A, b: B) -> Option<f64> {
+    let a = *a.borrow();
+    let b = *b.borrow();
+    if !a.is_finite() || !b.is_finite() { return None; }
+    let yi = b as i64;
+    if yi == 0 { return None; }
+    let xi = a as i64;
+    let r = if xi == i64::MIN && yi == -1 { 0 } else { xi % yi };
+    Some(r as f64)
+}
+
 pub fn rt_mod(a: &Value, b: &Value) -> Result<Value> {
     match (a, b) {
         (Value::Num(x, _), Value::Num(y, _)) => {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2116,7 +2116,7 @@ pub fn rt_setpath(v: &Value, path: &Value, val: &Value) -> Result<Value> {
                             let new_val = rt_setpath(&Value::Null, &rest, val)?;
                             let replacement = match &new_val {
                                 Value::Arr(r) => r.as_ref().clone(),
-                                _ => vec![new_val],
+                                _ => bail!("A slice of an array can only be assigned another array"),
                             };
                             let mut result = a[..si].to_vec();
                             result.extend(replacement);
@@ -2128,7 +2128,7 @@ pub fn rt_setpath(v: &Value, path: &Value, val: &Value) -> Result<Value> {
                             let new_val = rt_setpath(&Value::Null, &rest, val)?;
                             let replacement = match &new_val {
                                 Value::Arr(r) => r.as_ref().clone(),
-                                _ => vec![new_val],
+                                _ => bail!("A slice of an array can only be assigned another array"),
                             };
                             Ok(Value::Arr(Rc::new(replacement)))
                         }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2014,9 +2014,9 @@ pub fn rt_getpath(v: &Value, path: &Value) -> Result<Value> {
                         let actual = if idx < 0 { (a.len() as i64 + idx) as usize } else { idx as usize };
                         current = a.get(actual).cloned().unwrap_or(Value::Null);
                     }
-                    // jq allows string or number keys through null (yielding null) but
-                    // still errors on other key types — matches `.[null]` on null.
-                    (Value::Null, Value::Str(_)) | (Value::Null, Value::Num(_, _)) => {
+                    // jq short-circuits getpath on null for string/number/object keys
+                    // (matching `.[k]` on null), but still errors for null/bool/array keys.
+                    (Value::Null, Value::Str(_)) | (Value::Null, Value::Num(_, _)) | (Value::Null, Value::Obj(_)) => {
                         current = Value::Null;
                     }
                     // jq errors on type-incompatible path elements (issue #77).

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2105,14 +2105,25 @@ pub fn rt_setpath(v: &Value, path: &Value, val: &Value) -> Result<Value> {
                 }
                 // Slice assignment: path element is {start: N, end: N}
                 (_, Value::Obj(slice_spec)) if slice_spec.contains_key("start") && slice_spec.contains_key("end") => {
-                    let start = match slice_spec.get("start") { Some(Value::Num(n, _)) => *n as i64, _ => 0 };
-                    let end = match slice_spec.get("end") { Some(Value::Num(n, _)) => *n as i64, _ => 0 };
+                    // jq applies floor(start) / ceil(end) when consuming a slice path,
+                    // and treats null as the open endpoint (0 for start, len for end).
+                    let len = match v { Value::Arr(a) => a.len() as i64, _ => 0 };
+                    let start = match slice_spec.get("start") {
+                        Some(Value::Num(n, _)) => n.floor() as i64,
+                        _ => 0,
+                    };
+                    let end = match slice_spec.get("end") {
+                        Some(Value::Num(n, _)) => n.ceil() as i64,
+                        Some(Value::Null) | None => len,
+                        _ => 0,
+                    };
                     match v {
                         Value::Arr(a) => {
                             let len = a.len() as i64;
-                            let si = start.max(0).min(len) as usize;
-                            let ei = end.max(0).min(len) as usize;
-                            let ei = ei.max(si);
+                            let si_raw = if start < 0 { (len + start).max(0) } else { start.min(len) };
+                            let ei_raw = if end < 0 { (len + end).max(0) } else { end.min(len) };
+                            let si = si_raw as usize;
+                            let ei = (ei_raw as usize).max(si);
                             let new_val = rt_setpath(&Value::Null, &rest, val)?;
                             let replacement = match &new_val {
                                 Value::Arr(r) => r.as_ref().clone(),

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -147,7 +147,7 @@ pub fn call_builtin(name: &str, args: &[Value]) -> Result<Value> {
         "indices" | "rindices" => binary_arg(args, rt_indices),
         "test" => {
             if args.len() >= 3 {
-                let (pat, _) = apply_regex_flags(args[1].as_str().unwrap_or(""), &args[2]);
+                let (pat, _) = apply_regex_flags(args[1].as_str().unwrap_or(""), &args[2])?;
                 rt_test(&args[0], &Value::from_string(pat))
             } else {
                 binary_arg(args, rt_test)
@@ -155,7 +155,7 @@ pub fn call_builtin(name: &str, args: &[Value]) -> Result<Value> {
         }
         "match" => {
             if args.len() >= 3 {
-                let (pat, global) = apply_regex_flags(args[1].as_str().unwrap_or(""), &args[2]);
+                let (pat, global) = apply_regex_flags(args[1].as_str().unwrap_or(""), &args[2])?;
                 let re = Value::from_string(pat);
                 if global {
                     rt_match_global(&args[0], &re)
@@ -168,7 +168,7 @@ pub fn call_builtin(name: &str, args: &[Value]) -> Result<Value> {
         }
         "capture" => {
             if args.len() >= 3 {
-                let (pat, global) = apply_regex_flags(args[1].as_str().unwrap_or(""), &args[2]);
+                let (pat, global) = apply_regex_flags(args[1].as_str().unwrap_or(""), &args[2])?;
                 let re = Value::from_string(pat);
                 if global {
                     rt_capture_global(&args[0], &re)
@@ -181,7 +181,7 @@ pub fn call_builtin(name: &str, args: &[Value]) -> Result<Value> {
         }
         "scan" => {
             if args.len() >= 3 {
-                let (pat, _) = apply_regex_flags(args[1].as_str().unwrap_or(""), &args[2]);
+                let (pat, _) = apply_regex_flags(args[1].as_str().unwrap_or(""), &args[2])?;
                 rt_scan(&args[0], &Value::from_string(pat))
             } else {
                 binary_arg(args, rt_scan)
@@ -190,7 +190,7 @@ pub fn call_builtin(name: &str, args: &[Value]) -> Result<Value> {
         "sub" | "gsub" => {
             if args.len() >= 4 {
                 // sub/gsub with flags: input, regex, replacement, flags
-                let (pat, _) = apply_regex_flags(args[1].as_str().unwrap_or(""), &args[3]);
+                let (pat, _) = apply_regex_flags(args[1].as_str().unwrap_or(""), &args[3])?;
                 rt_sub_gsub(&args[0], &Value::from_string(pat), &args[2], name == "gsub")
             } else if args.len() >= 3 {
                 rt_sub_gsub(&args[0], &args[1], &args[2], name == "gsub")
@@ -1781,7 +1781,7 @@ fn rt_split(v: &Value, sep: &Value) -> Result<Value> {
 fn rt_regex_split(v: &Value, re: &Value, flags: &Value) -> Result<Value> {
     match (v, re) {
         (Value::Str(s), Value::Str(r)) => {
-            let (pat, _global) = apply_regex_flags(r.as_str(), flags);
+            let (pat, _global) = apply_regex_flags(r.as_str(), flags)?;
             with_regex(&pat, |regex| {
                 let parts: Vec<Value> = regex.split(s.as_str())
                     .map(Value::from_str)
@@ -2416,18 +2416,24 @@ fn next_char_boundary(s: &str, pos: usize) -> usize {
 
 /// Parse jq regex flags string and return (pattern_with_inline_flags, is_global).
 /// Supported flags: i (case-insensitive), x (extended), s (dotall/single-line), g (global).
-fn apply_regex_flags(pattern: &str, flags: &Value) -> (String, bool) {
+fn apply_regex_flags(pattern: &str, flags: &Value) -> Result<(String, bool)> {
     let flags_str = match flags {
         Value::Str(s) => s.as_str(),
-        _ => return (pattern.to_string(), false),
+        _ => return Ok((pattern.to_string(), false)),
     };
+    // jq accepts g, i, l, m, n, p, s, x. Any other character — even mixed in
+    // with valid ones — rejects the whole modifier string.
+    if !flags_str.chars().all(|c| matches!(c, 'g' | 'i' | 'l' | 'm' | 'n' | 'p' | 's' | 'x')) {
+        bail!("{} is not a valid modifier string", flags_str);
+    }
     let mut inline = String::new();
     let mut global = false;
     for ch in flags_str.chars() {
         match ch {
             'i' | 'x' | 's' => inline.push(ch),
             'g' => global = true,
-            _ => {} // ignore unknown flags (jq behavior)
+            // l, m, n, p have no inline equivalent in onig — accepted but ignored.
+            _ => {}
         }
     }
     let pat = if inline.is_empty() {
@@ -2435,7 +2441,7 @@ fn apply_regex_flags(pattern: &str, flags: &Value) -> (String, bool) {
     } else {
         format!("(?{}){}", inline, pattern)
     };
-    (pat, global)
+    Ok((pat, global))
 }
 
 fn rt_test(v: &Value, re: &Value) -> Result<Value> {
@@ -2661,7 +2667,7 @@ pub struct SubGsubSegment {
 /// Find regex matches and return segments for capture-aware sub/gsub replacement.
 /// Returns segments alternating: literal, capture_obj, literal, capture_obj, ..., literal.
 pub fn sub_gsub_segments(input: &str, pattern: &str, flags: &Value, global: bool) -> Result<Vec<SubGsubSegment>> {
-    let (pat, flag_global) = apply_regex_flags(pattern, flags);
+    let (pat, flag_global) = apply_regex_flags(pattern, flags)?;
     let is_global = global || flag_global;
     with_regex(&pat, |regex| {
         let mut segments = Vec::new();

--- a/src/value.rs
+++ b/src/value.rs
@@ -5043,6 +5043,7 @@ fn push_json_string(out: &mut String, s: &str) {
             0x08 => b'b' as u16 | 0x100,
             0x0c => b'f' as u16 | 0x100,
             c if c < 0x20 => c as u16,
+            0x7f => 0x7f,
             _ => continue,
         };
         if start < i {
@@ -5165,7 +5166,7 @@ use std::io;
 fn write_json_string(w: &mut dyn io::Write, s: &str) -> io::Result<()> {
     let bytes = s.as_bytes();
     // Find first byte needing escape
-    let first_esc = bytes.iter().position(|&b| b == b'"' || b == b'\\' || b < 0x20);
+    let first_esc = bytes.iter().position(|&b| b == b'"' || b == b'\\' || b < 0x20 || b == 0x7f);
     if first_esc.is_none() {
         // No escapes: write "string" in minimal calls
         if bytes.len() <= 126 {
@@ -5195,7 +5196,7 @@ fn write_json_string(w: &mut dyn io::Write, s: &str) -> io::Result<()> {
             b'\t' => b"\\t",
             0x08 => b"\\b",
             0x0c => b"\\f",
-            c if c < 0x20 => {
+            c if c < 0x20 || c == 0x7f => {
                 if start < i { w.write_all(&bytes[start..i])?; }
                 write!(w, "\\u{:04x}", c)?;
                 start = i + 1;
@@ -5479,7 +5480,7 @@ fn push_compact_value(buf: &mut Vec<u8>, v: &Value) {
             for (i, (k, val)) in o.iter().enumerate() {
                 let kb = k.as_bytes();
                 let klen = kb.len();
-                let key_needs_escape = kb.iter().any(|&b| b == b'"' || b == b'\\' || b < 0x20);
+                let key_needs_escape = kb.iter().any(|&b| b == b'"' || b == b'\\' || b < 0x20 || b == 0x7f);
                 if !key_needs_escape {
                     // Write ,"key": (or "key": for first) in a single memcpy
                     let prefix = if i > 0 { 1 } else { 0 }; // comma
@@ -5551,7 +5552,7 @@ fn push_json_string_to_vec(buf: &mut Vec<u8>, s: &str) {
     // Ultra-fast path for single-byte strings (common object keys like "x", "y")
     if len == 1 {
         let c = bytes[0];
-        if c >= 0x20 && c != b'"' && c != b'\\' {
+        if c >= 0x20 && c != b'"' && c != b'\\' && c != 0x7f {
             buf.reserve(3);
             unsafe {
                 let dst = buf.as_mut_ptr().add(buf.len());
@@ -5564,7 +5565,7 @@ fn push_json_string_to_vec(buf: &mut Vec<u8>, s: &str) {
         }
     }
     // Fast path: no escapes needed — write "str" in one contiguous block
-    let needs_escape = bytes.iter().any(|&b| b == b'"' || b == b'\\' || b < 0x20);
+    let needs_escape = bytes.iter().any(|&b| b == b'"' || b == b'\\' || b < 0x20 || b == 0x7f);
     if !needs_escape {
         buf.reserve(len + 2);
         // Safety: we just reserved enough space
@@ -5589,7 +5590,7 @@ fn push_json_string_to_vec(buf: &mut Vec<u8>, s: &str) {
             b'\t' => b't',
             0x08 => b'b',
             0x0c => b'f',
-            c if c < 0x20 => {
+            c if c < 0x20 || c == 0x7f => {
                 if start < i { buf.extend_from_slice(&bytes[start..i]); }
                 let hex = [
                     b'\\', b'u', b'0', b'0',
@@ -5649,7 +5650,7 @@ fn write_compact_buf_inner(v: &Value, buf: &mut [u8], pos: &mut usize) -> bool {
         }
         Value::Str(s) => {
             let bytes = s.as_bytes();
-            let needs_escape = bytes.iter().any(|&b| b == b'"' || b == b'\\' || b < 0x20);
+            let needs_escape = bytes.iter().any(|&b| b == b'"' || b == b'\\' || b < 0x20 || b == 0x7f);
             if needs_escape { return false; } // fall back to slow path
             if *pos + bytes.len() + 2 > buf.len() { return false; }
             buf[*pos] = b'"';
@@ -5673,7 +5674,7 @@ fn write_compact_buf_inner(v: &Value, buf: &mut [u8], pos: &mut usize) -> bool {
                 if i > 0 { push!(b","); }
                 // Write key
                 let kb = k.as_bytes();
-                let key_escape = kb.iter().any(|&b| b == b'"' || b == b'\\' || b < 0x20);
+                let key_escape = kb.iter().any(|&b| b == b'"' || b == b'\\' || b < 0x20 || b == 0x7f);
                 if key_escape { return false; }
                 if *pos + kb.len() + 3 > buf.len() { return false; } // "key":
                 buf[*pos] = b'"';

--- a/src/value.rs
+++ b/src/value.rs
@@ -4795,10 +4795,10 @@ fn format_as_scientific(n: f64) -> String {
     normalize_scientific(&sci)
 }
 
-/// Normalize scientific notation to match jq's format (e.g., e+07 not e+7 for small exponents).
+/// Normalize scientific notation to match jq 1.8.1's format: uppercase `E`,
+/// explicit `+`/`-` sign, two-digit exponent for values below 100.
 fn normalize_scientific(s: &str) -> String {
-    // Split at 'e'
-    if let Some(idx) = s.find('e') {
+    if let Some(idx) = s.find(|c: char| c == 'e' || c == 'E') {
         let mantissa = &s[..idx];
         let exp_str = &s[idx+1..]; // includes sign
         let (sign, digits) = if let Some(rest) = exp_str.strip_prefix('-') {
@@ -4808,12 +4808,11 @@ fn normalize_scientific(s: &str) -> String {
         } else {
             ("+", exp_str)
         };
-        // Parse exponent and re-format with at least 2 digits for < 100
         let exp: i32 = digits.parse().unwrap_or(0);
         if exp.abs() < 100 {
-            format!("{}e{}{:02}", mantissa, sign, exp.abs())
+            format!("{}E{}{:02}", mantissa, sign, exp.abs())
         } else {
-            format!("{}e{}{}", mantissa, sign, exp.abs())
+            format!("{}E{}{}", mantissa, sign, exp.abs())
         }
     } else {
         s.to_string()

--- a/src/value.rs
+++ b/src/value.rs
@@ -1514,7 +1514,7 @@ pub fn json_object_update_field_num(b: &[u8], pos: usize, field: &str, op: crate
     // (bytes before value) + (new number) + (bytes after value including closing brace)
     if let Some((val_start, val_end)) = json_object_get_field_raw(b, pos, field) {
         if let Some(a) = parse_json_num(&b[val_start..val_end]) {
-            let r = match op { BinOp::Add => a + n, BinOp::Sub => a - n, BinOp::Mul => a * n, BinOp::Div => a / n, BinOp::Mod => { if n == 0.0 || !a.is_finite() { return false; } a % n }, _ => a };
+            let r = match op { BinOp::Add => a + n, BinOp::Sub => a - n, BinOp::Mul => a * n, BinOp::Div => a / n, BinOp::Mod => match crate::runtime::jq_mod_f64(a, n) { Some(v) => v, None => return false }, _ => a };
             if !r.is_finite() { return false; }
             // Find object end by scanning backward for '}' — avoids full re-parse
             let mut obj_end = b.len();
@@ -1548,7 +1548,7 @@ pub fn json_object_update_field_num_chain(
                         v = match op {
                             BinOp::Add => v + n, BinOp::Sub => v - n,
                             BinOp::Mul => v * n, BinOp::Div => v / n,
-                            BinOp::Mod => { if *n == 0.0 || !v.is_finite() { return false; } v % n },
+                            BinOp::Mod => match crate::runtime::jq_mod_f64(v, *n) { Some(r) => r, None => return false },
                             _ => v,
                         };
                     }
@@ -1723,7 +1723,7 @@ pub fn json_object_assign_field_arith(
         BinOp::Sub => src_val - n,
         BinOp::Mul => src_val * n,
         BinOp::Div => src_val / n,
-        BinOp::Mod => { if n == 0.0 || !src_val.is_finite() { return false; } src_val % n },
+        BinOp::Mod => match crate::runtime::jq_mod_f64(src_val, n) { Some(v) => v, None => return false },
         _ => src_val,
     };
     if !r.is_finite() { return false; }
@@ -1762,7 +1762,7 @@ pub fn json_object_assign_two_fields_arith(
         BinOp::Sub => v1 - v2,
         BinOp::Mul => v1 * v2,
         BinOp::Div => v1 / v2,
-        BinOp::Mod => { if v2 == 0.0 || !v1.is_finite() { return false; } v1 % v2 },
+        BinOp::Mod => match crate::runtime::jq_mod_f64(v1, v2) { Some(v) => v, None => return false },
         _ => return false,
     };
     if !r.is_finite() { return false; }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -2162,3 +2162,8 @@ false
 [{(.k): empty}]
 {"a":1}
 []
+
+# Issue #202: $loopvar undefined inside reduce/foreach INIT
+reduce range(3) as $i (0; . + $i)
+null
+3

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -2130,3 +2130,10 @@ reverse
 getpath([{}])
 null
 null
+
+# Issue #207: label name accepted only via break, never as bare $name
+label $x | range(3), break $x
+null
+0
+1
+2

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -2147,3 +2147,8 @@ null
 test("a"; "ix") | not
 "abc"
 false
+
+# Issue #209: slice assignment requires array RHS
+.[0:1] |= [.]
+[1,2,3]
+[[1],2,3]

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -2177,3 +2177,8 @@ null
 -1 % 1
 null
 0
+
+# Issue #206: object-pattern destructure with duplicate var is first-wins
+. as {a: $a, b: $a} | $a
+{"a":1,"b":2}
+1

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -2157,3 +2157,8 @@ false
 [path(.a // .b)]
 {"a":null,"b":2}
 [["b"]]
+
+# Issue #201: {(non_string_key): empty} short-circuits silently
+[{(.k): empty}]
+{"a":1}
+[]

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -2152,3 +2152,8 @@ false
 .[0:2] = [9]
 [1,2,3]
 [9,3]
+
+# Issue #203: path(A // B) returns the surviving path
+[path(.a // .b)]
+{"a":null,"b":2}
+[["b"]]

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -2148,7 +2148,7 @@ test("a"; "ix") | not
 "abc"
 false
 
-# Issue #209: slice assignment requires array RHS
-.[0:1] |= [.]
+# Issue #209: slice assignment with array RHS still works
+.[0:2] = [9]
 [1,2,3]
-[[1],2,3]
+[9,3]

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -2182,3 +2182,8 @@ null
 . as {a: $a, b: $a} | $a
 {"a":1,"b":2}
 1
+
+# Issue #190: scientific notation uses uppercase E with explicit sign
+[1.5e-10] | .[0] | tojson
+null
+"1.5E-10"

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -2125,3 +2125,8 @@ reverse
 [.a = (1, 2)]
 {"a":1}
 [{"a":1},{"a":2}]
+
+# Issue #187: getpath on null short-circuits any path component
+getpath([{}])
+null
+null

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -2167,3 +2167,13 @@ false
 reduce range(3) as $i (0; . + $i)
 null
 3
+
+# Issue #183: % truncates operands to integer
+3.7 % 2
+null
+1
+
+# Issue #183: -1 % 1 yields 0, not -0
+-1 % 1
+null
+0

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -2142,3 +2142,8 @@ null
 [127] | implode | length
 null
 1
+
+# Issue #185: regex unknown flag rejected (not silently ignored)
+test("a"; "ix") | not
+"abc"
+false

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -2137,3 +2137,8 @@ null
 0
 1
 2
+
+# Issue #192: U+007F (DEL) escapes as  in JSON output
+[127] | implode | length
+null
+1


### PR DESCRIPTION
## Summary

Burns down 12 of the remaining bugs filed during the #176-#180 MECE sweep.
One fix per commit; remaining 4 (#188 builtins listing, #191 math edge cases,
#205 computed-key destructure parse, #213 --seq input, plus #190 items 3 / CLI
fast-path tojson) are deferred as larger / out-of-scope for this batch.

## Closed

- **#187** — `getpath` on null short-circuits for object keys (string / number / object — not bool / array / null).
- **#207** — bare `$out` reference outside `break $out` now compile-errors.
- **#192** — JSON output escapes U+007F (DEL) as `` everywhere (incl. compact / pretty / colour buffers).
- **#185** — regex `test/match/scan/capture/sub/gsub/split` reject any flag character outside `gilmnpsx`.
- **#209** — slice assignment `.[N:M] |= V` now requires V to be an array; non-array RHS errors.
- **#204** — `path(.[N:M])` preserves the literal slice expressions; floor / ceil moved to the consumer (`rt_setpath`).
- **#203** — `path(.a // .b)` returns the surviving truthy branch's path.
- **#201** — `{(non_string_key): empty}` short-circuits without complaining about the key.
- **#202** — `reduce` / `foreach` loop variable is no longer in scope inside `INIT`.
- **#183** — `%` truncates both operands to integer (jq's `(int)a % (int)b` semantics) at every site (eval, JIT, interpreter, CLI fast paths, JSON-stream field updates).
- **#206** — object-pattern destructure with duplicate variable name is first-wins, matching jq.

## Refs (partial)

- **#190** — scientific notation now emits uppercase `E` with explicit `+`/`-` for f64-derived output. Items 3 (literal-numbers preservation) and the CLI raw-byte tojson fast path that bypasses normalisation remain unaddressed.

## Test plan

- [x] `cargo build --release` zero warnings
- [x] `cargo test --release` — official + regression + differential all green
- [x] `./bench/comprehensive.sh --quick` within noise of v1.4 baseline
- [x] Each issue verified with the repro from its body

🤖 Generated with [Claude Code](https://claude.com/claude-code)