### PR TITLE
fix: normalise numbers in `tojson` raw-byte fast path (#190)

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -3335,6 +3335,10 @@ pub fn push_json_compact_raw(buf: &mut Vec<u8>, b: &[u8]) {
 
 /// Single-pass tojson: strip whitespace + escape `"` and `\` into a JSON string.
 /// Writes `"<escaped_compact_json>"` to buf (no trailing newline).
+///
+/// Numeric tokens are renormalised through [`normalize_jq_repr`] so the
+/// fast path matches jq 1.8.1's canonical scientific form (uppercase `E`,
+/// explicit `+`/`-` sign — issue #190 items 1 and 2).
 pub fn push_tojson_raw(buf: &mut Vec<u8>, b: &[u8]) {
     buf.push(b'"');
     let mut i = 0;
@@ -3365,6 +3369,28 @@ pub fn push_tojson_raw(buf: &mut Vec<u8>, b: &[u8]) {
                         else { buf.push(b[i]); }
                         i += 1;
                     }
+                }
+            }
+            b'-' | b'0'..=b'9' => {
+                let start = i;
+                if b[i] == b'-' { i += 1; }
+                while i < len && b[i].is_ascii_digit() { i += 1; }
+                if i < len && b[i] == b'.' {
+                    i += 1;
+                    while i < len && b[i].is_ascii_digit() { i += 1; }
+                }
+                if i < len && (b[i] == b'e' || b[i] == b'E') {
+                    i += 1;
+                    if i < len && (b[i] == b'+' || b[i] == b'-') { i += 1; }
+                    while i < len && b[i].is_ascii_digit() { i += 1; }
+                }
+                let num_bytes = &b[start..i];
+                // SAFETY: scanned bytes are ASCII digits/sign/dot/e/E/+/-.
+                let num_str = unsafe { std::str::from_utf8_unchecked(num_bytes) };
+                if let Some(canonical) = normalize_jq_repr(num_str) {
+                    buf.extend_from_slice(canonical.as_bytes());
+                } else {
+                    buf.extend_from_slice(num_bytes);
                 }
             }
             c => { buf.push(c); i += 1; }

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -3618,3 +3618,17 @@ null
 
 @base64d
 "////"
+
+# ---------- Issue #190: tojson stdin fast path normalises scientific notation ----------
+
+tojson
+1.5e-10
+
+tojson
+1e1000
+
+tojson
+[1.5e-10, 1e1000, 17.5]
+
+tojson
+{"a": 1.5e-10, "b": 1e1000}

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -2188,6 +2188,31 @@ null
 null
 "1.5E-10"
 
+# Issue #190: stdin tojson fast path normalises scientific to uppercase E
+tojson
+1.5e-10
+"1.5E-10"
+
+# Issue #190: stdin tojson fast path adds explicit `+` to positive exponent
+tojson
+1e1000
+"1E+1000"
+
+# Issue #190: stdin tojson fast path normalises numbers nested in arrays
+tojson
+[1.5e-10, 1e1000, 17.5]
+"[1.5E-10,1E+1000,17.5]"
+
+# Issue #190: stdin tojson fast path normalises numbers in object values
+tojson
+{"a": 1.5e-10, "b": 1e1000}
+"{\"a\":1.5E-10,\"b\":1E+1000}"
+
+# Issue #190: stdin tojson fast path preserves number-shaped string contents
+tojson
+{"k": "1.5e-10"}
+"{\"k\":\"1.5e-10\"}"
+
 # Issue #191: logb 0 returns -DBL_MAX (jq projects -inf to finite)
 0 | logb
 null


### PR DESCRIPTION
## Summary

The stdin `tojson` fast path (`is_tojson` → `push_tojson_raw`) copied
the input bytes verbatim, so scientific-notation literals shipped
through with their original lowercase `e` and missing exponent sign:

```
$ echo '1.5e-10' | jq -c 'tojson'
"1.5E-10"
$ echo '1.5e-10' | jq-jit -c 'tojson'   # before
"1.5e-10"

$ echo '1e1000' | jq -c 'tojson'
"1E+1000"
$ echo '1e1000' | jq-jit -c 'tojson'    # before
"1e1000"
```

The previous fix (c48554e) addressed items 1+2 of #190 only on the
f64-derived eval path; the raw-byte CLI fast path was deferred. This
patch closes that gap by detecting JSON numbers in the byte stream
and routing them through `normalize_jq_repr` before they land in the
output buffer. Strings stay untouched (the `b'"'` branch isolates
them already).

Item 3 of #190 (literal-numbers preservation across `tojson |
fromjson` for overflow/underflow values) remains deferred. The
official jq test suite (#435/#436/#441/#442/#443) explicitly branches
on `have_decnum` and expects the f64-rounded form for that path; a
proper fix needs a parallel decision about jq-jit's decnum stance.

Refs #190

## Test plan

- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` — regression 442/442, differential 1099/1099, official 509/509
- [x] `./bench/comprehensive.sh --quick` — within noise vs v1.1.0 baseline
- [x] Manual verification of the issue repro:
  ```
  $ echo '1.5e-10' | ./target/release/jq-jit -c 'tojson'
  "1.5E-10"
  $ echo '1e1000' | ./target/release/jq-jit -c 'tojson'
  "1E+1000"
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)