### PR TITLE
chore: bump to 1.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,7 +450,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jq-jit"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jq-jit"
-version = "1.4.1"
+version = "1.4.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A JIT-compiling implementation of jq using Cranelift"


### PR DESCRIPTION
## Summary

Release bump for v1.4.2.

Since v1.4.1:
- **fix**: normalise numbers in `tojson` raw-byte fast path (#190, PR #227) — uppercase `E` with explicit sign in scientific notation, matching jq 1.8.1 (`1.5E-10`, `1E+1000`).
- **docs**: refresh README — drop stale `jqx` branch wording, backfill missing CLI flags (`--raw-output0`, `-C`/`-M`, `--unbuffered`, `--seq`, `-L`, `-V`, `-h`), link `docs/benchmark-history.md` for full perf history (#147, PR #228).

## Test plan
- [x] `cargo build --release` — zero warnings
- [ ] Tag `v1.4.2` after merge to trigger the release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)