### PR TITLE
fix: simplify_expr Pipe preserves lhs runtime errors (#172)

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1228,7 +1228,12 @@ fn simplify_expr(expr: &crate::ir::Expr) -> crate::ir::Expr {
                 }
             }
             // Beta-reduction: .x | . + 1 → .x + 1
-            if sl.is_simple_scalar() && sr.is_input_free() {
+            // `sr` must actually reference Input. When it doesn't, the
+            // substitution is a no-op and folding away `sl |` would
+            // silently swallow lhs runtime errors — e.g. `.a | 0` on a
+            // non-object array must raise "Cannot index array with
+            // string a", not collapse to a bare `0` (#172).
+            if sl.is_simple_scalar() && sr.is_input_free() && contains_input(&sr) {
                 return sr.substitute_input(&sl);
             }
             // [gen] | map(f) = [gen] | [.[] | f] → [gen | f]

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -2248,3 +2248,33 @@ true
 .[0] as {(.k): $v} | $v
 [{"k":"x","x":42}]
 42
+
+# Issue #172: Pipe(.field, constant_rhs) preserves lhs runtime error — int rhs
+try (.a | 0) catch "err"
+[]
+"err"
+
+# Issue #172: same for object-construct rhs
+try (.a | {x:1}) catch "err"
+[]
+"err"
+
+# Issue #172: same for array-construct rhs
+try (.a | [1,2]) catch "err"
+[]
+"err"
+
+# Issue #172: same on a number input
+try (.a | 0) catch "err"
+5
+"err"
+
+# Issue #172: object input still folds correctly
+.a | 0
+{"a":42}
+0
+
+# Issue #172: existing beta-reduction `.x | . + 1` is preserved
+.x | . + 1
+{"x":5}
+6


### PR DESCRIPTION
## Summary

Fixes a silent error-drop in `simplify_expr`'s Pipe handler. The beta-reduction at `src/interpreter.rs:1231` collapsed `Pipe(simple_scalar_lhs, input_free_rhs)` into `rhs.substitute_input(lhs)` without checking that the rhs actually referenced Input. When it didn't, the substitution was a no-op and any runtime error the lhs would have raised was silently swallowed.

**Symptom**: `.a | 0` on `[]` returned `0` instead of jq's `Cannot index array with string "a"`. `(.a | 0)?` therefore yielded `0` instead of empty. The `.a | {x:1}` and `.a | [1,2]` shapes had the same leak.

**Discovery**: surfaced by `tests/fast_path_error_wrap_proptest.rs` (PR #230), which the generator had to gate around to land. This fix removes the gate's reason to exist.

**Fix**: add `contains_input(&sr)` to the guard. The intended `.x | . + 1 → .x + 1` rewrite still fires because there sr references Input.

## Test plan

- [x] `cargo build --release` — zero warnings
- [x] `cargo test --release` — official 509, regression 442→448 (six new cases), all suites pass
- [x] Manual reproduction confirmed: `.a | 0` on `[]` now errors correctly; `(.a | 0)?` empty
- [x] Existing beta-reduction preserved: `.x | . + 1` on `{"x":5}` → `6`
- [x] Bench: no impact — simplify_expr runs at compile time; the added `contains_input` walk only fires when prior conditions already matched. `field access .name` runs in 0.077–0.078s on this branch vs 0.079s on clean main (within noise).
- [ ] CI green

## Follow-up (not in this PR)

`tests/fast_path_error_wrap_proptest.rs` carries a `prop_filter` excluding `Pipe(_, all-constant-rhs)` to dodge this exact bug. After this PR merges, that filter can be lifted in a follow-up to widen the proptest's detection surface.

Refs #172