### PR TITLE
fix: {pairs} | length preserves runtime errors (#172)

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -602,16 +602,24 @@ fn simplify_expr(expr: &crate::ir::Expr) -> crate::ir::Expr {
             if let Expr::ObjectConstruct { pairs } = &sl {
                 if matches!(&sr, Expr::UnaryOp { op: UnaryOp::Length, operand } if matches!(operand.as_ref(), Expr::Input)) {
                     let mut extracted: Vec<(&str, ())> = Vec::with_capacity(pairs.len());
-                    let mut all_literal = true;
-                    for (k, _) in pairs {
+                    let mut all_static = true;
+                    for (k, v) in pairs {
+                        // Key must be a string literal AND value must not
+                        // touch Input. Input-touching values (e.g. `.a`)
+                        // can raise a runtime error against the actual
+                        // input, but folding to a bare integer drops that
+                        // error (same bug class as #172). The sibling
+                        // `[elements] | length` rewrite below already
+                        // honours this; the object form had drifted.
                         if let Expr::Literal(Literal::Str(s)) = k {
+                            if contains_input(v) { all_static = false; break; }
                             extracted.push((s.as_str(), ()));
                         } else {
-                            all_literal = false;
+                            all_static = false;
                             break;
                         }
                     }
-                    if all_literal {
+                    if all_static {
                         let n = normalize_object_pairs(extracted).len();
                         return Expr::Literal(Literal::Num(n as f64, None));
                     }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -2278,3 +2278,23 @@ try (.a | 0) catch "err"
 .x | . + 1
 {"x":5}
 6
+
+# Issue #172: {pairs} | length rewrite preserves runtime error from input-touching value
+try ({a: .a} | length) catch "err"
+[]
+"err"
+
+# Issue #172: literal-only {pairs} | length still folds at compile time
+{a: 1, b: 2} | length
+null
+2
+
+# Issue #172: literal-only {pairs} | length still dedupes
+{a: 1, a: 2} | length
+null
+1
+
+# Issue #172: input-touching {pairs} | length still works at runtime
+{a: .a} | length
+{"a":42}
+1


### PR DESCRIPTION
## Summary

`simplify_expr` collapsed `{a:1, b:2} | length` to a literal `2` at compile time as long as every key was a string literal. The guard ignored the value side: `{a: .a} | length` was also folded to a bare `1`, dropping the runtime error `.a` would raise on a non-object input.

**Symptom**: `{a: .a} | length` on `[]` returned `1` instead of jq's `Cannot index array with string a`. The wrap form `({a: .a} | length)?` therefore yielded `1` instead of empty.

**Discovery**: surfaced by `tests/fast_path_error_wrap_proptest.rs` (#230) while attempting to widen its generator after the const-rhs fold was fixed in #231.

**Fix**: add `contains_input(v)` to the per-pair guard. The sibling `[elements] | length` rewrite already honours this for exactly the same reason (issue #220 / `docs/maintenance.md` §3); the object form had drifted out of sync.

## Test plan

- [x] `cargo build --release` — zero warnings
- [x] `cargo test --release` — official 509, regression 448→452 (four new cases), all suites pass
- [x] Manual verification: `{a: .a} | length` on `[]` errors correctly; literal-only `{a:1, b:2} | length` still folds to `2`; literal dedupe `{a:1, a:2} | length` still folds to `1`; runtime `{a: .a} | length` on `{"a":42}` still returns `1`.
- [x] No bench impact: `simplify_expr` runs at compile time; `contains_input` walk only fires inside the existing fold path.
- [ ] CI green

## Follow-up (not in this PR)

The original goal of the branch was to widen the proptest by lifting its `Pipe(_, all-constant-rhs)` exclusion (now safe to drop after #231). That widening surfaced this bug, plus two more bug classes:

- duplicate-key inputs (`{"x":null,"x":false}`) parse with a different dedup policy than jq (jq is last-wins; jq-jit's raw parse keeps all and `.x` is first-wins)
- `[lits | gen] | .[N]` for any `N` drops input-touching element errors (related to docs/maintenance.md §3 / #42)

Each is its own bug class. After landing this PR, follow-up PRs will fix one at a time and gradually widen the proptest's generator. This PR ships only the smallest, surgical fix.

Refs #172