### PR TITLE
fix: [lits|gen] | .[N] preserves sibling runtime errors

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1065,7 +1065,21 @@ fn simplify_expr(expr: &crate::ir::Expr) -> crate::ir::Expr {
                             };
                             if all_single {
                                 if let Some(i) = effective {
-                                    return elems.swap_remove(i);
+                                    // jq evaluates every element when building
+                                    // the array literal, so a non-selected
+                                    // element that references Input may raise
+                                    // and must propagate. Skip the fold when
+                                    // any sibling touches Input — otherwise
+                                    // `[.[0], 0] | .[1]` on a non-indexable
+                                    // input would silently return `0` instead
+                                    // of erroring (#234).
+                                    let any_sibling_touches_input = elems
+                                        .iter()
+                                        .enumerate()
+                                        .any(|(j, e)| j != i && contains_input(e));
+                                    if !any_sibling_touches_input {
+                                        return elems.swap_remove(i);
+                                    }
                                 }
                             }
                             }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -2298,3 +2298,28 @@ null
 {a: .a} | length
 {"a":42}
 1
+
+# Issue #234: [lits, input-touching] | .[N] preserves sibling runtime error
+try ([.[0], 0] | .[1]) catch "err"
+false
+"err"
+
+# Issue #234: limit(1; .[N]) over array with input-touching sibling propagates error
+try ([0, floor] | limit(1; .[-2])) catch "err"
+null
+"err"
+
+# Issue #234: literal-only [a, b] | .[N] still folds at compile time
+[10, 20, 30] | .[1]
+null
+20
+
+# Issue #234: input-touching selected element still works (selected, not sibling)
+[0, .a] | .[1]
+{"a":7}
+7
+
+# Issue #234: negative index with input-touching sibling propagates error
+try ([0, floor] | .[-2]) catch "err"
+null
+"err"


### PR DESCRIPTION
## Summary

- The `[e0, e1, ...] | .[N] → eN` compile-time fold dropped non-selected elements without checking whether they reference Input. jq evaluates every element when constructing the array literal, so a sibling that raises must propagate.
- Adds a `contains_input` guard on sibling elements only — selected elements may freely reference Input. Mirrors the same fix pattern used for `[elements] | length` (#220) and `{pairs} | length` (#232).
- `[.[0], 0] | .[1]` on a non-indexable input now errors as in jq, instead of silently returning `0`.

## Test plan

- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (official + regression + proptest)
- [x] `JQJIT_PROPTEST_CASES=2000 cargo test --release --test fast_path_error_wrap_proptest` (18s, pass)
- [x] `./bench/comprehensive.sh --quick` — `field access .name` 0.079s, `identity -c` 0.090s — within main baseline noise (main: 0.080s / 0.089s today)
- [x] All three reproducers from #234 now error in jq-jit

Closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)