### PR TITLE
test: pin tojson scientific-notation casing/sign (#190 items 1+2)

### DIFF
--- a/tests/regression.test
+++ b/tests/regression.test
@@ -2323,3 +2323,33 @@ null
 try ([0, floor] | .[-2]) catch "err"
 null
 "err"
+
+# Issue #190: tojson on negative-exponent scientific input uppercases E with minus sign
+tojson
+1.5e-10
+"1.5E-10"
+
+# Issue #190: tojson on large positive-exponent input uses E+ (item 1/2; item 3 → #236)
+tojson
+1e1000
+"1E+1000"
+
+# Issue #190: tojson on negative-mantissa overflow keeps the sign
+tojson
+-1e1000
+"-1E+1000"
+
+# Issue #190: tojson on three-digit exponent with fractional mantissa
+tojson
+1.5e100
+"1.5E+100"
+
+# Issue #190: 1e-5 expands to decimal form (jq's E threshold)
+tojson
+1e-5
+"0.00001"
+
+# Issue #190: 1e-4 stays decimal (boundary between decimal and scientific)
+tojson
+0.0001
+"0.0001"


### PR DESCRIPTION
## Summary

Items 1 (lowercase \`e\`) and 2 (missing \`E+\` sign) of #190 were already resolved by the existing \`normalize_jq_repr\` path. This PR pins the behaviour with regression tests so the issue's repros can't silently regress.

Item 3 (overflow / >15-digit round-trip via libmpdecimal-style \"literal numbers\") is larger and tracked separately in #236.

## Verification

\`\`\`
$ for n in '1e10' '1e-5' '1.5e-10' '1e1000' '-1e1000' '1.5e100' '0.0001' '0.00001'; do
    diff <(echo "$n" | jq -c 'tojson') <(echo "$n" | jq-jit -c 'tojson')
  done
# (no output — all eight match)
\`\`\`

## Test plan

- [x] \`cargo test --release\` (regression + official + proptest)
- [x] \`cargo build --release\` (zero warnings)
- [x] All 8 boundary cases match jq output

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)