### PR TITLE
refactor: seal Value::Num / Value::Obj variants from external construction (#100)

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -12,7 +12,7 @@ use std::rc::Rc;
 use anyhow::{Result, bail};
 
 use crate::ir::*;
-use crate::value::{Value, KeyStr};
+use crate::value::{Value, ObjInner, NumRepr, KeyStr};
 
 type GenResult = Result<bool>;
 pub type EnvRef = Rc<RefCell<Env>>;
@@ -1090,7 +1090,7 @@ fn eval_one(expr: &Expr, input: &Value, env: &EnvRef) -> std::result::Result<Val
         Expr::Negate { operand } => {
             let val = eval_one(operand, input, env)?;
             match val {
-                Value::Num(n, repr) => {
+                Value::Num(n, NumRepr(repr)) => {
                     let neg = if n == 0.0 { 0.0 } else { -n };
                     Ok(Value::number_opt(neg, crate::value::Value::negate_repr(repr)))
                 }
@@ -1789,7 +1789,7 @@ pub fn eval(
                         }
                         Ok(true)
                     }
-                    Value::Obj(o) => {
+                    Value::Obj(ObjInner(o)) => {
                         for v in o.values() {
                             if !cb(v.clone())? { return Ok(false); }
                         }
@@ -1805,7 +1805,7 @@ pub fn eval(
             eval(input_expr, input, env, &mut |container| {
                 match &container {
                     Value::Arr(a) => { for v in a.iter() { if !cb(v.clone())? { return Ok(false); } } Ok(true) }
-                    Value::Obj(o) => { for v in o.values() { if !cb(v.clone())? { return Ok(false); } } Ok(true) }
+                    Value::Obj(ObjInner(o)) => { for v in o.values() { if !cb(v.clone())? { return Ok(false); } } Ok(true) }
                     _ => Ok(true),
                 }
             })
@@ -2082,7 +2082,7 @@ pub fn eval(
                             r
                         };
                         match (&mut acc, rhs_val) {
-                            (Value::Obj(o), Value::Obj(rhs_obj)) => {
+                            (Value::Obj(ObjInner(o)), Value::Obj(ObjInner(rhs_obj))) => {
                                 let obj = Rc::make_mut(o);
                                 for (k, v) in rhs_obj.iter() {
                                     obj.insert(k.clone(), v.clone());
@@ -2297,7 +2297,7 @@ pub fn eval(
         Expr::Negate { operand } => {
             eval(operand, input, env, &mut |val| {
                 match &val {
-                    Value::Num(n, repr) => {
+                    Value::Num(n, NumRepr(repr)) => {
                         // jq normalises `-(0)` back to `+0` (the literal `-0`
                         // and the `Negate` expr never produce a signed zero —
                         // only IEEE arithmetic like `0 * -1` does). Issue #110.
@@ -2360,7 +2360,7 @@ pub fn eval(
 
         Expr::Break { var_index, .. } => {
             let label = env.borrow().get_var(*var_index);
-            if let Value::Num(n, None) = &label {
+            if let Value::Num(n, NumRepr(None)) = &label {
                 return Err(BreakError(*n as u64).into());
             }
             bail!("break: invalid label")
@@ -2602,7 +2602,7 @@ pub fn eval(
 
         Expr::Limit { count, generator } => {
             eval(count, input.clone(), env, &mut |cv| {
-                if let Value::Num(n, None) = &cv {
+                if let Value::Num(n, NumRepr(None)) = &cv {
                     let limit = *n as i64;
                     if limit == 0 { return Ok(true); }
                     if limit < 0 {
@@ -3173,7 +3173,7 @@ pub fn eval_unaryop(op: UnaryOp, val: &Value) -> Result<Value> {
 
 pub fn eval_index(base: &Value, key: &Value, optional: bool) -> std::result::Result<Value, String> {
     match (base, key) {
-        (Value::Obj(o), Value::Str(k)) => Ok(o.get(k.as_str()).cloned().unwrap_or(Value::Null)),
+        (Value::Obj(ObjInner(o)), Value::Str(k)) => Ok(o.get(k.as_str()).cloned().unwrap_or(Value::Null)),
         (Value::Arr(a), Value::Num(n, _)) => {
             if n.is_nan() { return Ok(Value::Null); }
             let idx = *n as i64;
@@ -3240,7 +3240,7 @@ fn eval_recurse_default(val: &Value, cb: &mut dyn FnMut(Value) -> GenResult) -> 
     if !cb(val.clone())? { return Ok(false); }
     match val {
         Value::Arr(a) => { for item in a.iter() { if !stacker::maybe_grow(64 * 1024, 1024 * 1024, || eval_recurse_default(item, cb))? { return Ok(false); } } }
-        Value::Obj(o) => { for v in o.values() { if !stacker::maybe_grow(64 * 1024, 1024 * 1024, || eval_recurse_default(v, cb))? { return Ok(false); } } }
+        Value::Obj(ObjInner(o)) => { for v in o.values() { if !stacker::maybe_grow(64 * 1024, 1024 * 1024, || eval_recurse_default(v, cb))? { return Ok(false); } } }
         _ => {}
     }
     Ok(true)
@@ -3730,7 +3730,7 @@ fn try_eval_key_f64(expr: &Expr, input: &Value) -> Option<f64> {
                     return match v {
                         Value::Str(s) => Some(s.chars().count() as f64),
                         Value::Arr(a) => Some(a.len() as f64),
-                        Value::Obj(o) => Some(o.len() as f64),
+                        Value::Obj(ObjInner(o)) => Some(o.len() as f64),
                         Value::Num(n, _) => Some(n.abs()),
                         Value::Null => Some(0.0),
                         _ => None,
@@ -3753,7 +3753,7 @@ fn try_eval_key_f64(expr: &Expr, input: &Value) -> Option<f64> {
             if !matches!(base.as_ref(), Expr::Input) { return None; }
             if let Expr::Literal(Literal::Str(field)) = key.as_ref() {
                 match input {
-                    Value::Obj(o) => match o.get(field.as_str()) {
+                    Value::Obj(ObjInner(o)) => match o.get(field.as_str()) {
                         Some(Value::Num(n, _)) => Some(*n),
                         _ => None,
                     },
@@ -3784,7 +3784,7 @@ fn try_eval_key_value<'a>(expr: &Expr, input: &'a Value) -> Option<&'a Value> {
             if !matches!(base.as_ref(), Expr::Input) { return None; }
             if let Expr::Literal(Literal::Str(field)) = key.as_ref() {
                 match input {
-                    Value::Obj(o) => o.get(field.as_str()),
+                    Value::Obj(ObjInner(o)) => o.get(field.as_str()),
                     _ => None,
                 }
             } else { None }
@@ -4013,7 +4013,7 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
                 let base = crate::runtime::rt_getpath(&input, &bp).unwrap_or(Value::Null);
                 match &base {
                     Value::Arr(a) => { for i in 0..a.len() { let mut p = match &bp { Value::Arr(a)=>a.as_ref().clone(), _=>vec![] }; p.push(Value::number(i as f64)); if !cb(Value::Arr(Rc::new(p)))? { return Ok(false); } } Ok(true) }
-                    Value::Obj(o) => { for k in o.keys() { let mut p = match &bp { Value::Arr(a)=>a.as_ref().clone(), _=>vec![] }; p.push(Value::from_str(k)); if !cb(Value::Arr(Rc::new(p)))? { return Ok(false); } } Ok(true) }
+                    Value::Obj(ObjInner(o)) => { for k in o.keys() { let mut p = match &bp { Value::Arr(a)=>a.as_ref().clone(), _=>vec![] }; p.push(Value::from_str(k)); if !cb(Value::Arr(Rc::new(p)))? { return Ok(false); } } Ok(true) }
                     _ => {
                         // jq errors `del(.[])` etc. when the current path
                         // points at a non-iterable (issue #54). Silent
@@ -4173,7 +4173,7 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
                 let base = crate::runtime::rt_getpath(&input, &bp).unwrap_or(Value::Null);
                 match &base {
                     Value::Arr(a) => { for i in 0..a.len() { let mut p = match &bp { Value::Arr(a)=>a.as_ref().clone(), _=>vec![] }; p.push(Value::number(i as f64)); if !cb(Value::Arr(Rc::new(p)))? { return Ok(false); } } Ok(true) }
-                    Value::Obj(o) => { for k in o.keys() { let mut p = match &bp { Value::Arr(a)=>a.as_ref().clone(), _=>vec![] }; p.push(Value::from_str(k)); if !cb(Value::Arr(Rc::new(p)))? { return Ok(false); } } Ok(true) }
+                    Value::Obj(ObjInner(o)) => { for k in o.keys() { let mut p = match &bp { Value::Arr(a)=>a.as_ref().clone(), _=>vec![] }; p.push(Value::from_str(k)); if !cb(Value::Arr(Rc::new(p)))? { return Ok(false); } } Ok(true) }
                     _ => Ok(true),
                 }
             })
@@ -4227,7 +4227,7 @@ fn eval_recurse_paths_inner(val: &Value, path: &mut Vec<Value>, cb: &mut dyn FnM
                 path.pop();
             }
         }
-        Value::Obj(o) => {
+        Value::Obj(ObjInner(o)) => {
             for (k, v) in o.iter() {
                 path.push(Value::from_str(k));
                 if !eval_recurse_paths_inner(v, path, cb)? { return Ok(false); }
@@ -4715,7 +4715,7 @@ fn walk_type_guarded_inplace(type_name: &str, then_body: &Expr, mut input: Value
                 Ok(input)
             }
         }
-        Value::Obj(ref mut rc_obj) => {
+        Value::Obj(ObjInner(ref mut rc_obj)) => {
             let obj = Rc::make_mut(rc_obj);
             for (_k, v) in obj.iter_mut() {
                 let taken = std::mem::replace(v, Value::Null);
@@ -4751,7 +4751,7 @@ fn walk_value_cb(f: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value)
             let rebuilt = Value::Arr(Rc::new(new_arr));
             eval(f, rebuilt, env, cb)
         }
-        Value::Obj(ref o) => {
+        Value::Obj(ObjInner(ref o)) => {
             let mut new_obj = crate::value::new_objmap();
             for (k, v) in o.iter() {
                 let mut walked = Vec::new();
@@ -4783,7 +4783,7 @@ fn walk_value_single(f: &Expr, input: Value, env: &EnvRef, out: &mut Vec<Value>)
                 Ok(true)
             })?;
         }
-        Value::Obj(ref o) => {
+        Value::Obj(ObjInner(ref o)) => {
             let mut new_obj = crate::value::new_objmap();
             for (k, v) in o.iter() {
                 let mut walked = Vec::new();

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -62,7 +62,7 @@
 
 use anyhow::Result;
 
-use crate::value::{KeyStr, Value};
+use crate::value::{KeyStr, Value, ObjInner};
 
 /// A fast path whose type-dispatch obligations are encoded in its
 /// `run` signature. See the module docs for the contract.
@@ -97,7 +97,7 @@ impl FastPath for FieldAccessPath {
     fn run(&self, input: &Value) -> Option<Result<Value>> {
         match input {
             Value::Null => Some(Ok(Value::Null)),
-            Value::Obj(obj) => {
+            Value::Obj(ObjInner(obj)) => {
                 let v = obj.get(self.field.as_str()).cloned().unwrap_or(Value::Null);
                 Some(Ok(v))
             }

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -84,7 +84,7 @@ use cranelift_jit::{JITBuilder, JITModule};
 use cranelift_module::{Linkage, Module, FuncId};
 
 use crate::ir::*;
-use crate::value::Value;
+use crate::value::{Value, ObjInner, NumRepr};
 
 const GEN_CONTINUE: i64 = 1;
 const GEN_ERROR: i64 = -1;
@@ -5365,7 +5365,7 @@ extern "C" fn jit_rt_drop(v: *mut Value) {
     unsafe {
         // Fast path: try to pool Rc<ObjMap> instead of deallocating
         let val = std::ptr::read(v);
-        if let Value::Obj(rc) = val {
+        if let Value::Obj(ObjInner(rc)) = val {
             if !crate::value::rc_objmap_pool_return(rc) {
                 // Pool full or refcount > 1, drop normally (rc is consumed above)
             }
@@ -5408,7 +5408,7 @@ extern "C" fn jit_rt_is_truthy(v: *const Value) -> i64 {
 extern "C" fn jit_rt_field_is_truthy(base: *const Value, key_ptr: *const u8, key_len: usize) -> i64 {
     unsafe {
         match &*base {
-            Value::Obj(o) => {
+            Value::Obj(ObjInner(o)) => {
                 let key = std::str::from_utf8_unchecked(std::slice::from_raw_parts(key_ptr, key_len));
                 match o.get(key) {
                     Some(v) => if v.is_truthy() { 1 } else { 0 },
@@ -5425,7 +5425,7 @@ extern "C" fn jit_rt_field_is_truthy(base: *const Value, key_ptr: *const u8, key
 extern "C" fn jit_rt_field_cmp_num(base: *const Value, key_ptr: *const u8, key_len: usize, rhs: f64, op: i32) -> i64 {
     unsafe {
         let field_val = match &*base {
-            Value::Obj(o) => {
+            Value::Obj(ObjInner(o)) => {
                 let key = std::str::from_utf8_unchecked(std::slice::from_raw_parts(key_ptr, key_len));
                 match o.get(key) {
                     Some(v) => v,
@@ -5460,7 +5460,7 @@ extern "C" fn jit_rt_field_binop_field(
 ) -> i64 {
     unsafe {
         let obj = match &*base {
-            Value::Obj(o) => o,
+            Value::Obj(ObjInner(o)) => o,
             Value::Null => {
                 // null.field = null, so this is null OP null
                 match crate::eval::eval_binop(binop_from_i32(op), &Value::Null, &Value::Null) {
@@ -5517,7 +5517,7 @@ extern "C" fn jit_rt_field_binop_const(
 ) -> i64 {
     unsafe {
         let obj = match &*base {
-            Value::Obj(o) => o,
+            Value::Obj(ObjInner(o)) => o,
             Value::Null => {
                 let a = Value::Null;
                 let (l, r) = if field_is_lhs != 0 { (&a, &*rhs) } else { (&*rhs, &a) };
@@ -5572,7 +5572,7 @@ extern "C" fn jit_rt_field_binop_const(
 extern "C" fn jit_rt_index_field(dst: *mut Value, base: *const Value, key_ptr: *const u8, key_len: usize) -> i64 {
     unsafe {
         match &*base {
-            Value::Obj(o) => {
+            Value::Obj(ObjInner(o)) => {
                 let key = std::str::from_utf8_unchecked(std::slice::from_raw_parts(key_ptr, key_len));
                 match o.get(key) {
                     Some(v) => { std::ptr::write(dst, v.clone()); 0 }
@@ -5603,7 +5603,7 @@ extern "C" fn jit_rt_yield_field_ref(
 ) -> i64 {
     unsafe {
         match &*base {
-            Value::Obj(o) => {
+            Value::Obj(ObjInner(o)) => {
                 let key = std::str::from_utf8_unchecked(std::slice::from_raw_parts(key_ptr, key_len));
                 match o.get(key) {
                     Some(v) => cb(v as *const Value, ctx),
@@ -5649,7 +5649,7 @@ extern "C" fn jit_rt_index(dst: *mut Value, base: *const Value, key: *const Valu
             return 0;
         }
         // Fast path: Object[String]
-        if let (Value::Obj(o), Value::Str(k)) = (&*base, &*key) {
+        if let (Value::Obj(ObjInner(o)), Value::Str(k)) = (&*base, &*key) {
             std::ptr::write(dst, o.get(k.as_str()).cloned().unwrap_or(Value::Null));
             return 0;
         }
@@ -5802,7 +5802,7 @@ extern "C" fn jit_rt_unaryop(dst: *mut Value, op: i32, input: *const Value) -> i
                     Value::number(len as f64)
                 }
                 Value::Arr(a) => Value::number(a.len() as f64),
-                Value::Obj(o) => Value::number(o.len() as f64),
+                Value::Obj(ObjInner(o)) => Value::number(o.len() as f64),
                 Value::Error(_) => Value::number(0.0),
             };
             std::ptr::write(dst, v);
@@ -5825,7 +5825,7 @@ extern "C" fn jit_rt_unaryop(dst: *mut Value, op: i32, input: *const Value) -> i
         // Fast path: keys (op 2) and keys_unsorted (op 29)
         if op == 2 || op == 29 {
             match &*input {
-                Value::Obj(o) => {
+                Value::Obj(ObjInner(o)) => {
                     let mut keys: Vec<Value> = o.keys().map(|k| Value::from_str(k)).collect();
                     if op == 2 { keys.sort_by(crate::runtime::compare_values); }
                     std::ptr::write(dst, Value::Arr(Rc::new(keys)));
@@ -5842,7 +5842,7 @@ extern "C" fn jit_rt_unaryop(dst: *mut Value, op: i32, input: *const Value) -> i
         // Fast path: values (op 3)
         if op == 3 {
             match &*input {
-                Value::Obj(o) => {
+                Value::Obj(ObjInner(o)) => {
                     let vals: Vec<Value> = o.values().cloned().collect();
                     std::ptr::write(dst, Value::Arr(Rc::new(vals)));
                     return 0;
@@ -5856,7 +5856,7 @@ extern "C" fn jit_rt_unaryop(dst: *mut Value, op: i32, input: *const Value) -> i
         }
         // Fast path: to_entries (op 27)
         if op == 27 {
-            if let Value::Obj(o) = &*input {
+            if let Value::Obj(ObjInner(o)) = &*input {
                 let mut entries = Vec::with_capacity(o.len());
                 for (k, v) in o.iter() {
                     let mut entry = crate::value::new_objmap();
@@ -5957,7 +5957,7 @@ extern "C" fn jit_rt_unaryop(dst: *mut Value, op: i32, input: *const Value) -> i
                 let mut ok = true;
                 for entry in a.iter() {
                     match entry {
-                        Value::Obj(o) => {
+                        Value::Obj(ObjInner(o)) => {
                             let pick_truthy = |name: &str| -> Option<&Value> {
                                 match o.get(name) {
                                     Some(v) if !matches!(v, Value::Null | Value::False) => Some(v),
@@ -6077,7 +6077,7 @@ extern "C" fn jit_rt_unaryop(dst: *mut Value, op: i32, input: *const Value) -> i
             return 0;
         }
         // Fast path: inline math ops on numbers — avoids eval_unaryop → call_builtin chain
-        if let Value::Num(n, repr) = &*input {
+        if let Value::Num(n, NumRepr(repr)) = &*input {
             let n = *n;
             // abs/fabs: preserve repr for non-negative numbers
             if (op == 7 || op == 31) && n >= 0.0 {
@@ -6346,7 +6346,7 @@ extern "C" fn jit_rt_kind(v: *const Value) -> i64 {
 }
 extern "C" fn jit_rt_len(v: *const Value) -> i64 {
     unsafe {
-        match &*v { Value::Arr(a) => a.len() as i64, Value::Obj(o) => o.len() as i64, _ => 0 }
+        match &*v { Value::Arr(a) => a.len() as i64, Value::Obj(ObjInner(o)) => o.len() as i64, _ => 0 }
     }
 }
 extern "C" fn jit_rt_array_get(dst: *mut Value, arr: *const Value, idx: i64) {
@@ -6371,7 +6371,7 @@ extern "C" fn jit_rt_take_by_idx(dst: *mut Value, container: *mut Value, idx: i6
                     std::ptr::write(dst, Value::Null);
                 }
             }
-            Value::Obj(rc) => {
+            Value::Obj(ObjInner(rc)) => {
                 let obj = Rc::make_mut(rc);
                 if let Some(v) = obj.get_value_mut_by_index(i) {
                     std::ptr::write(dst, std::mem::replace(v, Value::Null));
@@ -6411,7 +6411,7 @@ extern "C" fn jit_rt_put_by_idx(container: *mut Value, idx: i64, val: *mut Value
                     arr[i] = new_val;
                 }
             }
-            Value::Obj(rc) => {
+            Value::Obj(ObjInner(rc)) => {
                 let obj = Rc::make_mut(rc);
                 if let Some(v) = obj.get_value_mut_by_index(i) {
                     *v = new_val;
@@ -6425,7 +6425,7 @@ extern "C" fn jit_rt_put_by_idx(container: *mut Value, idx: i64, val: *mut Value
 extern "C" fn jit_rt_obj_get_idx(dst: *mut Value, obj: *const Value, idx: i64) {
     unsafe {
         match &*obj {
-            Value::Obj(o) => match o.get_index(idx as usize) {
+            Value::Obj(ObjInner(o)) => match o.get_index(idx as usize) {
                 Some((_, v)) => std::ptr::write(dst, v.clone()),
                 None => std::ptr::write(dst, Value::Null),
             },
@@ -6497,7 +6497,7 @@ extern "C" fn jit_rt_path_extract(element: *mut Value, container: *mut Value, ke
                 }
                 0
             }
-            (Value::Obj(rc_obj), Value::Str(k)) => {
+            (Value::Obj(ObjInner(rc_obj)), Value::Str(k)) => {
                 let obj = Rc::make_mut(rc_obj);
                 if let Some(v) = obj.get_mut(k.as_str()) {
                     std::ptr::write(element, std::mem::replace(v, Value::Null));
@@ -6537,7 +6537,7 @@ extern "C" fn jit_rt_path_insert(container: *mut Value, key: *const Value, val: 
                 arr[idx] = new_val;
                 0
             }
-            (Value::Obj(rc_obj), Value::Str(k)) => {
+            (Value::Obj(ObjInner(rc_obj)), Value::Str(k)) => {
                 let obj = Rc::make_mut(rc_obj);
                 obj.insert(crate::value::KeyStr::from(k.as_str()), new_val);
                 0
@@ -6624,7 +6624,7 @@ extern "C" fn jit_rt_collect_finish(dst: *mut Value, env: *mut JitEnv) {
 
 // Object construction helpers
 extern "C" fn jit_rt_obj_new(dst: *mut Value, cap: usize) {
-    unsafe { std::ptr::write(dst, Value::Obj(crate::value::rc_objmap_pool_get(cap))); }
+    unsafe { std::ptr::write(dst, Value::Obj(ObjInner(crate::value::rc_objmap_pool_get(cap)))); }
 }
 /// Insert key-value pair into object. Takes ownership of both key and val (ptr::read, no clone).
 /// Returns 0 on success, -1 on error (jq errors when the key is not a string).
@@ -6632,7 +6632,7 @@ extern "C" fn jit_rt_obj_insert(obj: *mut Value, key: *mut Value, val: *mut Valu
     unsafe {
         let key_val = std::ptr::read(key);
         let val_val = std::ptr::read(val);
-        if let Value::Obj(o) = &mut *obj {
+        if let Value::Obj(ObjInner(o)) = &mut *obj {
             let k: crate::value::KeyStr = match key_val {
                 Value::Str(s) => s,
                 other => {
@@ -6657,7 +6657,7 @@ extern "C" fn jit_rt_obj_insert(obj: *mut Value, key: *mut Value, val: *mut Valu
 extern "C" fn jit_rt_obj_insert_str_key(obj: *mut Value, key_ptr: *const u8, key_len: usize, val: *mut Value) {
     unsafe {
         let val_val = std::ptr::read(val);
-        if let Value::Obj(o) = &mut *obj {
+        if let Value::Obj(ObjInner(o)) = &mut *obj {
             let key = std::str::from_utf8_unchecked(std::slice::from_raw_parts(key_ptr, key_len));
             let k = crate::value::KeyStr::from(key);
             Rc::get_mut(o).unwrap_unchecked().insert(k, val_val);
@@ -6669,7 +6669,7 @@ extern "C" fn jit_rt_obj_insert_str_key(obj: *mut Value, key_ptr: *const u8, key
 extern "C" fn jit_rt_obj_push_str_key(obj: *mut Value, key_ptr: *const u8, key_len: usize, val: *mut Value) {
     unsafe {
         let val_val = std::ptr::read(val);
-        if let Value::Obj(o) = &mut *obj {
+        if let Value::Obj(ObjInner(o)) = &mut *obj {
             let key = std::str::from_utf8_unchecked(std::slice::from_raw_parts(key_ptr, key_len));
             let k = crate::value::KeyStr::from(key);
             Rc::get_mut(o).unwrap_unchecked().push_unique(k, val_val);
@@ -6689,11 +6689,11 @@ extern "C" fn jit_rt_obj_copy_field(
     unsafe {
         let src_field = std::str::from_utf8_unchecked(std::slice::from_raw_parts(src_field_ptr, src_field_len));
         let val = match &*src {
-            Value::Obj(o) => o.get(src_field).cloned().unwrap_or(Value::Null),
+            Value::Obj(ObjInner(o)) => o.get(src_field).cloned().unwrap_or(Value::Null),
             Value::Null => Value::Null,
             _ => Value::Null,
         };
-        if let Value::Obj(o) = &mut *obj {
+        if let Value::Obj(ObjInner(o)) = &mut *obj {
             let obj_key = std::str::from_utf8_unchecked(std::slice::from_raw_parts(obj_key_ptr, obj_key_len));
             let k = crate::value::KeyStr::from(obj_key);
             Rc::get_mut(o).unwrap_unchecked().push_unique(k, val);
@@ -6713,7 +6713,7 @@ extern "C" fn jit_rt_obj_from_fields(
 ) {
     unsafe {
         let pairs = std::slice::from_raw_parts(pair_table, count);
-        if let Value::Obj(src_obj) = &*src {
+        if let Value::Obj(ObjInner(src_obj)) = &*src {
             // General path: single-pass extraction with field-order output
             let mut vals: [std::mem::MaybeUninit<Value>; 16] = std::mem::MaybeUninit::uninit().assume_init();
             let use_heap = count > 16;
@@ -6748,7 +6748,7 @@ extern "C" fn jit_rt_obj_from_fields(
                 };
                 map.push_unique(crate::value::KeyStr::from(name), val);
             }
-            std::ptr::write(dst, Value::Obj(obj));
+            std::ptr::write(dst, Value::Obj(ObjInner(obj)));
         } else {
             // Non-object source: all fields null
             let mut obj = crate::value::rc_objmap_pool_get(count);
@@ -6757,7 +6757,7 @@ extern "C" fn jit_rt_obj_from_fields(
                 let name = std::str::from_utf8_unchecked(std::slice::from_raw_parts(okp, okl));
                 map.push_unique(crate::value::KeyStr::from(name), Value::Null);
             }
-            std::ptr::write(dst, Value::Obj(obj));
+            std::ptr::write(dst, Value::Obj(ObjInner(obj)));
         }
     }
 }
@@ -6798,7 +6798,7 @@ extern "C" fn jit_rt_strbuf_append_val(env: *mut JitEnv, val: *const Value) {
             Value::Null => buf.push_str("null"),
             Value::False => buf.push_str("false"),
             Value::True => buf.push_str("true"),
-            Value::Num(n, repr) => {
+            Value::Num(n, NumRepr(repr)) => {
                 if let Some(r) = repr {
                     buf.push_str(r);
                 } else {
@@ -6892,7 +6892,7 @@ extern "C" fn jit_rt_call_builtin(dst: *mut Value, name_ptr: *const u8, name_len
                                 stack.push(item.clone());
                             }
                         }
-                        Value::Obj(o) => {
+                        Value::Obj(ObjInner(o)) => {
                             for val in o.values().rev() {
                                 stack.push(val.clone());
                             }
@@ -6916,7 +6916,7 @@ extern "C" fn jit_rt_call_builtin(dst: *mut Value, name_ptr: *const u8, name_len
                 let mut stack: Vec<(Value, Vec<Value>)> = Vec::new();
                 // Push root's children in reverse order for correct DFS ordering
                 match &args[0] {
-                    Value::Obj(o) => {
+                    Value::Obj(ObjInner(o)) => {
                         for (key, val) in o.iter().rev() {
                             stack.push((val.clone(), vec![Value::from_str(key.as_str())]));
                         }
@@ -6931,7 +6931,7 @@ extern "C" fn jit_rt_call_builtin(dst: *mut Value, name_ptr: *const u8, name_len
                 while let Some((val, path)) = stack.pop() {
                     results.push(Value::Arr(Rc::new(path.clone())));
                     match &val {
-                        Value::Obj(o) => {
+                        Value::Obj(ObjInner(o)) => {
                             for (key, child) in o.iter().rev() {
                                 let mut p = path.clone();
                                 p.push(Value::from_str(key.as_str()));
@@ -7015,7 +7015,7 @@ extern "C" fn jit_rt_call_builtin(dst: *mut Value, name_ptr: *const u8, name_len
                         match item {
                             Value::Str(sv) => buf.extend_from_slice(sv.as_bytes()),
                             Value::Null => {},
-                            Value::Num(n, repr) => {
+                            Value::Num(n, NumRepr(repr)) => {
                                 if let Some(r) = repr.as_ref().filter(|r| crate::value::is_valid_json_number(r)) {
                                     buf.extend_from_slice(r.as_bytes());
                                 } else {
@@ -7035,7 +7035,7 @@ extern "C" fn jit_rt_call_builtin(dst: *mut Value, name_ptr: *const u8, name_len
         // Fast path: has(key) — avoid dispatch overhead
         if name == "has" && args.len() == 2 {
             let result = match (&args[0], &args[1]) {
-                (Value::Obj(o), Value::Str(k)) => Some(Value::from_bool(o.contains_key(k.as_str()))),
+                (Value::Obj(ObjInner(o)), Value::Str(k)) => Some(Value::from_bool(o.contains_key(k.as_str()))),
                 (Value::Arr(a), Value::Num(n, _)) => {
                     if n.is_nan() || n.is_infinite() { Some(Value::False) }
                     else {
@@ -7053,7 +7053,7 @@ extern "C" fn jit_rt_call_builtin(dst: *mut Value, name_ptr: *const u8, name_len
         // Error cases (type mismatch) fall through to runtime for a proper jq error.
         if name == "in" && args.len() == 2 {
             let result = match (&args[1], &args[0]) {
-                (Value::Obj(o), Value::Str(k)) => Some(Value::from_bool(o.contains_key(k.as_str()))),
+                (Value::Obj(ObjInner(o)), Value::Str(k)) => Some(Value::from_bool(o.contains_key(k.as_str()))),
                 (Value::Arr(a), Value::Num(n, _)) => {
                     if n.is_nan() || n.is_infinite() { Some(Value::False) }
                     else {
@@ -7145,7 +7145,7 @@ extern "C" fn jit_rt_call_builtin(dst: *mut Value, name_ptr: *const u8, name_len
                 let mut ok = true;
                 for key in path.iter() {
                     match (&current, key) {
-                        (Value::Obj(o), Value::Str(k)) => {
+                        (Value::Obj(ObjInner(o)), Value::Str(k)) => {
                             current = o.get(k.as_str()).cloned().unwrap_or(Value::Null);
                         }
                         (Value::Arr(a), Value::Num(n, _)) => {
@@ -7354,7 +7354,7 @@ extern "C" fn jit_rt_call_builtin(dst: *mut Value, name_ptr: *const u8, name_len
                     }
                     // Recurse into children
                     match val {
-                        Value::Obj(o) => {
+                        Value::Obj(ObjInner(o)) => {
                             for (key, child) in o.iter() {
                                 path.push(Value::from_str(key.as_str()));
                                 paths_dfs_filtered(child, path, results, compiled_filter, filter_expr, env);

--- a/src/module.rs
+++ b/src/module.rs
@@ -2,7 +2,7 @@
 
 use std::rc::Rc;
 use anyhow::{Result, bail};
-use crate::value::{Value, KeyStr, new_objmap};
+use crate::value::{Value, ObjInner, KeyStr, new_objmap};
 
 /// Resolve a module name to a file path, searching lib_dirs.
 fn resolve_module(name: &str, lib_dirs: &[String]) -> Result<String> {
@@ -52,7 +52,7 @@ fn parse_module_metadata(content: &str) -> Result<Value> {
         if let Some(semi_pos) = full.find(';') {
             let module_stmt = &full[7..semi_pos].trim();
             // Parse the metadata object
-            if let Ok(Value::Obj(obj)) = parse_simple_object(module_stmt) {
+            if let Ok(Value::Obj(ObjInner(obj))) = parse_simple_object(module_stmt) {
                 for (k, v) in obj.iter() {
                     metadata.insert(k.clone(), v.clone());
                 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -6,7 +6,7 @@
 use std::rc::Rc;
 
 use anyhow::{Result, bail};
-use crate::value::{Value, ObjMap, KeyStr, new_objmap};
+use crate::value::{Value, ObjMap, ObjInner, NumRepr, KeyStr, new_objmap};
 
 // System libm bindings used to match jq's last-digit precision on
 // gamma-family functions, and to obtain logb's f64 return (libm crate
@@ -617,7 +617,7 @@ pub fn rt_add(a: &Value, b: &Value) -> Result<Value> {
             result.extend((**y).iter().cloned());
             Ok(Value::Arr(Rc::new(result)))
         }
-        (Value::Obj(x), Value::Obj(y)) => {
+        (Value::Obj(ObjInner(x)), Value::Obj(ObjInner(y))) => {
             let mut result = (**x).clone();
             for (k, v) in y.iter() {
                 result.insert(k.clone(), v.clone());
@@ -654,7 +654,7 @@ pub fn rt_add_owned(a: Value, b: &Value) -> Result<Value> {
                 }
             }
         }
-        (Value::Obj(x), Value::Obj(y)) => {
+        (Value::Obj(ObjInner(x)), Value::Obj(ObjInner(y))) => {
             match Rc::try_unwrap(x) {
                 Ok(mut map) => {
                     for (k, v) in y.iter() {
@@ -714,7 +714,7 @@ pub fn rt_mul(a: &Value, b: &Value) -> Result<Value> {
                 Ok(Value::from_string(s.as_str().repeat(count)))
             }
         }
-        (Value::Obj(x), Value::Obj(y)) => {
+        (Value::Obj(ObjInner(x)), Value::Obj(ObjInner(y))) => {
             // Object multiplication = recursive merge
             Ok(Value::object_from_map(merge_objects(x, y)))
         }
@@ -730,7 +730,7 @@ fn merge_objects(a: &ObjMap, b: &ObjMap) -> ObjMap {
     let mut result = a.clone();
     for (k, v) in b.iter() {
         if let Some(existing) = result.get(k) {
-            if let (Value::Obj(ea), Value::Obj(eb)) = (existing, v) {
+            if let (Value::Obj(ObjInner(ea)), Value::Obj(ObjInner(eb))) = (existing, v) {
                 result.insert(k.clone(), Value::object_from_map(merge_objects(ea, eb)));
                 continue;
             }
@@ -870,7 +870,7 @@ pub fn values_equal(a: &Value, b: &Value) -> bool {
         (Value::Arr(x), Value::Arr(y)) => {
             x.len() == y.len() && x.iter().zip(y.iter()).all(|(a, b)| values_equal(a, b))
         }
-        (Value::Obj(x), Value::Obj(y)) => {
+        (Value::Obj(ObjInner(x)), Value::Obj(ObjInner(y))) => {
             x.len() == y.len() && x.iter().all(|(k, v)| y.get(k).is_some_and(|yv| values_equal(v, yv)))
         }
         _ => false,
@@ -928,7 +928,7 @@ pub fn compare_values(a: &Value, b: &Value) -> std::cmp::Ordering {
             }
             x.len().cmp(&y.len())
         }
-        (Value::Obj(x), Value::Obj(y)) => {
+        (Value::Obj(ObjInner(x)), Value::Obj(ObjInner(y))) => {
             // Compare by sorted keys then values
             let mut xkeys: Vec<&KeyStr> = x.keys().collect();
             let mut ykeys: Vec<&KeyStr> = y.keys().collect();
@@ -973,7 +973,7 @@ fn rt_type(v: &Value) -> Result<Value> {
 
 fn rt_keys(v: &Value, sorted: bool) -> Result<Value> {
     match v {
-        Value::Obj(o) => {
+        Value::Obj(ObjInner(o)) => {
             let mut keys: Vec<Value> = o.keys().map(|k| Value::from_str(k)).collect();
             if sorted {
                 keys.sort_by(compare_values);
@@ -990,7 +990,7 @@ fn rt_keys(v: &Value, sorted: bool) -> Result<Value> {
 
 fn rt_values(v: &Value) -> Result<Value> {
     match v {
-        Value::Obj(o) => {
+        Value::Obj(ObjInner(o)) => {
             let vals: Vec<Value> = o.values().cloned().collect();
             Ok(Value::Arr(Rc::new(vals)))
         }
@@ -1055,7 +1055,7 @@ fn rt_reverse(v: &Value) -> Result<Value> {
         }
         Value::Null => Ok(Value::Arr(Rc::new(vec![]))),
         Value::Str(s) if s.is_empty() => Ok(Value::Arr(Rc::new(vec![]))),
-        Value::Obj(o) if o.is_empty() => Ok(Value::Arr(Rc::new(vec![]))),
+        Value::Obj(ObjInner(o)) if o.is_empty() => Ok(Value::Arr(Rc::new(vec![]))),
         Value::Str(_) => bail!("Cannot index string with number"),
         Value::Obj(_) => bail!("Cannot index object with number"),
         Value::Num(_, _) => bail!("Cannot index number with number"),
@@ -1074,7 +1074,7 @@ fn rt_flatten(v: &Value, depth: Option<usize>) -> Result<Value> {
         // jq treats an object's values as the array to flatten, then runs
         // the same recursive logic on it (#184). `flatten` on `{"a":[1,2]}`
         // becomes `[[1,2]] | flatten` = `[1,2]`.
-        Value::Obj(o) => {
+        Value::Obj(ObjInner(o)) => {
             let values: Vec<Value> = o.values().cloned().collect();
             let mut result = Vec::new();
             flatten_inner(&values, depth.unwrap_or(usize::MAX), &mut result);
@@ -1209,7 +1209,7 @@ fn rt_add_all(v: &Value) -> Result<Value> {
                     let mut all_obj = true;
                     for item in a.iter() {
                         match item {
-                            Value::Obj(o) => total += o.len(),
+                            Value::Obj(ObjInner(o)) => total += o.len(),
                             Value::Null => {}
                             _ => { all_obj = false; break; }
                         }
@@ -1220,7 +1220,7 @@ fn rt_add_all(v: &Value) -> Result<Value> {
                         let mut key_index: HashMap<crate::value::KeyStr, usize> = HashMap::with_capacity(total);
                         let mut entries: Vec<(crate::value::KeyStr, Value)> = Vec::with_capacity(total);
                         for item in a.iter() {
-                            if let Value::Obj(o) = item {
+                            if let Value::Obj(ObjInner(o)) = item {
                                 for (k, v) in o.iter() {
                                     if let Some(&idx) = key_index.get(k) {
                                         entries[idx].1 = v.clone();
@@ -1247,7 +1247,7 @@ fn rt_add_all(v: &Value) -> Result<Value> {
             }
             Ok(result)
         }
-        Value::Obj(o) => {
+        Value::Obj(ObjInner(o)) => {
             let mut iter = o.values();
             let Some(first) = iter.next() else { return Ok(Value::Null); };
             let mut result = first.clone();
@@ -1263,7 +1263,7 @@ fn rt_add_all(v: &Value) -> Result<Value> {
 fn rt_any(v: &Value) -> Result<Value> {
     match v {
         Value::Arr(a) => Ok(Value::from_bool(a.iter().any(|v| v.is_true()))),
-        Value::Obj(o) => Ok(Value::from_bool(o.values().any(|v| v.is_true()))),
+        Value::Obj(ObjInner(o)) => Ok(Value::from_bool(o.values().any(|v| v.is_true()))),
         _ => bail!("Cannot iterate over {}", v.type_name()),
     }
 }
@@ -1271,7 +1271,7 @@ fn rt_any(v: &Value) -> Result<Value> {
 fn rt_all(v: &Value) -> Result<Value> {
     match v {
         Value::Arr(a) => Ok(Value::from_bool(a.iter().all(|v| v.is_true()))),
-        Value::Obj(o) => Ok(Value::from_bool(o.values().all(|v| v.is_true()))),
+        Value::Obj(ObjInner(o)) => Ok(Value::from_bool(o.values().all(|v| v.is_true()))),
         _ => bail!("Cannot iterate over {}", v.type_name()),
     }
 }
@@ -1299,7 +1299,7 @@ fn rt_round(v: &Value) -> Result<Value> {
 
 fn rt_fabs(v: &Value) -> Result<Value> {
     match v {
-        Value::Num(n, repr) => {
+        Value::Num(n, NumRepr(repr)) => {
             if *n >= 0.0 { Ok(Value::number_opt(*n, repr.clone())) }
             else { Ok(Value::number(n.abs())) }
         }
@@ -1309,7 +1309,7 @@ fn rt_fabs(v: &Value) -> Result<Value> {
 
 fn rt_abs(v: &Value) -> Result<Value> {
     match v {
-        Value::Num(n, repr) => {
+        Value::Num(n, NumRepr(repr)) => {
             if *n >= 0.0 { Ok(Value::number_opt(*n, repr.clone())) }
             else { Ok(Value::number(n.abs())) }
         }
@@ -1504,7 +1504,7 @@ fn rt_fromjson(v: &Value) -> Result<Value> {
 
 fn rt_to_entries(v: &Value) -> Result<Value> {
     match v {
-        Value::Obj(o) => {
+        Value::Obj(ObjInner(o)) => {
             let entries: Vec<Value> = o.iter().map(|(k, v)| {
                 let mut entry = new_objmap();
                 entry.insert("key".into(), Value::from_str(k));
@@ -1532,7 +1532,7 @@ fn rt_from_entries(v: &Value) -> Result<Value> {
             let mut obj = new_objmap();
             for entry in a.iter() {
                 match entry {
-                    Value::Obj(o) => {
+                    Value::Obj(ObjInner(o)) => {
                         // jq resolves the key via `.key // .key_ // .Key // .name // .Name`
                         // — `//` skips null/false — and errors when the resolved key is
                         // not a string. Matches jq 1.8.1 wording.
@@ -1568,7 +1568,7 @@ fn rt_from_entries(v: &Value) -> Result<Value> {
         }
         // jq's from_entries desugars to `map(...) | add + {}`. On {} the map yields [],
         // add yields null, and null + {} is {} — so empty objects round-trip to {}.
-        Value::Obj(o) if o.is_empty() => Ok(Value::object_from_map(new_objmap())),
+        Value::Obj(ObjInner(o)) if o.is_empty() => Ok(Value::object_from_map(new_objmap())),
         _ => bail!("{} cannot be converted from entries", v.type_name()),
     }
 }
@@ -1611,7 +1611,7 @@ fn rt_not(v: &Value) -> Result<Value> {
 
 fn rt_has(v: &Value, key: &Value) -> Result<Value> {
     match (v, key) {
-        (Value::Obj(o), Value::Str(k)) => Ok(Value::from_bool(o.contains_key(k.as_str()))),
+        (Value::Obj(ObjInner(o)), Value::Str(k)) => Ok(Value::from_bool(o.contains_key(k.as_str()))),
         (Value::Arr(a), Value::Num(n, _)) => {
             if n.is_nan() || n.is_infinite() { return Ok(Value::False); }
             let idx = *n as i64;
@@ -1663,7 +1663,7 @@ fn value_contains(a: &Value, b: &Value) -> bool {
         (Value::Arr(x), Value::Arr(y)) => {
             y.iter().all(|yv| x.iter().any(|xv| value_contains(xv, yv)))
         }
-        (Value::Obj(x), Value::Obj(y)) => {
+        (Value::Obj(ObjInner(x)), Value::Obj(ObjInner(y))) => {
             y.iter().all(|(k, yv)| {
                 x.get(k).is_some_and(|xv| value_contains(xv, yv))
             })
@@ -1829,7 +1829,7 @@ fn rt_join(v: &Value, sep: &Value) -> Result<Value> {
                 match item {
                     Value::Str(sv) => buf.extend_from_slice(sv.as_bytes()),
                     Value::Null => {},
-                    Value::Num(n, repr) => {
+                    Value::Num(n, NumRepr(repr)) => {
                         if let Some(r) = repr.as_ref().filter(|r| crate::value::is_valid_json_number(r)) {
                             buf.extend_from_slice(r.as_bytes());
                         } else {
@@ -1934,7 +1934,7 @@ fn rt_indices_dot_fallback(v: &Value, target: &Value) -> Result<Value> {
         (Value::Null, Value::Str(_)) => Ok(Value::Null),
         (Value::Null, Value::Num(_, _)) => Ok(Value::Null),
         (Value::Null, Value::Obj(_)) => Ok(Value::Null),
-        (Value::Obj(o), Value::Str(k)) => Ok(o.get(k.as_str()).cloned().unwrap_or(Value::Null)),
+        (Value::Obj(ObjInner(o)), Value::Str(k)) => Ok(o.get(k.as_str()).cloned().unwrap_or(Value::Null)),
         _ => bail!("Cannot index {} with {}", v.type_name(), index_err_desc(target)),
     }
 }
@@ -2031,7 +2031,7 @@ pub fn rt_getpath(v: &Value, path: &Value) -> Result<Value> {
             let mut current = v.clone();
             for key in p.iter() {
                 match (&current, key) {
-                    (Value::Obj(o), Value::Str(k)) => {
+                    (Value::Obj(ObjInner(o)), Value::Str(k)) => {
                         current = o.get(k.as_str()).cloned().unwrap_or(Value::Null);
                     }
                     (Value::Arr(a), Value::Num(n, _)) => {
@@ -2079,7 +2079,7 @@ pub fn rt_setpath(v: &Value, path: &Value, val: &Value) -> Result<Value> {
             let key = &p[0];
             let rest = Value::Arr(Rc::new(p[1..].to_vec()));
             match (v, key) {
-                (Value::Obj(o), Value::Str(k)) => {
+                (Value::Obj(ObjInner(o)), Value::Str(k)) => {
                     let inner = o.get(k.as_str()).cloned().unwrap_or(Value::Null);
                     let new_inner = rt_setpath(&inner, &rest, val)?;
                     let mut new_obj = (**o).clone();
@@ -2129,7 +2129,7 @@ pub fn rt_setpath(v: &Value, path: &Value, val: &Value) -> Result<Value> {
                     bail!("Cannot index array with string (\"{}\")", k);
                 }
                 // Slice assignment: path element is {start: N, end: N}
-                (_, Value::Obj(slice_spec)) if slice_spec.contains_key("start") && slice_spec.contains_key("end") => {
+                (_, Value::Obj(ObjInner(slice_spec))) if slice_spec.contains_key("start") && slice_spec.contains_key("end") => {
                     // jq applies floor(start) / ceil(end) when consuming a slice path,
                     // and treats null as the open endpoint (0 for start, len for end).
                     let len = match v { Value::Arr(a) => a.len() as i64, _ => 0 };
@@ -2202,7 +2202,7 @@ pub fn rt_setpath_mut(v: &mut Value, path: &[Value], val: Value) -> Result<()> {
             if matches!(v, Value::Null) {
                 *v = Value::object_from_map(new_objmap());
             }
-            if let Value::Obj(o) = v {
+            if let Value::Obj(ObjInner(o)) = v {
                 let obj = Rc::make_mut(o);
                 if rest.is_empty() {
                     obj.insert(KeyStr::from(k.as_str()), val);
@@ -2283,7 +2283,7 @@ fn delete_path(v: &Value, path: &Value) -> Result<Value> {
         Value::Arr(p) if p.len() == 1 => {
             match (v, &p[0]) {
                 (Value::Null, _) => Ok(Value::Null),
-                (Value::Obj(o), Value::Str(k)) => {
+                (Value::Obj(ObjInner(o)), Value::Str(k)) => {
                     let mut new_obj = (**o).clone();
                     new_obj.shift_remove(k.as_str());
                     Ok(Value::object_from_map(new_obj))
@@ -2310,7 +2310,7 @@ fn delete_path(v: &Value, path: &Value) -> Result<Value> {
             let rest = Value::Arr(Rc::new(p[1..].to_vec()));
             match (v, key) {
                 (Value::Null, _) => Ok(Value::Null),
-                (Value::Obj(o), Value::Str(k)) => {
+                (Value::Obj(ObjInner(o)), Value::Str(k)) => {
                     if let Some(inner) = o.get(k.as_str()) {
                         let new_inner = delete_path(inner, &rest)?;
                         let mut new_obj = (**o).clone();

--- a/src/value.rs
+++ b/src/value.rs
@@ -95,7 +95,7 @@ fn pool_return(mut v: Vec<(KeyStr, Value)>) {
     let trivial = v.iter().all(|(k, val)| {
         !k.is_heap_allocated() && match val {
             Value::Null | Value::True | Value::False => true,
-            Value::Num(_, repr) => repr.is_none(),
+            Value::Num(_, NumRepr(repr)) => repr.is_none(),
             Value::Str(s) => !s.is_heap_allocated(),
             _ => false,
         }
@@ -120,7 +120,7 @@ fn pool_return(mut v: Vec<(KeyStr, Value)>) {
 /// Call this instead of letting a Value drop when you know it won't be used again.
 #[inline]
 pub fn pool_value(v: Value) {
-    if let Value::Obj(rc) = v {
+    if let Value::Obj(ObjInner(rc)) = v {
         rc_objmap_pool_return(rc);
     }
 }
@@ -388,16 +388,50 @@ pub const TAG_ARR: u64 = 5;
 pub const TAG_OBJ: u64 = 6;
 pub const TAG_ERROR: u64 = 7;
 
+/// Opaque wrapper around the optional source-repr `Rc<str>` of `Value::Num`.
+///
+/// The inner field is `pub(crate)`, so external crates can name the type
+/// (needed to write the `Value::Num(_, _)` pattern) but cannot construct it
+/// nor access its inner Option. This routes external `Value::Num` construction
+/// through `Value::number` / `Value::number_with_repr` / `Value::number_opt` /
+/// `Value::from_f64`, which preserve the f64↔repr invariant.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NumRepr(pub(crate) Option<Rc<str>>);
+
+impl std::ops::Deref for NumRepr {
+    type Target = Option<Rc<str>>;
+    #[inline]
+    fn deref(&self) -> &Self::Target { &self.0 }
+}
+
+/// Opaque wrapper around the `Rc<ObjMap>` of `Value::Obj`.
+///
+/// The inner field is `pub(crate)`, so external crates can name the type
+/// (needed to write the `Value::Obj(_)` pattern) but cannot construct it nor
+/// access its inner `Rc<ObjMap>`. This routes external `Value::Obj`
+/// construction through `Value::object_from_pairs` /
+/// `Value::object_from_normalized_pairs` / `Value::object_from_map` /
+/// `Value::from_pairs`, which fold the dedup invariant into construction
+/// instead of leaving it to `ObjMap::push_unique` callers.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ObjInner(pub(crate) Rc<ObjMap>);
+
+impl std::ops::Deref for ObjInner {
+    type Target = Rc<ObjMap>;
+    #[inline]
+    fn deref(&self) -> &Self::Target { &self.0 }
+}
+
 /// A jq value.
 pub enum Value {
     Null,
     False,
     True,
     /// Numeric value. Optional Rc<str> preserves original representation for precision.
-    Num(f64, Option<Rc<str>>),
+    Num(f64, NumRepr),
     Str(KeyStr),
     Arr(Rc<Vec<Value>>),
-    Obj(Rc<ObjMap>),
+    Obj(ObjInner),
     Error(Rc<String>),
 }
 
@@ -407,10 +441,10 @@ impl Clone for Value {
             Value::Null => Value::Null,
             Value::False => Value::False,
             Value::True => Value::True,
-            Value::Num(n, repr) => Value::number_opt(*n, repr.clone()),
+            Value::Num(n, NumRepr(repr)) => Value::number_opt(*n, repr.clone()),
             Value::Str(s) => Value::Str(s.clone()),
             Value::Arr(a) => Value::Arr(Rc::clone(a)),
-            Value::Obj(o) => Value::Obj(Rc::clone(o)),
+            Value::Obj(ObjInner(o)) => Value::Obj(ObjInner(Rc::clone(o))),
             Value::Error(e) => Value::Error(Rc::clone(e)),
         }
     }
@@ -425,7 +459,7 @@ impl PartialEq for Value {
             (Value::Num(a, _), Value::Num(b, _)) => a == b,
             (Value::Str(a), Value::Str(b)) => a == b,
             (Value::Arr(a), Value::Arr(b)) => a == b,
-            (Value::Obj(a), Value::Obj(b)) => a == b,
+            (Value::Obj(ObjInner(a)), Value::Obj(ObjInner(b))) => a == b,
             _ => false,
         }
     }
@@ -433,7 +467,7 @@ impl PartialEq for Value {
 
 impl Value {
     pub fn from_f64(n: f64) -> Self {
-        Value::Num(n, None)
+        Value::Num(n, NumRepr(None))
     }
 
     pub fn from_bool(b: bool) -> Self {
@@ -450,7 +484,7 @@ impl Value {
     }
 
     pub fn from_pairs(pairs: impl IntoIterator<Item = (String, Value)>) -> Self {
-        Value::Obj(Rc::new(pairs.into_iter().map(|(k, v)| (KeyStr::from(k), v)).collect()))
+        Value::Obj(ObjInner(Rc::new(pairs.into_iter().map(|(k, v)| (KeyStr::from(k), v)).collect())))
     }
 
     /// Canonical object factory: dedupes duplicate keys (last value wins,
@@ -471,7 +505,7 @@ impl Value {
         for (k, v) in iter {
             map.insert(k.into(), v);
         }
-        Value::Obj(Rc::new(map))
+        Value::Obj(ObjInner(Rc::new(map)))
     }
 
     /// Bypass variant of [`Value::object_from_pairs`]: trusts the caller to
@@ -497,21 +531,21 @@ impl Value {
             );
             map.push_unique(key, v);
         }
-        Value::Obj(Rc::new(map))
+        Value::Obj(ObjInner(Rc::new(map)))
     }
 
     /// Wrap an existing `ObjMap` that was built with invariant-preserving
     /// operations (`insert` / `push_unique` / JSON parsing). Reuses the
     /// caller's allocation — does not dedupe.
     pub fn object_from_map(map: ObjMap) -> Self {
-        Value::Obj(Rc::new(map))
+        Value::Obj(ObjInner(Rc::new(map)))
     }
 
     /// Numeric factory that drops the repr annotation. Equivalent to
     /// [`Value::from_f64`], named consistently with [`Value::object_from_pairs`].
     #[inline]
     pub fn number(n: f64) -> Self {
-        Value::Num(n, None)
+        Value::Num(n, NumRepr(None))
     }
 
     /// Numeric factory that preserves the original textual representation.
@@ -522,7 +556,7 @@ impl Value {
     /// repr does not carry over misleadingly.
     #[inline]
     pub fn number_with_repr(n: f64, repr: Rc<str>) -> Self {
-        Value::Num(n, Some(repr))
+        Value::Num(n, NumRepr(Some(repr)))
     }
 
     /// Numeric factory that takes an already-built repr option. Convenience
@@ -532,7 +566,7 @@ impl Value {
     /// [`Value::number_with_repr`].
     #[inline]
     pub fn number_opt(n: f64, repr: Option<Rc<str>>) -> Self {
-        Value::Num(n, repr)
+        Value::Num(n, NumRepr(repr))
     }
 
     /// Flip the sign of a numeric repr, preserving the original textual form
@@ -590,7 +624,7 @@ impl Value {
 
     pub fn as_obj(&self) -> Option<&Rc<ObjMap>> {
         match self {
-            Value::Obj(o) => Some(o),
+            Value::Obj(ObjInner(o)) => Some(o),
             _ => None,
         }
     }
@@ -617,7 +651,7 @@ impl Value {
             Value::True | Value::False => {
                 bail!("{} ({}) has no length", self.type_name(), crate::value::value_to_json(self))
             }
-            Value::Num(n, repr) => {
+            Value::Num(n, NumRepr(repr)) => {
                 if *n >= 0.0 { Ok(Value::number_opt(*n, repr.clone())) }
                 else { Ok(Value::number(n.abs())) }
             }
@@ -626,7 +660,7 @@ impl Value {
                 Ok(Value::number(s.chars().count() as f64))
             }
             Value::Arr(a) => Ok(Value::number(a.len() as f64)),
-            Value::Obj(o) => Ok(Value::number(o.len() as f64)),
+            Value::Obj(ObjInner(o)) => Ok(Value::number(o.len() as f64)),
             Value::Error(_) => bail!("error has no length"),
         }
     }
@@ -651,7 +685,7 @@ impl fmt::Debug for Value {
             Value::Num(n, _) => write!(f, "Num({})", n),
             Value::Str(s) => write!(f, "Str({:?})", s.as_str()),
             Value::Arr(a) => write!(f, "Arr({:?})", a.as_ref()),
-            Value::Obj(o) => write!(f, "Obj({:?})", o.as_ref()),
+            Value::Obj(ObjInner(o)) => write!(f, "Obj({:?})", o.as_ref()),
             Value::Error(e) => write!(f, "Error({:?})", e.as_str()),
         }
     }
@@ -4054,7 +4088,7 @@ fn parse_json_object(b: &[u8], pos: usize, depth: usize) -> Result<(Value, usize
         map.push_unique(key, val);
         i = skip_ws(b, end);
         if i >= b.len() { bail!("Unterminated object"); }
-        if b[i] == b'}' { return Ok((Value::Obj(rc), i + 1)); }
+        if b[i] == b'}' { return Ok((Value::Obj(ObjInner(rc)), i + 1)); }
         if b[i] != b',' { bail!("Expected ',' or '}}' at position {}", i); }
         i = skip_ws(b, i + 1);
     }
@@ -4875,7 +4909,7 @@ fn push_value_tojson(v: &Value, out: &mut String, depth: usize) {
         Value::Null => out.push_str("null"),
         Value::False => out.push_str("false"),
         Value::True => out.push_str("true"),
-        Value::Num(n, repr) => {
+        Value::Num(n, NumRepr(repr)) => {
             if let Some(r) = repr.as_ref().filter(|r| is_valid_json_number(r) && repr_is_exact_for_f64(r, *n)) {
                 if let Some(canonical) = normalize_jq_repr(r) {
                     out.push_str(&canonical);
@@ -4895,7 +4929,7 @@ fn push_value_tojson(v: &Value, out: &mut String, depth: usize) {
             }
             out.push(']');
         }
-        Value::Obj(o) => {
+        Value::Obj(ObjInner(o)) => {
             out.push('{');
             for (i, (k, v)) in o.iter().enumerate() {
                 if i > 0 { out.push(','); }
@@ -4951,7 +4985,7 @@ fn value_to_json_depth(v: &Value, depth: usize, precise: bool) -> String {
         Value::Null => "null".to_string(),
         Value::False => "false".to_string(),
         Value::True => "true".to_string(),
-        Value::Num(n, repr) => {
+        Value::Num(n, NumRepr(repr)) => {
             if precise {
                 if let Some(r) = repr {
                     if is_valid_json_number(r) {
@@ -4980,7 +5014,7 @@ fn value_to_json_depth(v: &Value, depth: usize, precise: bool) -> String {
             out.push(']');
             out
         }
-        Value::Obj(o) => {
+        Value::Obj(ObjInner(o)) => {
             let mut out = String::from("{");
             for (i, (k, v)) in o.iter().enumerate() {
                 if i > 0 {
@@ -5112,7 +5146,7 @@ fn write_pretty_to_string_impl<const COLOR: bool>(out: &mut String, v: &Value, d
         Value::Null => { c!(COLOR_NULL); out.push_str("null"); c!(COLOR_RESET); }
         Value::False => { c!(COLOR_FALSE); out.push_str("false"); c!(COLOR_RESET); }
         Value::True => { c!(COLOR_TRUE); out.push_str("true"); c!(COLOR_RESET); }
-        Value::Num(n, repr) => {
+        Value::Num(n, NumRepr(repr)) => {
             c!(COLOR_NUMBER);
             if let Some(r) = repr.as_ref().filter(|r| is_valid_json_number(r)) {
                 if let Some(canonical) = normalize_jq_repr(r) {
@@ -5128,7 +5162,7 @@ fn write_pretty_to_string_impl<const COLOR: bool>(out: &mut String, v: &Value, d
         Value::Str(s) => { c!(COLOR_STRING); push_json_string(out, s); c!(COLOR_RESET); }
         Value::Error(e) => push_json_string(out, e),
         Value::Arr(a) if a.is_empty() => { c!(COLOR_ARRAY); out.push_str("[]"); c!(COLOR_RESET); }
-        Value::Obj(o) if o.is_empty() => { c!(COLOR_OBJECT); out.push_str("{}"); c!(COLOR_RESET); }
+        Value::Obj(ObjInner(o)) if o.is_empty() => { c!(COLOR_OBJECT); out.push_str("{}"); c!(COLOR_RESET); }
         Value::Arr(a) => {
             let inner_depth = depth + step;
             // Emit `\033[0m` before each newline so terminals that paint
@@ -5144,7 +5178,7 @@ fn write_pretty_to_string_impl<const COLOR: bool>(out: &mut String, v: &Value, d
             push_indent(out, depth, use_tab);
             c!(COLOR_ARRAY); out.push(']'); c!(COLOR_RESET);
         }
-        Value::Obj(o) => {
+        Value::Obj(ObjInner(o)) => {
             let inner_depth = depth + step;
             c!(COLOR_OBJECT); out.push('{'); c!(COLOR_RESET); out.push('\n');
             if sort_keys {
@@ -5291,7 +5325,7 @@ pub fn write_value_pretty_line_color(w: &mut dyn io::Write, v: &Value, indent: u
                 return w.write_all(b"\n");
             }
             Value::Arr(a) if a.is_empty() => return w.write_all(b"[]\n"),
-            Value::Obj(o) if o.is_empty() => return w.write_all(b"{}\n"),
+            Value::Obj(ObjInner(o)) if o.is_empty() => return w.write_all(b"{}\n"),
             _ => {}
         }
     }
@@ -5356,7 +5390,7 @@ fn push_compact_value_color(buf: &mut Vec<u8>, v: &Value) {
         Value::Null => { c!(COLOR_NULL); buf.extend_from_slice(b"null"); c!(COLOR_RESET); }
         Value::False => { c!(COLOR_FALSE); buf.extend_from_slice(b"false"); c!(COLOR_RESET); }
         Value::True => { c!(COLOR_TRUE); buf.extend_from_slice(b"true"); c!(COLOR_RESET); }
-        Value::Num(n, repr) => {
+        Value::Num(n, NumRepr(repr)) => {
             c!(COLOR_NUMBER);
             if let Some(r) = repr.as_ref().filter(|r| is_valid_json_number(r)) {
                 buf.extend_from_slice(canonical_repr_bytes(r).as_bytes());
@@ -5375,7 +5409,7 @@ fn push_compact_value_color(buf: &mut Vec<u8>, v: &Value) {
             }
             c!(COLOR_ARRAY); buf.push(b']'); c!(COLOR_RESET);
         }
-        Value::Obj(o) => {
+        Value::Obj(ObjInner(o)) => {
             c!(COLOR_OBJECT); buf.push(b'{');
             for (i, (k, val)) in o.iter().enumerate() {
                 if i > 0 { buf.push(b','); }
@@ -5411,7 +5445,7 @@ fn push_pretty_value_impl<const COLOR: bool>(buf: &mut Vec<u8>, v: &Value, depth
         Value::Null => { c!(COLOR_NULL); buf.extend_from_slice(b"null"); c!(COLOR_RESET); }
         Value::False => { c!(COLOR_FALSE); buf.extend_from_slice(b"false"); c!(COLOR_RESET); }
         Value::True => { c!(COLOR_TRUE); buf.extend_from_slice(b"true"); c!(COLOR_RESET); }
-        Value::Num(n, repr) => {
+        Value::Num(n, NumRepr(repr)) => {
             c!(COLOR_NUMBER);
             if let Some(r) = repr.as_ref().filter(|r| is_valid_json_number(r)) {
                 buf.extend_from_slice(canonical_repr_bytes(r).as_bytes());
@@ -5423,7 +5457,7 @@ fn push_pretty_value_impl<const COLOR: bool>(buf: &mut Vec<u8>, v: &Value, depth
         Value::Str(s) => { c!(COLOR_STRING); push_json_string_to_vec(buf, s.as_str()); c!(COLOR_RESET); }
         Value::Error(e) => push_json_string_to_vec(buf, e.as_str()),
         Value::Arr(a) if a.is_empty() => { c!(COLOR_ARRAY); buf.extend_from_slice(b"[]"); c!(COLOR_RESET); }
-        Value::Obj(o) if o.is_empty() => { c!(COLOR_OBJECT); buf.extend_from_slice(b"{}"); c!(COLOR_RESET); }
+        Value::Obj(ObjInner(o)) if o.is_empty() => { c!(COLOR_OBJECT); buf.extend_from_slice(b"{}"); c!(COLOR_RESET); }
         Value::Arr(a) => {
             let inner = depth + step;
             // Reset color before every newline so terminals that paint
@@ -5439,7 +5473,7 @@ fn push_pretty_value_impl<const COLOR: bool>(buf: &mut Vec<u8>, v: &Value, depth
             push_indent_bytes(buf, depth, use_tab);
             c!(COLOR_ARRAY); buf.push(b']'); c!(COLOR_RESET);
         }
-        Value::Obj(o) => {
+        Value::Obj(ObjInner(o)) => {
             let inner = depth + step;
             c!(COLOR_OBJECT); buf.push(b'{'); c!(COLOR_RESET); buf.push(b'\n');
             for (i, (k, val)) in o.iter().enumerate() {
@@ -5482,7 +5516,7 @@ fn push_compact_value(buf: &mut Vec<u8>, v: &Value) {
         Value::Null => buf.extend_from_slice(b"null"),
         Value::False => buf.extend_from_slice(b"false"),
         Value::True => buf.extend_from_slice(b"true"),
-        Value::Num(n, repr) => {
+        Value::Num(n, NumRepr(repr)) => {
             if let Some(r) = repr.as_ref().filter(|r| is_valid_json_number(r)) {
                 buf.extend_from_slice(canonical_repr_bytes(r).as_bytes());
             } else {
@@ -5500,7 +5534,7 @@ fn push_compact_value(buf: &mut Vec<u8>, v: &Value) {
             }
             buf.push(b']');
         }
-        Value::Obj(o) => {
+        Value::Obj(ObjInner(o)) => {
             buf.push(b'{');
             for (i, (k, val)) in o.iter().enumerate() {
                 let kb = k.as_bytes();
@@ -5655,7 +5689,7 @@ fn write_compact_buf_inner(v: &Value, buf: &mut [u8], pos: &mut usize) -> bool {
         Value::Null => push!(b"null"),
         Value::False => push!(b"false"),
         Value::True => push!(b"true"),
-        Value::Num(n, repr) => {
+        Value::Num(n, NumRepr(repr)) => {
             if let Some(r) = repr.as_ref().filter(|r| is_valid_json_number(r)) {
                 let canonical = canonical_repr_bytes(r);
                 push!(canonical.as_bytes());
@@ -5693,7 +5727,7 @@ fn write_compact_buf_inner(v: &Value, buf: &mut [u8], pos: &mut usize) -> bool {
             }
             push!(b"]");
         }
-        Value::Obj(o) => {
+        Value::Obj(ObjInner(o)) => {
             push!(b"{");
             for (i, (k, val)) in o.iter().enumerate() {
                 if i > 0 { push!(b","); }
@@ -5733,7 +5767,7 @@ fn write_value_compact_ext_inner(w: &mut dyn io::Write, v: &Value, sort_keys: bo
         Value::Null => w.write_all(b"null"),
         Value::False => w.write_all(b"false"),
         Value::True => w.write_all(b"true"),
-        Value::Num(n, repr) => {
+        Value::Num(n, NumRepr(repr)) => {
             if let Some(r) = repr.as_ref().filter(|r| is_valid_json_number(r)) {
                 w.write_all(canonical_repr_bytes(r).as_bytes())
             } else {
@@ -5749,7 +5783,7 @@ fn write_value_compact_ext_inner(w: &mut dyn io::Write, v: &Value, sort_keys: bo
             }
             w.write_all(b"]")
         }
-        Value::Obj(o) => {
+        Value::Obj(ObjInner(o)) => {
             w.write_all(b"{")?;
             if sort_keys {
                 let mut entries: Vec<_> = o.iter().collect();

--- a/tests/value_factory_enforcement.rs
+++ b/tests/value_factory_enforcement.rs
@@ -26,7 +26,7 @@
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 
-const GUARDED_PATTERN: &str = "Value::Obj(Rc::new";
+const GUARDED_PATTERN: &str = "Value::Obj(ObjInner(Rc::new";
 
 fn scan_src() -> BTreeMap<String, usize> {
     let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src");


### PR DESCRIPTION
## Summary

- Wrap `Value::Num` and `Value::Obj` payloads in `pub` newtype structs (`NumRepr`, `ObjInner`) with `pub(crate)` inner fields, so external crates cannot construct those variants directly while still being able to pattern-match by name.
- Add `Deref` impls so external read access (`inner.iter()`, `repr.is_none()`, etc.) keeps working transparently.
- Update the factory-enforcement test pattern to track the new wrapped construction form.

## Why this design

The issue's proposal sketch listed two designs and acknowledged design A (struct variants with `pub(crate)` fields) doesn't work in Rust today — variant fields inherit the enum's visibility, so `pub(crate)` on a variant field of a `pub enum` is rejected (E0449, verified). I tried `#[non_exhaustive]` on the tuple variants first, but that makes the variant entirely inaccessible to external pattern matching (even `Value::Num(_, _, ..)` — E0603, verified), which broke the integration tests. Approach B (newtype wrappers) is what landed.

## Seal verification

External construction is blocked at compile time:

```rust
use jq_jit::value::{Value, NumRepr};
let _bad = Value::Num(3.0, NumRepr(None));
// error[E0423]: cannot initialize a tuple struct which contains private fields
```

Field access on the wrapper from outside the crate is also blocked (E0616). The `value_factories` integration test still passes — its read-only pattern matching survives via the `Deref` impls.

## Test plan

- [x] `cargo build --release` — zero warnings
- [x] `cargo test --release` — official 509 + regression + factory + factories suites pass
- [x] Manually verified external construction fails (`E0423`) and external field access fails (`E0616`) in a throwaway consumer crate
- [x] `./bench/comprehensive.sh --quick` — within noise of pre-refactor `main` (e.g. field access `.name` 0.078–0.079s vs pre-refactor 0.081s)
- [x] Factory-enforcement allowlist still valid (4 grandfathered sites in `src/value.rs` for the factory bodies themselves)

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)