### PR TITLE
refactor: nested .a.b apply-site uses RawApplyOutcome (#83 Phase B)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -138,7 +138,7 @@ fn print_jq_error(msg: &str) {
 
 use jq_jit::value::{Value, json_to_value, json_stream, json_stream_offsets, json_stream_raw, json_stream_project, json_value_has_duplicate_keys, json_stream_has_duplicate_keys, json_object_get_num, json_object_get_two_nums, json_object_get_field_raw, json_object_get_fields_raw_buf, json_object_get_nested_field_raw, parse_json_num, json_value_length, json_object_keys_to_buf_reuse, json_object_extract_keys_only, json_object_keys_unsorted_to_buf, json_object_keys_join_to_buf, json_object_has_key, json_object_has_all_keys, json_object_has_any_key, json_type_byte, json_object_del_field, json_object_del_fields, json_object_filter_by_key_str, json_object_merge_literal, json_object_sort_keys, json_object_filter_by_value_type, json_each_value_raw, json_each_value_cb, json_to_entries_raw, json_with_entries_select_value_cmp, json_object_set_field_raw, json_object_update_field_num, json_object_update_field_num_chain, json_object_update_field_case, json_object_update_field_gsub, json_object_update_field_split_first, json_object_update_field_split_last, json_object_update_field_trim, json_object_update_field_slice, json_object_update_field_str_map, json_object_update_field_str_concat, json_object_update_field_length, json_object_update_field_tostring, json_object_update_field_test, json_object_assign_field_arith, json_object_assign_two_fields_arith, json_object_select_then_update_num, json_object_select_then_update_str_concat, json_object_select_compound_then_update_num, json_object_select_str_then_update_num, json_object_values_tostring, is_json_compact, push_json_compact_raw, push_tojson_raw, push_json_pretty_raw, push_json_pretty_raw_at, value_to_json_precise, value_to_json_pretty_ext, push_compact_line, push_compact_line_color, push_pretty_line, push_pretty_line_color, push_jq_number_bytes, write_value_compact_ext, write_value_compact_line, write_value_pretty_line_color, value_to_json_pretty_color, walk_json_transform_nums, pool_value, skip_json_value};
 use jq_jit::interpreter::Filter;
-use jq_jit::fast_path::{apply_field_access_raw, RawApplyOutcome};
+use jq_jit::fast_path::{apply_field_access_raw, apply_nested_field_access_raw, RawApplyOutcome};
 
 fn json_escape_bytes(bytes: &[u8]) -> Vec<u8> {
     let mut buf = Vec::with_capacity(bytes.len());
@@ -5535,21 +5535,12 @@ fn real_main() {
                     let nf_refs: Vec<&str> = nf.iter().map(|s| s.as_str()).collect();
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        match raw[0] {
-                            b'{' => {
-                                if let Some((vs, ve)) = json_object_get_nested_field_raw(raw, 0, &nf_refs) {
-                                    let val_bytes = &raw[vs..ve];
-                                    emit_raw_ln!(&mut compact_buf, val_bytes);
-                                } else {
-                                    let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                    process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                                }
-                            }
-                            b'n' => { compact_buf.extend_from_slice(b"null\n"); }
-                            _ => {
-                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                            }
+                        let outcome = apply_nested_field_access_raw(raw, &nf_refs, |bytes| {
+                            emit_raw_ln!(&mut compact_buf, bytes);
+                        });
+                        if let RawApplyOutcome::Bail = outcome {
+                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }
                         if compact_buf.len() >= 1 << 17 {
                             let _ = out.write_all(&compact_buf);
@@ -15216,21 +15207,12 @@ fn real_main() {
                 let nf_refs: Vec<&str> = nf.iter().map(|s| s.as_str()).collect();
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    match raw[0] {
-                        b'{' => {
-                            if let Some((vs, ve)) = json_object_get_nested_field_raw(raw, 0, &nf_refs) {
-                                let val_bytes = &raw[vs..ve];
-                                emit_raw_ln!(&mut compact_buf, val_bytes);
-                            } else {
-                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                            }
-                        }
-                        b'n' => { compact_buf.extend_from_slice(b"null\n"); }
-                        _ => {
-                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                        }
+                    let outcome = apply_nested_field_access_raw(raw, &nf_refs, |bytes| {
+                        emit_raw_ln!(&mut compact_buf, bytes);
+                    });
+                    if let RawApplyOutcome::Bail = outcome {
+                        let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                        process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                     }
                     if compact_buf.len() >= 1 << 17 {
                         let _ = out.write_all(&compact_buf);

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -62,7 +62,7 @@
 
 use anyhow::Result;
 
-use crate::value::{KeyStr, Value, ObjInner, json_object_get_field_raw};
+use crate::value::{KeyStr, Value, ObjInner, json_object_get_field_raw, json_object_get_nested_field_raw};
 
 /// A fast path whose type-dispatch obligations are encoded in its
 /// `run` signature. See the module docs for the contract.
@@ -180,6 +180,45 @@ where
         }
         // Non-object, non-null: jq raises a type error. Hand off to the
         // generic path; do NOT silently emit `null` (that's #50).
+        _ => RawApplyOutcome::Bail,
+    }
+}
+
+/// Apply the nested `.a.b.c` raw-byte fast path on a single JSON record.
+///
+/// * Object input, fully-resolvable nested path — invokes `emit` with the
+///   final value's raw bytes.
+/// * Object input, path doesn't resolve cleanly — returns
+///   [`RawApplyOutcome::Bail`]. The cause may be a missing key (jq says
+///   `null`) *or* a non-object intermediate (jq says
+///   `Cannot index <type> with "<field>"`); the raw scanner can't
+///   distinguish, so the caller hands off to the generic path which produces
+///   the correct verdict in either case.
+/// * `null` input — invokes `emit` with `b"null"` (jq semantics: any nested
+///   `.a.b…` on null is null).
+/// * Any other input — returns [`RawApplyOutcome::Bail`] for the same reason
+///   as [`apply_field_access_raw`]: the generic path raises the correct
+///   type-error.
+pub fn apply_nested_field_access_raw<E>(
+    raw: &[u8],
+    fields: &[&str],
+    mut emit: E,
+) -> RawApplyOutcome
+where
+    E: FnMut(&[u8]),
+{
+    match raw.first().copied() {
+        Some(b'{') => match json_object_get_nested_field_raw(raw, 0, fields) {
+            Some((vs, ve)) => {
+                emit(&raw[vs..ve]);
+                RawApplyOutcome::Emit
+            }
+            None => RawApplyOutcome::Bail,
+        },
+        Some(b'n') => {
+            emit(b"null");
+            RawApplyOutcome::Emit
+        }
         _ => RawApplyOutcome::Bail,
     }
 }

--- a/tests/fast_path_contract.rs
+++ b/tests/fast_path_contract.rs
@@ -8,7 +8,10 @@
 //! - `Filter::try_typed_fast_path` routes `.field` filters through the
 //!   pilot and returns `None` for filters that aren't yet migrated.
 
-use jq_jit::fast_path::{FastPath, FieldAccessPath, RawApplyOutcome, apply_field_access_raw};
+use jq_jit::fast_path::{
+    FastPath, FieldAccessPath, RawApplyOutcome, apply_field_access_raw,
+    apply_nested_field_access_raw,
+};
 use jq_jit::interpreter::Filter;
 use jq_jit::value::Value;
 
@@ -217,5 +220,81 @@ fn raw_field_access_non_object_non_null_bails() {
             emitted,
             std::str::from_utf8(raw).unwrap(),
         );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Nested field access (`.a.b.c`) — same Bail discipline as the single-field
+// pilot, with one extra wrinkle: when the path doesn't resolve, the helper
+// can't tell apart a missing key (jq → null) from a non-object intermediate
+// (jq → type error). Both cases bail to the generic path.
+
+#[test]
+fn raw_nested_field_full_path_emits_value_bytes() {
+    let mut emitted: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_nested_field_access_raw(
+        b"{\"a\":{\"b\":42}}",
+        &["a", "b"],
+        |b| emitted.push(b.to_vec()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec![b"42".to_vec()]);
+}
+
+#[test]
+fn raw_nested_field_null_input_emits_null_literal() {
+    // jq: `.a.b` on null is null. Emit the literal directly.
+    let mut emitted: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_nested_field_access_raw(b"null", &["a", "b"], |b| emitted.push(b.to_vec()));
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec![b"null".to_vec()]);
+}
+
+#[test]
+fn raw_nested_field_missing_key_bails() {
+    // Top-level key missing — jq produces null, but the raw scanner can't
+    // distinguish this from "intermediate is non-object" (which jq errors on),
+    // so it bails and the generic path picks the right semantics.
+    let mut emitted: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_nested_field_access_raw(b"{}", &["a", "b"], |bytes| {
+        emitted.push(bytes.to_vec())
+    });
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_nested_field_non_object_intermediate_bails() {
+    // `.a.b` on `{"a":"hello"}` — intermediate is string, jq raises a
+    // type error. The helper bails so the generic path raises it.
+    let mut emitted: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_nested_field_access_raw(
+        b"{\"a\":\"hello\"}",
+        &["a", "b"],
+        |bytes| emitted.push(bytes.to_vec()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_nested_field_non_object_non_null_input_bails() {
+    for raw in [
+        b"42".as_slice(),
+        b"\"hello\"".as_slice(),
+        b"true".as_slice(),
+        b"[1,2,3]".as_slice(),
+    ] {
+        let mut emitted: Vec<Vec<u8>> = Vec::new();
+        let outcome = apply_nested_field_access_raw(raw, &["a", "b"], |bytes| {
+            emitted.push(bytes.to_vec())
+        });
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "expected Bail for input {:?}, got {:?}",
+            std::str::from_utf8(raw).unwrap(),
+            outcome,
+        );
+        assert!(emitted.is_empty());
     }
 }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -2412,3 +2412,47 @@ null
 .x?
 null
 null
+
+# Issue #83 Phase B: raw .a.b nested apply-site bails on non-object inputs and
+# on intermediate type mismatches, so `(filter)?` on those inputs yields empty
+# (jq's behaviour) instead of leaking null-masking via the raw fast path.
+
+# Nested access on a number under `?`
+.a.b?
+42
+
+# Nested access on a string under `?`
+.a.b?
+"hi"
+
+# Nested access on a boolean under `?`
+.a.b?
+true
+
+# Nested access where the intermediate is a string (type error) under `?`
+.a.b?
+{"a":"hello"}
+
+# Nested access where the intermediate is a number (type error) under `?`
+.a.b?
+{"a":1}
+
+# Fully-resolved nested path still emits the value
+.a.b
+{"a":{"b":42}}
+42
+
+# Missing nested key still emits null (object intermediate)
+.a.b
+{"a":{}}
+null
+
+# Missing top-level key still emits null
+.a.b
+{}
+null
+
+# Null input still emits null for nested access
+.a.b
+null
+null


### PR DESCRIPTION
## Summary

Second sibling in the Phase B migration started by #241: ports the nested
field-access raw apply-site to the same named-`Bail` discipline.

### Why nested as #2

It's the closest neighbour to the pilot: the apply-site uses the same
`match raw[0]` shape gate, and the bug class (#50 null-masking) hits
nested paths the same way. The pattern transfers verbatim — the only
extra wrinkle is that the raw scanner can't tell apart \"missing key\"
(jq → null) from \"non-object intermediate\" (jq → type error), so the
helper bails to the generic path in both cases.

### What's new

- **`apply_nested_field_access_raw`** in `src/fast_path.rs`. Same
  single-closure shape as `apply_field_access_raw`. Object input bails
  when the nested path doesn't resolve cleanly so the generic path
  picks the right jq verdict.
- Both `nested_field` apply-sites in `bin/jq-jit.rs` (stdin and file
  dispatch) call the helper. The implicit `match raw[0]` cascade is
  replaced by an explicit verdict check.

### Tests

- `tests/fast_path_contract.rs` — 5 new cases pinning the verdict:
  full-path emit, null input null literal, missing key bail,
  non-object intermediate bail, non-{object,null} input bail.
- `tests/regression.test` — 9 new cases covering `.a.b?` over the bail
  matrix (number / string / bool / intermediate-string / intermediate-
  number) plus happy paths (full path, missing nested key, missing top
  key, null input).

## Verification

- [x] `cargo build --release` — zero warnings
- [x] `cargo test --release` — 1099 official+regression PASS, 20
      `fast_path_contract` cases pass, full suite green
- [x] `./bench/comprehensive.sh --quick` — `field access .name`
      0.083s (within noise vs main's 0.082s baseline), `nested
      .x,.y,.name` 0.116s (unchanged) — no regression
- [ ] CI green (auto-merge on pass)

Refs #83