### PR TITLE
refactor: multi-field .a, .b apply-site uses RawApplyOutcome (#83 Phase B)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -138,7 +138,10 @@ fn print_jq_error(msg: &str) {
 
 use jq_jit::value::{Value, json_to_value, json_stream, json_stream_offsets, json_stream_raw, json_stream_project, json_value_has_duplicate_keys, json_stream_has_duplicate_keys, json_object_get_num, json_object_get_two_nums, json_object_get_field_raw, json_object_get_fields_raw_buf, json_object_get_nested_field_raw, parse_json_num, json_value_length, json_object_keys_to_buf_reuse, json_object_extract_keys_only, json_object_keys_unsorted_to_buf, json_object_keys_join_to_buf, json_object_has_key, json_object_has_all_keys, json_object_has_any_key, json_type_byte, json_object_del_field, json_object_del_fields, json_object_filter_by_key_str, json_object_merge_literal, json_object_sort_keys, json_object_filter_by_value_type, json_each_value_raw, json_each_value_cb, json_to_entries_raw, json_with_entries_select_value_cmp, json_object_set_field_raw, json_object_update_field_num, json_object_update_field_num_chain, json_object_update_field_case, json_object_update_field_gsub, json_object_update_field_split_first, json_object_update_field_split_last, json_object_update_field_trim, json_object_update_field_slice, json_object_update_field_str_map, json_object_update_field_str_concat, json_object_update_field_length, json_object_update_field_tostring, json_object_update_field_test, json_object_assign_field_arith, json_object_assign_two_fields_arith, json_object_select_then_update_num, json_object_select_then_update_str_concat, json_object_select_compound_then_update_num, json_object_select_str_then_update_num, json_object_values_tostring, is_json_compact, push_json_compact_raw, push_tojson_raw, push_json_pretty_raw, push_json_pretty_raw_at, value_to_json_precise, value_to_json_pretty_ext, push_compact_line, push_compact_line_color, push_pretty_line, push_pretty_line_color, push_jq_number_bytes, write_value_compact_ext, write_value_compact_line, write_value_pretty_line_color, value_to_json_pretty_color, walk_json_transform_nums, pool_value, skip_json_value};
 use jq_jit::interpreter::Filter;
-use jq_jit::fast_path::{apply_field_access_raw, apply_nested_field_access_raw, RawApplyOutcome};
+use jq_jit::fast_path::{
+    apply_field_access_raw, apply_multi_field_access_raw, apply_nested_field_access_raw,
+    RawApplyOutcome,
+};
 
 fn json_escape_bytes(bytes: &[u8]) -> Vec<u8> {
     let mut buf = Vec::with_capacity(bytes.len());
@@ -5641,12 +5644,13 @@ fn real_main() {
                     let mut ranges_buf = vec![(0usize, 0usize); mf_refs.len()];
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        if json_object_get_fields_raw_buf(raw, 0, &mf_refs, &mut ranges_buf) {
-                            for (vs, ve) in &ranges_buf {
-                                let val_bytes = &raw[*vs..*ve];
-                                emit_raw_ln!(&mut compact_buf, val_bytes);
-                            }
-                        } else {
+                        let outcome = apply_multi_field_access_raw(
+                            raw,
+                            &mf_refs,
+                            &mut ranges_buf,
+                            |bytes| { emit_raw_ln!(&mut compact_buf, bytes); },
+                        );
+                        if let RawApplyOutcome::Bail = outcome {
                             let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                             process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }
@@ -15312,12 +15316,13 @@ fn real_main() {
                 let mut ranges_buf = vec![(0usize, 0usize); mf_refs.len()];
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    if json_object_get_fields_raw_buf(raw, 0, &mf_refs, &mut ranges_buf) {
-                        for (vs, ve) in &ranges_buf {
-                            let val_bytes = &raw[*vs..*ve];
-                            emit_raw_ln!(&mut compact_buf, val_bytes);
-                        }
-                    } else {
+                    let outcome = apply_multi_field_access_raw(
+                        raw,
+                        &mf_refs,
+                        &mut ranges_buf,
+                        |bytes| { emit_raw_ln!(&mut compact_buf, bytes); },
+                    );
+                    if let RawApplyOutcome::Bail = outcome {
                         let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                         process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                     }

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -62,7 +62,10 @@
 
 use anyhow::Result;
 
-use crate::value::{KeyStr, Value, ObjInner, json_object_get_field_raw, json_object_get_nested_field_raw};
+use crate::value::{
+    KeyStr, Value, ObjInner, json_object_get_field_raw, json_object_get_fields_raw_buf,
+    json_object_get_nested_field_raw,
+};
 
 /// A fast path whose type-dispatch obligations are encoded in its
 /// `run` signature. See the module docs for the contract.
@@ -181,6 +184,48 @@ where
         // Non-object, non-null: jq raises a type error. Hand off to the
         // generic path; do NOT silently emit `null` (that's #50).
         _ => RawApplyOutcome::Bail,
+    }
+}
+
+/// Apply the multi-field `.a, .b, .c` raw-byte fast path on a single JSON
+/// record.
+///
+/// The fast path can only emit when the input is an object that contains
+/// **every** requested field — those are the only inputs where the right
+/// answer is exactly the sequence of raw byte ranges in `ranges_buf` after
+/// `json_object_get_fields_raw_buf` succeeds. For everything else the helper
+/// returns [`RawApplyOutcome::Bail`]:
+///
+/// * `null` input — jq emits `null` per field. The generic path produces that
+///   sequence; the raw scanner can't because it has no per-field literal to
+///   emit and falls back to bytes copying.
+/// * partially-missing object — jq emits a mix of values and `null`s. Same
+///   reason as above: the raw scanner is all-or-nothing.
+/// * non-object non-null input — jq raises a type error (one per field, but
+///   it stops at the first); the generic path produces the right error.
+///
+/// `ranges_buf` is borrowed from the caller so the apply-site can keep one
+/// allocation hot across the input stream. Its length must be at least
+/// `fields.len()`.
+pub fn apply_multi_field_access_raw<E>(
+    raw: &[u8],
+    fields: &[&str],
+    ranges_buf: &mut [(usize, usize)],
+    mut emit: E,
+) -> RawApplyOutcome
+where
+    E: FnMut(&[u8]),
+{
+    if json_object_get_fields_raw_buf(raw, 0, fields, ranges_buf) {
+        for (vs, ve) in ranges_buf.iter() {
+            emit(&raw[*vs..*ve]);
+        }
+        RawApplyOutcome::Emit
+    } else {
+        // Includes: non-object inputs, malformed JSON, and any object that
+        // doesn't contain every requested field. The generic path picks the
+        // right jq verdict in each case.
+        RawApplyOutcome::Bail
     }
 }
 

--- a/tests/fast_path_contract.rs
+++ b/tests/fast_path_contract.rs
@@ -10,7 +10,7 @@
 
 use jq_jit::fast_path::{
     FastPath, FieldAccessPath, RawApplyOutcome, apply_field_access_raw,
-    apply_nested_field_access_raw,
+    apply_multi_field_access_raw, apply_nested_field_access_raw,
 };
 use jq_jit::interpreter::Filter;
 use jq_jit::value::Value;
@@ -289,6 +289,85 @@ fn raw_nested_field_non_object_non_null_input_bails() {
         let outcome = apply_nested_field_access_raw(raw, &["a", "b"], |bytes| {
             emitted.push(bytes.to_vec())
         });
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "expected Bail for input {:?}, got {:?}",
+            std::str::from_utf8(raw).unwrap(),
+            outcome,
+        );
+        assert!(emitted.is_empty());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Multi-field comma access (`.a, .b, .c`) — fires only on objects that contain
+// every requested field. Anything else bails (null input, partial object,
+// non-object) so jq's per-field semantics (`null` for null input, mix of
+// values/nulls for partial objects, type error for non-object non-null) come
+// from the generic path.
+
+#[test]
+fn raw_multi_field_complete_object_emits_each_field() {
+    let mut ranges_buf = vec![(0usize, 0usize); 3];
+    let mut emitted: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_multi_field_access_raw(
+        b"{\"a\":1,\"b\":2,\"c\":3}",
+        &["a", "b", "c"],
+        &mut ranges_buf,
+        |bytes| emitted.push(bytes.to_vec()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec![b"1".to_vec(), b"2".to_vec(), b"3".to_vec()]);
+}
+
+#[test]
+fn raw_multi_field_partial_object_bails() {
+    // jq emits a mix of values and nulls; the raw scanner is all-or-nothing,
+    // so the helper bails to the generic path.
+    let mut ranges_buf = vec![(0usize, 0usize); 3];
+    let mut emitted: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_multi_field_access_raw(
+        b"{\"a\":1,\"c\":3}",
+        &["a", "b", "c"],
+        &mut ranges_buf,
+        |bytes| emitted.push(bytes.to_vec()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_multi_field_null_input_bails() {
+    // jq emits one `null` per field; the raw scanner bails so the generic
+    // path produces the per-field nulls.
+    let mut ranges_buf = vec![(0usize, 0usize); 2];
+    let mut emitted: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_multi_field_access_raw(
+        b"null",
+        &["a", "b"],
+        &mut ranges_buf,
+        |bytes| emitted.push(bytes.to_vec()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_multi_field_non_object_non_null_input_bails() {
+    for raw in [
+        b"42".as_slice(),
+        b"\"hello\"".as_slice(),
+        b"true".as_slice(),
+        b"[1,2,3]".as_slice(),
+    ] {
+        let mut ranges_buf = vec![(0usize, 0usize); 2];
+        let mut emitted: Vec<Vec<u8>> = Vec::new();
+        let outcome = apply_multi_field_access_raw(
+            raw,
+            &["a", "b"],
+            &mut ranges_buf,
+            |bytes| emitted.push(bytes.to_vec()),
+        );
         assert!(
             matches!(outcome, RawApplyOutcome::Bail),
             "expected Bail for input {:?}, got {:?}",

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -2456,3 +2456,43 @@ null
 .a.b
 null
 null
+
+# Issue #83 Phase B: raw .a, .b multi-field apply-site bails on partial objects,
+# null input, and non-object non-null input. The generic path fills in the
+# correct per-field semantics (mix of values+nulls, null per field, type error).
+
+# Multi-field on a fully-populated object emits each value
+.a, .b, .c
+{"a":1,"b":2,"c":3}
+1
+2
+3
+
+# Multi-field on a partially-populated object emits values + nulls
+.a, .b, .c
+{"a":1,"c":3}
+1
+null
+3
+
+# Multi-field on null emits one null per field
+.a, .b
+null
+null
+null
+
+# Multi-field under `?` on a number — bail then generic raises, `?` swallows
+.a, .b?
+42
+
+# Multi-field under `?` on a string
+.a, .b?
+"hi"
+
+# Multi-field under `?` on a boolean
+.a, .b?
+true
+
+# Multi-field under `?` on an array
+.a, .b?
+[1,2,3]


### PR DESCRIPTION
## Summary

Third sibling in the Phase B migration started by #241 / #242: ports the
multi-field comma apply-site (`.a, .b, .c`) to the named-`Bail` discipline.

### Verdict shape

The fast path can only emit when the input is an object containing every
requested field — that's the only input where the right answer is exactly
the sequence of raw byte ranges `json_object_get_fields_raw_buf` fills in.
Anything else bails so the generic path produces the right per-field jq
verdict:

- **null input** → jq emits one `null` per field. Generic produces that.
- **partially-populated object** → jq emits a mix of values and `null`s.
  The raw scanner is all-or-nothing; bail to generic.
- **non-object non-null** → jq raises a type error on the first field.
  Generic raises it correctly.

### What's new

- **`apply_multi_field_access_raw`** in `src/fast_path.rs`. Takes the
  caller-owned `ranges_buf` so the apply-site keeps one allocation hot
  across the input stream — same perf shape as the existing code.
- Both `multi_field` apply-sites in `bin/jq-jit.rs` (stdin and file
  dispatch) call the helper. The implicit if-else is replaced by an
  explicit verdict check.

### Tests

- `tests/fast_path_contract.rs` — 4 new cases pinning the verdict
  surface (complete object emit, partial-object bail, null bail,
  non-object non-null bail).
- `tests/regression.test` — 7 new cases covering happy paths (full
  object, partial object, null) plus `.a, .b?` over number / string /
  bool / array.

## Verification

- [x] `cargo build --release` — zero warnings
- [x] `cargo test --release` — 1099 official+regression PASS, 24
      `fast_path_contract` cases pass, full suite green
- [x] `./bench/comprehensive.sh --quick` — `nested .x,.y,.name`
      (the multi_field bench) 0.115s vs main 0.115s, `field access
      .name` 0.083s vs main 0.082s — noise level, no regression
- [ ] CI green (auto-merge on pass)

Refs #83