### PR TITLE
refactor: array-collect [.a, .b] apply-site uses RawApplyOutcome (#83 Phase B)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -139,8 +139,8 @@ fn print_jq_error(msg: &str) {
 use jq_jit::value::{Value, json_to_value, json_stream, json_stream_offsets, json_stream_raw, json_stream_project, json_value_has_duplicate_keys, json_stream_has_duplicate_keys, json_object_get_num, json_object_get_two_nums, json_object_get_field_raw, json_object_get_fields_raw_buf, json_object_get_nested_field_raw, parse_json_num, json_value_length, json_object_keys_to_buf_reuse, json_object_extract_keys_only, json_object_keys_unsorted_to_buf, json_object_keys_join_to_buf, json_object_has_key, json_object_has_all_keys, json_object_has_any_key, json_type_byte, json_object_del_field, json_object_del_fields, json_object_filter_by_key_str, json_object_merge_literal, json_object_sort_keys, json_object_filter_by_value_type, json_each_value_raw, json_each_value_cb, json_to_entries_raw, json_with_entries_select_value_cmp, json_object_set_field_raw, json_object_update_field_num, json_object_update_field_num_chain, json_object_update_field_case, json_object_update_field_gsub, json_object_update_field_split_first, json_object_update_field_split_last, json_object_update_field_trim, json_object_update_field_slice, json_object_update_field_str_map, json_object_update_field_str_concat, json_object_update_field_length, json_object_update_field_tostring, json_object_update_field_test, json_object_assign_field_arith, json_object_assign_two_fields_arith, json_object_select_then_update_num, json_object_select_then_update_str_concat, json_object_select_compound_then_update_num, json_object_select_str_then_update_num, json_object_values_tostring, is_json_compact, push_json_compact_raw, push_tojson_raw, push_json_pretty_raw, push_json_pretty_raw_at, value_to_json_precise, value_to_json_pretty_ext, push_compact_line, push_compact_line_color, push_pretty_line, push_pretty_line_color, push_jq_number_bytes, write_value_compact_ext, write_value_compact_line, write_value_pretty_line_color, value_to_json_pretty_color, walk_json_transform_nums, pool_value, skip_json_value};
 use jq_jit::interpreter::Filter;
 use jq_jit::fast_path::{
-    apply_field_access_raw, apply_multi_field_access_raw, apply_nested_field_access_raw,
-    RawApplyOutcome,
+    apply_array_field_access_raw, apply_field_access_raw, apply_multi_field_access_raw,
+    apply_nested_field_access_raw, RawApplyOutcome,
 };
 
 fn json_escape_bytes(bytes: &[u8]) -> Vec<u8> {
@@ -5607,29 +5607,35 @@ fn real_main() {
                     let mut ranges_buf = vec![(0usize, 0usize); af_refs.len()];
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        if json_object_get_fields_raw_buf(raw, 0, &af_refs, &mut ranges_buf) {
-                            if use_pretty_buf {
-                                compact_buf.extend_from_slice(b"[\n");
-                                for (i, (vs, ve)) in ranges_buf.iter().enumerate() {
-                                    if i > 0 { compact_buf.extend_from_slice(b",\n"); }
-                                    compact_buf.extend_from_slice(b"  ");
-                                    let val = &raw[*vs..*ve];
-                                    if val[0] == b'{' || val[0] == b'[' {
-                                        push_json_pretty_raw_at(&mut compact_buf, val, 2, false, 1);
-                                    } else {
-                                        compact_buf.extend_from_slice(val);
+                        let outcome = apply_array_field_access_raw(
+                            raw,
+                            &af_refs,
+                            &mut ranges_buf,
+                            |ranges, raw| {
+                                if use_pretty_buf {
+                                    compact_buf.extend_from_slice(b"[\n");
+                                    for (i, (vs, ve)) in ranges.iter().enumerate() {
+                                        if i > 0 { compact_buf.extend_from_slice(b",\n"); }
+                                        compact_buf.extend_from_slice(b"  ");
+                                        let val = &raw[*vs..*ve];
+                                        if val[0] == b'{' || val[0] == b'[' {
+                                            push_json_pretty_raw_at(&mut compact_buf, val, 2, false, 1);
+                                        } else {
+                                            compact_buf.extend_from_slice(val);
+                                        }
                                     }
+                                    compact_buf.extend_from_slice(b"\n]\n");
+                                } else {
+                                    compact_buf.push(b'[');
+                                    for (i, (vs, ve)) in ranges.iter().enumerate() {
+                                        if i > 0 { compact_buf.push(b','); }
+                                        compact_buf.extend_from_slice(&raw[*vs..*ve]);
+                                    }
+                                    compact_buf.extend_from_slice(b"]\n");
                                 }
-                                compact_buf.extend_from_slice(b"\n]\n");
-                            } else {
-                                compact_buf.push(b'[');
-                                for (i, (vs, ve)) in ranges_buf.iter().enumerate() {
-                                    if i > 0 { compact_buf.push(b','); }
-                                    compact_buf.extend_from_slice(&raw[*vs..*ve]);
-                                }
-                                compact_buf.extend_from_slice(b"]\n");
-                            }
-                        } else {
+                            },
+                        );
+                        if let RawApplyOutcome::Bail = outcome {
                             let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                             process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }
@@ -15278,29 +15284,35 @@ fn real_main() {
                 let mut ranges_buf = vec![(0usize, 0usize); af_refs.len()];
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    if json_object_get_fields_raw_buf(raw, 0, &af_refs, &mut ranges_buf) {
-                        if use_pretty_buf {
-                            compact_buf.extend_from_slice(b"[\n");
-                            for (i, (vs, ve)) in ranges_buf.iter().enumerate() {
-                                if i > 0 { compact_buf.extend_from_slice(b",\n"); }
-                                compact_buf.extend_from_slice(b"  ");
-                                let val = &raw[*vs..*ve];
-                                if val[0] == b'{' || val[0] == b'[' {
-                                    push_json_pretty_raw_at(&mut compact_buf, val, 2, false, 1);
-                                } else {
-                                    compact_buf.extend_from_slice(val);
+                    let outcome = apply_array_field_access_raw(
+                        raw,
+                        &af_refs,
+                        &mut ranges_buf,
+                        |ranges, raw| {
+                            if use_pretty_buf {
+                                compact_buf.extend_from_slice(b"[\n");
+                                for (i, (vs, ve)) in ranges.iter().enumerate() {
+                                    if i > 0 { compact_buf.extend_from_slice(b",\n"); }
+                                    compact_buf.extend_from_slice(b"  ");
+                                    let val = &raw[*vs..*ve];
+                                    if val[0] == b'{' || val[0] == b'[' {
+                                        push_json_pretty_raw_at(&mut compact_buf, val, 2, false, 1);
+                                    } else {
+                                        compact_buf.extend_from_slice(val);
+                                    }
                                 }
+                                compact_buf.extend_from_slice(b"\n]\n");
+                            } else {
+                                compact_buf.push(b'[');
+                                for (i, (vs, ve)) in ranges.iter().enumerate() {
+                                    if i > 0 { compact_buf.push(b','); }
+                                    compact_buf.extend_from_slice(&raw[*vs..*ve]);
+                                }
+                                compact_buf.extend_from_slice(b"]\n");
                             }
-                            compact_buf.extend_from_slice(b"\n]\n");
-                        } else {
-                            compact_buf.push(b'[');
-                            for (i, (vs, ve)) in ranges_buf.iter().enumerate() {
-                                if i > 0 { compact_buf.push(b','); }
-                                compact_buf.extend_from_slice(&raw[*vs..*ve]);
-                            }
-                            compact_buf.extend_from_slice(b"]\n");
-                        }
-                    } else {
+                        },
+                    );
+                    if let RawApplyOutcome::Bail = outcome {
                         let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                         process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                     }

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -229,6 +229,39 @@ where
     }
 }
 
+/// Apply the array-of-fields `[.a, .b, .c]` raw-byte fast path on a single
+/// JSON record.
+///
+/// Bail discipline mirrors [`apply_multi_field_access_raw`]: the path can
+/// only emit when the input is an object that contains every requested
+/// field. Anything else returns [`RawApplyOutcome::Bail`] and the caller
+/// hands off to the generic path.
+///
+/// Serialisation is left to the caller: when the fields resolve, the helper
+/// hands the filled `ranges_buf` and the raw input bytes to `emit_array`,
+/// which writes the array form (compact or pretty, with whatever indentation
+/// or nesting handling the apply-site needs) into its captured buffer. This
+/// keeps the helper independent of `use_pretty_buf` / colour flags while
+/// still naming the commit point at the function boundary.
+///
+/// `ranges_buf` must have length `>= fields.len()`.
+pub fn apply_array_field_access_raw<E>(
+    raw: &[u8],
+    fields: &[&str],
+    ranges_buf: &mut [(usize, usize)],
+    emit_array: E,
+) -> RawApplyOutcome
+where
+    E: FnOnce(&[(usize, usize)], &[u8]),
+{
+    if json_object_get_fields_raw_buf(raw, 0, fields, ranges_buf) {
+        emit_array(&ranges_buf[..fields.len()], raw);
+        RawApplyOutcome::Emit
+    } else {
+        RawApplyOutcome::Bail
+    }
+}
+
 /// Apply the nested `.a.b.c` raw-byte fast path on a single JSON record.
 ///
 /// * Object input, fully-resolvable nested path — invokes `emit` with the

--- a/tests/fast_path_contract.rs
+++ b/tests/fast_path_contract.rs
@@ -9,8 +9,8 @@
 //!   pilot and returns `None` for filters that aren't yet migrated.
 
 use jq_jit::fast_path::{
-    FastPath, FieldAccessPath, RawApplyOutcome, apply_field_access_raw,
-    apply_multi_field_access_raw, apply_nested_field_access_raw,
+    FastPath, FieldAccessPath, RawApplyOutcome, apply_array_field_access_raw,
+    apply_field_access_raw, apply_multi_field_access_raw, apply_nested_field_access_raw,
 };
 use jq_jit::interpreter::Filter;
 use jq_jit::value::Value;
@@ -375,5 +375,85 @@ fn raw_multi_field_non_object_non_null_input_bails() {
             outcome,
         );
         assert!(emitted.is_empty());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Array-of-fields collect (`[.a, .b, .c]`) — same Bail shape as multi-field
+// (object with every field present, otherwise Bail). Serialisation is left to
+// the caller's closure so pretty / compact framing stays at the apply-site.
+
+#[test]
+fn raw_array_field_complete_object_invokes_emit_once() {
+    let mut ranges_buf = vec![(0usize, 0usize); 3];
+    let mut calls = 0usize;
+    let mut collected: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_array_field_access_raw(
+        b"{\"a\":1,\"b\":2,\"c\":3}",
+        &["a", "b", "c"],
+        &mut ranges_buf,
+        |ranges, raw| {
+            calls += 1;
+            for (vs, ve) in ranges {
+                collected.push(raw[*vs..*ve].to_vec());
+            }
+        },
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(calls, 1, "emit_array must be invoked exactly once");
+    assert_eq!(collected, vec![b"1".to_vec(), b"2".to_vec(), b"3".to_vec()]);
+}
+
+#[test]
+fn raw_array_field_partial_object_bails_without_calling_emit() {
+    let mut ranges_buf = vec![(0usize, 0usize); 3];
+    let mut calls = 0usize;
+    let outcome = apply_array_field_access_raw(
+        b"{\"a\":1,\"c\":3}",
+        &["a", "b", "c"],
+        &mut ranges_buf,
+        |_, _| { calls += 1; },
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert_eq!(calls, 0, "Bail must not invoke emit_array");
+}
+
+#[test]
+fn raw_array_field_null_input_bails_without_calling_emit() {
+    let mut ranges_buf = vec![(0usize, 0usize); 2];
+    let mut calls = 0usize;
+    let outcome = apply_array_field_access_raw(
+        b"null",
+        &["a", "b"],
+        &mut ranges_buf,
+        |_, _| { calls += 1; },
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert_eq!(calls, 0);
+}
+
+#[test]
+fn raw_array_field_non_object_non_null_input_bails() {
+    for raw in [
+        b"42".as_slice(),
+        b"\"hello\"".as_slice(),
+        b"true".as_slice(),
+        b"[1,2,3]".as_slice(),
+    ] {
+        let mut ranges_buf = vec![(0usize, 0usize); 2];
+        let mut calls = 0usize;
+        let outcome = apply_array_field_access_raw(
+            raw,
+            &["a", "b"],
+            &mut ranges_buf,
+            |_, _| { calls += 1; },
+        );
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "expected Bail for input {:?}, got {:?}",
+            std::str::from_utf8(raw).unwrap(),
+            outcome,
+        );
+        assert_eq!(calls, 0);
     }
 }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -2496,3 +2496,39 @@ true
 # Multi-field under `?` on an array
 .a, .b?
 [1,2,3]
+
+# Issue #83 Phase B: raw [.a, .b] array-collect apply-site bails on partial
+# objects, null, and non-object non-null inputs. The generic path produces the
+# right per-field array (with nulls for missing keys, type errors for non-
+# object non-null inputs).
+
+# Array-collect on a fully-populated object emits the values as an array
+[.a, .b, .c]
+{"a":1,"b":2,"c":3}
+[1,2,3]
+
+# Array-collect on a partially-populated object emits values + nulls
+[.a, .b, .c]
+{"a":1,"c":3}
+[1,null,3]
+
+# Array-collect on null emits an array of nulls
+[.a, .b]
+null
+[null,null]
+
+# Array-collect under `?` on a number — bail then generic raises, `?` swallows
+[.a, .b]?
+42
+
+# Array-collect under `?` on a string
+[.a, .b]?
+"hi"
+
+# Array-collect under `?` on a boolean
+[.a, .b]?
+true
+
+# Array-collect under `?` on an array
+[.a, .b]?
+[1,2,3]


### PR DESCRIPTION
## Summary

Fourth sibling in the Phase B migration started by #241 / #242 / #243:
ports the array-of-fields apply-site (`[.a, .b, .c]`) to the named-`Bail`
discipline.

### Verdict shape

Same as `apply_multi_field_access_raw`: emit only when the input is an
object containing every requested field; otherwise bail so the generic
path produces the per-field array (mix of values + nulls for partial
objects, all-null array for null input, type error for non-object
non-null).

### Why an `FnOnce` closure for emit

Serialisation depends on `use_pretty_buf`, on \`push_json_pretty_raw_at\`
for nested object/array values, and on the apply-site's captured output
buffer — none of which generalise. So the helper hands back the filled
`ranges_buf` and the raw input bytes through an `FnOnce` closure and
lets the apply-site keep writing the array form verbatim. The helper
still owns the bail decision (`json_object_get_fields_raw_buf` succeeded
or not), which is the only part that needs to be structurally explicit.

### What's new

- **`apply_array_field_access_raw`** in `src/fast_path.rs`. Same
  caller-owned `ranges_buf` shape as the multi-field helper.
- Both `array_field` apply-sites in `bin/jq-jit.rs` (stdin and file
  dispatch) call the helper. The implicit if-else is replaced by an
  explicit verdict check; the array framing logic moves into the emit
  closure verbatim.

### Tests

- `tests/fast_path_contract.rs` — 4 new cases pinning the verdict.
  Tests assert the emit closure is invoked exactly once on `Emit` and
  zero times on `Bail`.
- `tests/regression.test` — 7 new cases covering happy paths (full
  object, partial object filled with nulls by generic path, null
  input filled with nulls) plus `[.a, .b]?` over number / string /
  bool / array.

## Verification

- [x] `cargo build --release` — zero warnings
- [x] `cargo test --release` — 1099 official+regression PASS, 28
      `fast_path_contract` cases pass, full suite green
- [x] `./bench/comprehensive.sh --quick` — `field access .name`
      0.083s (within noise of main's 0.082s), `nested .x,.y,.name`
      0.117s (within noise of main's 0.115s) — no regression
- [ ] CI green (auto-merge on pass)

Refs #83