### PR TITLE
refactor: has("x") apply-sites use RawApplyOutcome (#83 Phase B)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -139,8 +139,9 @@ fn print_jq_error(msg: &str) {
 use jq_jit::value::{Value, json_to_value, json_stream, json_stream_offsets, json_stream_raw, json_stream_project, json_value_has_duplicate_keys, json_stream_has_duplicate_keys, json_object_get_num, json_object_get_two_nums, json_object_get_field_raw, json_object_get_fields_raw_buf, json_object_get_nested_field_raw, parse_json_num, json_value_length, json_object_keys_to_buf_reuse, json_object_extract_keys_only, json_object_keys_unsorted_to_buf, json_object_keys_join_to_buf, json_object_has_key, json_object_has_all_keys, json_object_has_any_key, json_type_byte, json_object_del_field, json_object_del_fields, json_object_filter_by_key_str, json_object_merge_literal, json_object_sort_keys, json_object_filter_by_value_type, json_each_value_raw, json_each_value_cb, json_to_entries_raw, json_with_entries_select_value_cmp, json_object_set_field_raw, json_object_update_field_num, json_object_update_field_num_chain, json_object_update_field_case, json_object_update_field_gsub, json_object_update_field_split_first, json_object_update_field_split_last, json_object_update_field_trim, json_object_update_field_slice, json_object_update_field_str_map, json_object_update_field_str_concat, json_object_update_field_length, json_object_update_field_tostring, json_object_update_field_test, json_object_assign_field_arith, json_object_assign_two_fields_arith, json_object_select_then_update_num, json_object_select_then_update_str_concat, json_object_select_compound_then_update_num, json_object_select_str_then_update_num, json_object_values_tostring, is_json_compact, push_json_compact_raw, push_tojson_raw, push_json_pretty_raw, push_json_pretty_raw_at, value_to_json_precise, value_to_json_pretty_ext, push_compact_line, push_compact_line_color, push_pretty_line, push_pretty_line_color, push_jq_number_bytes, write_value_compact_ext, write_value_compact_line, write_value_pretty_line_color, value_to_json_pretty_color, walk_json_transform_nums, pool_value, skip_json_value};
 use jq_jit::interpreter::Filter;
 use jq_jit::fast_path::{
-    apply_array_field_access_raw, apply_field_access_raw, apply_multi_field_access_raw,
-    apply_nested_field_access_raw, RawApplyOutcome,
+    apply_array_field_access_raw, apply_field_access_raw, apply_has_field_raw,
+    apply_has_multi_field_raw, apply_multi_field_access_raw, apply_nested_field_access_raw,
+    RawApplyOutcome,
 };
 
 fn json_escape_bytes(bytes: &[u8]) -> Vec<u8> {
@@ -11652,9 +11653,10 @@ fn real_main() {
                 } else if let Some(ref hf) = has_field {
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        if let Some(found) = json_object_has_key(raw, 0, hf) {
-                            compact_buf.extend_from_slice(if found { b"true\n" } else { b"false\n" });
-                        } else {
+                        let outcome = apply_has_field_raw(raw, hf, |bytes| {
+                            emit_raw_ln!(&mut compact_buf, bytes);
+                        });
+                        if let RawApplyOutcome::Bail = outcome {
                             let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                             process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }
@@ -11668,14 +11670,10 @@ fn real_main() {
                     let field_refs: Vec<&str> = hm_fields.iter().map(|s| s.as_str()).collect();
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        let result = if hm_is_and {
-                            json_object_has_all_keys(raw, 0, &field_refs)
-                        } else {
-                            json_object_has_any_key(raw, 0, &field_refs)
-                        };
-                        if let Some(found) = result {
-                            compact_buf.extend_from_slice(if found { b"true\n" } else { b"false\n" });
-                        } else {
+                        let outcome = apply_has_multi_field_raw(raw, &field_refs, hm_is_and, |bytes| {
+                            emit_raw_ln!(&mut compact_buf, bytes);
+                        });
+                        if let RawApplyOutcome::Bail = outcome {
                             let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                             process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }
@@ -21104,9 +21102,10 @@ fn real_main() {
                 let content_bytes = content.as_bytes();
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    if let Some(found) = json_object_has_key(raw, 0, hf) {
-                        compact_buf.extend_from_slice(if found { b"true\n" } else { b"false\n" });
-                    } else {
+                    let outcome = apply_has_field_raw(raw, hf, |bytes| {
+                        emit_raw_ln!(&mut compact_buf, bytes);
+                    });
+                    if let RawApplyOutcome::Bail = outcome {
                         let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                         process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                     }
@@ -21121,14 +21120,10 @@ fn real_main() {
                 let content_bytes = content.as_bytes();
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    let result = if hm_is_and {
-                        json_object_has_all_keys(raw, 0, &field_refs)
-                    } else {
-                        json_object_has_any_key(raw, 0, &field_refs)
-                    };
-                    if let Some(found) = result {
-                        compact_buf.extend_from_slice(if found { b"true\n" } else { b"false\n" });
-                    } else {
+                    let outcome = apply_has_multi_field_raw(raw, &field_refs, hm_is_and, |bytes| {
+                        emit_raw_ln!(&mut compact_buf, bytes);
+                    });
+                    if let RawApplyOutcome::Bail = outcome {
                         let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                         process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                     }

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -64,7 +64,8 @@ use anyhow::Result;
 
 use crate::value::{
     KeyStr, Value, ObjInner, json_object_get_field_raw, json_object_get_fields_raw_buf,
-    json_object_get_nested_field_raw,
+    json_object_get_nested_field_raw, json_object_has_all_keys, json_object_has_any_key,
+    json_object_has_key,
 };
 
 /// A fast path whose type-dispatch obligations are encoded in its
@@ -226,6 +227,63 @@ where
         // doesn't contain every requested field. The generic path picks the
         // right jq verdict in each case.
         RawApplyOutcome::Bail
+    }
+}
+
+/// Apply the `has("x")` raw-byte fast path on a single JSON record.
+///
+/// * Object input — invokes `emit` with `b"true"` if the key is present and
+///   `b"false"` otherwise.
+/// * Any non-object input — returns [`RawApplyOutcome::Bail`]. jq's
+///   `has(IDX)` is type-sensitive (arrays accept integer indices, strings
+///   error, …); the generic path raises the right verdict.
+pub fn apply_has_field_raw<E>(raw: &[u8], field: &str, mut emit: E) -> RawApplyOutcome
+where
+    E: FnMut(&[u8]),
+{
+    match json_object_has_key(raw, 0, field) {
+        Some(true) => {
+            emit(b"true");
+            RawApplyOutcome::Emit
+        }
+        Some(false) => {
+            emit(b"false");
+            RawApplyOutcome::Emit
+        }
+        None => RawApplyOutcome::Bail,
+    }
+}
+
+/// Apply the multi-key `has("a") and has("b")` / `has("a") or has("b")`
+/// raw-byte fast path on a single JSON record.
+///
+/// `is_and` selects between AND-folding (`all`) and OR-folding (`any`) of
+/// the per-key results. Bail discipline matches [`apply_has_field_raw`]:
+/// non-object inputs route to the generic path.
+pub fn apply_has_multi_field_raw<E>(
+    raw: &[u8],
+    fields: &[&str],
+    is_and: bool,
+    mut emit: E,
+) -> RawApplyOutcome
+where
+    E: FnMut(&[u8]),
+{
+    let result = if is_and {
+        json_object_has_all_keys(raw, 0, fields)
+    } else {
+        json_object_has_any_key(raw, 0, fields)
+    };
+    match result {
+        Some(true) => {
+            emit(b"true");
+            RawApplyOutcome::Emit
+        }
+        Some(false) => {
+            emit(b"false");
+            RawApplyOutcome::Emit
+        }
+        None => RawApplyOutcome::Bail,
     }
 }
 

--- a/tests/fast_path_contract.rs
+++ b/tests/fast_path_contract.rs
@@ -10,7 +10,8 @@
 
 use jq_jit::fast_path::{
     FastPath, FieldAccessPath, RawApplyOutcome, apply_array_field_access_raw,
-    apply_field_access_raw, apply_multi_field_access_raw, apply_nested_field_access_raw,
+    apply_field_access_raw, apply_has_field_raw, apply_has_multi_field_raw,
+    apply_multi_field_access_raw, apply_nested_field_access_raw,
 };
 use jq_jit::interpreter::Filter;
 use jq_jit::value::Value;
@@ -455,5 +456,124 @@ fn raw_array_field_non_object_non_null_input_bails() {
             outcome,
         );
         assert_eq!(calls, 0);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// has("x") / has("x") and|or has("y") — emit a literal `true` / `false` for
+// object inputs; bail to generic for any non-object input so jq's
+// type-sensitive `has(IDX)` semantics (arrays accept indices, others error)
+// surface correctly.
+
+#[test]
+fn raw_has_field_present_emits_true() {
+    let mut emitted: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_has_field_raw(b"{\"x\":1,\"y\":2}", "x", |b| emitted.push(b.to_vec()));
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec![b"true".to_vec()]);
+}
+
+#[test]
+fn raw_has_field_absent_emits_false() {
+    let mut emitted: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_has_field_raw(b"{\"y\":2}", "x", |b| emitted.push(b.to_vec()));
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec![b"false".to_vec()]);
+}
+
+#[test]
+fn raw_has_field_non_object_input_bails() {
+    for raw in [
+        b"null".as_slice(),
+        b"42".as_slice(),
+        b"\"hi\"".as_slice(),
+        b"true".as_slice(),
+        b"[1,2,3]".as_slice(),
+    ] {
+        let mut emitted: Vec<Vec<u8>> = Vec::new();
+        let outcome = apply_has_field_raw(raw, "x", |b| emitted.push(b.to_vec()));
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "expected Bail for input {:?}, got {:?}",
+            std::str::from_utf8(raw).unwrap(),
+            outcome,
+        );
+        assert!(emitted.is_empty());
+    }
+}
+
+#[test]
+fn raw_has_multi_field_and_returns_true_when_all_present() {
+    let mut emitted: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_has_multi_field_raw(
+        b"{\"a\":1,\"b\":2,\"c\":3}",
+        &["a", "b"],
+        true,
+        |b| emitted.push(b.to_vec()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec![b"true".to_vec()]);
+}
+
+#[test]
+fn raw_has_multi_field_and_returns_false_when_one_missing() {
+    let mut emitted: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_has_multi_field_raw(
+        b"{\"a\":1}",
+        &["a", "b"],
+        true,
+        |b| emitted.push(b.to_vec()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec![b"false".to_vec()]);
+}
+
+#[test]
+fn raw_has_multi_field_or_returns_true_when_any_present() {
+    let mut emitted: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_has_multi_field_raw(
+        b"{\"a\":1}",
+        &["a", "b"],
+        false,
+        |b| emitted.push(b.to_vec()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec![b"true".to_vec()]);
+}
+
+#[test]
+fn raw_has_multi_field_or_returns_false_when_all_missing() {
+    let mut emitted: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_has_multi_field_raw(
+        b"{\"c\":3}",
+        &["a", "b"],
+        false,
+        |b| emitted.push(b.to_vec()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec![b"false".to_vec()]);
+}
+
+#[test]
+fn raw_has_multi_field_non_object_input_bails() {
+    for is_and in [true, false] {
+        for raw in [
+            b"null".as_slice(),
+            b"42".as_slice(),
+            b"\"hi\"".as_slice(),
+            b"[1,2,3]".as_slice(),
+        ] {
+            let mut emitted: Vec<Vec<u8>> = Vec::new();
+            let outcome =
+                apply_has_multi_field_raw(raw, &["a", "b"], is_and, |b| emitted.push(b.to_vec()));
+            assert!(
+                matches!(outcome, RawApplyOutcome::Bail),
+                "expected Bail for input {:?} (is_and={}), got {:?}",
+                std::str::from_utf8(raw).unwrap(),
+                is_and,
+                outcome,
+            );
+            assert!(emitted.is_empty());
+        }
     }
 }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -2532,3 +2532,61 @@ true
 # Array-collect under `?` on an array
 [.a, .b]?
 [1,2,3]
+
+# Issue #83 Phase B: raw has("x") and has("a") and/or has("b") apply-sites bail
+# on non-object inputs so jq's type-sensitive has(IDX) semantics surface
+# correctly through the generic path.
+
+# has("x") on object with key
+has("x")
+{"x":1,"y":2}
+true
+
+# has("x") on object without key
+has("x")
+{"y":2}
+false
+
+# has("x") under `?` on a number — bails to generic, jq raises, `?` swallows
+has("x")?
+42
+
+# has("x") under `?` on a string
+has("x")?
+"hi"
+
+# has("x") on null returns false (jq's null-tolerance, not an error to swallow)
+has("x")?
+null
+false
+
+# has("x") on array — array indexing semantics differ; bail lets generic handle
+has("x")?
+[1,2,3]
+
+# has("a") and has("b") returns true when both present
+has("a") and has("b")
+{"a":1,"b":2}
+true
+
+# has("a") and has("b") returns false when one missing
+has("a") and has("b")
+{"a":1}
+false
+
+# has("a") or has("b") returns true when one present
+has("a") or has("b")
+{"a":1}
+true
+
+# has("a") or has("b") returns false when both missing
+has("a") or has("b")
+{"c":3}
+false
+
+# has-multi under `?` on a non-object bails
+(has("a") and has("b"))?
+42
+
+(has("a") or has("b"))?
+"hi"


### PR DESCRIPTION
## Summary

Fifth set of siblings in the Phase B migration started by #241 / #242 /
#243 / #244: ports the has-key fast paths (`has(\"x\")` and
`has(\"x\") and|or has(\"y\")`) to the named-`Bail` discipline.

### Verdict shape

Simple Bail-on-non-object: jq's `has(IDX)` is type-sensitive (objects
accept string keys, arrays accept integer indices, others error —
except null which jq tolerates with `false`), and the raw scanners
only recognise objects. Bailing for everything else lets the generic
path produce jq's per-type verdict, including the null-tolerance case.

### What's new

- **`apply_has_field_raw`** and **`apply_has_multi_field_raw`** in
  `src/fast_path.rs`. The multi-key helper takes `is_and: bool` to
  pick between AND-folding and OR-folding.
- All four apply-sites in `bin/jq-jit.rs` (stdin + file dispatch for
  both `has_field` and `has_multi`) call the helpers. Implicit
  if-else cascades become explicit verdict checks.

### Tests

- `tests/fast_path_contract.rs` — 8 new cases pinning the verdicts
  (present/absent emit, all-true/all-false/any-present/all-missing for
  multi, non-object Bail across both shapes).
- `tests/regression.test` — 13 new cases covering happy paths plus
  `?` over number / string / null / array. Notably `has(\"x\")?` on
  null returns `false` (not empty) — jq tolerates null with `false`
  rather than erroring, and bailing to generic correctly produces it.

## Verification

- [x] `cargo build --release` — zero warnings
- [x] `cargo test --release` — 1100 official+regression PASS, 36
      `fast_path_contract` cases pass, full suite green
- [x] `./bench/comprehensive.sh --quick` — `field access .name`
      0.082s (vs main 0.082s), `nested .x,.y,.name` 0.113s (vs main
      0.115s) — noise level, no regression
- [ ] CI green (auto-merge on pass)

Refs #83