### PR TITLE
refactor: object-compute apply-sites use RawApplyOutcome (#83 Phase B)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -141,7 +141,7 @@ use jq_jit::interpreter::Filter;
 use jq_jit::fast_path::{
     apply_array_field_access_raw, apply_field_access_raw, apply_has_field_raw,
     apply_has_multi_field_raw, apply_multi_field_access_raw, apply_nested_field_access_raw,
-    RawApplyOutcome,
+    apply_object_compute_raw, RawApplyOutcome,
 };
 
 fn json_escape_bytes(bytes: &[u8]) -> Vec<u8> {
@@ -5569,31 +5569,34 @@ fn real_main() {
                     let mut ranges_buf = vec![(0usize, 0usize); field_refs.len()];
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        if json_object_get_fields_raw_buf(raw, 0, &field_refs, &mut ranges_buf) {
-                            // Bail to generic eval whenever any computed cell would
-                            // raise a type error in jq (#163). The fast path can
-                            // only emit num+num and str+str arithmetic; anything
-                            // else gets routed through the generic path.
-                            if resolved.iter().any(|r| resolved_would_error(r, raw, &ranges_buf)) {
-                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                            } else if use_pretty_buf {
-                                compact_buf.extend_from_slice(b"[\n");
-                                for (i, res) in resolved.iter().enumerate() {
-                                    if i > 0 { compact_buf.extend_from_slice(b",\n"); }
-                                    compact_buf.extend_from_slice(b"  ");
-                                    emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf);
+                        let outcome = apply_object_compute_raw(
+                            raw,
+                            &field_refs,
+                            &mut ranges_buf,
+                            // Inner bail (#163): bail when any computed cell would raise a
+                            // jq type error (e.g. str + num). The raw scanner only handles
+                            // num+num / str+str arithmetic; everything else goes generic.
+                            |ranges, raw| resolved.iter().any(|r| resolved_would_error(r, raw, ranges)),
+                            |ranges, raw| {
+                                if use_pretty_buf {
+                                    compact_buf.extend_from_slice(b"[\n");
+                                    for (i, res) in resolved.iter().enumerate() {
+                                        if i > 0 { compact_buf.extend_from_slice(b",\n"); }
+                                        compact_buf.extend_from_slice(b"  ");
+                                        emit_resolved_value(&mut compact_buf, res, raw, ranges);
+                                    }
+                                    compact_buf.extend_from_slice(b"\n]\n");
+                                } else {
+                                    compact_buf.push(b'[');
+                                    for (i, res) in resolved.iter().enumerate() {
+                                        if i > 0 { compact_buf.push(b','); }
+                                        emit_resolved_value(&mut compact_buf, res, raw, ranges);
+                                    }
+                                    compact_buf.extend_from_slice(b"]\n");
                                 }
-                                compact_buf.extend_from_slice(b"\n]\n");
-                            } else {
-                                compact_buf.push(b'[');
-                                for (i, res) in resolved.iter().enumerate() {
-                                    if i > 0 { compact_buf.push(b','); }
-                                    emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf);
-                                }
-                                compact_buf.extend_from_slice(b"]\n");
-                            }
-                        } else {
+                            },
+                        );
+                        if let RawApplyOutcome::Bail = outcome {
                             let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                             process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }
@@ -5753,22 +5756,20 @@ fn real_main() {
                     let mut ranges_buf = vec![(0usize, 0usize); field_refs.len()];
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        if json_object_get_fields_raw_buf(raw, 0, &field_refs, &mut ranges_buf) {
-                            // jq raises a type error for things like `str + num`;
-                            // the raw fast path silently writes `null`, so bail to
-                            // generic eval whenever any computed cell would error
-                            // (#163).
-                            if resolved.iter().any(|r| resolved_would_error(r, raw, &ranges_buf)) {
-                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                            } else {
+                        let outcome = apply_object_compute_raw(
+                            raw,
+                            &field_refs,
+                            &mut ranges_buf,
+                            |ranges, raw| resolved.iter().any(|r| resolved_would_error(r, raw, ranges)),
+                            |ranges, raw| {
                                 for (i, res) in resolved.iter().enumerate() {
                                     compact_buf.extend_from_slice(&key_prefixes[i]);
-                                    emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf);
+                                    emit_resolved_value(&mut compact_buf, res, raw, ranges);
                                 }
                                 compact_buf.extend_from_slice(obj_close);
-                            }
-                        } else {
+                            },
+                        );
+                        if let RawApplyOutcome::Bail = outcome {
                             let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                             process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }
@@ -5796,19 +5797,21 @@ fn real_main() {
                     let mut ranges_buf = vec![(0usize, 0usize); field_refs.len()];
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        if json_object_get_fields_raw_buf(raw, 0, &field_refs, &mut ranges_buf) {
-                            if resolved.iter().any(|r| resolved_would_error(r, raw, &ranges_buf)) {
-                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                            } else {
+                        let outcome = apply_object_compute_raw(
+                            raw,
+                            &field_refs,
+                            &mut ranges_buf,
+                            |ranges, raw| resolved.iter().any(|r| resolved_would_error(r, raw, ranges)),
+                            |ranges, raw| {
                                 compact_buf.push(b'[');
                                 for (i, res) in resolved.iter().enumerate() {
                                     if i > 0 { compact_buf.push(b','); }
-                                    emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf);
+                                    emit_resolved_value(&mut compact_buf, res, raw, ranges);
                                 }
                                 compact_buf.extend_from_slice(b"]\n");
-                            }
-                        } else {
+                            },
+                        );
+                        if let RawApplyOutcome::Bail = outcome {
                             let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                             process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }
@@ -15246,27 +15249,31 @@ fn real_main() {
                 let mut ranges_buf = vec![(0usize, 0usize); field_refs.len()];
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    if json_object_get_fields_raw_buf(raw, 0, &field_refs, &mut ranges_buf) {
-                        if resolved.iter().any(|r| resolved_would_error(r, raw, &ranges_buf)) {
-                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                        } else if use_pretty_buf {
-                            compact_buf.extend_from_slice(b"[\n");
-                            for (i, res) in resolved.iter().enumerate() {
-                                if i > 0 { compact_buf.extend_from_slice(b",\n"); }
-                                compact_buf.extend_from_slice(b"  ");
-                                emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf);
+                    let outcome = apply_object_compute_raw(
+                        raw,
+                        &field_refs,
+                        &mut ranges_buf,
+                        |ranges, raw| resolved.iter().any(|r| resolved_would_error(r, raw, ranges)),
+                        |ranges, raw| {
+                            if use_pretty_buf {
+                                compact_buf.extend_from_slice(b"[\n");
+                                for (i, res) in resolved.iter().enumerate() {
+                                    if i > 0 { compact_buf.extend_from_slice(b",\n"); }
+                                    compact_buf.extend_from_slice(b"  ");
+                                    emit_resolved_value(&mut compact_buf, res, raw, ranges);
+                                }
+                                compact_buf.extend_from_slice(b"\n]\n");
+                            } else {
+                                compact_buf.push(b'[');
+                                for (i, res) in resolved.iter().enumerate() {
+                                    if i > 0 { compact_buf.push(b','); }
+                                    emit_resolved_value(&mut compact_buf, res, raw, ranges);
+                                }
+                                compact_buf.extend_from_slice(b"]\n");
                             }
-                            compact_buf.extend_from_slice(b"\n]\n");
-                        } else {
-                            compact_buf.push(b'[');
-                            for (i, res) in resolved.iter().enumerate() {
-                                if i > 0 { compact_buf.push(b','); }
-                                emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf);
-                            }
-                            compact_buf.extend_from_slice(b"]\n");
-                        }
-                    } else {
+                        },
+                    );
+                    if let RawApplyOutcome::Bail = outcome {
                         let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                         process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                     }
@@ -19179,18 +19186,20 @@ fn real_main() {
                 let mut ranges_buf = vec![(0usize, 0usize); field_refs.len()];
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    if json_object_get_fields_raw_buf(raw, 0, &field_refs, &mut ranges_buf) {
-                        if resolved.iter().any(|r| resolved_would_error(r, raw, &ranges_buf)) {
-                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                        } else {
+                    let outcome = apply_object_compute_raw(
+                        raw,
+                        &field_refs,
+                        &mut ranges_buf,
+                        |ranges, raw| resolved.iter().any(|r| resolved_would_error(r, raw, ranges)),
+                        |ranges, raw| {
                             for (i, res) in resolved.iter().enumerate() {
                                 compact_buf.extend_from_slice(&key_prefixes[i]);
-                                emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf);
+                                emit_resolved_value(&mut compact_buf, res, raw, ranges);
                             }
                             compact_buf.extend_from_slice(obj_close);
-                        }
-                    } else {
+                        },
+                    );
+                    if let RawApplyOutcome::Bail = outcome {
                         let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                         process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                     }
@@ -19219,19 +19228,21 @@ fn real_main() {
                 let mut ranges_buf = vec![(0usize, 0usize); field_refs.len()];
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    if json_object_get_fields_raw_buf(raw, 0, &field_refs, &mut ranges_buf) {
-                        if resolved.iter().any(|r| resolved_would_error(r, raw, &ranges_buf)) {
-                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                        } else {
+                    let outcome = apply_object_compute_raw(
+                        raw,
+                        &field_refs,
+                        &mut ranges_buf,
+                        |ranges, raw| resolved.iter().any(|r| resolved_would_error(r, raw, ranges)),
+                        |ranges, raw| {
                             compact_buf.push(b'[');
                             for (i, res) in resolved.iter().enumerate() {
                                 if i > 0 { compact_buf.push(b','); }
-                                emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf);
+                                emit_resolved_value(&mut compact_buf, res, raw, ranges);
                             }
                             compact_buf.extend_from_slice(b"]\n");
-                        }
-                    } else {
+                        },
+                    );
+                    if let RawApplyOutcome::Bail = outcome {
                         let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                         process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                     }

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -230,6 +230,50 @@ where
     }
 }
 
+/// Apply the "object → resolved compute" raw-byte fast path on a single
+/// JSON record.
+///
+/// Used by the apply-sites for `[.x + 1, .y * 2]` (`computed_array` /
+/// `standalone_array`) and `{a: .x + 1, b: .y * 2}` (`computed_remap`),
+/// which all share the same two-stage bail discipline:
+///
+/// 1. **Outer bail** — `json_object_get_fields_raw_buf` fails (input isn't
+///    an object, or some required field is missing). `RawApplyOutcome::Bail`
+///    so the generic path produces jq's per-input verdict.
+/// 2. **Inner bail** — `bail_check` returns `true`. This is the #163 hook:
+///    the raw scanner can only emit `num+num` and `str+str` arithmetic;
+///    anything else (e.g. `str + num`) is a type error in jq, and silently
+///    writing `null` would re-introduce the null-masking bug class. The
+///    apply-site's `bail_check` walks the resolved cells once with the
+///    actual byte ranges and returns `true` if any cell would raise.
+///
+/// When both bails clear, `emit` is invoked with the filled ranges and the
+/// raw input bytes; the apply-site writes the array or object form into its
+/// captured buffer.
+///
+/// `ranges_buf` must have length `>= fields.len()`.
+pub fn apply_object_compute_raw<C, E>(
+    raw: &[u8],
+    fields: &[&str],
+    ranges_buf: &mut [(usize, usize)],
+    bail_check: C,
+    emit: E,
+) -> RawApplyOutcome
+where
+    C: FnOnce(&[(usize, usize)], &[u8]) -> bool,
+    E: FnOnce(&[(usize, usize)], &[u8]),
+{
+    if !json_object_get_fields_raw_buf(raw, 0, fields, ranges_buf) {
+        return RawApplyOutcome::Bail;
+    }
+    let ranges = &ranges_buf[..fields.len()];
+    if bail_check(ranges, raw) {
+        return RawApplyOutcome::Bail;
+    }
+    emit(ranges, raw);
+    RawApplyOutcome::Emit
+}
+
 /// Apply the `has("x")` raw-byte fast path on a single JSON record.
 ///
 /// * Object input — invokes `emit` with `b"true"` if the key is present and

--- a/tests/fast_path_contract.rs
+++ b/tests/fast_path_contract.rs
@@ -11,7 +11,7 @@
 use jq_jit::fast_path::{
     FastPath, FieldAccessPath, RawApplyOutcome, apply_array_field_access_raw,
     apply_field_access_raw, apply_has_field_raw, apply_has_multi_field_raw,
-    apply_multi_field_access_raw, apply_nested_field_access_raw,
+    apply_multi_field_access_raw, apply_nested_field_access_raw, apply_object_compute_raw,
 };
 use jq_jit::interpreter::Filter;
 use jq_jit::value::Value;
@@ -576,4 +576,82 @@ fn raw_has_multi_field_non_object_input_bails() {
             assert!(emitted.is_empty());
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// Object-compute (`{a: .x + 1, b: .y * 2}` / `[.x + 1, .y * 2]` / standalone-
+// array variants). The helper exposes a two-stage Bail: outer for non-object
+// or partially-missing inputs, inner for the per-cell type-error check (#163,
+// e.g. `str + num`). Both must invoke neither `bail_check` nor `emit` once
+// they decide to bail.
+
+#[test]
+fn raw_object_compute_full_object_invokes_emit_after_inner_check() {
+    let mut ranges_buf = vec![(0usize, 0usize); 2];
+    let mut bail_calls = 0usize;
+    let mut emit_calls = 0usize;
+    let outcome = apply_object_compute_raw(
+        b"{\"a\":1,\"b\":2}",
+        &["a", "b"],
+        &mut ranges_buf,
+        |_, _| { bail_calls += 1; false }, // inner check passes
+        |_, _| { emit_calls += 1; },
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(bail_calls, 1, "bail_check must run exactly once on outer success");
+    assert_eq!(emit_calls, 1, "emit must run exactly once when both checks pass");
+}
+
+#[test]
+fn raw_object_compute_outer_bail_skips_inner_and_emit() {
+    // Non-object input — outer bail at fields_raw_buf, neither closure runs.
+    let mut ranges_buf = vec![(0usize, 0usize); 2];
+    let mut bail_calls = 0usize;
+    let mut emit_calls = 0usize;
+    let outcome = apply_object_compute_raw(
+        b"42",
+        &["a", "b"],
+        &mut ranges_buf,
+        |_, _| { bail_calls += 1; false },
+        |_, _| { emit_calls += 1; },
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert_eq!(bail_calls, 0, "outer bail must skip the inner check");
+    assert_eq!(emit_calls, 0, "outer bail must skip emit");
+}
+
+#[test]
+fn raw_object_compute_inner_bail_skips_emit() {
+    // Outer succeeds, inner says "would error" — bail without emitting.
+    let mut ranges_buf = vec![(0usize, 0usize); 2];
+    let mut emit_calls = 0usize;
+    let outcome = apply_object_compute_raw(
+        b"{\"a\":1,\"b\":2}",
+        &["a", "b"],
+        &mut ranges_buf,
+        |_, _| true, // inner says bail
+        |_, _| { emit_calls += 1; },
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert_eq!(emit_calls, 0, "inner bail must skip emit");
+}
+
+#[test]
+fn raw_object_compute_partial_object_outer_bails() {
+    // Object missing one field — `json_object_get_fields_raw_buf` returns
+    // false, so it's an outer bail (jq emits a mix of values and nulls,
+    // generic produces it).
+    let mut ranges_buf = vec![(0usize, 0usize); 2];
+    let mut bail_calls = 0usize;
+    let mut emit_calls = 0usize;
+    let outcome = apply_object_compute_raw(
+        b"{\"a\":1}",
+        &["a", "b"],
+        &mut ranges_buf,
+        |_, _| { bail_calls += 1; false },
+        |_, _| { emit_calls += 1; },
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert_eq!(bail_calls, 0);
+    assert_eq!(emit_calls, 0);
 }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -2590,3 +2590,50 @@ false
 
 (has("a") or has("b"))?
 "hi"
+
+# Issue #83 Phase B: raw object-compute apply-sites (computed_array,
+# computed_remap, standalone_array) now bail through RawApplyOutcome.
+# Both the outer bail (non-object / missing fields) and the inner bail
+# (#163: per-cell type error like str + num) are explicit at the helper
+# boundary; happy paths still emit the structural array / object.
+
+# computed_array on a fully-populated object emits the computed array
+[.x + 1, .y * 2]
+{"x":3,"y":4}
+[4,8]
+
+# computed_array on a partial object errors via generic (null * 2);
+# wrapping in `?` swallows the error.
+([.x + 1, .y * 2])?
+{"x":3}
+
+# computed_array under `?` on a non-object: outer bail, generic raises, `?` swallows
+[.x + 1, .y * 2]?
+42
+
+# computed_array on str+num triggers the inner bail; jq raises so `?` swallows
+[.x + .y]?
+{"x":"a","y":1}
+
+# computed_remap on a fully-populated object emits the computed object
+{a: .x + 1, b: .y * 2}
+{"x":3,"y":4}
+{"a":4,"b":8}
+
+# computed_remap on str+num triggers the inner bail; `?` swallows
+({a: .x + .y})?
+{"x":"a","y":1}
+
+# computed_remap on partial object (missing field): outer bail -> generic emits null
+{a: .x + 1}
+{}
+{"a":1}
+
+# standalone_array (no key remap) on str+str concatenates
+[.x + .y]
+{"x":"a","y":"b"}
+["ab"]
+
+# standalone_array on str+num triggers inner bail; `?` swallows
+[.x + .y]?
+{"x":"a","y":1}


### PR DESCRIPTION
## Summary

Sixth set of siblings in the Phase B migration started by #241 / #242 /
#243 / #244 / #245: ports the three \"object → resolved compute\"
apply-sites — `[.x + 1, .y * 2]` (`computed_array`),
`{a: .x + 1, b: .y * 2}` (`computed_remap`), and standalone-array
(`standalone_array`) — to the named-`Bail` discipline.

### Why this batch is the most valuable Phase B target so far

Each of these already had a hand-written two-stage bail from #163:

1. **Outer bail** when `json_object_get_fields_raw_buf` fails (input
   isn't an object, or some required field is missing).
2. **Inner bail** when `resolved_would_error` returns `true` on any
   computed cell (e.g. `str + num`). The raw scanner only handles
   `num+num` / `str+str` arithmetic, so anything else needs the
   generic path to raise jq's type error.

Both bails are now structural at the helper boundary instead of being
inline in each apply-site — this is exactly the bug class #83 names
(\"silent default for an input the fast path can't handle\"), already
guarded since #163 but invisible at review.

### What's new

- **`apply_object_compute_raw`** in `src/fast_path.rs`. Takes a
  `bail_check` closure (the inner #163 hook) plus an `emit` closure
  for the structural array / object framing. Both are `FnOnce`; the
  helper invokes neither once it decides to bail.
- All six apply-sites in `bin/jq-jit.rs` (stdin + file dispatch for
  each of the three shapes) call the helper. The two-stage if-else
  cascade in each is replaced by a single `apply_object_compute_raw`
  call returning `RawApplyOutcome`.

### Tests

- `tests/fast_path_contract.rs` — 4 new cases pinning the helper's
  staged Bail surface (full pass invokes both closures once, outer bail
  skips both, inner bail skips emit, partial object outer-bails).
- `tests/regression.test` — 9 new cases covering happy paths (full
  object emits computed array / object, str+str concat in standalone)
  plus `?` over partial-object null-arithmetic and str+num inner-bail
  across all three shapes.

## Verification

- [x] `cargo build --release` — zero warnings
- [x] `cargo test --release` — 1100 official+regression PASS, 40
      `fast_path_contract` cases pass, full suite green
- [x] `./bench/comprehensive.sh --quick` — `field access .name`
      0.082s (vs main 0.082s), `nested .x,.y,.name` 0.112s (vs main
      0.115s) — noise level, no regression
- [ ] CI green (auto-merge on pass)

Refs #83