### PR TITLE
refactor: field_remap apply-site uses RawApplyOutcome (#83 Phase B)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -139,7 +139,7 @@ fn print_jq_error(msg: &str) {
 use jq_jit::value::{Value, json_to_value, json_stream, json_stream_offsets, json_stream_raw, json_stream_project, json_value_has_duplicate_keys, json_stream_has_duplicate_keys, json_object_get_num, json_object_get_two_nums, json_object_get_field_raw, json_object_get_fields_raw_buf, json_object_get_nested_field_raw, parse_json_num, json_value_length, json_object_keys_to_buf_reuse, json_object_extract_keys_only, json_object_keys_unsorted_to_buf, json_object_keys_join_to_buf, json_object_has_key, json_object_has_all_keys, json_object_has_any_key, json_type_byte, json_object_del_field, json_object_del_fields, json_object_filter_by_key_str, json_object_merge_literal, json_object_sort_keys, json_object_filter_by_value_type, json_each_value_raw, json_each_value_cb, json_to_entries_raw, json_with_entries_select_value_cmp, json_object_set_field_raw, json_object_update_field_num, json_object_update_field_num_chain, json_object_update_field_case, json_object_update_field_gsub, json_object_update_field_split_first, json_object_update_field_split_last, json_object_update_field_trim, json_object_update_field_slice, json_object_update_field_str_map, json_object_update_field_str_concat, json_object_update_field_length, json_object_update_field_tostring, json_object_update_field_test, json_object_assign_field_arith, json_object_assign_two_fields_arith, json_object_select_then_update_num, json_object_select_then_update_str_concat, json_object_select_compound_then_update_num, json_object_select_str_then_update_num, json_object_values_tostring, is_json_compact, push_json_compact_raw, push_tojson_raw, push_json_pretty_raw, push_json_pretty_raw_at, value_to_json_precise, value_to_json_pretty_ext, push_compact_line, push_compact_line_color, push_pretty_line, push_pretty_line_color, push_jq_number_bytes, write_value_compact_ext, write_value_compact_line, write_value_pretty_line_color, value_to_json_pretty_color, walk_json_transform_nums, pool_value, skip_json_value};
 use jq_jit::interpreter::Filter;
 use jq_jit::fast_path::{
-    apply_array_field_access_raw, apply_field_access_raw, apply_has_field_raw,
+    apply_field_access_raw, apply_full_object_fields_raw, apply_has_field_raw,
     apply_has_multi_field_raw, apply_multi_field_access_raw, apply_nested_field_access_raw,
     apply_object_compute_raw, RawApplyOutcome,
 };
@@ -5611,7 +5611,7 @@ fn real_main() {
                     let mut ranges_buf = vec![(0usize, 0usize); af_refs.len()];
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        let outcome = apply_array_field_access_raw(
+                        let outcome = apply_full_object_fields_raw(
                             raw,
                             &af_refs,
                             &mut ranges_buf,
@@ -5680,22 +5680,28 @@ fn real_main() {
                         // }
                         json_stream_raw(&input_str, |start, end| {
                             let raw = &input_bytes[start..end];
-                            if json_object_get_fields_raw_buf(raw, 0, &input_fields, &mut ranges_buf) {
-                                compact_buf.extend_from_slice(b"{\n");
-                                for (i, (vs, ve)) in ranges_buf.iter().enumerate() {
-                                    if i > 0 { compact_buf.extend_from_slice(b",\n"); }
-                                    compact_buf.extend_from_slice(b"  \"");
-                                    compact_buf.extend_from_slice(remap[i].0.as_bytes());
-                                    compact_buf.extend_from_slice(b"\": ");
-                                    let val = &raw[*vs..*ve];
-                                    if val[0] == b'{' || val[0] == b'[' {
-                                        push_json_pretty_raw_at(&mut compact_buf, val, 2, false, 1);
-                                    } else {
-                                        compact_buf.extend_from_slice(val);
+                            let outcome = apply_full_object_fields_raw(
+                                raw,
+                                &input_fields,
+                                &mut ranges_buf,
+                                |ranges, raw| {
+                                    compact_buf.extend_from_slice(b"{\n");
+                                    for (i, (vs, ve)) in ranges.iter().enumerate() {
+                                        if i > 0 { compact_buf.extend_from_slice(b",\n"); }
+                                        compact_buf.extend_from_slice(b"  \"");
+                                        compact_buf.extend_from_slice(remap[i].0.as_bytes());
+                                        compact_buf.extend_from_slice(b"\": ");
+                                        let val = &raw[*vs..*ve];
+                                        if val[0] == b'{' || val[0] == b'[' {
+                                            push_json_pretty_raw_at(&mut compact_buf, val, 2, false, 1);
+                                        } else {
+                                            compact_buf.extend_from_slice(val);
+                                        }
                                     }
-                                }
-                                compact_buf.extend_from_slice(b"\n}\n");
-                            } else {
+                                    compact_buf.extend_from_slice(b"\n}\n");
+                                },
+                            );
+                            if let RawApplyOutcome::Bail = outcome {
                                 let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                                 process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                             }
@@ -5717,13 +5723,19 @@ fn real_main() {
                         }
                         json_stream_raw(&input_str, |start, end| {
                             let raw = &input_bytes[start..end];
-                            if json_object_get_fields_raw_buf(raw, 0, &input_fields, &mut ranges_buf) {
-                                for (i, (vs, ve)) in ranges_buf.iter().enumerate() {
-                                    compact_buf.extend_from_slice(&key_prefixes[i]);
-                                    compact_buf.extend_from_slice(&raw[*vs..*ve]);
-                                }
-                                compact_buf.extend_from_slice(b"}\n");
-                            } else {
+                            let outcome = apply_full_object_fields_raw(
+                                raw,
+                                &input_fields,
+                                &mut ranges_buf,
+                                |ranges, raw| {
+                                    for (i, (vs, ve)) in ranges.iter().enumerate() {
+                                        compact_buf.extend_from_slice(&key_prefixes[i]);
+                                        compact_buf.extend_from_slice(&raw[*vs..*ve]);
+                                    }
+                                    compact_buf.extend_from_slice(b"}\n");
+                                },
+                            );
+                            if let RawApplyOutcome::Bail = outcome {
                                 let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                                 process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                             }
@@ -15289,7 +15301,7 @@ fn real_main() {
                 let mut ranges_buf = vec![(0usize, 0usize); af_refs.len()];
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    let outcome = apply_array_field_access_raw(
+                    let outcome = apply_full_object_fields_raw(
                         raw,
                         &af_refs,
                         &mut ranges_buf,
@@ -19109,22 +19121,28 @@ fn real_main() {
                 if use_pretty_buf {
                     json_stream_raw(content, |start, end| {
                         let raw = &content_bytes[start..end];
-                        if json_object_get_fields_raw_buf(raw, 0, &input_fields, &mut ranges_buf) {
-                            compact_buf.extend_from_slice(b"{\n");
-                            for (i, (vs, ve)) in ranges_buf.iter().enumerate() {
-                                if i > 0 { compact_buf.extend_from_slice(b",\n"); }
-                                compact_buf.extend_from_slice(b"  \"");
-                                compact_buf.extend_from_slice(remap[i].0.as_bytes());
-                                compact_buf.extend_from_slice(b"\": ");
-                                let val = &raw[*vs..*ve];
-                                if val[0] == b'{' || val[0] == b'[' {
-                                    push_json_pretty_raw_at(&mut compact_buf, val, 2, false, 1);
-                                } else {
-                                    compact_buf.extend_from_slice(val);
+                        let outcome = apply_full_object_fields_raw(
+                            raw,
+                            &input_fields,
+                            &mut ranges_buf,
+                            |ranges, raw| {
+                                compact_buf.extend_from_slice(b"{\n");
+                                for (i, (vs, ve)) in ranges.iter().enumerate() {
+                                    if i > 0 { compact_buf.extend_from_slice(b",\n"); }
+                                    compact_buf.extend_from_slice(b"  \"");
+                                    compact_buf.extend_from_slice(remap[i].0.as_bytes());
+                                    compact_buf.extend_from_slice(b"\": ");
+                                    let val = &raw[*vs..*ve];
+                                    if val[0] == b'{' || val[0] == b'[' {
+                                        push_json_pretty_raw_at(&mut compact_buf, val, 2, false, 1);
+                                    } else {
+                                        compact_buf.extend_from_slice(val);
+                                    }
                                 }
-                            }
-                            compact_buf.extend_from_slice(b"\n}\n");
-                        } else {
+                                compact_buf.extend_from_slice(b"\n}\n");
+                            },
+                        );
+                        if let RawApplyOutcome::Bail = outcome {
                             let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                             process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }
@@ -19146,13 +19164,19 @@ fn real_main() {
                     }
                     json_stream_raw(content, |start, end| {
                         let raw = &content_bytes[start..end];
-                        if json_object_get_fields_raw_buf(raw, 0, &input_fields, &mut ranges_buf) {
-                            for (i, (vs, ve)) in ranges_buf.iter().enumerate() {
-                                compact_buf.extend_from_slice(&key_prefixes[i]);
-                                compact_buf.extend_from_slice(&raw[*vs..*ve]);
-                            }
-                            compact_buf.extend_from_slice(b"}\n");
-                        } else {
+                        let outcome = apply_full_object_fields_raw(
+                            raw,
+                            &input_fields,
+                            &mut ranges_buf,
+                            |ranges, raw| {
+                                for (i, (vs, ve)) in ranges.iter().enumerate() {
+                                    compact_buf.extend_from_slice(&key_prefixes[i]);
+                                    compact_buf.extend_from_slice(&raw[*vs..*ve]);
+                                }
+                                compact_buf.extend_from_slice(b"}\n");
+                            },
+                        );
+                        if let RawApplyOutcome::Bail = outcome {
                             let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                             process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -331,33 +331,37 @@ where
     }
 }
 
-/// Apply the array-of-fields `[.a, .b, .c]` raw-byte fast path on a single
-/// JSON record.
+/// Apply an "all fields required" raw-byte fast path on a single JSON
+/// record.
 ///
-/// Bail discipline mirrors [`apply_multi_field_access_raw`]: the path can
-/// only emit when the input is an object that contains every requested
-/// field. Anything else returns [`RawApplyOutcome::Bail`] and the caller
-/// hands off to the generic path.
+/// Used by every shape that emits a structural form built from the input
+/// object's field values: `[.a, .b, .c]` (`array_field`),
+/// `{a: .x, b: .y}` (`field_remap`), and any future fast path with the
+/// same all-or-nothing fetch semantics. Bail discipline matches
+/// [`apply_multi_field_access_raw`]: emit only when the input is an
+/// object containing every requested field; anything else routes to the
+/// generic path.
 ///
-/// Serialisation is left to the caller: when the fields resolve, the helper
-/// hands the filled `ranges_buf` and the raw input bytes to `emit_array`,
-/// which writes the array form (compact or pretty, with whatever indentation
-/// or nesting handling the apply-site needs) into its captured buffer. This
-/// keeps the helper independent of `use_pretty_buf` / colour flags while
+/// Serialisation is left to the caller: when the fields resolve, the
+/// helper hands the filled `ranges_buf` and the raw input bytes to
+/// `emit_structural`, which writes whatever shape the apply-site wants
+/// (array form, object form, pretty / compact framing, nested-value
+/// pretty-print) into its captured buffer. This keeps the helper
+/// independent of `use_pretty_buf` / colour / per-shape flags while
 /// still naming the commit point at the function boundary.
 ///
 /// `ranges_buf` must have length `>= fields.len()`.
-pub fn apply_array_field_access_raw<E>(
+pub fn apply_full_object_fields_raw<E>(
     raw: &[u8],
     fields: &[&str],
     ranges_buf: &mut [(usize, usize)],
-    emit_array: E,
+    emit_structural: E,
 ) -> RawApplyOutcome
 where
     E: FnOnce(&[(usize, usize)], &[u8]),
 {
     if json_object_get_fields_raw_buf(raw, 0, fields, ranges_buf) {
-        emit_array(&ranges_buf[..fields.len()], raw);
+        emit_structural(&ranges_buf[..fields.len()], raw);
         RawApplyOutcome::Emit
     } else {
         RawApplyOutcome::Bail

--- a/tests/fast_path_contract.rs
+++ b/tests/fast_path_contract.rs
@@ -9,7 +9,7 @@
 //!   pilot and returns `None` for filters that aren't yet migrated.
 
 use jq_jit::fast_path::{
-    FastPath, FieldAccessPath, RawApplyOutcome, apply_array_field_access_raw,
+    FastPath, FieldAccessPath, RawApplyOutcome, apply_full_object_fields_raw,
     apply_field_access_raw, apply_has_field_raw, apply_has_multi_field_raw,
     apply_multi_field_access_raw, apply_nested_field_access_raw, apply_object_compute_raw,
 };
@@ -385,11 +385,11 @@ fn raw_multi_field_non_object_non_null_input_bails() {
 // the caller's closure so pretty / compact framing stays at the apply-site.
 
 #[test]
-fn raw_array_field_complete_object_invokes_emit_once() {
+fn raw_full_object_fields_complete_object_invokes_emit_once() {
     let mut ranges_buf = vec![(0usize, 0usize); 3];
     let mut calls = 0usize;
     let mut collected: Vec<Vec<u8>> = Vec::new();
-    let outcome = apply_array_field_access_raw(
+    let outcome = apply_full_object_fields_raw(
         b"{\"a\":1,\"b\":2,\"c\":3}",
         &["a", "b", "c"],
         &mut ranges_buf,
@@ -406,10 +406,10 @@ fn raw_array_field_complete_object_invokes_emit_once() {
 }
 
 #[test]
-fn raw_array_field_partial_object_bails_without_calling_emit() {
+fn raw_full_object_fields_partial_object_bails_without_calling_emit() {
     let mut ranges_buf = vec![(0usize, 0usize); 3];
     let mut calls = 0usize;
-    let outcome = apply_array_field_access_raw(
+    let outcome = apply_full_object_fields_raw(
         b"{\"a\":1,\"c\":3}",
         &["a", "b", "c"],
         &mut ranges_buf,
@@ -420,10 +420,10 @@ fn raw_array_field_partial_object_bails_without_calling_emit() {
 }
 
 #[test]
-fn raw_array_field_null_input_bails_without_calling_emit() {
+fn raw_full_object_fields_null_input_bails_without_calling_emit() {
     let mut ranges_buf = vec![(0usize, 0usize); 2];
     let mut calls = 0usize;
-    let outcome = apply_array_field_access_raw(
+    let outcome = apply_full_object_fields_raw(
         b"null",
         &["a", "b"],
         &mut ranges_buf,
@@ -434,7 +434,7 @@ fn raw_array_field_null_input_bails_without_calling_emit() {
 }
 
 #[test]
-fn raw_array_field_non_object_non_null_input_bails() {
+fn raw_full_object_fields_non_object_non_null_input_bails() {
     for raw in [
         b"42".as_slice(),
         b"\"hello\"".as_slice(),
@@ -443,7 +443,7 @@ fn raw_array_field_non_object_non_null_input_bails() {
     ] {
         let mut ranges_buf = vec![(0usize, 0usize); 2];
         let mut calls = 0usize;
-        let outcome = apply_array_field_access_raw(
+        let outcome = apply_full_object_fields_raw(
             raw,
             &["a", "b"],
             &mut ranges_buf,

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -2637,3 +2637,45 @@ false
 # standalone_array on str+num triggers inner bail; `?` swallows
 [.x + .y]?
 {"x":"a","y":1}
+
+# Issue #83 Phase B: raw field_remap apply-site (`{a: .x, b: .y}` — pure key
+# rename, no arithmetic) now goes through apply_full_object_fields_raw. The
+# bail discipline matches array_field: emit when the input is an object with
+# every required field, otherwise route to the generic path.
+
+# field_remap on a fully-populated object emits the renamed object
+{a: .x, b: .y}
+{"x":1,"y":2}
+{"a":1,"b":2}
+
+# field_remap on partial object: outer bail -> generic emits null for missing
+{a: .x, b: .y}
+{"x":1}
+{"a":1,"b":null}
+
+# field_remap on null: outer bail -> generic emits {a:null, b:null}
+{a: .x, b: .y}
+null
+{"a":null,"b":null}
+
+# field_remap under `?` on a number: outer bail, generic raises, `?` swallows
+({a: .x, b: .y})?
+42
+
+# field_remap under `?` on a string
+({a: .x, b: .y})?
+"hi"
+
+# field_remap under `?` on an array
+({a: .x, b: .y})?
+[1,2,3]
+
+# field_remap with nested object value emits the nested object correctly
+{a: .x}
+{"x":{"nested":1}}
+{"a":{"nested":1}}
+
+# field_remap with nested array value emits the nested array correctly
+{a: .x}
+{"x":[1,2,3]}
+{"a":[1,2,3]}


### PR DESCRIPTION
## Summary

Seventh sibling in the Phase B migration started by #241 / #242 / #243
/ #244 / #245 / #246: ports `{a: .x, b: .y}` (`field_remap` — pure
key-rename, no arithmetic) to the named-`Bail` discipline.

### Helper rename

The bail logic for field_remap is identical to the previously-introduced
`apply_array_field_access_raw` (succeed on object with all fields,
otherwise `Bail`), so this PR also:

- **Renames `apply_array_field_access_raw` -> `apply_full_object_fields_raw`**
  to reflect the generic shape: it works for any "all fields required"
  fast path, not only the array-collect emitter. Doc updated.
- field_remap (both pretty and compact branches, in both stdin + file
  dispatch — 4 closure bodies) now calls the helper. Each closure hands
  its captured `compact_buf` and key-prefix data to the `emit`
  closure, while the helper owns the structural Bail decision.
- Test names `raw_array_field_*` → `raw_full_object_fields_*` to match.

The helper is now used by three siblings (`array_field`, `field_remap`,
plus implicitly by `apply_object_compute_raw` which adds an inner #163
bail on top of the same outer fetch).

### Tests

- `tests/regression.test` — 8 new cases for field_remap pinning the
  pattern: happy path, partial object (generic fills with null), null
  input (generic emits `{k: null, ...}`), `?` over number / string /
  array, plus nested object / array values to verify the pretty-print
  path still routes through `push_json_pretty_raw_at`.

## Verification

- [x] `cargo build --release` — zero warnings
- [x] `cargo test --release` — 1100 official+regression PASS, 40
      `fast_path_contract` cases pass, full suite green
- [x] `./bench/comprehensive.sh --quick` — `field access .name`
      0.081s (vs main 0.082s), `nested .x,.y,.name` 0.115s (vs main
      0.115s) — noise level, no regression
- [ ] CI green (auto-merge on pass)

Refs #83