### PR TITLE
refactor: field_alternative apply-sites use RawApplyOutcome (#83 Phase B)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -139,9 +139,10 @@ fn print_jq_error(msg: &str) {
 use jq_jit::value::{Value, json_to_value, json_stream, json_stream_offsets, json_stream_raw, json_stream_project, json_value_has_duplicate_keys, json_stream_has_duplicate_keys, json_object_get_num, json_object_get_two_nums, json_object_get_field_raw, json_object_get_fields_raw_buf, json_object_get_nested_field_raw, parse_json_num, json_value_length, json_object_keys_to_buf_reuse, json_object_extract_keys_only, json_object_keys_unsorted_to_buf, json_object_keys_join_to_buf, json_object_has_key, json_object_has_all_keys, json_object_has_any_key, json_type_byte, json_object_del_field, json_object_del_fields, json_object_filter_by_key_str, json_object_merge_literal, json_object_sort_keys, json_object_filter_by_value_type, json_each_value_raw, json_each_value_cb, json_to_entries_raw, json_with_entries_select_value_cmp, json_object_set_field_raw, json_object_update_field_num, json_object_update_field_num_chain, json_object_update_field_case, json_object_update_field_gsub, json_object_update_field_split_first, json_object_update_field_split_last, json_object_update_field_trim, json_object_update_field_slice, json_object_update_field_str_map, json_object_update_field_str_concat, json_object_update_field_length, json_object_update_field_tostring, json_object_update_field_test, json_object_assign_field_arith, json_object_assign_two_fields_arith, json_object_select_then_update_num, json_object_select_then_update_str_concat, json_object_select_compound_then_update_num, json_object_select_str_then_update_num, json_object_values_tostring, is_json_compact, push_json_compact_raw, push_tojson_raw, push_json_pretty_raw, push_json_pretty_raw_at, value_to_json_precise, value_to_json_pretty_ext, push_compact_line, push_compact_line_color, push_pretty_line, push_pretty_line_color, push_jq_number_bytes, write_value_compact_ext, write_value_compact_line, write_value_pretty_line_color, value_to_json_pretty_color, walk_json_transform_nums, pool_value, skip_json_value};
 use jq_jit::interpreter::Filter;
 use jq_jit::fast_path::{
-    apply_field_access_raw, apply_full_object_fields_raw, apply_has_field_raw,
-    apply_has_multi_field_raw, apply_multi_field_access_raw, apply_nested_field_access_raw,
-    apply_object_compute_raw, RawApplyOutcome,
+    apply_field_access_raw, apply_field_alternative_raw, apply_field_field_alternative_raw,
+    apply_full_object_fields_raw, apply_has_field_raw, apply_has_multi_field_raw,
+    apply_multi_field_access_raw, apply_nested_field_access_raw, apply_object_compute_raw,
+    RawApplyOutcome,
 };
 
 fn json_escape_bytes(bytes: &[u8]) -> Vec<u8> {
@@ -8098,26 +8099,23 @@ fn real_main() {
                     })
                 } else if let Some((ref alt_field, ref fallback_bytes)) = field_alt {
                     // .field // literal. `//` must not swallow type errors, so
-                    // route non-object, non-null inputs through the eval path
-                    // where `.field` raises "Cannot index ... with string".
+                    // non-object, non-null inputs Bail to the eval path where
+                    // `.field` raises "Cannot index ... with string" (#198).
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        if raw.is_empty() || (raw[0] != b'{' && raw != b"null") {
-                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                            return Ok(());
-                        }
-                        if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, alt_field) {
-                            let val = &raw[vs..ve];
-                            if val == b"null" || val == b"false" {
-                                compact_buf.extend_from_slice(fallback_bytes);
-                            } else {
-                                compact_buf.extend_from_slice(val);
+                        let outcome = apply_field_alternative_raw(
+                            raw,
+                            alt_field,
+                            fallback_bytes,
+                            |bytes| compact_buf.extend_from_slice(bytes),
+                        );
+                        match outcome {
+                            RawApplyOutcome::Emit => compact_buf.push(b'\n'),
+                            RawApplyOutcome::Bail => {
+                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                             }
-                        } else {
-                            compact_buf.extend_from_slice(fallback_bytes);
                         }
-                        compact_buf.push(b'\n');
                         if compact_buf.len() >= 1 << 17 {
                             let _ = out.write_all(&compact_buf);
                             compact_buf.clear();
@@ -8125,32 +8123,22 @@ fn real_main() {
                         Ok(())
                     })
                 } else if let Some((ref prim_field, ref fallback_field)) = field_field_alt {
-                    // .field1 // .field2: try primary, if null/false/missing use
-                    // fallback. `//` must not swallow type errors (#198), so non-
-                    // object, non-null inputs flow through the eval path so
-                    // `.field1` surfaces "Cannot index ... with string".
+                    // .field1 // .field2: same Bail discipline as field_alt (#198).
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        if raw.is_empty() || (raw[0] != b'{' && raw != b"null") {
-                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                            return Ok(());
-                        }
-                        let use_primary = if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, prim_field) {
-                            let pval = &raw[vs..ve];
-                            if pval != b"null" && pval != b"false" {
-                                compact_buf.extend_from_slice(pval);
-                                true
-                            } else { false }
-                        } else { false };
-                        if !use_primary {
-                            if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, fallback_field) {
-                                compact_buf.extend_from_slice(&raw[vs..ve]);
-                            } else {
-                                compact_buf.extend_from_slice(b"null");
+                        let outcome = apply_field_field_alternative_raw(
+                            raw,
+                            prim_field,
+                            fallback_field,
+                            |bytes| compact_buf.extend_from_slice(bytes),
+                        );
+                        match outcome {
+                            RawApplyOutcome::Emit => compact_buf.push(b'\n'),
+                            RawApplyOutcome::Bail => {
+                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                             }
                         }
-                        compact_buf.push(b'\n');
                         if compact_buf.len() >= 1 << 17 {
                             let _ = out.write_all(&compact_buf);
                             compact_buf.clear();
@@ -15799,22 +15787,19 @@ fn real_main() {
                 let content_bytes = content.as_bytes();
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    if raw.is_empty() || (raw[0] != b'{' && raw != b"null") {
-                        let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                        process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                        return Ok(());
-                    }
-                    if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, alt_field) {
-                        let val = &raw[vs..ve];
-                        if val == b"null" || val == b"false" {
-                            compact_buf.extend_from_slice(fallback_bytes);
-                        } else {
-                            compact_buf.extend_from_slice(val);
+                    let outcome = apply_field_alternative_raw(
+                        raw,
+                        alt_field,
+                        fallback_bytes,
+                        |bytes| compact_buf.extend_from_slice(bytes),
+                    );
+                    match outcome {
+                        RawApplyOutcome::Emit => compact_buf.push(b'\n'),
+                        RawApplyOutcome::Bail => {
+                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }
-                    } else {
-                        compact_buf.extend_from_slice(fallback_bytes);
                     }
-                    compact_buf.push(b'\n');
                     if compact_buf.len() >= 1 << 17 {
                         let _ = out.write_all(&compact_buf);
                         compact_buf.clear();
@@ -15825,26 +15810,19 @@ fn real_main() {
                 let content_bytes = content.as_bytes();
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    if raw.is_empty() || (raw[0] != b'{' && raw != b"null") {
-                        let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                        process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                        return Ok(());
-                    }
-                    let use_primary = if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, prim_field) {
-                        let pval = &raw[vs..ve];
-                        if pval != b"null" && pval != b"false" {
-                            compact_buf.extend_from_slice(pval);
-                            true
-                        } else { false }
-                    } else { false };
-                    if !use_primary {
-                        if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, fallback_field) {
-                            compact_buf.extend_from_slice(&raw[vs..ve]);
-                        } else {
-                            compact_buf.extend_from_slice(b"null");
+                    let outcome = apply_field_field_alternative_raw(
+                        raw,
+                        prim_field,
+                        fallback_field,
+                        |bytes| compact_buf.extend_from_slice(bytes),
+                    );
+                    match outcome {
+                        RawApplyOutcome::Emit => compact_buf.push(b'\n'),
+                        RawApplyOutcome::Bail => {
+                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }
                     }
-                    compact_buf.push(b'\n');
                     if compact_buf.len() >= 1 << 17 {
                         let _ = out.write_all(&compact_buf);
                         compact_buf.clear();

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -274,6 +274,95 @@ where
     RawApplyOutcome::Emit
 }
 
+/// Apply the `.field // fallback` raw-byte fast path on a single JSON
+/// record.
+///
+/// `//` (jq's alternative operator) **must not swallow type errors**
+/// (#198): when `.field` itself would raise (i.e. the input isn't an
+/// object and isn't the literal `null`), the alternative fallback does
+/// not apply — jq still raises. The helper enforces this with an outer
+/// type-guard:
+///
+/// * Object input — extract the field. If the value is `null` / `false`
+///   (jq's "false-y" gate for `//`) or the field is absent, invoke
+///   `emit` with `fallback_bytes`. Otherwise `emit` with the field's
+///   raw bytes.
+/// * Literal `null` input — there's no field to extract, so emit
+///   `fallback_bytes`.
+/// * Anything else — return [`RawApplyOutcome::Bail`] so the generic
+///   path raises `Cannot index <type> with "<field>"`.
+pub fn apply_field_alternative_raw<E>(
+    raw: &[u8],
+    field: &str,
+    fallback_bytes: &[u8],
+    mut emit: E,
+) -> RawApplyOutcome
+where
+    E: FnMut(&[u8]),
+{
+    // Outer guard: only object or the literal `null` proceed; non-
+    // object non-null inputs bail so jq's type error surfaces (#198).
+    if raw.is_empty() || (raw.first() != Some(&b'{') && raw != b"null") {
+        return RawApplyOutcome::Bail;
+    }
+    match json_object_get_field_raw(raw, 0, field) {
+        Some((vs, ve)) => {
+            let val = &raw[vs..ve];
+            if val == b"null" || val == b"false" {
+                emit(fallback_bytes);
+            } else {
+                emit(val);
+            }
+        }
+        None => emit(fallback_bytes),
+    }
+    RawApplyOutcome::Emit
+}
+
+/// Apply the `.field1 // .field2` raw-byte fast path on a single JSON
+/// record.
+///
+/// Same outer type-guard as [`apply_field_alternative_raw`]: non-object,
+/// non-null inputs bail so the generic path raises `Cannot index ...`
+/// (#198). When the input is an object (or the literal `null`):
+///
+/// * If `primary_field` is present and its value is **not** `null` or
+///   `false`, `emit` is invoked with the primary's raw bytes.
+/// * Otherwise `emit` is invoked with `fallback_field`'s raw bytes if
+///   present, else with `b"null"` (jq's `null` for missing fallback).
+pub fn apply_field_field_alternative_raw<E>(
+    raw: &[u8],
+    primary_field: &str,
+    fallback_field: &str,
+    mut emit: E,
+) -> RawApplyOutcome
+where
+    E: FnMut(&[u8]),
+{
+    if raw.is_empty() || (raw.first() != Some(&b'{') && raw != b"null") {
+        return RawApplyOutcome::Bail;
+    }
+    let primary_emitted = match json_object_get_field_raw(raw, 0, primary_field) {
+        Some((vs, ve)) => {
+            let pval = &raw[vs..ve];
+            if pval != b"null" && pval != b"false" {
+                emit(pval);
+                true
+            } else {
+                false
+            }
+        }
+        None => false,
+    };
+    if !primary_emitted {
+        match json_object_get_field_raw(raw, 0, fallback_field) {
+            Some((vs, ve)) => emit(&raw[vs..ve]),
+            None => emit(b"null"),
+        }
+    }
+    RawApplyOutcome::Emit
+}
+
 /// Apply the `has("x")` raw-byte fast path on a single JSON record.
 ///
 /// * Object input — invokes `emit` with `b"true"` if the key is present and

--- a/tests/fast_path_contract.rs
+++ b/tests/fast_path_contract.rs
@@ -9,9 +9,10 @@
 //!   pilot and returns `None` for filters that aren't yet migrated.
 
 use jq_jit::fast_path::{
-    FastPath, FieldAccessPath, RawApplyOutcome, apply_full_object_fields_raw,
-    apply_field_access_raw, apply_has_field_raw, apply_has_multi_field_raw,
-    apply_multi_field_access_raw, apply_nested_field_access_raw, apply_object_compute_raw,
+    FastPath, FieldAccessPath, RawApplyOutcome, apply_field_access_raw,
+    apply_field_alternative_raw, apply_field_field_alternative_raw, apply_full_object_fields_raw,
+    apply_has_field_raw, apply_has_multi_field_raw, apply_multi_field_access_raw,
+    apply_nested_field_access_raw, apply_object_compute_raw,
 };
 use jq_jit::interpreter::Filter;
 use jq_jit::value::Value;
@@ -654,4 +655,150 @@ fn raw_object_compute_partial_object_outer_bails() {
     assert!(matches!(outcome, RawApplyOutcome::Bail));
     assert_eq!(bail_calls, 0);
     assert_eq!(emit_calls, 0);
+}
+
+// ---------------------------------------------------------------------------
+// `.field // fallback` and `.field // .other` — `//` MUST NOT swallow type
+// errors (#198). Both helpers Bail for non-object non-null inputs so the
+// generic path raises `Cannot index ... with string`. On object / null they
+// emit per jq's `//` falsey gate (`null` / `false` -> fallback).
+
+#[test]
+fn raw_field_alt_present_truthy_emits_value() {
+    let mut emitted: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_field_alternative_raw(
+        b"{\"x\":42}",
+        "x",
+        b"\"fallback\"",
+        |b| emitted.push(b.to_vec()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec![b"42".to_vec()]);
+}
+
+#[test]
+fn raw_field_alt_present_falsey_emits_fallback() {
+    for falsey in [&b"null"[..], &b"false"[..]] {
+        let raw = format!("{{\"x\":{}}}", std::str::from_utf8(falsey).unwrap());
+        let mut emitted: Vec<Vec<u8>> = Vec::new();
+        let outcome = apply_field_alternative_raw(
+            raw.as_bytes(),
+            "x",
+            b"99",
+            |b| emitted.push(b.to_vec()),
+        );
+        assert!(matches!(outcome, RawApplyOutcome::Emit));
+        assert_eq!(
+            emitted,
+            vec![b"99".to_vec()],
+            "input {} (field is falsey) must emit fallback",
+            raw,
+        );
+    }
+}
+
+#[test]
+fn raw_field_alt_missing_emits_fallback() {
+    let mut emitted: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_field_alternative_raw(
+        b"{\"y\":1}",
+        "x",
+        b"\"missing\"",
+        |b| emitted.push(b.to_vec()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec![b"\"missing\"".to_vec()]);
+}
+
+#[test]
+fn raw_field_alt_null_input_emits_fallback() {
+    let mut emitted: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_field_alternative_raw(
+        b"null",
+        "x",
+        b"77",
+        |b| emitted.push(b.to_vec()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec![b"77".to_vec()]);
+}
+
+#[test]
+fn raw_field_alt_non_object_non_null_bails() {
+    for raw in [
+        b"42".as_slice(),
+        b"\"hi\"".as_slice(),
+        b"true".as_slice(),
+        b"[1,2,3]".as_slice(),
+    ] {
+        let mut emitted: Vec<Vec<u8>> = Vec::new();
+        let outcome = apply_field_alternative_raw(raw, "x", b"99", |b| emitted.push(b.to_vec()));
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "expected Bail for input {:?}, got {:?}",
+            std::str::from_utf8(raw).unwrap(),
+            outcome,
+        );
+        assert!(emitted.is_empty());
+    }
+}
+
+#[test]
+fn raw_field_field_alt_primary_truthy_emits_primary() {
+    let mut emitted: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_field_field_alternative_raw(
+        b"{\"a\":1,\"b\":2}",
+        "a",
+        "b",
+        |bytes| emitted.push(bytes.to_vec()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec![b"1".to_vec()]);
+}
+
+#[test]
+fn raw_field_field_alt_primary_falsey_emits_fallback_value() {
+    let mut emitted: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_field_field_alternative_raw(
+        b"{\"a\":null,\"b\":2}",
+        "a",
+        "b",
+        |bytes| emitted.push(bytes.to_vec()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec![b"2".to_vec()]);
+}
+
+#[test]
+fn raw_field_field_alt_both_missing_emits_null_literal() {
+    let mut emitted: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_field_field_alternative_raw(
+        b"{\"c\":3}",
+        "a",
+        "b",
+        |bytes| emitted.push(bytes.to_vec()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec![b"null".to_vec()]);
+}
+
+#[test]
+fn raw_field_field_alt_non_object_non_null_bails() {
+    for raw in [
+        b"42".as_slice(),
+        b"\"hi\"".as_slice(),
+        b"true".as_slice(),
+        b"[1,2,3]".as_slice(),
+    ] {
+        let mut emitted: Vec<Vec<u8>> = Vec::new();
+        let outcome =
+            apply_field_field_alternative_raw(raw, "a", "b", |b| emitted.push(b.to_vec()));
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "expected Bail for input {:?}, got {:?}",
+            std::str::from_utf8(raw).unwrap(),
+            outcome,
+        );
+        assert!(emitted.is_empty());
+    }
 }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -2679,3 +2679,71 @@ null
 {a: .x}
 {"x":[1,2,3]}
 {"a":[1,2,3]}
+
+# Issue #83 Phase B: raw .field // fallback and .field // .other apply-sites
+# now route their #198 type-error guard through RawApplyOutcome::Bail. `//`
+# must never swallow type errors -- a non-object non-null input bails so the
+# generic path raises `Cannot index ... with string`.
+
+# .field // literal emits the value when present and truthy
+.x // 99
+{"x":42}
+42
+
+# .field // literal emits fallback when value is null
+.x // 99
+{"x":null}
+99
+
+# .field // literal emits fallback when value is false
+.x // 99
+{"x":false}
+99
+
+# .field // literal emits fallback when key is missing
+.x // 99
+{"y":1}
+99
+
+# .field // literal on null input emits fallback (no field to extract)
+.x // 99
+null
+99
+
+# .field // literal under `?` on a number bails to generic, generic raises
+(.x // 99)?
+42
+
+# .field // literal under `?` on a string
+(.x // 99)?
+"hi"
+
+# .field // literal under `?` on a boolean
+(.x // 99)?
+true
+
+# .field // literal under `?` on an array
+(.x // 99)?
+[1,2,3]
+
+# .field1 // .field2 emits primary when truthy
+.a // .b
+{"a":1,"b":2}
+1
+
+# .field1 // .field2 emits fallback when primary is null
+.a // .b
+{"a":null,"b":2}
+2
+
+# .field1 // .field2 emits null when both missing
+.a // .b
+{"c":3}
+null
+
+# .field1 // .field2 under `?` on a non-object bails
+(.a // .b)?
+42
+
+(.a // .b)?
+"hi"


### PR DESCRIPTION
## Summary

Eighth set of siblings in the Phase B migration started by #241 / #242 /
#243 / #244 / #245 / #246 / #247: ports the two `.field // fallback`
shapes (`field_alt` for literal fallback, `field_field_alt` for
`.field1 // .field2`) to the named-`Bail` discipline.

### Why these are valuable Phase B targets

Both already had the explicit type-guard added in #198 (`//` must not
swallow type errors — a non-object non-null input has to surface
`Cannot index ... with string` from the generic path, NOT silently
take the fallback). The guard was inline; this PR pushes it into the
helper boundary so it's structurally explicit at the function signature
— same shape as the other Phase B helpers.

### What's new

- **`apply_field_alternative_raw`** and
  **`apply_field_field_alternative_raw`** in `src/fast_path.rs`. Both
  apply jq's `//` falsey gate (`null` / `false` / missing →
  fallback) inside the helper; both Bail for non-object non-null inputs.
- All four apply-sites in `bin/jq-jit.rs` (stdin + file dispatch for
  both shapes) call the helpers. The implicit
  `if raw.is_empty() || ...` guard collapses into the helper's outer
  Bail.

### Tests

- `tests/fast_path_contract.rs` — 9 new cases covering both helpers
  (truthy primary emit, falsey fallback, missing fallback, null input
  → fallback, every non-{object,null} type bails).
- `tests/regression.test` — 14 new cases pinning happy paths plus
  `?` over number / string / bool / array for both shapes.

## Verification

- [x] `cargo build --release` — zero warnings
- [x] `cargo test --release` — 1100 official+regression PASS, 49
      `fast_path_contract` cases pass, full suite green
- [x] `./bench/comprehensive.sh --quick` — `field access .name`
      0.082s (vs main 0.082s), `nested .x,.y,.name` 0.116s (vs main
      0.115s) — noise level, no regression. The dedicated
      `alternative //` bench at 0.031s is unchanged.
- [ ] CI green (auto-merge on pass)

Refs #83