### PR TITLE
refactor: field_test apply-site uses RawApplyOutcome (#83 Phase B)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -140,9 +140,9 @@ use jq_jit::value::{Value, json_to_value, json_stream, json_stream_offsets, json
 use jq_jit::interpreter::Filter;
 use jq_jit::fast_path::{
     apply_field_access_raw, apply_field_alternative_raw, apply_field_field_alternative_raw,
-    apply_full_object_fields_raw, apply_has_field_raw, apply_has_multi_field_raw,
-    apply_multi_field_access_raw, apply_nested_field_access_raw, apply_object_compute_raw,
-    RawApplyOutcome,
+    apply_field_test_raw, apply_full_object_fields_raw, apply_has_field_raw,
+    apply_has_multi_field_raw, apply_multi_field_access_raw, apply_nested_field_access_raw,
+    apply_object_compute_raw, RawApplyOutcome,
 };
 
 fn json_escape_bytes(bytes: &[u8]) -> Vec<u8> {
@@ -6683,28 +6683,13 @@ fn real_main() {
                     } else {
                         ft_pattern.clone()
                     };
-                    let re = regex::Regex::new(&re_pattern);
-                    if let Ok(re) = re {
+                    if let Ok(re) = regex::Regex::new(&re_pattern) {
                         json_stream_raw(&input_str, |start, end| {
                             let raw = &input_bytes[start..end];
-                            if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, ft_field) {
-                                let val = &raw[vs..ve];
-                                if val.len() >= 2 && val[0] == b'"' && val[val.len()-1] == b'"'
-                                    && !val[1..val.len()-1].contains(&b'\\')
-                                {
-                                    let content = &val[1..val.len()-1];
-                                    let content_str = unsafe { std::str::from_utf8_unchecked(content) };
-                                    if re.is_match(content_str) {
-                                        compact_buf.extend_from_slice(b"true\n");
-                                    } else {
-                                        compact_buf.extend_from_slice(b"false\n");
-                                    }
-                                } else {
-                                    // Has escape sequences — fallback
-                                    let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                    process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                                }
-                            } else {
+                            let outcome = apply_field_test_raw(raw, ft_field, &re, |bytes| {
+                                emit_raw_ln!(&mut compact_buf, bytes);
+                            });
+                            if let RawApplyOutcome::Bail = outcome {
                                 let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                                 process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                             }
@@ -20062,28 +20047,14 @@ fn real_main() {
                 } else {
                     ft_pattern.clone()
                 };
-                let re = regex::Regex::new(&re_pattern);
-                if let Ok(re) = re {
+                if let Ok(re) = regex::Regex::new(&re_pattern) {
                     let content_bytes = content.as_bytes();
                     json_stream_raw(content, |start, end| {
                         let raw = &content_bytes[start..end];
-                        if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, ft_field) {
-                            let val = &raw[vs..ve];
-                            if val.len() >= 2 && val[0] == b'"' && val[val.len()-1] == b'"'
-                                && !val[1..val.len()-1].contains(&b'\\')
-                            {
-                                let content = &val[1..val.len()-1];
-                                let content_str = unsafe { std::str::from_utf8_unchecked(content) };
-                                if re.is_match(content_str) {
-                                    compact_buf.extend_from_slice(b"true\n");
-                                } else {
-                                    compact_buf.extend_from_slice(b"false\n");
-                                }
-                            } else {
-                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                            }
-                        } else {
+                        let outcome = apply_field_test_raw(raw, ft_field, &re, |bytes| {
+                            emit_raw_ln!(&mut compact_buf, bytes);
+                        });
+                        if let RawApplyOutcome::Bail = outcome {
                             let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                             process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -274,6 +274,57 @@ where
     RawApplyOutcome::Emit
 }
 
+/// Apply the `.field | test("pattern"; flags)` raw-byte fast path on a
+/// single JSON record.
+///
+/// The raw scanner can only run the regex over a quoted-string field with
+/// **no backslash escapes** (decoding escapes would defeat the
+/// no-materialise contract); everything else bails:
+///
+/// * Object input, field present, value is a quoted string with no `\`
+///   escapes — invokes `emit` with `b"true"` or `b"false"`.
+/// * Field absent, value isn't a quoted string, or the string contains
+///   any backslash escape — returns [`RawApplyOutcome::Bail`] so the
+///   generic path produces jq's verdict (which knows how to decode
+///   escapes and how to raise on non-string inputs).
+/// * Non-object input — returns [`RawApplyOutcome::Bail`] (the field
+///   fetch fails, so this is collapsed into the same Bail branch).
+///
+/// The caller owns the compiled `regex::Regex` so it can be reused
+/// across the input stream.
+pub fn apply_field_test_raw<E>(
+    raw: &[u8],
+    field: &str,
+    re: &regex::Regex,
+    mut emit: E,
+) -> RawApplyOutcome
+where
+    E: FnMut(&[u8]),
+{
+    let (vs, ve) = match json_object_get_field_raw(raw, 0, field) {
+        Some(r) => r,
+        None => return RawApplyOutcome::Bail,
+    };
+    let val = &raw[vs..ve];
+    // Only handle the no-escape ASCII-or-UTF-8 quoted-string fast lane.
+    // Anything else (non-string, escaped string, missing trailing quote)
+    // bails — the generic path can decode escapes and raise the right
+    // error for non-strings.
+    if val.len() < 2 || val[0] != b'"' || val[val.len() - 1] != b'"'
+        || val[1..val.len() - 1].contains(&b'\\')
+    {
+        return RawApplyOutcome::Bail;
+    }
+    let content = &val[1..val.len() - 1];
+    let content_str = unsafe { std::str::from_utf8_unchecked(content) };
+    if re.is_match(content_str) {
+        emit(b"true");
+    } else {
+        emit(b"false");
+    }
+    RawApplyOutcome::Emit
+}
+
 /// Apply the `.field // fallback` raw-byte fast path on a single JSON
 /// record.
 ///

--- a/tests/fast_path_contract.rs
+++ b/tests/fast_path_contract.rs
@@ -10,9 +10,9 @@
 
 use jq_jit::fast_path::{
     FastPath, FieldAccessPath, RawApplyOutcome, apply_field_access_raw,
-    apply_field_alternative_raw, apply_field_field_alternative_raw, apply_full_object_fields_raw,
-    apply_has_field_raw, apply_has_multi_field_raw, apply_multi_field_access_raw,
-    apply_nested_field_access_raw, apply_object_compute_raw,
+    apply_field_alternative_raw, apply_field_field_alternative_raw, apply_field_test_raw,
+    apply_full_object_fields_raw, apply_has_field_raw, apply_has_multi_field_raw,
+    apply_multi_field_access_raw, apply_nested_field_access_raw, apply_object_compute_raw,
 };
 use jq_jit::interpreter::Filter;
 use jq_jit::value::Value;
@@ -793,6 +793,106 @@ fn raw_field_field_alt_non_object_non_null_bails() {
         let mut emitted: Vec<Vec<u8>> = Vec::new();
         let outcome =
             apply_field_field_alternative_raw(raw, "a", "b", |b| emitted.push(b.to_vec()));
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "expected Bail for input {:?}, got {:?}",
+            std::str::from_utf8(raw).unwrap(),
+            outcome,
+        );
+        assert!(emitted.is_empty());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// `.field | test("pattern")` — raw scanner only handles quoted strings with
+// no backslash escapes; everything else bails. The helper hands the regex
+// match verdict (`true`/`false`) back through the emit closure.
+
+#[test]
+fn raw_field_test_match_emits_true() {
+    let re = regex::Regex::new(r"^foo").unwrap();
+    let mut emitted: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_field_test_raw(
+        b"{\"x\":\"foobar\"}",
+        "x",
+        &re,
+        |b| emitted.push(b.to_vec()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec![b"true".to_vec()]);
+}
+
+#[test]
+fn raw_field_test_no_match_emits_false() {
+    let re = regex::Regex::new(r"^foo").unwrap();
+    let mut emitted: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_field_test_raw(
+        b"{\"x\":\"barfoo\"}",
+        "x",
+        &re,
+        |b| emitted.push(b.to_vec()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec![b"false".to_vec()]);
+}
+
+#[test]
+fn raw_field_test_field_missing_bails() {
+    let re = regex::Regex::new(r"^foo").unwrap();
+    let mut emitted: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_field_test_raw(
+        b"{\"y\":\"hi\"}",
+        "x",
+        &re,
+        |b| emitted.push(b.to_vec()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_field_test_non_string_field_bails() {
+    let re = regex::Regex::new(r"^foo").unwrap();
+    for inner in [&b"{\"x\":42}"[..], &b"{\"x\":null}"[..], &b"{\"x\":[1,2]}"[..]] {
+        let mut emitted: Vec<Vec<u8>> = Vec::new();
+        let outcome = apply_field_test_raw(inner, "x", &re, |b| emitted.push(b.to_vec()));
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "expected Bail for non-string field input {:?}, got {:?}",
+            std::str::from_utf8(inner).unwrap(),
+            outcome,
+        );
+        assert!(emitted.is_empty());
+    }
+}
+
+#[test]
+fn raw_field_test_escaped_string_bails() {
+    // Backslash escapes need decoding; the raw scanner can't, so it bails.
+    let re = regex::Regex::new(r"\n").unwrap();
+    let mut emitted: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_field_test_raw(
+        br#"{"x":"a\nb"}"#,
+        "x",
+        &re,
+        |b| emitted.push(b.to_vec()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_field_test_non_object_input_bails() {
+    let re = regex::Regex::new(r".*").unwrap();
+    for raw in [
+        b"42".as_slice(),
+        b"\"hi\"".as_slice(),
+        b"null".as_slice(),
+        b"true".as_slice(),
+        b"[1,2,3]".as_slice(),
+    ] {
+        let mut emitted: Vec<Vec<u8>> = Vec::new();
+        let outcome = apply_field_test_raw(raw, "x", &re, |b| emitted.push(b.to_vec()));
         assert!(
             matches!(outcome, RawApplyOutcome::Bail),
             "expected Bail for input {:?}, got {:?}",

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -2747,3 +2747,50 @@ null
 
 (.a // .b)?
 "hi"
+
+# Issue #83 Phase B: raw .field | test("p"; flags) apply-site now uses
+# RawApplyOutcome. Field absent / non-string field / escape-bearing string /
+# non-object input all bail to generic so jq's correct verdict surfaces.
+
+# Plain regex match emits true
+.x | test("foo")
+{"x":"foobar"}
+true
+
+# Plain regex no-match emits false
+.x | test("foo")
+{"x":"barbaz"}
+false
+
+# Case-insensitive flag
+.x | test("foo"; "i")
+{"x":"FOO"}
+true
+
+# Field absent: bail to generic, jq raises (test on null), `?` swallows
+(.x | test("foo"))?
+{"y":"foobar"}
+
+# Non-string field: bail to generic, jq raises type error; `?` swallows
+(.x | test("foo"))?
+{"x":42}
+
+# Escape-bearing string: bail to generic so escape gets decoded correctly
+.x | test("ab")
+{"x":"a\nb"}
+false
+
+# Escape-bearing string with newline-spanning regex: relies on decoded value
+.x | test("a.b"; "s")
+{"x":"a\nb"}
+true
+
+# Non-object input under `?` bails, jq raises, `?` swallows
+(.x | test("foo"))?
+42
+
+(.x | test("foo"))?
+"hello"
+
+(.x | test("foo"))?
+[1,2,3]


### PR DESCRIPTION
## Summary

Ninth sibling in the Phase B migration: ports
`.field | test(\"pattern\"; flags)` to the named-`Bail` discipline.

### Why this is a Phase B target

The raw scanner can only run the regex over a quoted-string field with
**no backslash escapes** (decoding escapes would defeat the
no-materialise contract). The existing apply-site already had three
implicit Bail branches (missing field, non-string field, escaped
string); this PR pushes them into the helper boundary so the bail
discipline is structural at the function signature.

### What's new

- **`apply_field_test_raw`** in `src/fast_path.rs`. Caller owns the
  compiled `regex::Regex` so it's reused across the input stream; the
  helper just runs per-record bail + match.
- Both apply-sites in `bin/jq-jit.rs` (stdin + file dispatch) call
  the helper. The implicit if-else branches collapse into an explicit
  verdict check.

### Tests

- `tests/fast_path_contract.rs` — 6 new cases (match → emit true,
  no-match → emit false, missing field → bail, non-string field →
  bail, escape-bearing string → bail, every non-object input bails).
- `tests/regression.test` — 9 new cases covering happy paths (plain
  match, no-match, case-insensitive flag), `?` over non-string field
  / missing field / non-object inputs, plus escape-decoding scenarios
  that go through generic.

## Verification

- [x] `cargo build --release` — zero warnings
- [x] `cargo test --release` — 1100 official+regression PASS, 55
      `fast_path_contract` cases pass, full suite green
- [x] `./bench/comprehensive.sh --quick` — `field access .name`
      0.083s (vs main 0.082s), `nested .x,.y,.name` 0.113s (vs main
      0.115s), `test (regex)` 0.014s — noise level, no regression
- [ ] CI green (auto-merge on pass)

Refs #83