### PR TITLE
refactor: field_gsub apply-site uses RawApplyOutcome (#83 Phase B)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -140,9 +140,9 @@ use jq_jit::value::{Value, json_to_value, json_stream, json_stream_offsets, json
 use jq_jit::interpreter::Filter;
 use jq_jit::fast_path::{
     apply_field_access_raw, apply_field_alternative_raw, apply_field_field_alternative_raw,
-    apply_field_test_raw, apply_full_object_fields_raw, apply_has_field_raw,
-    apply_has_multi_field_raw, apply_multi_field_access_raw, apply_nested_field_access_raw,
-    apply_object_compute_raw, RawApplyOutcome,
+    apply_field_gsub_raw, apply_field_test_raw, apply_full_object_fields_raw,
+    apply_has_field_raw, apply_has_multi_field_raw, apply_multi_field_access_raw,
+    apply_nested_field_access_raw, apply_object_compute_raw, RawApplyOutcome,
 };
 
 fn json_escape_bytes(bytes: &[u8]) -> Vec<u8> {
@@ -6725,17 +6725,13 @@ fn real_main() {
                         let repl = gs_replacement.as_str();
                         json_stream_raw(&input_str, |start, end| {
                             let raw = &input_bytes[start..end];
-                            if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, gs_field) {
-                                let val = &raw[vs..ve];
-                                if val.len() >= 2 && val[0] == b'"' && val[val.len()-1] == b'"'
-                                    && !val[1..val.len()-1].contains(&b'\\')
-                                {
-                                    let content = unsafe { std::str::from_utf8_unchecked(&val[1..val.len()-1]) };
-                                    let result = if gs_global {
-                                        re.replace_all(content, repl)
-                                    } else {
-                                        re.replace(content, repl)
-                                    };
+                            let outcome = apply_field_gsub_raw(
+                                raw,
+                                gs_field,
+                                &re,
+                                repl,
+                                gs_global,
+                                |result| {
                                     compact_buf.push(b'"');
                                     // Escape the result for JSON
                                     for &b in result.as_bytes() {
@@ -6750,11 +6746,9 @@ fn real_main() {
                                         }
                                     }
                                     compact_buf.extend_from_slice(b"\"\n");
-                                } else {
-                                    let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                    process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                                }
-                            } else {
+                                },
+                            );
+                            if let RawApplyOutcome::Bail = outcome {
                                 let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                                 process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                             }
@@ -20091,17 +20085,13 @@ fn real_main() {
                     let content_bytes = content.as_bytes();
                     json_stream_raw(content, |start, end| {
                         let raw = &content_bytes[start..end];
-                        if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, gs_field) {
-                            let val = &raw[vs..ve];
-                            if val.len() >= 2 && val[0] == b'"' && val[val.len()-1] == b'"'
-                                && !val[1..val.len()-1].contains(&b'\\')
-                            {
-                                let content_str = unsafe { std::str::from_utf8_unchecked(&val[1..val.len()-1]) };
-                                let result = if gs_global {
-                                    re.replace_all(content_str, repl)
-                                } else {
-                                    re.replace(content_str, repl)
-                                };
+                        let outcome = apply_field_gsub_raw(
+                            raw,
+                            gs_field,
+                            &re,
+                            repl,
+                            gs_global,
+                            |result| {
                                 compact_buf.push(b'"');
                                 for &b in result.as_bytes() {
                                     match b {
@@ -20115,11 +20105,9 @@ fn real_main() {
                                     }
                                 }
                                 compact_buf.extend_from_slice(b"\"\n");
-                            } else {
-                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                            }
-                        } else {
+                            },
+                        );
+                        if let RawApplyOutcome::Bail = outcome {
                             let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                             process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -325,6 +325,49 @@ where
     RawApplyOutcome::Emit
 }
 
+/// Apply the `.field | gsub/sub("pattern"; "replacement"; flags)` raw-byte
+/// fast path on a single JSON record.
+///
+/// Bail discipline matches [`apply_field_test_raw`] (only quoted-string
+/// fields with no backslash escapes are handled by the raw scanner; the
+/// generic path takes everything else, including the type errors jq raises
+/// on non-strings). When the bail clears, `emit` is invoked with the
+/// `Cow<str>` produced by the regex replacement; the caller is responsible
+/// for JSON-escaping the result and writing the surrounding quotes /
+/// trailing newline.
+///
+/// `is_global` selects between `replace_all` (gsub) and `replace` (sub).
+pub fn apply_field_gsub_raw<E>(
+    raw: &[u8],
+    field: &str,
+    re: &regex::Regex,
+    replacement: &str,
+    is_global: bool,
+    mut emit: E,
+) -> RawApplyOutcome
+where
+    E: FnMut(&str),
+{
+    let (vs, ve) = match json_object_get_field_raw(raw, 0, field) {
+        Some(r) => r,
+        None => return RawApplyOutcome::Bail,
+    };
+    let val = &raw[vs..ve];
+    if val.len() < 2 || val[0] != b'"' || val[val.len() - 1] != b'"'
+        || val[1..val.len() - 1].contains(&b'\\')
+    {
+        return RawApplyOutcome::Bail;
+    }
+    let content = unsafe { std::str::from_utf8_unchecked(&val[1..val.len() - 1]) };
+    let result = if is_global {
+        re.replace_all(content, replacement)
+    } else {
+        re.replace(content, replacement)
+    };
+    emit(&result);
+    RawApplyOutcome::Emit
+}
+
 /// Apply the `.field // fallback` raw-byte fast path on a single JSON
 /// record.
 ///

--- a/tests/fast_path_contract.rs
+++ b/tests/fast_path_contract.rs
@@ -10,9 +10,10 @@
 
 use jq_jit::fast_path::{
     FastPath, FieldAccessPath, RawApplyOutcome, apply_field_access_raw,
-    apply_field_alternative_raw, apply_field_field_alternative_raw, apply_field_test_raw,
-    apply_full_object_fields_raw, apply_has_field_raw, apply_has_multi_field_raw,
-    apply_multi_field_access_raw, apply_nested_field_access_raw, apply_object_compute_raw,
+    apply_field_alternative_raw, apply_field_field_alternative_raw, apply_field_gsub_raw,
+    apply_field_test_raw, apply_full_object_fields_raw, apply_has_field_raw,
+    apply_has_multi_field_raw, apply_multi_field_access_raw, apply_nested_field_access_raw,
+    apply_object_compute_raw,
 };
 use jq_jit::interpreter::Filter;
 use jq_jit::value::Value;
@@ -893,6 +894,120 @@ fn raw_field_test_non_object_input_bails() {
     ] {
         let mut emitted: Vec<Vec<u8>> = Vec::new();
         let outcome = apply_field_test_raw(raw, "x", &re, |b| emitted.push(b.to_vec()));
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "expected Bail for input {:?}, got {:?}",
+            std::str::from_utf8(raw).unwrap(),
+            outcome,
+        );
+        assert!(emitted.is_empty());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// `.field | gsub("p"; "r")` / `sub` — same Bail discipline as `field_test`,
+// with the helper handing the regex replacement result back as `&str` so the
+// apply-site owns JSON-escape framing.
+
+#[test]
+fn raw_field_gsub_global_replaces_all_matches() {
+    let re = regex::Regex::new("a").unwrap();
+    let mut emitted: Vec<String> = Vec::new();
+    let outcome = apply_field_gsub_raw(
+        b"{\"x\":\"banana\"}",
+        "x",
+        &re,
+        "X",
+        true,
+        |s| emitted.push(s.to_string()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec!["bXnXnX".to_string()]);
+}
+
+#[test]
+fn raw_field_gsub_non_global_replaces_first_only() {
+    let re = regex::Regex::new("a").unwrap();
+    let mut emitted: Vec<String> = Vec::new();
+    let outcome = apply_field_gsub_raw(
+        b"{\"x\":\"banana\"}",
+        "x",
+        &re,
+        "X",
+        false,
+        |s| emitted.push(s.to_string()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec!["bXnana".to_string()]);
+}
+
+#[test]
+fn raw_field_gsub_no_match_emits_unchanged() {
+    let re = regex::Regex::new("z").unwrap();
+    let mut emitted: Vec<String> = Vec::new();
+    let outcome = apply_field_gsub_raw(
+        b"{\"x\":\"banana\"}",
+        "x",
+        &re,
+        "X",
+        true,
+        |s| emitted.push(s.to_string()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec!["banana".to_string()]);
+}
+
+#[test]
+fn raw_field_gsub_field_missing_or_non_string_bails() {
+    let re = regex::Regex::new("a").unwrap();
+    for inner in [
+        &b"{\"y\":\"hi\"}"[..],
+        &b"{\"x\":42}"[..],
+        &b"{\"x\":null}"[..],
+        &b"{\"x\":[1,2,3]}"[..],
+    ] {
+        let mut emitted: Vec<String> = Vec::new();
+        let outcome =
+            apply_field_gsub_raw(inner, "x", &re, "X", true, |s| emitted.push(s.to_string()));
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "expected Bail for input {:?}, got {:?}",
+            std::str::from_utf8(inner).unwrap(),
+            outcome,
+        );
+        assert!(emitted.is_empty());
+    }
+}
+
+#[test]
+fn raw_field_gsub_escaped_string_bails() {
+    let re = regex::Regex::new("a").unwrap();
+    let mut emitted: Vec<String> = Vec::new();
+    let outcome = apply_field_gsub_raw(
+        br#"{"x":"a\nb"}"#,
+        "x",
+        &re,
+        "X",
+        true,
+        |s| emitted.push(s.to_string()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_field_gsub_non_object_input_bails() {
+    let re = regex::Regex::new(".*").unwrap();
+    for raw in [
+        b"42".as_slice(),
+        b"\"hi\"".as_slice(),
+        b"null".as_slice(),
+        b"true".as_slice(),
+        b"[1,2,3]".as_slice(),
+    ] {
+        let mut emitted: Vec<String> = Vec::new();
+        let outcome =
+            apply_field_gsub_raw(raw, "x", &re, "X", true, |s| emitted.push(s.to_string()));
         assert!(
             matches!(outcome, RawApplyOutcome::Bail),
             "expected Bail for input {:?}, got {:?}",

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -2794,3 +2794,50 @@ true
 
 (.x | test("foo"))?
 [1,2,3]
+
+# Issue #83 Phase B: raw .field | gsub/sub("p"; "r"; flags) apply-site uses
+# RawApplyOutcome. Same Bail discipline as field_test (only quoted strings
+# without backslash escapes).
+
+# gsub replaces all matches
+.x | gsub("a"; "X")
+{"x":"banana"}
+"bXnXnX"
+
+# sub replaces first match only
+.x | sub("a"; "X")
+{"x":"banana"}
+"bXnana"
+
+# No match emits unchanged
+.x | gsub("z"; "X")
+{"x":"banana"}
+"banana"
+
+# Case-insensitive flag (only the matched chars are replaced; original case kept elsewhere)
+.x | gsub("a"; "X"; "i")
+{"x":"BAnana"}
+"BXnXnX"
+
+# Field missing under `?` bails to generic, jq raises, `?` swallows
+(.x | gsub("a"; "X"))?
+{"y":"hi"}
+
+# Non-string field under `?`
+(.x | gsub("a"; "X"))?
+{"x":42}
+
+# Escape-bearing string: bail to generic (decodes correctly)
+.x | gsub("ab"; "X")
+{"x":"a\nb"}
+"a\nb"
+
+# Non-object input under `?`
+(.x | gsub("a"; "X"))?
+42
+
+(.x | gsub("a"; "X"))?
+"hi"
+
+(.x | gsub("a"; "X"))?
+[1,2,3]


### PR DESCRIPTION
## Summary

Tenth sibling in the Phase B migration: ports
`.field | gsub/sub(\"pattern\"; \"replacement\"; flags)` to the
named-`Bail` discipline.

Same Bail shape as `field_test` (#249): only quoted-string fields
with no backslash escapes are handled by the raw scanner; everything
else bails so the generic path raises jq's type errors and decodes
escapes correctly.

### What's new

- **`apply_field_gsub_raw`** in `src/fast_path.rs`. Caller owns the
  compiled `regex::Regex` and the replacement `&str`. `is_global`
  selects between `replace_all` (gsub) and `replace` (sub). The
  helper hands the result back as `&str` so the apply-site keeps
  ownership of JSON-escape framing.
- Both apply-sites in `bin/jq-jit.rs` (stdin + file dispatch) call
  the helper. Implicit if-else collapses into an explicit verdict
  check.

### Tests

- `tests/fast_path_contract.rs` — 6 new cases (gsub global replace,
  sub first-only, no-match unchanged, missing/non-string field bail,
  escape-bearing string bail, non-object input bails).
- `tests/regression.test` — 10 new cases covering happy paths
  (gsub, sub, no-match, case-insensitive flag) plus `?` over missing
  field / non-string field / non-object inputs, plus escape-decoding
  scenarios that go through generic.

## Verification

- [x] `cargo build --release` — zero warnings
- [x] `cargo test --release` — 1100 official+regression PASS, 61
      `fast_path_contract` cases pass, full suite green
- [x] `./bench/comprehensive.sh --quick` — `field access .name`
      0.084s, `nested .x,.y,.name` 0.117s, `gsub` 0.018s,
      `test (regex)` 0.014s — noise level, no regression
- [ ] CI green (auto-merge on pass)

Refs #83