### PR TITLE
refactor: field_match apply-site uses RawApplyOutcome (#83 Phase B)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -140,9 +140,10 @@ use jq_jit::value::{Value, json_to_value, json_stream, json_stream_offsets, json
 use jq_jit::interpreter::Filter;
 use jq_jit::fast_path::{
     apply_field_access_raw, apply_field_alternative_raw, apply_field_field_alternative_raw,
-    apply_field_gsub_raw, apply_field_test_raw, apply_full_object_fields_raw,
-    apply_has_field_raw, apply_has_multi_field_raw, apply_multi_field_access_raw,
-    apply_nested_field_access_raw, apply_object_compute_raw, RawApplyOutcome,
+    apply_field_gsub_raw, apply_field_match_raw, apply_field_test_raw,
+    apply_full_object_fields_raw, apply_has_field_raw, apply_has_multi_field_raw,
+    apply_multi_field_access_raw, apply_nested_field_access_raw, apply_object_compute_raw,
+    RawApplyOutcome,
 };
 
 fn json_escape_bytes(bytes: &[u8]) -> Vec<u8> {
@@ -6970,79 +6971,68 @@ fn real_main() {
                         let capture_names: Vec<Option<String>> = re.capture_names().map(|n| n.map(|s| s.to_string())).collect();
                         json_stream_raw(&input_str, |start, end| {
                             let raw = &input_bytes[start..end];
-                            if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, fm_field) {
-                                let val = &raw[vs..ve];
-                                if val.len() >= 2 && val[0] == b'"' && val[val.len()-1] == b'"'
-                                    && !val[1..val.len()-1].contains(&b'\\')
-                                {
-                                    let content = unsafe { std::str::from_utf8_unchecked(&val[1..val.len()-1]) };
-                                    if let Some(caps) = re.captures(content) {
-                                        let m = caps.get(0).unwrap();
-                                        let offset_cp = content[..m.start()].chars().count();
-                                        let length_cp = m.as_str().chars().count();
-                                        // {"offset":N,"length":N,"string":"...","captures":[...]}
-                                        compact_buf.extend_from_slice(b"{\"offset\":");
-                                        compact_buf.extend_from_slice(itoa::Buffer::new().format(offset_cp).as_bytes());
-                                        compact_buf.extend_from_slice(b",\"length\":");
-                                        compact_buf.extend_from_slice(itoa::Buffer::new().format(length_cp).as_bytes());
-                                        compact_buf.extend_from_slice(b",\"string\":\"");
-                                        for &b in m.as_str().as_bytes() {
-                                            match b {
-                                                b'"' => compact_buf.extend_from_slice(b"\\\""),
-                                                b'\\' => compact_buf.extend_from_slice(b"\\\\"),
-                                                _ => compact_buf.push(b),
-                                            }
-                                        }
-                                        compact_buf.extend_from_slice(b"\",\"captures\":[");
-                                        for i in 1..caps.len() {
-                                            if i > 1 { compact_buf.push(b','); }
-                                            match caps.get(i) {
-                                                Some(cm) => {
-                                                    let c_offset = content[..cm.start()].chars().count();
-                                                    let c_length = cm.as_str().chars().count();
-                                                    compact_buf.extend_from_slice(b"{\"offset\":");
-                                                    compact_buf.extend_from_slice(itoa::Buffer::new().format(c_offset).as_bytes());
-                                                    compact_buf.extend_from_slice(b",\"length\":");
-                                                    compact_buf.extend_from_slice(itoa::Buffer::new().format(c_length).as_bytes());
-                                                    compact_buf.extend_from_slice(b",\"string\":\"");
-                                                    for &b in cm.as_str().as_bytes() {
-                                                        match b {
-                                                            b'"' => compact_buf.extend_from_slice(b"\\\""),
-                                                            b'\\' => compact_buf.extend_from_slice(b"\\\\"),
-                                                            _ => compact_buf.push(b),
-                                                        }
-                                                    }
-                                                    compact_buf.extend_from_slice(b"\",\"name\":");
-                                                    if let Some(Some(ref name)) = capture_names.get(i) {
-                                                        compact_buf.push(b'"');
-                                                        compact_buf.extend_from_slice(name.as_bytes());
-                                                        compact_buf.push(b'"');
-                                                    } else {
-                                                        compact_buf.extend_from_slice(b"null");
-                                                    }
-                                                    compact_buf.push(b'}');
-                                                }
-                                                None => {
-                                                    compact_buf.extend_from_slice(b"{\"offset\":-1,\"length\":0,\"string\":null,\"name\":");
-                                                    if let Some(Some(ref name)) = capture_names.get(i) {
-                                                        compact_buf.push(b'"');
-                                                        compact_buf.extend_from_slice(name.as_bytes());
-                                                        compact_buf.push(b'"');
-                                                    } else {
-                                                        compact_buf.extend_from_slice(b"null");
-                                                    }
-                                                    compact_buf.push(b'}');
-                                                }
-                                            }
-                                        }
-                                        compact_buf.extend_from_slice(b"]}\n");
+                            let outcome = apply_field_match_raw(raw, fm_field, &re, |content, caps| {
+                                let m = caps.get(0).unwrap();
+                                let offset_cp = content[..m.start()].chars().count();
+                                let length_cp = m.as_str().chars().count();
+                                // {"offset":N,"length":N,"string":"...","captures":[...]}
+                                compact_buf.extend_from_slice(b"{\"offset\":");
+                                compact_buf.extend_from_slice(itoa::Buffer::new().format(offset_cp).as_bytes());
+                                compact_buf.extend_from_slice(b",\"length\":");
+                                compact_buf.extend_from_slice(itoa::Buffer::new().format(length_cp).as_bytes());
+                                compact_buf.extend_from_slice(b",\"string\":\"");
+                                for &b in m.as_str().as_bytes() {
+                                    match b {
+                                        b'"' => compact_buf.extend_from_slice(b"\\\""),
+                                        b'\\' => compact_buf.extend_from_slice(b"\\\\"),
+                                        _ => compact_buf.push(b),
                                     }
-                                    // no match → empty (no output), matching jq behavior
-                                } else {
-                                    let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                    process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                                 }
-                            } else {
+                                compact_buf.extend_from_slice(b"\",\"captures\":[");
+                                for i in 1..caps.len() {
+                                    if i > 1 { compact_buf.push(b','); }
+                                    match caps.get(i) {
+                                        Some(cm) => {
+                                            let c_offset = content[..cm.start()].chars().count();
+                                            let c_length = cm.as_str().chars().count();
+                                            compact_buf.extend_from_slice(b"{\"offset\":");
+                                            compact_buf.extend_from_slice(itoa::Buffer::new().format(c_offset).as_bytes());
+                                            compact_buf.extend_from_slice(b",\"length\":");
+                                            compact_buf.extend_from_slice(itoa::Buffer::new().format(c_length).as_bytes());
+                                            compact_buf.extend_from_slice(b",\"string\":\"");
+                                            for &b in cm.as_str().as_bytes() {
+                                                match b {
+                                                    b'"' => compact_buf.extend_from_slice(b"\\\""),
+                                                    b'\\' => compact_buf.extend_from_slice(b"\\\\"),
+                                                    _ => compact_buf.push(b),
+                                                }
+                                            }
+                                            compact_buf.extend_from_slice(b"\",\"name\":");
+                                            if let Some(Some(ref name)) = capture_names.get(i) {
+                                                compact_buf.push(b'"');
+                                                compact_buf.extend_from_slice(name.as_bytes());
+                                                compact_buf.push(b'"');
+                                            } else {
+                                                compact_buf.extend_from_slice(b"null");
+                                            }
+                                            compact_buf.push(b'}');
+                                        }
+                                        None => {
+                                            compact_buf.extend_from_slice(b"{\"offset\":-1,\"length\":0,\"string\":null,\"name\":");
+                                            if let Some(Some(ref name)) = capture_names.get(i) {
+                                                compact_buf.push(b'"');
+                                                compact_buf.extend_from_slice(name.as_bytes());
+                                                compact_buf.push(b'"');
+                                            } else {
+                                                compact_buf.extend_from_slice(b"null");
+                                            }
+                                            compact_buf.push(b'}');
+                                        }
+                                    }
+                                }
+                                compact_buf.extend_from_slice(b"]}\n");
+                            });
+                            if let RawApplyOutcome::Bail = outcome {
                                 let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                                 process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                             }
@@ -20336,78 +20326,67 @@ fn real_main() {
                     let content_bytes = content.as_bytes();
                     json_stream_raw(content, |start, end| {
                         let raw = &content_bytes[start..end];
-                        if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, fm_field) {
-                            let val = &raw[vs..ve];
-                            if val.len() >= 2 && val[0] == b'"' && val[val.len()-1] == b'"'
-                                && !val[1..val.len()-1].contains(&b'\\')
-                            {
-                                let content_str = unsafe { std::str::from_utf8_unchecked(&val[1..val.len()-1]) };
-                                if let Some(caps) = re.captures(content_str) {
-                                    let m = caps.get(0).unwrap();
-                                    let offset_cp = content_str[..m.start()].chars().count();
-                                    let length_cp = m.as_str().chars().count();
-                                    compact_buf.extend_from_slice(b"{\"offset\":");
-                                    compact_buf.extend_from_slice(itoa::Buffer::new().format(offset_cp).as_bytes());
-                                    compact_buf.extend_from_slice(b",\"length\":");
-                                    compact_buf.extend_from_slice(itoa::Buffer::new().format(length_cp).as_bytes());
-                                    compact_buf.extend_from_slice(b",\"string\":\"");
-                                    for &b in m.as_str().as_bytes() {
-                                        match b {
-                                            b'"' => compact_buf.extend_from_slice(b"\\\""),
-                                            b'\\' => compact_buf.extend_from_slice(b"\\\\"),
-                                            _ => compact_buf.push(b),
-                                        }
-                                    }
-                                    compact_buf.extend_from_slice(b"\",\"captures\":[");
-                                    for i in 1..caps.len() {
-                                        if i > 1 { compact_buf.push(b','); }
-                                        match caps.get(i) {
-                                            Some(cm) => {
-                                                let c_offset = content_str[..cm.start()].chars().count();
-                                                let c_length = cm.as_str().chars().count();
-                                                compact_buf.extend_from_slice(b"{\"offset\":");
-                                                compact_buf.extend_from_slice(itoa::Buffer::new().format(c_offset).as_bytes());
-                                                compact_buf.extend_from_slice(b",\"length\":");
-                                                compact_buf.extend_from_slice(itoa::Buffer::new().format(c_length).as_bytes());
-                                                compact_buf.extend_from_slice(b",\"string\":\"");
-                                                for &b in cm.as_str().as_bytes() {
-                                                    match b {
-                                                        b'"' => compact_buf.extend_from_slice(b"\\\""),
-                                                        b'\\' => compact_buf.extend_from_slice(b"\\\\"),
-                                                        _ => compact_buf.push(b),
-                                                    }
-                                                }
-                                                compact_buf.extend_from_slice(b"\",\"name\":");
-                                                if let Some(Some(ref name)) = capture_names.get(i) {
-                                                    compact_buf.push(b'"');
-                                                    compact_buf.extend_from_slice(name.as_bytes());
-                                                    compact_buf.push(b'"');
-                                                } else {
-                                                    compact_buf.extend_from_slice(b"null");
-                                                }
-                                                compact_buf.push(b'}');
-                                            }
-                                            None => {
-                                                compact_buf.extend_from_slice(b"{\"offset\":-1,\"length\":0,\"string\":null,\"name\":");
-                                                if let Some(Some(ref name)) = capture_names.get(i) {
-                                                    compact_buf.push(b'"');
-                                                    compact_buf.extend_from_slice(name.as_bytes());
-                                                    compact_buf.push(b'"');
-                                                } else {
-                                                    compact_buf.extend_from_slice(b"null");
-                                                }
-                                                compact_buf.push(b'}');
-                                            }
-                                        }
-                                    }
-                                    compact_buf.extend_from_slice(b"]}\n");
+                        let outcome = apply_field_match_raw(raw, fm_field, &re, |content_str, caps| {
+                            let m = caps.get(0).unwrap();
+                            let offset_cp = content_str[..m.start()].chars().count();
+                            let length_cp = m.as_str().chars().count();
+                            compact_buf.extend_from_slice(b"{\"offset\":");
+                            compact_buf.extend_from_slice(itoa::Buffer::new().format(offset_cp).as_bytes());
+                            compact_buf.extend_from_slice(b",\"length\":");
+                            compact_buf.extend_from_slice(itoa::Buffer::new().format(length_cp).as_bytes());
+                            compact_buf.extend_from_slice(b",\"string\":\"");
+                            for &b in m.as_str().as_bytes() {
+                                match b {
+                                    b'"' => compact_buf.extend_from_slice(b"\\\""),
+                                    b'\\' => compact_buf.extend_from_slice(b"\\\\"),
+                                    _ => compact_buf.push(b),
                                 }
-                                // no match → empty (no output), matching jq behavior
-                            } else {
-                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                             }
-                        } else {
+                            compact_buf.extend_from_slice(b"\",\"captures\":[");
+                            for i in 1..caps.len() {
+                                if i > 1 { compact_buf.push(b','); }
+                                match caps.get(i) {
+                                    Some(cm) => {
+                                        let c_offset = content_str[..cm.start()].chars().count();
+                                        let c_length = cm.as_str().chars().count();
+                                        compact_buf.extend_from_slice(b"{\"offset\":");
+                                        compact_buf.extend_from_slice(itoa::Buffer::new().format(c_offset).as_bytes());
+                                        compact_buf.extend_from_slice(b",\"length\":");
+                                        compact_buf.extend_from_slice(itoa::Buffer::new().format(c_length).as_bytes());
+                                        compact_buf.extend_from_slice(b",\"string\":\"");
+                                        for &b in cm.as_str().as_bytes() {
+                                            match b {
+                                                b'"' => compact_buf.extend_from_slice(b"\\\""),
+                                                b'\\' => compact_buf.extend_from_slice(b"\\\\"),
+                                                _ => compact_buf.push(b),
+                                            }
+                                        }
+                                        compact_buf.extend_from_slice(b"\",\"name\":");
+                                        if let Some(Some(ref name)) = capture_names.get(i) {
+                                            compact_buf.push(b'"');
+                                            compact_buf.extend_from_slice(name.as_bytes());
+                                            compact_buf.push(b'"');
+                                        } else {
+                                            compact_buf.extend_from_slice(b"null");
+                                        }
+                                        compact_buf.push(b'}');
+                                    }
+                                    None => {
+                                        compact_buf.extend_from_slice(b"{\"offset\":-1,\"length\":0,\"string\":null,\"name\":");
+                                        if let Some(Some(ref name)) = capture_names.get(i) {
+                                            compact_buf.push(b'"');
+                                            compact_buf.extend_from_slice(name.as_bytes());
+                                            compact_buf.push(b'"');
+                                        } else {
+                                            compact_buf.extend_from_slice(b"null");
+                                        }
+                                        compact_buf.push(b'}');
+                                    }
+                                }
+                            }
+                            compact_buf.extend_from_slice(b"]}\n");
+                        });
+                        if let RawApplyOutcome::Bail = outcome {
                             let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                             process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -368,6 +368,55 @@ where
     RawApplyOutcome::Emit
 }
 
+/// Apply the `.field | match("pattern"; flags)` raw-byte fast path on a
+/// single JSON record.
+///
+/// Bail discipline matches [`apply_field_test_raw`] (only quoted-string
+/// fields with no backslash escapes are handled by the raw scanner; the
+/// generic path takes everything else, including the type errors jq raises
+/// on non-strings):
+///
+/// * Object input, field present, value is a quoted string with no `\`
+///   escapes — runs `re.captures(content)`. On a match, invokes
+///   `on_match(content, captures)` so the caller can build jq's
+///   `{offset,length,string,captures:[...]}` output bytes. On no match,
+///   `on_match` is **not** called (jq emits no output for a non-match —
+///   `match` is multi-output / 0-arity for "no match").
+/// * Field absent, value isn't a quoted string, or the string contains
+///   any backslash escape — returns [`RawApplyOutcome::Bail`] so the
+///   generic path produces jq's verdict (decoded escapes, type errors).
+/// * Non-object input — returns [`RawApplyOutcome::Bail`] (the field
+///   fetch fails, so this is collapsed into the same Bail branch).
+///
+/// The caller owns the compiled `regex::Regex` and any
+/// `capture_names`-style metadata (typically built once outside the
+/// stream loop) so they can be reused across the input stream.
+pub fn apply_field_match_raw<F>(
+    raw: &[u8],
+    field: &str,
+    re: &regex::Regex,
+    mut on_match: F,
+) -> RawApplyOutcome
+where
+    F: FnMut(&str, &regex::Captures<'_>),
+{
+    let (vs, ve) = match json_object_get_field_raw(raw, 0, field) {
+        Some(r) => r,
+        None => return RawApplyOutcome::Bail,
+    };
+    let val = &raw[vs..ve];
+    if val.len() < 2 || val[0] != b'"' || val[val.len() - 1] != b'"'
+        || val[1..val.len() - 1].contains(&b'\\')
+    {
+        return RawApplyOutcome::Bail;
+    }
+    let content = unsafe { std::str::from_utf8_unchecked(&val[1..val.len() - 1]) };
+    if let Some(caps) = re.captures(content) {
+        on_match(content, &caps);
+    }
+    RawApplyOutcome::Emit
+}
+
 /// Apply the `.field // fallback` raw-byte fast path on a single JSON
 /// record.
 ///

--- a/tests/fast_path_contract.rs
+++ b/tests/fast_path_contract.rs
@@ -11,7 +11,7 @@
 use jq_jit::fast_path::{
     FastPath, FieldAccessPath, RawApplyOutcome, apply_field_access_raw,
     apply_field_alternative_raw, apply_field_field_alternative_raw, apply_field_gsub_raw,
-    apply_field_test_raw, apply_full_object_fields_raw, apply_has_field_raw,
+    apply_field_match_raw, apply_field_test_raw, apply_full_object_fields_raw, apply_has_field_raw,
     apply_has_multi_field_raw, apply_multi_field_access_raw, apply_nested_field_access_raw,
     apply_object_compute_raw,
 };
@@ -1015,5 +1015,122 @@ fn raw_field_gsub_non_object_input_bails() {
             outcome,
         );
         assert!(emitted.is_empty());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// `.field | match("p")` — same Bail discipline as `field_test`. The helper
+// hands `(content_str, captures)` back to the apply-site so it can build jq's
+// `{offset,length,string,captures:[...]}` output bytes; on no match the
+// closure is not invoked (jq's `match` emits no output for a non-match).
+
+#[test]
+fn raw_field_match_invokes_closure_on_match() {
+    let re = regex::Regex::new(r"f(o+)").unwrap();
+    let mut hits: Vec<(String, String)> = Vec::new();
+    let outcome = apply_field_match_raw(
+        b"{\"x\":\"foobar\"}",
+        "x",
+        &re,
+        |content, caps| {
+            let m = caps.get(0).unwrap();
+            let g1 = caps.get(1).unwrap();
+            hits.push((content.to_string(), format!("{}|{}", m.as_str(), g1.as_str())));
+        },
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(hits, vec![("foobar".to_string(), "foo|oo".to_string())]);
+}
+
+#[test]
+fn raw_field_match_no_match_skips_closure() {
+    let re = regex::Regex::new(r"^foo").unwrap();
+    let mut called = 0u32;
+    let outcome = apply_field_match_raw(
+        b"{\"x\":\"barfoo\"}",
+        "x",
+        &re,
+        |_, _| {
+            called += 1;
+        },
+    );
+    // Emit verdict (the helper handled the input — jq emits nothing on no
+    // match), but the closure is never invoked.
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(called, 0);
+}
+
+#[test]
+fn raw_field_match_field_missing_bails() {
+    let re = regex::Regex::new(r"^foo").unwrap();
+    let mut called = 0u32;
+    let outcome = apply_field_match_raw(
+        b"{\"y\":\"hi\"}",
+        "x",
+        &re,
+        |_, _| {
+            called += 1;
+        },
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert_eq!(called, 0);
+}
+
+#[test]
+fn raw_field_match_non_string_field_bails() {
+    let re = regex::Regex::new(r".").unwrap();
+    for inner in [&b"{\"x\":42}"[..], &b"{\"x\":null}"[..], &b"{\"x\":[1,2]}"[..]] {
+        let mut called = 0u32;
+        let outcome = apply_field_match_raw(inner, "x", &re, |_, _| {
+            called += 1;
+        });
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "expected Bail for non-string field input {:?}, got {:?}",
+            std::str::from_utf8(inner).unwrap(),
+            outcome,
+        );
+        assert_eq!(called, 0);
+    }
+}
+
+#[test]
+fn raw_field_match_escaped_string_bails() {
+    // Backslash escapes need decoding; the raw scanner can't, so it bails.
+    let re = regex::Regex::new(r"\n").unwrap();
+    let mut called = 0u32;
+    let outcome = apply_field_match_raw(
+        br#"{"x":"a\nb"}"#,
+        "x",
+        &re,
+        |_, _| {
+            called += 1;
+        },
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert_eq!(called, 0);
+}
+
+#[test]
+fn raw_field_match_non_object_input_bails() {
+    let re = regex::Regex::new(r".*").unwrap();
+    for raw in [
+        b"42".as_slice(),
+        b"\"hi\"".as_slice(),
+        b"null".as_slice(),
+        b"true".as_slice(),
+        b"[1,2,3]".as_slice(),
+    ] {
+        let mut called = 0u32;
+        let outcome = apply_field_match_raw(raw, "x", &re, |_, _| {
+            called += 1;
+        });
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "expected Bail for input {:?}, got {:?}",
+            std::str::from_utf8(raw).unwrap(),
+            outcome,
+        );
+        assert_eq!(called, 0);
     }
 }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -2841,3 +2841,45 @@ true
 
 (.x | gsub("a"; "X"))?
 [1,2,3]
+
+# #83 Phase B: .x | match("p") apply-site uses RawApplyOutcome::Bail.
+# Happy path emits jq's match-result object via the raw scanner.
+.x | match("f(o+)")
+{"x":"foobar"}
+{"offset":0,"length":3,"string":"foo","captures":[{"offset":1,"length":2,"string":"oo","name":null}]}
+
+# No-match emits no output (jq behavior — single-call match is 0/1 output).
+.x | match("zz")
+{"x":"foobar"}
+
+# Field missing under `?` bails to generic, jq raises (null | match), `?` swallows.
+(.x | match("p"))?
+{"y":"hi"}
+
+# Non-string field under `?`
+(.x | match("p"))?
+{"x":42}
+
+(.x | match("p"))?
+{"x":null}
+
+(.x | match("p"))?
+{"x":[1,2,3]}
+
+# Escape-bearing string: bail to generic, which decodes the escape correctly.
+.x | match("\\n") | .string
+{"x":"a\nb"}
+"\n"
+
+# Non-object input under `?` — generic raises, `?` swallows.
+(.x | match("p"))?
+42
+
+(.x | match("p"))?
+"hi"
+
+(.x | match("p"))?
+null
+
+(.x | match("p"))?
+[1,2,3]


### PR DESCRIPTION
## Summary
- Migrate `.field | match("p"; flags)` (stdin + file dispatch) to the named-Bail discipline introduced for #83 Phase B.
- New helper `apply_field_match_raw` in `src/fast_path.rs` mirrors `apply_field_test_raw`'s type-guard ladder and hands `(content_str, captures)` back through a closure so the apply-site keeps its `{offset,length,string,captures:[...]}` emitter.
- Bail branches: missing field, non-string value, escape-bearing string, non-object input — all route through `process_input` for jq's real error (or `?`-swallow). No-match-on-string stays Emit (jq emits no output and that's the fast path's behaviour).

## Test plan
- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` — 67 fast_path_contract cases + full regression
- [x] `tests/fast_path_contract.rs`: 6 new cases (Emit happy-path with captures, no-match-skips-closure, every Bail branch)
- [x] `tests/regression.test`: 9 new cases, including a `?`-wrapped Bail matrix
- [x] `./bench/comprehensive.sh --quick` — adjacent string-heavy numbers track v1.1.0 baseline; no regression

Refs: #251 follow-up checkbox `field_match`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)