### PR TITLE
refactor: field_scan apply-site uses RawApplyOutcome (#83 Phase B)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -140,7 +140,7 @@ use jq_jit::value::{Value, json_to_value, json_stream, json_stream_offsets, json
 use jq_jit::interpreter::Filter;
 use jq_jit::fast_path::{
     apply_field_access_raw, apply_field_alternative_raw, apply_field_field_alternative_raw,
-    apply_field_gsub_raw, apply_field_match_raw, apply_field_test_raw,
+    apply_field_gsub_raw, apply_field_match_raw, apply_field_scan_raw, apply_field_test_raw,
     apply_full_object_fields_raw, apply_has_field_raw, apply_has_multi_field_raw,
     apply_multi_field_access_raw, apply_nested_field_access_raw, apply_object_compute_raw,
     RawApplyOutcome,
@@ -6888,55 +6888,43 @@ fn real_main() {
                 } else if let Some((ref sc_field, ref sc_pattern)) = field_scan {
                     // .field | scan("regex") — raw byte regex scan, multiple outputs per input
                     if let Ok(re) = regex::Regex::new(sc_pattern) {
-                        let has_captures = re.captures_len() > 1;
                         json_stream_raw(&input_str, |start, end| {
                             let raw = &input_bytes[start..end];
-                            if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, sc_field) {
-                                let val = &raw[vs..ve];
-                                if val.len() >= 2 && val[0] == b'"' && val[val.len()-1] == b'"'
-                                    && !val[1..val.len()-1].contains(&b'\\')
-                                {
-                                    let content = unsafe { std::str::from_utf8_unchecked(&val[1..val.len()-1]) };
-                                    if has_captures {
-                                        for caps in re.captures_iter(content) {
-                                            compact_buf.push(b'[');
-                                            for i in 1..caps.len() {
-                                                if i > 1 { compact_buf.push(b','); }
-                                                match caps.get(i) {
-                                                    Some(m) => {
-                                                        compact_buf.push(b'"');
-                                                        for &b in m.as_str().as_bytes() {
-                                                            match b {
-                                                                b'"' => compact_buf.extend_from_slice(b"\\\""),
-                                                                b'\\' => compact_buf.extend_from_slice(b"\\\\"),
-                                                                _ => compact_buf.push(b),
-                                                            }
-                                                        }
-                                                        compact_buf.push(b'"');
+                            let outcome = apply_field_scan_raw(raw, sc_field, &re, |_content, caps| {
+                                if caps.len() > 1 {
+                                    compact_buf.push(b'[');
+                                    for i in 1..caps.len() {
+                                        if i > 1 { compact_buf.push(b','); }
+                                        match caps.get(i) {
+                                            Some(m) => {
+                                                compact_buf.push(b'"');
+                                                for &b in m.as_str().as_bytes() {
+                                                    match b {
+                                                        b'"' => compact_buf.extend_from_slice(b"\\\""),
+                                                        b'\\' => compact_buf.extend_from_slice(b"\\\\"),
+                                                        _ => compact_buf.push(b),
                                                     }
-                                                    None => compact_buf.extend_from_slice(b"\"\""),
                                                 }
+                                                compact_buf.push(b'"');
                                             }
-                                            compact_buf.extend_from_slice(b"]\n");
-                                        }
-                                    } else {
-                                        for m in re.find_iter(content) {
-                                            compact_buf.push(b'"');
-                                            for &b in m.as_str().as_bytes() {
-                                                match b {
-                                                    b'"' => compact_buf.extend_from_slice(b"\\\""),
-                                                    b'\\' => compact_buf.extend_from_slice(b"\\\\"),
-                                                    _ => compact_buf.push(b),
-                                                }
-                                            }
-                                            compact_buf.extend_from_slice(b"\"\n");
+                                            None => compact_buf.extend_from_slice(b"\"\""),
                                         }
                                     }
+                                    compact_buf.extend_from_slice(b"]\n");
                                 } else {
-                                    let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                    process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                                    let m = caps.get(0).unwrap();
+                                    compact_buf.push(b'"');
+                                    for &b in m.as_str().as_bytes() {
+                                        match b {
+                                            b'"' => compact_buf.extend_from_slice(b"\\\""),
+                                            b'\\' => compact_buf.extend_from_slice(b"\\\\"),
+                                            _ => compact_buf.push(b),
+                                        }
+                                    }
+                                    compact_buf.extend_from_slice(b"\"\n");
                                 }
-                            } else {
+                            });
+                            if let RawApplyOutcome::Bail = outcome {
                                 let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                                 process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                             }
@@ -20240,56 +20228,44 @@ fn real_main() {
             } else if let Some((ref sc_field, ref sc_pattern)) = field_scan {
                 // .field | scan("regex") — raw byte regex scan (stdin)
                 if let Ok(re) = regex::Regex::new(sc_pattern) {
-                    let has_captures = re.captures_len() > 1;
                     let content_bytes = content.as_bytes();
                     json_stream_raw(content, |start, end| {
                         let raw = &content_bytes[start..end];
-                        if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, sc_field) {
-                            let val = &raw[vs..ve];
-                            if val.len() >= 2 && val[0] == b'"' && val[val.len()-1] == b'"'
-                                && !val[1..val.len()-1].contains(&b'\\')
-                            {
-                                let content_str = unsafe { std::str::from_utf8_unchecked(&val[1..val.len()-1]) };
-                                if has_captures {
-                                    for caps in re.captures_iter(content_str) {
-                                        compact_buf.push(b'[');
-                                        for i in 1..caps.len() {
-                                            if i > 1 { compact_buf.push(b','); }
-                                            match caps.get(i) {
-                                                Some(m) => {
-                                                    compact_buf.push(b'"');
-                                                    for &b in m.as_str().as_bytes() {
-                                                        match b {
-                                                            b'"' => compact_buf.extend_from_slice(b"\\\""),
-                                                            b'\\' => compact_buf.extend_from_slice(b"\\\\"),
-                                                            _ => compact_buf.push(b),
-                                                        }
-                                                    }
-                                                    compact_buf.push(b'"');
+                        let outcome = apply_field_scan_raw(raw, sc_field, &re, |_content_str, caps| {
+                            if caps.len() > 1 {
+                                compact_buf.push(b'[');
+                                for i in 1..caps.len() {
+                                    if i > 1 { compact_buf.push(b','); }
+                                    match caps.get(i) {
+                                        Some(m) => {
+                                            compact_buf.push(b'"');
+                                            for &b in m.as_str().as_bytes() {
+                                                match b {
+                                                    b'"' => compact_buf.extend_from_slice(b"\\\""),
+                                                    b'\\' => compact_buf.extend_from_slice(b"\\\\"),
+                                                    _ => compact_buf.push(b),
                                                 }
-                                                None => compact_buf.extend_from_slice(b"null"),
                                             }
+                                            compact_buf.push(b'"');
                                         }
-                                        compact_buf.extend_from_slice(b"]\n");
-                                    }
-                                } else {
-                                    for m in re.find_iter(content_str) {
-                                        compact_buf.push(b'"');
-                                        for &b in m.as_str().as_bytes() {
-                                            match b {
-                                                b'"' => compact_buf.extend_from_slice(b"\\\""),
-                                                b'\\' => compact_buf.extend_from_slice(b"\\\\"),
-                                                _ => compact_buf.push(b),
-                                            }
-                                        }
-                                        compact_buf.extend_from_slice(b"\"\n");
+                                        None => compact_buf.extend_from_slice(b"null"),
                                     }
                                 }
+                                compact_buf.extend_from_slice(b"]\n");
                             } else {
-                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                                let m = caps.get(0).unwrap();
+                                compact_buf.push(b'"');
+                                for &b in m.as_str().as_bytes() {
+                                    match b {
+                                        b'"' => compact_buf.extend_from_slice(b"\\\""),
+                                        b'\\' => compact_buf.extend_from_slice(b"\\\\"),
+                                        _ => compact_buf.push(b),
+                                    }
+                                }
+                                compact_buf.extend_from_slice(b"\"\n");
                             }
-                        } else {
+                        });
+                        if let RawApplyOutcome::Bail = outcome {
                             let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                             process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -417,6 +417,50 @@ where
     RawApplyOutcome::Emit
 }
 
+/// Apply the `.field | scan("pattern")` raw-byte fast path on a single
+/// JSON record.
+///
+/// `scan` is a *multi-output* filter: it emits one value per
+/// non-overlapping regex match. Bail discipline matches
+/// [`apply_field_match_raw`] (object input + quoted-string field with no
+/// backslash escapes); on a passing type-guard the helper iterates
+/// `re.captures_iter(content)` and invokes `on_match(content,
+/// captures)` for **each** match. On zero matches the closure is not
+/// called — the helper still returns [`RawApplyOutcome::Emit`] (jq emits
+/// no output for `scan` with no match, and that is the fast path's
+/// intended semantics).
+///
+/// `captures_iter` is used uniformly for both the no-capture-group and
+/// capture-group cases — for a no-group regex, each `Captures` exposes
+/// only group 0 (the full match), so the apply-site can branch on
+/// `caps.len()` to choose between scalar and array output without the
+/// helper needing to know about it.
+pub fn apply_field_scan_raw<F>(
+    raw: &[u8],
+    field: &str,
+    re: &regex::Regex,
+    mut on_match: F,
+) -> RawApplyOutcome
+where
+    F: FnMut(&str, &regex::Captures<'_>),
+{
+    let (vs, ve) = match json_object_get_field_raw(raw, 0, field) {
+        Some(r) => r,
+        None => return RawApplyOutcome::Bail,
+    };
+    let val = &raw[vs..ve];
+    if val.len() < 2 || val[0] != b'"' || val[val.len() - 1] != b'"'
+        || val[1..val.len() - 1].contains(&b'\\')
+    {
+        return RawApplyOutcome::Bail;
+    }
+    let content = unsafe { std::str::from_utf8_unchecked(&val[1..val.len() - 1]) };
+    for caps in re.captures_iter(content) {
+        on_match(content, &caps);
+    }
+    RawApplyOutcome::Emit
+}
+
 /// Apply the `.field // fallback` raw-byte fast path on a single JSON
 /// record.
 ///

--- a/tests/fast_path_contract.rs
+++ b/tests/fast_path_contract.rs
@@ -11,7 +11,7 @@
 use jq_jit::fast_path::{
     FastPath, FieldAccessPath, RawApplyOutcome, apply_field_access_raw,
     apply_field_alternative_raw, apply_field_field_alternative_raw, apply_field_gsub_raw,
-    apply_field_match_raw, apply_field_test_raw, apply_full_object_fields_raw, apply_has_field_raw,
+    apply_field_match_raw, apply_field_scan_raw, apply_field_test_raw, apply_full_object_fields_raw, apply_has_field_raw,
     apply_has_multi_field_raw, apply_multi_field_access_raw, apply_nested_field_access_raw,
     apply_object_compute_raw,
 };
@@ -1123,6 +1123,145 @@ fn raw_field_match_non_object_input_bails() {
     ] {
         let mut called = 0u32;
         let outcome = apply_field_match_raw(raw, "x", &re, |_, _| {
+            called += 1;
+        });
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "expected Bail for input {:?}, got {:?}",
+            std::str::from_utf8(raw).unwrap(),
+            outcome,
+        );
+        assert_eq!(called, 0);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// `.field | scan("p")` — same Bail discipline as `field_match`. The helper
+// iterates `re.captures_iter` and invokes the closure once per non-overlapping
+// match (zero invocations for no-match-on-string, still Emit verdict).
+
+#[test]
+fn raw_field_scan_emits_one_per_match() {
+    let re = regex::Regex::new("a").unwrap();
+    let mut hits: Vec<String> = Vec::new();
+    let outcome = apply_field_scan_raw(
+        b"{\"x\":\"banana\"}",
+        "x",
+        &re,
+        |_content, caps| {
+            hits.push(caps.get(0).unwrap().as_str().to_string());
+        },
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(hits, vec!["a".to_string(), "a".to_string(), "a".to_string()]);
+}
+
+#[test]
+fn raw_field_scan_with_capture_groups_yields_all_captures() {
+    // Optional group simulates jq's "unmatched group → null" semantic; the
+    // helper just hands each `Captures` to the apply-site so it can decide.
+    let re = regex::Regex::new("(z)?(a)").unwrap();
+    let mut hits: Vec<(Option<String>, Option<String>)> = Vec::new();
+    let outcome = apply_field_scan_raw(
+        b"{\"x\":\"banana\"}",
+        "x",
+        &re,
+        |_content, caps| {
+            hits.push((
+                caps.get(1).map(|m| m.as_str().to_string()),
+                caps.get(2).map(|m| m.as_str().to_string()),
+            ));
+        },
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(
+        hits,
+        vec![
+            (None, Some("a".to_string())),
+            (None, Some("a".to_string())),
+            (None, Some("a".to_string())),
+        ],
+    );
+}
+
+#[test]
+fn raw_field_scan_no_match_skips_closure() {
+    let re = regex::Regex::new("z").unwrap();
+    let mut called = 0u32;
+    let outcome = apply_field_scan_raw(
+        b"{\"x\":\"banana\"}",
+        "x",
+        &re,
+        |_, _| {
+            called += 1;
+        },
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(called, 0);
+}
+
+#[test]
+fn raw_field_scan_field_missing_bails() {
+    let re = regex::Regex::new("a").unwrap();
+    let mut called = 0u32;
+    let outcome = apply_field_scan_raw(
+        b"{\"y\":\"banana\"}",
+        "x",
+        &re,
+        |_, _| {
+            called += 1;
+        },
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert_eq!(called, 0);
+}
+
+#[test]
+fn raw_field_scan_non_string_field_bails() {
+    let re = regex::Regex::new(r".").unwrap();
+    for inner in [&b"{\"x\":42}"[..], &b"{\"x\":null}"[..], &b"{\"x\":[1,2]}"[..]] {
+        let mut called = 0u32;
+        let outcome = apply_field_scan_raw(inner, "x", &re, |_, _| {
+            called += 1;
+        });
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "expected Bail for non-string field input {:?}, got {:?}",
+            std::str::from_utf8(inner).unwrap(),
+            outcome,
+        );
+        assert_eq!(called, 0);
+    }
+}
+
+#[test]
+fn raw_field_scan_escaped_string_bails() {
+    let re = regex::Regex::new("a").unwrap();
+    let mut called = 0u32;
+    let outcome = apply_field_scan_raw(
+        br#"{"x":"a\nb"}"#,
+        "x",
+        &re,
+        |_, _| {
+            called += 1;
+        },
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert_eq!(called, 0);
+}
+
+#[test]
+fn raw_field_scan_non_object_input_bails() {
+    let re = regex::Regex::new(r".*").unwrap();
+    for raw in [
+        b"42".as_slice(),
+        b"\"hi\"".as_slice(),
+        b"null".as_slice(),
+        b"true".as_slice(),
+        b"[1,2,3]".as_slice(),
+    ] {
+        let mut called = 0u32;
+        let outcome = apply_field_scan_raw(raw, "x", &re, |_, _| {
             called += 1;
         });
         assert!(

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -2883,3 +2883,61 @@ null
 
 (.x | match("p"))?
 [1,2,3]
+
+# #83 Phase B: .x | scan("p") apply-site uses RawApplyOutcome::Bail.
+# Multi-output happy path emits one value per non-overlapping match.
+[ .x | scan("a") ]
+{"x":"banana"}
+["a","a","a"]
+
+# Capture-groups path emits an array per match.
+[ .x | scan("(a)(n)") ]
+{"x":"banana"}
+[["a","n"],["a","n"]]
+
+# No match emits no output (jq behaviour for scan on a string).
+[ .x | scan("z") ]
+{"x":"banana"}
+[]
+
+# Field missing under `?` bails to generic, jq raises (null | scan), `?` swallows.
+[ (.x | scan("p"))? ]
+{"y":"hi"}
+[]
+
+# Non-string field under `?`
+[ (.x | scan("p"))? ]
+{"x":42}
+[]
+
+[ (.x | scan("p"))? ]
+{"x":null}
+[]
+
+[ (.x | scan("p"))? ]
+{"x":[1,2,3]}
+[]
+
+# Escape-bearing string: bail to generic, which decodes the escape correctly.
+# (`.` does not match `\n` in jq's default regex semantics, so newline
+# splits the input into "a" and "b".)
+[ .x | scan(".") ]
+{"x":"a\nb"}
+["a","b"]
+
+# Non-object input under `?`
+[ (.x | scan("p"))? ]
+42
+[]
+
+[ (.x | scan("p"))? ]
+"hi"
+[]
+
+[ (.x | scan("p"))? ]
+null
+[]
+
+[ (.x | scan("p"))? ]
+[1,2,3]
+[]


### PR DESCRIPTION
## Summary
- Migrate `.field | scan("p")` (stdin + file dispatch) to the named-Bail discipline introduced for #83 Phase B.
- New helper `apply_field_scan_raw` in `src/fast_path.rs` mirrors `apply_field_match_raw`'s type-guard ladder. Iterates `re.captures_iter` and calls the closure once per non-overlapping match; zero-match still returns `Emit` (jq emits nothing for scan with no match).
- The helper hands back `(content_str, captures)`; the apply-site keeps its existing scalar-vs-array branching on `caps.len()`.

## Test plan
- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` — 74 fast_path_contract cases + full regression
- [x] `tests/fast_path_contract.rs`: 7 new cases (multi-output emit, capture-group emit, no-match-skips-closure, every Bail branch)
- [x] `tests/regression.test`: 13 new cases, including `?`-wrapped Bail matrix and an escape-bearing-string case routed through the generic path
- [x] `./bench/comprehensive.sh --quick` — adjacent string-heavy numbers track v1.1.0 baseline; no regression

Refs: #251 follow-up checkbox `field_scan`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)