### PR TITLE
refactor: field_capture apply-site uses RawApplyOutcome (#83 Phase B)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -7039,7 +7039,10 @@ fn real_main() {
                         })
                     }
                 } else if let Some((ref fc_field, ref fc_pattern, ref fc_flags)) = field_capture {
-                    // .field | capture("regex") — raw byte regex capture
+                    // .field | capture("regex") — raw byte regex capture.
+                    // Same Bail discipline / single-captures shape as `match`,
+                    // so both share `apply_field_match_raw`; only the emit
+                    // bytes (an object keyed by capture-group name) differ.
                     let re_pattern = if let Some(flags) = fc_flags {
                         let mut prefix = String::from("(?");
                         for c in flags.chars() {
@@ -7068,35 +7071,24 @@ fn real_main() {
                         }
                         json_stream_raw(&input_str, |start, end| {
                             let raw = &input_bytes[start..end];
-                            if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, fc_field) {
-                                let val = &raw[vs..ve];
-                                if val.len() >= 2 && val[0] == b'"' && val[val.len()-1] == b'"'
-                                    && !val[1..val.len()-1].contains(&b'\\')
-                                {
-                                    let content = unsafe { std::str::from_utf8_unchecked(&val[1..val.len()-1]) };
-                                    if let Some(caps) = re.captures(content) {
-                                        compact_buf.push(b'{');
-                                        for i in 1..caps.len() {
-                                            compact_buf.extend_from_slice(&key_prefixes[i]);
-                                            if let Some(m) = caps.get(i) {
-                                                for &b in m.as_str().as_bytes() {
-                                                    match b {
-                                                        b'"' => compact_buf.extend_from_slice(b"\\\""),
-                                                        b'\\' => compact_buf.extend_from_slice(b"\\\\"),
-                                                        _ => compact_buf.push(b),
-                                                    }
-                                                }
+                            let outcome = apply_field_match_raw(raw, fc_field, &re, |_content, caps| {
+                                compact_buf.push(b'{');
+                                for i in 1..caps.len() {
+                                    compact_buf.extend_from_slice(&key_prefixes[i]);
+                                    if let Some(m) = caps.get(i) {
+                                        for &b in m.as_str().as_bytes() {
+                                            match b {
+                                                b'"' => compact_buf.extend_from_slice(b"\\\""),
+                                                b'\\' => compact_buf.extend_from_slice(b"\\\\"),
+                                                _ => compact_buf.push(b),
                                             }
-                                            compact_buf.push(b'"');
                                         }
-                                        compact_buf.extend_from_slice(b"}\n");
                                     }
-                                    // no match → empty (no output)
-                                } else {
-                                    let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                    process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                                    compact_buf.push(b'"');
                                 }
-                            } else {
+                                compact_buf.extend_from_slice(b"}\n");
+                            });
+                            if let RawApplyOutcome::Bail = outcome {
                                 let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                                 process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                             }
@@ -20411,34 +20403,24 @@ fn real_main() {
                     let content_bytes = content.as_bytes();
                     json_stream_raw(content, |start, end| {
                         let raw = &content_bytes[start..end];
-                        if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, fc_field) {
-                            let val = &raw[vs..ve];
-                            if val.len() >= 2 && val[0] == b'"' && val[val.len()-1] == b'"'
-                                && !val[1..val.len()-1].contains(&b'\\')
-                            {
-                                let content_str = unsafe { std::str::from_utf8_unchecked(&val[1..val.len()-1]) };
-                                if let Some(caps) = re.captures(content_str) {
-                                    compact_buf.push(b'{');
-                                    for i in 1..caps.len() {
-                                        compact_buf.extend_from_slice(&key_prefixes[i]);
-                                        if let Some(m) = caps.get(i) {
-                                            for &b in m.as_str().as_bytes() {
-                                                match b {
-                                                    b'"' => compact_buf.extend_from_slice(b"\\\""),
-                                                    b'\\' => compact_buf.extend_from_slice(b"\\\\"),
-                                                    _ => compact_buf.push(b),
-                                                }
-                                            }
+                        let outcome = apply_field_match_raw(raw, fc_field, &re, |_content_str, caps| {
+                            compact_buf.push(b'{');
+                            for i in 1..caps.len() {
+                                compact_buf.extend_from_slice(&key_prefixes[i]);
+                                if let Some(m) = caps.get(i) {
+                                    for &b in m.as_str().as_bytes() {
+                                        match b {
+                                            b'"' => compact_buf.extend_from_slice(b"\\\""),
+                                            b'\\' => compact_buf.extend_from_slice(b"\\\\"),
+                                            _ => compact_buf.push(b),
                                         }
-                                        compact_buf.push(b'"');
                                     }
-                                    compact_buf.extend_from_slice(b"}\n");
                                 }
-                            } else {
-                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                                compact_buf.push(b'"');
                             }
-                        } else {
+                            compact_buf.extend_from_slice(b"}\n");
+                        });
+                        if let RawApplyOutcome::Bail = outcome {
                             let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                             process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -368,8 +368,13 @@ where
     RawApplyOutcome::Emit
 }
 
-/// Apply the `.field | match("pattern"; flags)` raw-byte fast path on a
-/// single JSON record.
+/// Apply a single-call `.field | re.captures(content)` raw-byte fast path
+/// on one JSON record. Used by both `match` and `capture` apply-sites:
+/// both run a single `captures()` call (not an iterator), emit one output
+/// on a successful match, and emit nothing on a non-match — the only
+/// difference is the bytes the apply-site builds in `on_match` (`match`
+/// emits `{offset,length,string,captures:[...]}`, `capture` emits an
+/// object keyed by the named groups).
 ///
 /// Bail discipline matches [`apply_field_test_raw`] (only quoted-string
 /// fields with no backslash escapes are handled by the raw scanner; the
@@ -378,10 +383,8 @@ where
 ///
 /// * Object input, field present, value is a quoted string with no `\`
 ///   escapes — runs `re.captures(content)`. On a match, invokes
-///   `on_match(content, captures)` so the caller can build jq's
-///   `{offset,length,string,captures:[...]}` output bytes. On no match,
-///   `on_match` is **not** called (jq emits no output for a non-match —
-///   `match` is multi-output / 0-arity for "no match").
+///   `on_match(content, captures)` so the caller can build jq's output
+///   bytes. On no match, `on_match` is **not** called.
 /// * Field absent, value isn't a quoted string, or the string contains
 ///   any backslash escape — returns [`RawApplyOutcome::Bail`] so the
 ///   generic path produces jq's verdict (decoded escapes, type errors).

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -2941,3 +2941,51 @@ null
 [ (.x | scan("p"))? ]
 [1,2,3]
 []
+
+# #83 Phase B: .x | capture("p") apply-site reuses apply_field_match_raw
+# (same Bail discipline as match: single re.captures, emit on match,
+# nothing on no-match). Happy path emits jq's named-group object.
+.x | capture("(?<head>[a-z]+)(?<tail>[0-9]+)")
+{"x":"abc123"}
+{"head":"abc","tail":"123"}
+
+# Unnamed groups: capture emits only named groups, so the output is `{}`.
+.x | capture("[a-z]+")
+{"x":"abc"}
+{}
+
+# No match emits no output (jq behaviour for capture on a string).
+.x | capture("z")
+{"x":"abc"}
+
+# Field missing under `?` bails to generic, jq raises (null | capture), `?` swallows.
+(.x | capture("(?<v>p)"))?
+{"y":"hi"}
+
+# Non-string field under `?`
+(.x | capture("(?<v>p)"))?
+{"x":42}
+
+(.x | capture("(?<v>p)"))?
+{"x":null}
+
+(.x | capture("(?<v>p)"))?
+{"x":[1,2,3]}
+
+# Escape-bearing string: bail to generic (decodes the escape correctly).
+.x | capture("(?<a>.)\\n(?<b>.)")
+{"x":"a\nb"}
+{"a":"a","b":"b"}
+
+# Non-object input under `?`
+(.x | capture("(?<v>p)"))?
+42
+
+(.x | capture("(?<v>p)"))?
+"hi"
+
+(.x | capture("(?<v>p)"))?
+null
+
+(.x | capture("(?<v>p)"))?
+[1,2,3]


### PR DESCRIPTION
## Summary
- `capture` shares the exact same Bail surface and single-`captures()` shape as `match` — only the emit bytes differ. Reuse `apply_field_match_raw` from #252 for both stdin and file dispatch apply-sites instead of adding a near-duplicate helper.
- The doc comment on `apply_field_match_raw` is rewritten to acknowledge both callers.

## Test plan
- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` — full regression including new capture cases
- [x] `tests/regression.test`: 13 new cases, including a named-group happy path, no-match no-output, an escape-bearing-string case routed through the generic, and the `?`-wrapped Bail matrix
- [x] Existing `apply_field_match_raw` contract tests in `tests/fast_path_contract.rs` already pin every Bail branch — no new helper, so no new contract tests needed
- [x] `./bench/comprehensive.sh --quick` — adjacent string-heavy numbers track v1.1.0 baseline; no regression

Refs: #251 follow-up checkbox `field_capture`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)