### PR TITLE
refactor: field_format apply-site uses RawApplyOutcome (#83 Phase B)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -140,10 +140,10 @@ use jq_jit::value::{Value, json_to_value, json_stream, json_stream_offsets, json
 use jq_jit::interpreter::Filter;
 use jq_jit::fast_path::{
     apply_field_access_raw, apply_field_alternative_raw, apply_field_field_alternative_raw,
-    apply_field_gsub_raw, apply_field_match_raw, apply_field_scan_raw, apply_field_test_raw,
-    apply_full_object_fields_raw, apply_has_field_raw, apply_has_multi_field_raw,
-    apply_multi_field_access_raw, apply_nested_field_access_raw, apply_object_compute_raw,
-    RawApplyOutcome,
+    apply_field_format_raw, apply_field_gsub_raw, apply_field_match_raw, apply_field_scan_raw,
+    apply_field_test_raw, apply_full_object_fields_raw, apply_has_field_raw,
+    apply_has_multi_field_raw, apply_multi_field_access_raw, apply_nested_field_access_raw,
+    apply_object_compute_raw, RawApplyOutcome,
 };
 
 fn json_escape_bytes(bytes: &[u8]) -> Vec<u8> {
@@ -7107,53 +7107,45 @@ fn real_main() {
                         })
                     }
                 } else if let Some((ref ff_field, ref ff_format)) = field_format {
-                    // .field | @base64 / @uri / @html — raw byte format
+                    // .field | @text / @json / @base64 / @uri / @html — raw byte format
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, ff_field) {
-                            let val = &raw[vs..ve];
-                            if val.len() >= 2 && val[0] == b'"' && val[val.len()-1] == b'"'
-                                && !val[1..val.len()-1].contains(&b'\\')
-                            {
-                                let content = &val[1..val.len()-1];
-                                match ff_format.as_str() {
-                                    "text" => {
-                                        // @text on string: identity — output the JSON string as-is
-                                        compact_buf.extend_from_slice(val);
-                                        compact_buf.push(b'\n');
-                                    }
-                                    "json" => {
-                                        // @json on string: wrap the JSON string value in extra quotes + escape
-                                        push_tojson_raw(&mut compact_buf, val);
-                                        compact_buf.push(b'\n');
-                                    }
-                                    _ => {
-                                        compact_buf.push(b'"');
-                                        match ff_format.as_str() {
-                                            "base64" => base64_encode_to(content, &mut compact_buf),
-                                            "uri" => uri_encode_to(content, &mut compact_buf),
-                                            "html" => html_encode_to(content, &mut compact_buf),
-                                            _ => {}
-                                        }
-                                        compact_buf.extend_from_slice(b"\"\n");
-                                    }
+                        let outcome = apply_field_format_raw(raw, ff_field, |val, content| {
+                            match (ff_format.as_str(), content) {
+                                ("text", Some(_)) => {
+                                    // @text on string: identity — output the JSON string as-is
+                                    compact_buf.extend_from_slice(val);
+                                    compact_buf.push(b'\n');
+                                    RawApplyOutcome::Emit
                                 }
-                            } else {
-                                // Non-string field values (numbers, booleans, null)
-                                match ff_format.as_str() {
-                                    "json" | "text" => {
-                                        // @json/@text on non-string: wrap raw bytes in quotes
-                                        compact_buf.push(b'"');
-                                        compact_buf.extend_from_slice(val);
-                                        compact_buf.extend_from_slice(b"\"\n");
-                                    }
-                                    _ => {
-                                        let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                        process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                                    }
+                                ("json", Some(_)) => {
+                                    // @json on string: wrap the JSON string value in extra quotes + escape
+                                    push_tojson_raw(&mut compact_buf, val);
+                                    compact_buf.push(b'\n');
+                                    RawApplyOutcome::Emit
                                 }
+                                (_, Some(content_bytes)) => {
+                                    compact_buf.push(b'"');
+                                    match ff_format.as_str() {
+                                        "base64" => base64_encode_to(content_bytes, &mut compact_buf),
+                                        "uri" => uri_encode_to(content_bytes, &mut compact_buf),
+                                        "html" => html_encode_to(content_bytes, &mut compact_buf),
+                                        _ => {}
+                                    }
+                                    compact_buf.extend_from_slice(b"\"\n");
+                                    RawApplyOutcome::Emit
+                                }
+                                ("json" | "text", None) => {
+                                    // @json/@text on non-string scalars: wrap raw bytes in quotes
+                                    compact_buf.push(b'"');
+                                    compact_buf.extend_from_slice(val);
+                                    compact_buf.extend_from_slice(b"\"\n");
+                                    RawApplyOutcome::Emit
+                                }
+                                _ => RawApplyOutcome::Bail,
                             }
-                        } else {
+                        });
+                        if let RawApplyOutcome::Bail = outcome {
                             let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                             process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }
@@ -20443,47 +20435,39 @@ fn real_main() {
                 let content_bytes = content.as_bytes();
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, ff_field) {
-                        let val = &raw[vs..ve];
-                        if val.len() >= 2 && val[0] == b'"' && val[val.len()-1] == b'"'
-                            && !val[1..val.len()-1].contains(&b'\\')
-                        {
-                            let content = &val[1..val.len()-1];
-                            match ff_format.as_str() {
-                                "text" => {
-                                    compact_buf.extend_from_slice(val);
-                                    compact_buf.push(b'\n');
-                                }
-                                "json" => {
-                                    push_tojson_raw(&mut compact_buf, val);
-                                    compact_buf.push(b'\n');
-                                }
-                                _ => {
-                                    compact_buf.push(b'"');
-                                    match ff_format.as_str() {
-                                        "base64" => base64_encode_to(content, &mut compact_buf),
-                                        "uri" => uri_encode_to(content, &mut compact_buf),
-                                        "html" => html_encode_to(content, &mut compact_buf),
-                                        _ => {}
-                                    }
-                                    compact_buf.extend_from_slice(b"\"\n");
-                                }
+                    let outcome = apply_field_format_raw(raw, ff_field, |val, content_no_quotes| {
+                        match (ff_format.as_str(), content_no_quotes) {
+                            ("text", Some(_)) => {
+                                compact_buf.extend_from_slice(val);
+                                compact_buf.push(b'\n');
+                                RawApplyOutcome::Emit
                             }
-                        } else {
-                            // Non-string field values (numbers, booleans, null)
-                            match ff_format.as_str() {
-                                "json" | "text" => {
-                                    compact_buf.push(b'"');
-                                    compact_buf.extend_from_slice(val);
-                                    compact_buf.extend_from_slice(b"\"\n");
-                                }
-                                _ => {
-                                    let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                    process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                                }
+                            ("json", Some(_)) => {
+                                push_tojson_raw(&mut compact_buf, val);
+                                compact_buf.push(b'\n');
+                                RawApplyOutcome::Emit
                             }
+                            (_, Some(content_bytes)) => {
+                                compact_buf.push(b'"');
+                                match ff_format.as_str() {
+                                    "base64" => base64_encode_to(content_bytes, &mut compact_buf),
+                                    "uri" => uri_encode_to(content_bytes, &mut compact_buf),
+                                    "html" => html_encode_to(content_bytes, &mut compact_buf),
+                                    _ => {}
+                                }
+                                compact_buf.extend_from_slice(b"\"\n");
+                                RawApplyOutcome::Emit
+                            }
+                            ("json" | "text", None) => {
+                                compact_buf.push(b'"');
+                                compact_buf.extend_from_slice(val);
+                                compact_buf.extend_from_slice(b"\"\n");
+                                RawApplyOutcome::Emit
+                            }
+                            _ => RawApplyOutcome::Bail,
                         }
-                    } else {
+                    });
+                    if let RawApplyOutcome::Bail = outcome {
                         let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                         process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                     }

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -464,6 +464,54 @@ where
     RawApplyOutcome::Emit
 }
 
+/// Apply the `.field | @<format>` raw-byte fast path on a single JSON
+/// record. Used by `@text`, `@json`, `@base64`, `@uri`, `@html`.
+///
+/// jq's `@<format>` family doesn't share a single Bail discipline
+/// across formats: `@base64`/`@uri`/`@html` raise on non-string input,
+/// while `@json`/`@text` accept any scalar (and wrap its raw bytes in
+/// quotes for output). The helper therefore handles only the
+/// **structural** type-guard — field present and the value is not an
+/// escape-bearing quoted string — and delegates the
+/// format-specific Emit-vs-Bail decision to the closure via its
+/// returned [`RawApplyOutcome`].
+///
+/// * Object input, field present, value is a quoted string with no `\`
+///   escapes — invokes `on_value(val_with_quotes, Some(content))`.
+/// * Object input, field present, value is a non-string scalar
+///   (number / bool / null / array / object literal) — invokes
+///   `on_value(val_bytes, None)`. The closure decides whether to emit
+///   or to return [`RawApplyOutcome::Bail`] (e.g. `@base64` returns
+///   Bail, `@json` returns Emit after wrapping the raw bytes).
+/// * Field absent, or value is a quoted string with at least one `\`
+///   escape — returns [`RawApplyOutcome::Bail`] without invoking the
+///   closure (the generic path decodes the escape / raises the error).
+/// * Non-object input — returns [`RawApplyOutcome::Bail`] (the field
+///   fetch fails).
+pub fn apply_field_format_raw<F>(
+    raw: &[u8],
+    field: &str,
+    on_value: F,
+) -> RawApplyOutcome
+where
+    F: FnOnce(&[u8], Option<&[u8]>) -> RawApplyOutcome,
+{
+    let (vs, ve) = match json_object_get_field_raw(raw, 0, field) {
+        Some(r) => r,
+        None => return RawApplyOutcome::Bail,
+    };
+    let val = &raw[vs..ve];
+    let content = if val.len() >= 2 && val[0] == b'"' && val[val.len() - 1] == b'"' {
+        if val[1..val.len() - 1].contains(&b'\\') {
+            return RawApplyOutcome::Bail;
+        }
+        Some(&val[1..val.len() - 1])
+    } else {
+        None
+    };
+    on_value(val, content)
+}
+
 /// Apply the `.field // fallback` raw-byte fast path on a single JSON
 /// record.
 ///

--- a/tests/fast_path_contract.rs
+++ b/tests/fast_path_contract.rs
@@ -10,8 +10,9 @@
 
 use jq_jit::fast_path::{
     FastPath, FieldAccessPath, RawApplyOutcome, apply_field_access_raw,
-    apply_field_alternative_raw, apply_field_field_alternative_raw, apply_field_gsub_raw,
-    apply_field_match_raw, apply_field_scan_raw, apply_field_test_raw, apply_full_object_fields_raw, apply_has_field_raw,
+    apply_field_alternative_raw, apply_field_field_alternative_raw, apply_field_format_raw,
+    apply_field_gsub_raw, apply_field_match_raw, apply_field_scan_raw, apply_field_test_raw,
+    apply_full_object_fields_raw, apply_has_field_raw,
     apply_has_multi_field_raw, apply_multi_field_access_raw, apply_nested_field_access_raw,
     apply_object_compute_raw,
 };
@@ -1267,6 +1268,116 @@ fn raw_field_scan_non_object_input_bails() {
         assert!(
             matches!(outcome, RawApplyOutcome::Bail),
             "expected Bail for input {:?}, got {:?}",
+            std::str::from_utf8(raw).unwrap(),
+            outcome,
+        );
+        assert_eq!(called, 0);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// `.field | @<format>` — the helper handles only the *structural* type-guard
+// (field present + non-escape-bearing quoted string check). The
+// format-specific Emit-vs-Bail decision is delegated to the closure via its
+// returned `RawApplyOutcome`. These tests pin the structural surface.
+
+#[test]
+fn raw_field_format_string_value_emits() {
+    let mut seen: Vec<(Vec<u8>, Option<Vec<u8>>)> = Vec::new();
+    let outcome = apply_field_format_raw(
+        b"{\"x\":\"hi\"}",
+        "x",
+        |val, content| {
+            seen.push((val.to_vec(), content.map(|c| c.to_vec())));
+            RawApplyOutcome::Emit
+        },
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(
+        seen,
+        vec![(b"\"hi\"".to_vec(), Some(b"hi".to_vec()))],
+    );
+}
+
+#[test]
+fn raw_field_format_non_string_scalar_invokes_with_none() {
+    // The helper hands the closure `(val, None)` for non-string scalars; the
+    // closure decides whether to Emit (e.g. @json wraps raw bytes) or Bail
+    // (e.g. @base64 raises on non-string).
+    for (input, expected_val) in [
+        (&b"{\"x\":42}"[..], &b"42"[..]),
+        (&b"{\"x\":null}"[..], &b"null"[..]),
+        (&b"{\"x\":true}"[..], &b"true"[..]),
+    ] {
+        let mut seen: Vec<(Vec<u8>, Option<Vec<u8>>)> = Vec::new();
+        let outcome = apply_field_format_raw(input, "x", |val, content| {
+            seen.push((val.to_vec(), content.map(|c| c.to_vec())));
+            RawApplyOutcome::Emit
+        });
+        assert!(matches!(outcome, RawApplyOutcome::Emit));
+        assert_eq!(seen, vec![(expected_val.to_vec(), None)]);
+    }
+}
+
+#[test]
+fn raw_field_format_propagates_closure_bail_verdict() {
+    // The closure can choose to Bail even on a structurally-OK input
+    // (this is what `@base64`/`@uri`/`@html` do for non-string values).
+    let outcome = apply_field_format_raw(
+        b"{\"x\":42}",
+        "x",
+        |_, _| RawApplyOutcome::Bail,
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+}
+
+#[test]
+fn raw_field_format_field_missing_bails_without_invoking_closure() {
+    let mut called = 0u32;
+    let outcome = apply_field_format_raw(
+        b"{\"y\":\"hi\"}",
+        "x",
+        |_, _| {
+            called += 1;
+            RawApplyOutcome::Emit
+        },
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert_eq!(called, 0);
+}
+
+#[test]
+fn raw_field_format_escaped_string_bails_without_invoking_closure() {
+    let mut called = 0u32;
+    let outcome = apply_field_format_raw(
+        br#"{"x":"a\nb"}"#,
+        "x",
+        |_, _| {
+            called += 1;
+            RawApplyOutcome::Emit
+        },
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert_eq!(called, 0);
+}
+
+#[test]
+fn raw_field_format_non_object_input_bails_without_invoking_closure() {
+    for raw in [
+        b"42".as_slice(),
+        b"\"hi\"".as_slice(),
+        b"null".as_slice(),
+        b"true".as_slice(),
+        b"[1,2,3]".as_slice(),
+    ] {
+        let mut called = 0u32;
+        let outcome = apply_field_format_raw(raw, "x", |_, _| {
+            called += 1;
+            RawApplyOutcome::Emit
+        });
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "expected Bail for format input {:?}, got {:?}",
             std::str::from_utf8(raw).unwrap(),
             outcome,
         );

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -2989,3 +2989,94 @@ null
 
 (.x | capture("(?<v>p)"))?
 [1,2,3]
+
+# #83 Phase B: .x | @<format> apply-site uses RawApplyOutcome::Bail for
+# the structural type-guard (field present, no escapes); the closure
+# returns its own verdict for format-specific bails (e.g. @base64 on
+# non-string).
+
+# @text on string: identity output.
+.x | @text
+{"x":"hi"}
+"hi"
+
+# @json on string: extra-quote-and-escape (so it round-trips).
+.x | @json
+{"x":"hi"}
+"\"hi\""
+
+# @base64 on string: encode raw bytes.
+.x | @base64
+{"x":"hi"}
+"aGk="
+
+# @uri on string: percent-encode.
+.x | @uri
+{"x":"a b"}
+"a%20b"
+
+# @html on string: HTML-escape.
+.x | @html
+{"x":"<p>"}
+"&lt;p&gt;"
+
+# @text on number: wraps raw bytes (jq behaviour).
+.x | @text
+{"x":42}
+"42"
+
+# @json on null: wraps raw bytes.
+.x | @json
+{"x":null}
+"null"
+
+# @base64/@uri/@html on non-string scalars: closure returns Bail to the
+# generic path, which stringifies first (jq's @format on non-string is
+# permissive — no error raised).
+(.x | @base64)?
+{"x":42}
+"NDI="
+
+(.x | @uri)?
+{"x":null}
+"null"
+
+(.x | @html)?
+{"x":[1,2,3]}
+"[1,2,3]"
+
+# Field missing on object: helper bails (field absent); generic resolves
+# `.x` to null, then formats `null` per jq's permissive semantics.
+(.x | @text)?
+{"y":"hi"}
+"null"
+
+(.x | @json)?
+{"y":"hi"}
+"null"
+
+(.x | @base64)?
+{"y":"hi"}
+"bnVsbA=="
+
+# Escape-bearing string: bail to generic, which decodes the escape correctly.
+.x | @base64
+{"x":"a\nb"}
+"YQpi"
+
+# Non-object/non-null input: jq raises "Cannot index <type>"; `?` swallows
+# to empty.
+(.x | @text)?
+42
+
+(.x | @json)?
+"hi"
+
+(.x | @uri)?
+[1,2,3]
+
+# null input: `.x` returns null in jq (null is the only non-object that's
+# indexable), so the generic path emits the formatted null.
+(.x | @base64)?
+null
+"bnVsbA=="


### PR DESCRIPTION
## Summary
- Migrate `.field | @text|@json|@base64|@uri|@html` (stdin + file dispatch) to the named-Bail discipline introduced for #83 Phase B.
- The new `apply_field_format_raw` helper handles only the *structural* type-guard (field present, no escape-bearing string) and lets the closure return its own `RawApplyOutcome` for format-specific cases — `@base64`/`@uri`/`@html` raise on non-string while `@json`/`@text` are permissive, so a single helper Bail can't capture both.

## Test plan
- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` — 80 fast_path_contract cases + full regression
- [x] `tests/fast_path_contract.rs`: 6 new cases pinning the structural surface and the closure-bail propagation
- [x] `tests/regression.test`: 18 new cases covering each format's happy path, the closure-Bail-to-generic route (non-string under `@base64`/`@uri`/`@html`), and the `?`-wrapped Bail matrix
- [x] `./bench/comprehensive.sh --quick` — `@base64`/`@uri`/`@html` benchmarks track historical numbers (0.012–0.014s); no regression

Refs: #251 follow-up checkbox `field_format`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)