### PR TITLE
refactor: field_ltrimstr_tonumber apply-site uses RawApplyOutcome (#83 Phase B)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -140,10 +140,11 @@ use jq_jit::value::{Value, json_to_value, json_stream, json_stream_offsets, json
 use jq_jit::interpreter::Filter;
 use jq_jit::fast_path::{
     apply_field_access_raw, apply_field_alternative_raw, apply_field_field_alternative_raw,
-    apply_field_format_raw, apply_field_gsub_raw, apply_field_match_raw, apply_field_scan_raw,
-    apply_field_test_raw, apply_full_object_fields_raw, apply_has_field_raw,
-    apply_has_multi_field_raw, apply_multi_field_access_raw, apply_nested_field_access_raw,
-    apply_object_compute_raw, RawApplyOutcome,
+    apply_field_format_raw, apply_field_gsub_raw, apply_field_ltrimstr_tonumber_raw,
+    apply_field_match_raw, apply_field_scan_raw, apply_field_test_raw,
+    apply_full_object_fields_raw, apply_has_field_raw, apply_has_multi_field_raw,
+    apply_multi_field_access_raw, apply_nested_field_access_raw, apply_object_compute_raw,
+    RawApplyOutcome,
 };
 
 fn json_escape_bytes(bytes: &[u8]) -> Vec<u8> {
@@ -7159,43 +7160,14 @@ fn real_main() {
                     let prefix_bytes = lt_prefix.as_bytes();
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, lt_field) {
-                            let val = &raw[vs..ve];
-                            if val.len() >= 2 && val[0] == b'"' && val[val.len()-1] == b'"'
-                                && !val[1..val.len()-1].contains(&b'\\')
-                            {
-                                let content = &val[1..val.len()-1];
-                                let num_str = if content.len() >= prefix_bytes.len() && &content[..prefix_bytes.len()] == prefix_bytes {
-                                    &content[prefix_bytes.len()..]
-                                } else {
-                                    content
-                                };
-                                // Parse the remaining string as a number
-                                if let Ok(mut n) = fast_float::parse::<f64, _>(num_str) {
-                                    for (op, c) in lt_arith_ops {
-                                        n = match op {
-                                            jq_jit::ir::BinOp::Add => n + c,
-                                            jq_jit::ir::BinOp::Sub => n - c,
-                                            jq_jit::ir::BinOp::Mul => n * c,
-                                            jq_jit::ir::BinOp::Div => n / c,
-                                            jq_jit::ir::BinOp::Mod => jq_jit::runtime::jq_mod_f64(n, *c).unwrap_or(f64::NAN),
-                                            _ => n,
-                                        };
-                                    }
-                                    push_jq_number_bytes(&mut compact_buf, n);
-                                    compact_buf.push(b'\n');
-                                } else {
-                                    // tonumber on a non-numeric string → jq raises
-                                    // `cannot be parsed as a number`. Defer to
-                                    // generic eval so the error fires (#160).
-                                    let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                    process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                                }
-                            } else {
-                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                            }
-                        } else {
+                        let outcome = apply_field_ltrimstr_tonumber_raw(
+                            raw, lt_field, prefix_bytes, lt_arith_ops,
+                            |n| {
+                                push_jq_number_bytes(&mut compact_buf, n);
+                                compact_buf.push(b'\n');
+                            },
+                        );
+                        if let RawApplyOutcome::Bail = outcome {
                             let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                             process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }
@@ -20482,38 +20454,14 @@ fn real_main() {
                 let content_bytes = content.as_bytes();
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, lt_field) {
-                        let val = &raw[vs..ve];
-                        if val.len() >= 2 && val[0] == b'"' && val[val.len()-1] == b'"'
-                            && !val[1..val.len()-1].contains(&b'\\')
-                        {
-                            let content = &val[1..val.len()-1];
-                            let num_str = if content.len() >= prefix_bytes.len() && &content[..prefix_bytes.len()] == prefix_bytes {
-                                &content[prefix_bytes.len()..]
-                            } else {
-                                content
-                            };
-                            if let Ok(mut n) = fast_float::parse::<f64, _>(num_str) {
-                                for (op, c) in lt_arith_ops {
-                                    n = match op {
-                                        jq_jit::ir::BinOp::Add => n + c,
-                                        jq_jit::ir::BinOp::Sub => n - c,
-                                        jq_jit::ir::BinOp::Mul => n * c,
-                                        jq_jit::ir::BinOp::Div => n / c,
-                                        jq_jit::ir::BinOp::Mod => jq_jit::runtime::jq_mod_f64(n, *c).unwrap_or(f64::NAN),
-                                        _ => n,
-                                    };
-                                }
-                                push_jq_number_bytes(&mut compact_buf, n);
-                                compact_buf.push(b'\n');
-                            } else {
-                                compact_buf.extend_from_slice(b"null\n");
-                            }
-                        } else {
-                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                        }
-                    } else {
+                    let outcome = apply_field_ltrimstr_tonumber_raw(
+                        raw, lt_field, prefix_bytes, lt_arith_ops,
+                        |n| {
+                            push_jq_number_bytes(&mut compact_buf, n);
+                            compact_buf.push(b'\n');
+                        },
+                    );
+                    if let RawApplyOutcome::Bail = outcome {
                         let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                         process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                     }

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -62,6 +62,8 @@
 
 use anyhow::Result;
 
+use crate::ir::BinOp;
+use crate::runtime::jq_mod_f64;
 use crate::value::{
     KeyStr, Value, ObjInner, json_object_get_field_raw, json_object_get_fields_raw_buf,
     json_object_get_nested_field_raw, json_object_has_all_keys, json_object_has_any_key,
@@ -510,6 +512,71 @@ where
         None
     };
     on_value(val, content)
+}
+
+/// Apply the `.field | ltrimstr("prefix") | tonumber [ | <arith> ]*`
+/// raw-byte fast path on a single JSON record.
+///
+/// Bail discipline matches [`apply_field_test_raw`] for the structural
+/// type-guard (object input + quoted-string field with no `\` escapes),
+/// plus a numeric-parse Bail (#160): if the post-prefix-strip content
+/// can't be parsed as an `f64`, jq raises `... cannot be parsed as a
+/// number`, so the fast path returns [`RawApplyOutcome::Bail`] and lets
+/// the generic path produce the real error.
+///
+/// On success, the helper applies the post-`tonumber` arithmetic chain
+/// `arith_ops` (each `(BinOp, f64)` is folded left over the parsed
+/// number) and invokes `emit` with the final `f64` so the apply-site
+/// owns JSON-number formatting (see `push_jq_number_bytes`).
+///
+/// `arith_ops` may be empty (a bare `ltrimstr | tonumber` chain). Only
+/// the arithmetic ops jq actually emits in this lowering are honoured —
+/// `Add`, `Sub`, `Mul`, `Div`, `Mod`. Comparison/logical ops would
+/// require Boolean output and are not part of the fast path's contract;
+/// any other variant is treated as identity (defensive).
+pub fn apply_field_ltrimstr_tonumber_raw<F>(
+    raw: &[u8],
+    field: &str,
+    prefix: &[u8],
+    arith_ops: &[(BinOp, f64)],
+    mut emit: F,
+) -> RawApplyOutcome
+where
+    F: FnMut(f64),
+{
+    let (vs, ve) = match json_object_get_field_raw(raw, 0, field) {
+        Some(r) => r,
+        None => return RawApplyOutcome::Bail,
+    };
+    let val = &raw[vs..ve];
+    if val.len() < 2 || val[0] != b'"' || val[val.len() - 1] != b'"'
+        || val[1..val.len() - 1].contains(&b'\\')
+    {
+        return RawApplyOutcome::Bail;
+    }
+    let content = &val[1..val.len() - 1];
+    let num_bytes = if content.len() >= prefix.len() && &content[..prefix.len()] == prefix {
+        &content[prefix.len()..]
+    } else {
+        content
+    };
+    let num_str = unsafe { std::str::from_utf8_unchecked(num_bytes) };
+    let mut n: f64 = match fast_float::parse(num_str) {
+        Ok(n) => n,
+        Err(_) => return RawApplyOutcome::Bail,
+    };
+    for (op, c) in arith_ops {
+        n = match op {
+            BinOp::Add => n + c,
+            BinOp::Sub => n - c,
+            BinOp::Mul => n * c,
+            BinOp::Div => n / c,
+            BinOp::Mod => jq_mod_f64(n, *c).unwrap_or(f64::NAN),
+            _ => n,
+        };
+    }
+    emit(n);
+    RawApplyOutcome::Emit
 }
 
 /// Apply the `.field // fallback` raw-byte fast path on a single JSON

--- a/tests/fast_path_contract.rs
+++ b/tests/fast_path_contract.rs
@@ -11,12 +11,13 @@
 use jq_jit::fast_path::{
     FastPath, FieldAccessPath, RawApplyOutcome, apply_field_access_raw,
     apply_field_alternative_raw, apply_field_field_alternative_raw, apply_field_format_raw,
-    apply_field_gsub_raw, apply_field_match_raw, apply_field_scan_raw, apply_field_test_raw,
-    apply_full_object_fields_raw, apply_has_field_raw,
+    apply_field_gsub_raw, apply_field_ltrimstr_tonumber_raw, apply_field_match_raw,
+    apply_field_scan_raw, apply_field_test_raw, apply_full_object_fields_raw, apply_has_field_raw,
     apply_has_multi_field_raw, apply_multi_field_access_raw, apply_nested_field_access_raw,
     apply_object_compute_raw,
 };
 use jq_jit::interpreter::Filter;
+use jq_jit::ir::BinOp;
 use jq_jit::value::Value;
 
 #[test]
@@ -1382,5 +1383,131 @@ fn raw_field_format_non_object_input_bails_without_invoking_closure() {
             outcome,
         );
         assert_eq!(called, 0);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// `.field | ltrimstr("p") | tonumber [ | <arith> ]*` — same Bail discipline
+// as the regex helpers (object input + quoted-string field with no escapes),
+// plus a numeric-parse Bail (#160) so the generic path produces jq's
+// "Invalid numeric literal" error on non-numeric strings.
+
+#[test]
+fn raw_field_ltrimstr_tonumber_strips_prefix_and_parses() {
+    let mut emitted: Vec<f64> = Vec::new();
+    let outcome = apply_field_ltrimstr_tonumber_raw(
+        b"{\"x\":\"id-42\"}",
+        "x",
+        b"id-",
+        &[],
+        |n| emitted.push(n),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec![42.0]);
+}
+
+#[test]
+fn raw_field_ltrimstr_tonumber_no_prefix_match_keeps_content() {
+    let mut emitted: Vec<f64> = Vec::new();
+    let outcome = apply_field_ltrimstr_tonumber_raw(
+        b"{\"x\":\"42\"}",
+        "x",
+        b"id-",
+        &[],
+        |n| emitted.push(n),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec![42.0]);
+}
+
+#[test]
+fn raw_field_ltrimstr_tonumber_applies_arith_chain() {
+    let mut emitted: Vec<f64> = Vec::new();
+    let outcome = apply_field_ltrimstr_tonumber_raw(
+        b"{\"x\":\"10\"}",
+        "x",
+        b"",
+        &[(BinOp::Add, 5.0), (BinOp::Mul, 2.0)],
+        |n| emitted.push(n),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec![30.0]);
+}
+
+#[test]
+fn raw_field_ltrimstr_tonumber_non_numeric_bails() {
+    let mut emitted: Vec<f64> = Vec::new();
+    let outcome = apply_field_ltrimstr_tonumber_raw(
+        b"{\"x\":\"abc\"}",
+        "x",
+        b"",
+        &[],
+        |n| emitted.push(n),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_field_ltrimstr_tonumber_field_missing_bails() {
+    let mut emitted: Vec<f64> = Vec::new();
+    let outcome = apply_field_ltrimstr_tonumber_raw(
+        b"{\"y\":\"42\"}",
+        "x",
+        b"",
+        &[],
+        |n| emitted.push(n),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_field_ltrimstr_tonumber_non_string_field_bails() {
+    for inner in [&b"{\"x\":42}"[..], &b"{\"x\":null}"[..], &b"{\"x\":[1,2]}"[..]] {
+        let mut emitted: Vec<f64> = Vec::new();
+        let outcome = apply_field_ltrimstr_tonumber_raw(inner, "x", b"", &[], |n| emitted.push(n));
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "expected Bail for non-string field input {:?}, got {:?}",
+            std::str::from_utf8(inner).unwrap(),
+            outcome,
+        );
+        assert!(emitted.is_empty());
+    }
+}
+
+#[test]
+fn raw_field_ltrimstr_tonumber_escaped_string_bails() {
+    let mut emitted: Vec<f64> = Vec::new();
+    let outcome = apply_field_ltrimstr_tonumber_raw(
+        br#"{"x":"4\n2"}"#,
+        "x",
+        b"",
+        &[],
+        |n| emitted.push(n),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_field_ltrimstr_tonumber_non_object_input_bails() {
+    for raw in [
+        b"42".as_slice(),
+        b"\"hi\"".as_slice(),
+        b"null".as_slice(),
+        b"true".as_slice(),
+        b"[1,2,3]".as_slice(),
+    ] {
+        let mut emitted: Vec<f64> = Vec::new();
+        let outcome = apply_field_ltrimstr_tonumber_raw(raw, "x", b"", &[], |n| emitted.push(n));
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "expected Bail for ltrimstr_tonumber input {:?}, got {:?}",
+            std::str::from_utf8(raw).unwrap(),
+            outcome,
+        );
+        assert!(emitted.is_empty());
     }
 }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -3080,3 +3080,53 @@ null
 (.x | @base64)?
 null
 "bnVsbA=="
+
+# #83 Phase B: .x | ltrimstr("p") | tonumber [ | <arith> ]* apply-site
+# uses RawApplyOutcome::Bail.
+# Happy path: prefix strip + tonumber + arithmetic chain.
+.x | ltrimstr("id-") | tonumber + 5
+{"x":"id-37"}
+42
+
+# Prefix not present: keep content, parse as number.
+.x | ltrimstr("id-") | tonumber
+{"x":"100"}
+100
+
+# Bare ltrimstr | tonumber (empty arith chain).
+.x | ltrimstr("v") | tonumber
+{"x":"v3.14"}
+3.14
+
+# Non-numeric remainder: bail to generic; jq raises; `?` swallows.
+(.x | ltrimstr("p") | tonumber)?
+{"x":"pabc"}
+
+# Field missing under `?`: bail to generic; jq raises null|tonumber; `?` swallows.
+(.x | ltrimstr("p") | tonumber)?
+{"y":"42"}
+
+# Non-string field under `?`
+(.x | ltrimstr("p") | tonumber)?
+{"x":42}
+
+(.x | ltrimstr("p") | tonumber)?
+{"x":null}
+
+(.x | ltrimstr("p") | tonumber)?
+{"x":[1,2,3]}
+
+# Escape-bearing string: bail to generic, which decodes the escape.
+# After decoding, the content is non-numeric, so jq raises; `?` swallows.
+(.x | ltrimstr("p") | tonumber)?
+{"x":"p4\n2"}
+
+# Non-object input under `?`
+(.x | ltrimstr("p") | tonumber)?
+42
+
+(.x | ltrimstr("p") | tonumber)?
+"hi"
+
+(.x | ltrimstr("p") | tonumber)?
+[1,2,3]


### PR DESCRIPTION
## Summary
- Migrate `.field | ltrimstr("p") | tonumber [ | <arith> ]*` (stdin + file dispatch) to the named-Bail discipline introduced for #83 Phase B.
- New helper `apply_field_ltrimstr_tonumber_raw` mirrors `apply_field_test_raw`'s type-guard ladder and adds a numeric-parse Bail (#160) so the generic path produces jq's "Invalid numeric literal" on a non-numeric remainder.
- The migration also fixes a pre-existing divergence between the two apply-sites: the file-mode path was silently emitting `null` on parse failure (a #83-class bug — silent wrong answer); the stdin path already bailed to generic. Both now route through the helper.

## Test plan
- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` — 88 fast_path_contract cases + full regression
- [x] `tests/fast_path_contract.rs`: 8 new cases pinning the prefix-strip Emit path, the arith-chain fold, and every Bail branch (non-numeric, missing field, non-string, escape-bearing, non-object)
- [x] `tests/regression.test`: 11 new cases including a `?`-wrapped Bail matrix
- [x] `./bench/comprehensive.sh --quick` — adjacent benchmarks track v1.1.0 baseline; no regression

Refs: #251 follow-up checkbox `field_ltrimstr_tonumber`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)