### PR TITLE
refactor: field_str_concat apply-site uses RawApplyOutcome (#83 Phase B)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -141,10 +141,10 @@ use jq_jit::interpreter::Filter;
 use jq_jit::fast_path::{
     apply_field_access_raw, apply_field_alternative_raw, apply_field_field_alternative_raw,
     apply_field_format_raw, apply_field_gsub_raw, apply_field_ltrimstr_tonumber_raw,
-    apply_field_match_raw, apply_field_scan_raw, apply_field_test_raw,
-    apply_full_object_fields_raw, apply_has_field_raw, apply_has_multi_field_raw,
-    apply_multi_field_access_raw, apply_nested_field_access_raw, apply_object_compute_raw,
-    RawApplyOutcome,
+    apply_field_match_raw, apply_field_scan_raw, apply_field_str_concat_raw,
+    apply_field_test_raw, apply_full_object_fields_raw, apply_has_field_raw,
+    apply_has_multi_field_raw, apply_multi_field_access_raw, apply_nested_field_access_raw,
+    apply_object_compute_raw, RawApplyOutcome,
 };
 
 fn json_escape_bytes(bytes: &[u8]) -> Vec<u8> {
@@ -7198,23 +7198,15 @@ fn real_main() {
                     };
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        if raw[0] == b'{' {
-                            if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, sc_field) {
-                                let val = &raw[vs..ve];
-                                if val[0] == b'"' && !val[1..ve-vs-1].contains(&b'\\') {
-                                    compact_buf.extend_from_slice(&val[..val.len()-1]);
-                                    compact_buf.extend_from_slice(&suffix_escaped);
-                                    compact_buf.extend_from_slice(b"\"\n");
-                                } else {
-                                    let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                    process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                                }
-                            } else {
-                                compact_buf.push(b'"');
-                                compact_buf.extend_from_slice(&suffix_escaped);
-                                compact_buf.extend_from_slice(b"\"\n");
+                        let outcome = apply_field_str_concat_raw(raw, sc_field, |content| {
+                            compact_buf.push(b'"');
+                            if let Some(c) = content {
+                                compact_buf.extend_from_slice(c);
                             }
-                        } else {
+                            compact_buf.extend_from_slice(&suffix_escaped);
+                            compact_buf.extend_from_slice(b"\"\n");
+                        });
+                        if let RawApplyOutcome::Bail = outcome {
                             let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                             process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }
@@ -20496,27 +20488,15 @@ fn real_main() {
                 };
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    if raw[0] == b'{' {
-                        if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, sc_field) {
-                            let val = &raw[vs..ve];
-                            // Only use fast path for simple strings (quoted, no backslash)
-                            if val[0] == b'"' && !val[1..ve-vs-1].contains(&b'\\') {
-                                // Copy everything except trailing quote, append suffix + quote + newline
-                                compact_buf.extend_from_slice(&val[..val.len()-1]);
-                                compact_buf.extend_from_slice(&suffix_escaped);
-                                compact_buf.extend_from_slice(b"\"\n");
-                            } else {
-                                // Fall back for non-string or escaped string values
-                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                            }
-                        } else {
-                            // Field not found → null + "str" = "str"
-                            compact_buf.push(b'"');
-                            compact_buf.extend_from_slice(&suffix_escaped);
-                            compact_buf.extend_from_slice(b"\"\n");
+                    let outcome = apply_field_str_concat_raw(raw, sc_field, |content| {
+                        compact_buf.push(b'"');
+                        if let Some(c) = content {
+                            compact_buf.extend_from_slice(c);
                         }
-                    } else {
+                        compact_buf.extend_from_slice(&suffix_escaped);
+                        compact_buf.extend_from_slice(b"\"\n");
+                    });
+                    if let RawApplyOutcome::Bail = outcome {
                         let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                         process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                     }

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -579,6 +579,59 @@ where
     RawApplyOutcome::Emit
 }
 
+/// Apply the `.field + "<literal-suffix>"` raw-byte fast path on a single
+/// JSON record.
+///
+/// jq's `+` on strings concatenates, and `null + "x"` returns `"x"` (jq
+/// treats `null` as a left-identity for most operations), so this fast
+/// path's discipline is not just "string field, otherwise bail":
+///
+/// * Object input, field absent — invokes `on_field(None)`. The
+///   apply-site emits `"<suffix>"` (matching `null + "suffix"` →
+///   `"suffix"`).
+/// * Object input, field present, value is a quoted string with no `\`
+///   escapes — invokes `on_field(Some(content))` where `content` is the
+///   field bytes without the surrounding quotes. The apply-site emits
+///   `"<content><suffix>"`.
+/// * Object input, field present, value is a non-string scalar (number,
+///   bool, array, etc.) — returns [`RawApplyOutcome::Bail`] so the
+///   generic path raises jq's `<type> and string cannot be added`.
+/// * Object input, field present, value is an escape-bearing string —
+///   returns [`RawApplyOutcome::Bail`] (the raw scanner can't decode
+///   escapes safely; the generic path will).
+/// * Non-object input — returns [`RawApplyOutcome::Bail`]. Notably this
+///   includes `null`, even though `null | (.x + "s") == "s"` is jq's
+///   answer; the helper conservatively delegates the lookup-and-fold to
+///   the generic path.
+pub fn apply_field_str_concat_raw<E>(
+    raw: &[u8],
+    field: &str,
+    on_field: E,
+) -> RawApplyOutcome
+where
+    E: FnOnce(Option<&[u8]>),
+{
+    if raw.first() != Some(&b'{') {
+        return RawApplyOutcome::Bail;
+    }
+    match json_object_get_field_raw(raw, 0, field) {
+        None => {
+            on_field(None);
+            RawApplyOutcome::Emit
+        }
+        Some((vs, ve)) => {
+            let val = &raw[vs..ve];
+            if val.len() < 2 || val[0] != b'"' || val[val.len() - 1] != b'"'
+                || val[1..val.len() - 1].contains(&b'\\')
+            {
+                return RawApplyOutcome::Bail;
+            }
+            on_field(Some(&val[1..val.len() - 1]));
+            RawApplyOutcome::Emit
+        }
+    }
+}
+
 /// Apply the `.field // fallback` raw-byte fast path on a single JSON
 /// record.
 ///

--- a/tests/fast_path_contract.rs
+++ b/tests/fast_path_contract.rs
@@ -12,9 +12,9 @@ use jq_jit::fast_path::{
     FastPath, FieldAccessPath, RawApplyOutcome, apply_field_access_raw,
     apply_field_alternative_raw, apply_field_field_alternative_raw, apply_field_format_raw,
     apply_field_gsub_raw, apply_field_ltrimstr_tonumber_raw, apply_field_match_raw,
-    apply_field_scan_raw, apply_field_test_raw, apply_full_object_fields_raw, apply_has_field_raw,
-    apply_has_multi_field_raw, apply_multi_field_access_raw, apply_nested_field_access_raw,
-    apply_object_compute_raw,
+    apply_field_scan_raw, apply_field_str_concat_raw, apply_field_test_raw,
+    apply_full_object_fields_raw, apply_has_field_raw, apply_has_multi_field_raw,
+    apply_multi_field_access_raw, apply_nested_field_access_raw, apply_object_compute_raw,
 };
 use jq_jit::interpreter::Filter;
 use jq_jit::ir::BinOp;
@@ -1509,5 +1509,90 @@ fn raw_field_ltrimstr_tonumber_non_object_input_bails() {
             outcome,
         );
         assert!(emitted.is_empty());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// `.field + "<literal-suffix>"` — the helper hands the closure
+// `Some(content)` for a present-and-valid string, `None` for a missing
+// field (jq's `null + "s" == "s"`), and Bails on every other shape.
+
+#[test]
+fn raw_field_str_concat_present_string_yields_content() {
+    let mut seen: Vec<Option<Vec<u8>>> = Vec::new();
+    let outcome = apply_field_str_concat_raw(
+        b"{\"x\":\"hi\"}",
+        "x",
+        |c| seen.push(c.map(|s| s.to_vec())),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(seen, vec![Some(b"hi".to_vec())]);
+}
+
+#[test]
+fn raw_field_str_concat_missing_field_yields_none() {
+    let mut seen: Vec<Option<Vec<u8>>> = Vec::new();
+    let outcome = apply_field_str_concat_raw(
+        b"{\"y\":\"hi\"}",
+        "x",
+        |c| seen.push(c.map(|s| s.to_vec())),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(seen, vec![None]);
+}
+
+#[test]
+fn raw_field_str_concat_non_string_field_bails() {
+    for inner in [&b"{\"x\":42}"[..], &b"{\"x\":null}"[..], &b"{\"x\":[1,2]}"[..]] {
+        let mut called = 0u32;
+        let outcome = apply_field_str_concat_raw(inner, "x", |_| {
+            called += 1;
+        });
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "expected Bail for non-string field input {:?}, got {:?}",
+            std::str::from_utf8(inner).unwrap(),
+            outcome,
+        );
+        assert_eq!(called, 0);
+    }
+}
+
+#[test]
+fn raw_field_str_concat_escaped_string_bails() {
+    let mut called = 0u32;
+    let outcome = apply_field_str_concat_raw(
+        br#"{"x":"a\nb"}"#,
+        "x",
+        |_| {
+            called += 1;
+        },
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert_eq!(called, 0);
+}
+
+#[test]
+fn raw_field_str_concat_non_object_input_bails() {
+    // Includes `null`, even though `null + "s" == "s"` in jq — the helper
+    // delegates that fold to the generic path.
+    for raw in [
+        b"42".as_slice(),
+        b"\"hi\"".as_slice(),
+        b"null".as_slice(),
+        b"true".as_slice(),
+        b"[1,2,3]".as_slice(),
+    ] {
+        let mut called = 0u32;
+        let outcome = apply_field_str_concat_raw(raw, "x", |_| {
+            called += 1;
+        });
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "expected Bail for str_concat input {:?}, got {:?}",
+            std::str::from_utf8(raw).unwrap(),
+            outcome,
+        );
+        assert_eq!(called, 0);
     }
 }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -3130,3 +3130,48 @@ null
 
 (.x | ltrimstr("p") | tonumber)?
 [1,2,3]
+
+# #83 Phase B: `.x + "literal"` apply-site uses RawApplyOutcome::Bail.
+# Happy path: present-and-valid string concatenated with literal suffix.
+.x + "_done"
+{"x":"task"}
+"task_done"
+
+# Suffix with characters needing JSON escape.
+.x + "\nB"
+{"x":"A"}
+"A\nB"
+
+# Field absent: jq's `null + "s" == "s"`, so the helper hands `None` to
+# the closure and the apply-site emits `"<suffix>"`.
+.x + "_done"
+{"y":"hi"}
+"_done"
+
+# Non-string field under `?`: closure not invoked; helper bails to generic
+# which raises (number + string), `?` swallows.
+(.x + "_done")?
+{"x":42}
+
+(.x + "_done")?
+{"x":[1,2,3]}
+
+# Escape-bearing string: bail to generic; concat decodes correctly.
+.x + "_done"
+{"x":"a\nb"}
+"a\nb_done"
+
+# null input: helper bails (non-object); generic produces `null + "s" == "s"`.
+.x + "_done"
+null
+"_done"
+
+# Non-object/non-null input: jq raises "Cannot index <type>"; `?` swallows.
+(.x + "_done")?
+42
+
+(.x + "_done")?
+"hi"
+
+(.x + "_done")?
+[1,2,3]


### PR DESCRIPTION
## Summary
- Migrate `.field + "<literal-suffix>"` (stdin + file dispatch) to the named-Bail discipline introduced for #83 Phase B.
- New helper `apply_field_str_concat_raw`. Different shape from the regex helpers: jq's `null + "s" == "s"` means a missing field is **not** a Bail — the helper hands `None` to the closure so the apply-site emits `"<suffix>"`. Bail covers everything else: non-string value, escape-bearing string, non-object input (including `null`, which is delegated to the generic path so the lookup-then-fold runs correctly).

## Test plan
- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` — 93 fast_path_contract cases + full regression
- [x] `tests/fast_path_contract.rs`: 5 new cases pinning Some/None Emit paths and every Bail branch
- [x] `tests/regression.test`: 11 new cases including suffix-needs-escape, missing-field-yields-suffix, escape-bearing-string round-trip, and the `?`-wrapped Bail matrix
- [x] `./bench/comprehensive.sh --quick` — adjacent benchmarks track baseline; no regression

Refs: #251 follow-up checkbox `field_str_concat`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)