### PR TITLE
refactor: field_str_reverse apply-site uses RawApplyOutcome (#83 Phase B)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -142,9 +142,9 @@ use jq_jit::fast_path::{
     apply_field_access_raw, apply_field_alternative_raw, apply_field_field_alternative_raw,
     apply_field_format_raw, apply_field_gsub_raw, apply_field_ltrimstr_tonumber_raw,
     apply_field_match_raw, apply_field_scan_raw, apply_field_str_concat_raw,
-    apply_field_test_raw, apply_full_object_fields_raw, apply_has_field_raw,
-    apply_has_multi_field_raw, apply_multi_field_access_raw, apply_nested_field_access_raw,
-    apply_object_compute_raw, RawApplyOutcome,
+    apply_field_str_reverse_raw, apply_field_test_raw, apply_full_object_fields_raw,
+    apply_has_field_raw, apply_has_multi_field_raw, apply_multi_field_access_raw,
+    apply_nested_field_access_raw, apply_object_compute_raw, RawApplyOutcome,
 };
 
 fn json_escape_bytes(bytes: &[u8]) -> Vec<u8> {
@@ -3378,35 +3378,30 @@ fn real_main() {
                     // .field | split("") | reverse | join("") — string reversal
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, rev_field) {
-                            let val = &raw[vs..ve];
-                            if val.len() >= 2 && val[0] == b'"' && val[val.len()-1] == b'"' {
-                                let inner = &val[1..val.len()-1];
-                                // Fast path: ASCII-only with no escapes
-                                if !inner.contains(&b'\\') && inner.iter().all(|&b| b < 0x80) {
-                                    compact_buf.push(b'"');
-                                    for &b in inner.iter().rev() {
-                                        compact_buf.push(b);
-                                    }
-                                    compact_buf.extend_from_slice(b"\"\n");
-                                } else {
-                                    // Decode JSON string, reverse chars, re-encode
-                                    let unescaped = json_unescape_bytes(inner);
-                                    if let Ok(s) = std::str::from_utf8(&unescaped) {
-                                        let reversed: String = s.chars().rev().collect();
-                                        compact_buf.push(b'"');
-                                        compact_buf.extend_from_slice(&json_escape_bytes(reversed.as_bytes()));
-                                        compact_buf.extend_from_slice(b"\"\n");
-                                    } else {
-                                        let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                        process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                                    }
+                        let outcome = apply_field_str_reverse_raw(raw, rev_field, |inner| {
+                            if !inner.contains(&b'\\') && inner.iter().all(|&b| b < 0x80) {
+                                // ASCII-only no-escape: byte-reverse directly.
+                                compact_buf.push(b'"');
+                                for &b in inner.iter().rev() {
+                                    compact_buf.push(b);
                                 }
+                                compact_buf.extend_from_slice(b"\"\n");
+                                RawApplyOutcome::Emit
                             } else {
-                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                                // General string: decode JSON escapes, reverse chars, re-encode.
+                                let unescaped = json_unescape_bytes(inner);
+                                if let Ok(s) = std::str::from_utf8(&unescaped) {
+                                    let reversed: String = s.chars().rev().collect();
+                                    compact_buf.push(b'"');
+                                    compact_buf.extend_from_slice(&json_escape_bytes(reversed.as_bytes()));
+                                    compact_buf.extend_from_slice(b"\"\n");
+                                    RawApplyOutcome::Emit
+                                } else {
+                                    RawApplyOutcome::Bail
+                                }
                             }
-                        } else {
+                        });
+                        if let RawApplyOutcome::Bail = outcome {
                             let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                             process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }
@@ -13088,33 +13083,28 @@ fn real_main() {
                 let content_bytes = content.as_bytes();
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, rev_field) {
-                        let val = &raw[vs..ve];
-                        if val.len() >= 2 && val[0] == b'"' && val[val.len()-1] == b'"' {
-                            let inner = &val[1..val.len()-1];
-                            if !inner.contains(&b'\\') && inner.iter().all(|&b| b < 0x80) {
-                                compact_buf.push(b'"');
-                                for &b in inner.iter().rev() {
-                                    compact_buf.push(b);
-                                }
-                                compact_buf.extend_from_slice(b"\"\n");
-                            } else {
-                                let unescaped = json_unescape_bytes(inner);
-                                if let Ok(s) = std::str::from_utf8(&unescaped) {
-                                    let reversed: String = s.chars().rev().collect();
-                                    compact_buf.push(b'"');
-                                    compact_buf.extend_from_slice(&json_escape_bytes(reversed.as_bytes()));
-                                    compact_buf.extend_from_slice(b"\"\n");
-                                } else {
-                                    let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                    process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                                }
+                    let outcome = apply_field_str_reverse_raw(raw, rev_field, |inner| {
+                        if !inner.contains(&b'\\') && inner.iter().all(|&b| b < 0x80) {
+                            compact_buf.push(b'"');
+                            for &b in inner.iter().rev() {
+                                compact_buf.push(b);
                             }
+                            compact_buf.extend_from_slice(b"\"\n");
+                            RawApplyOutcome::Emit
                         } else {
-                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                            let unescaped = json_unescape_bytes(inner);
+                            if let Ok(s) = std::str::from_utf8(&unescaped) {
+                                let reversed: String = s.chars().rev().collect();
+                                compact_buf.push(b'"');
+                                compact_buf.extend_from_slice(&json_escape_bytes(reversed.as_bytes()));
+                                compact_buf.extend_from_slice(b"\"\n");
+                                RawApplyOutcome::Emit
+                            } else {
+                                RawApplyOutcome::Bail
+                            }
                         }
-                    } else {
+                    });
+                    if let RawApplyOutcome::Bail = outcome {
                         let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                         process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                     }

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -632,6 +632,44 @@ where
     }
 }
 
+/// Apply the `.field | split("") | reverse | join("")` raw-byte fast
+/// path (string reversal) on a single JSON record.
+///
+/// The bail discipline here is *structural-only*: the helper guarantees
+/// the input is an object whose `field` is a quoted string, and hands
+/// the caller the raw inner bytes (still possibly containing JSON
+/// escapes). The caller decides between two emit strategies and signals
+/// the verdict via the closure's return value:
+///
+/// 1. ASCII-only with no `\` escapes — emit reversed bytes directly
+///    (returns [`RawApplyOutcome::Emit`]).
+/// 2. Any other string — decode JSON escapes, reverse Unicode code
+///    points, re-encode (returns [`RawApplyOutcome::Emit`]) — or, if
+///    decode fails (e.g. invalid UTF-8 after escape unescape), return
+///    [`RawApplyOutcome::Bail`] so the generic path handles it.
+///
+/// Helper-side Bail: field absent, value isn't a quoted string, input
+/// isn't an object. (`null` input bails too — `null | split("")`
+/// raises in jq.)
+pub fn apply_field_str_reverse_raw<E>(
+    raw: &[u8],
+    field: &str,
+    on_string: E,
+) -> RawApplyOutcome
+where
+    E: FnOnce(&[u8]) -> RawApplyOutcome,
+{
+    let (vs, ve) = match json_object_get_field_raw(raw, 0, field) {
+        Some(r) => r,
+        None => return RawApplyOutcome::Bail,
+    };
+    let val = &raw[vs..ve];
+    if val.len() < 2 || val[0] != b'"' || val[val.len() - 1] != b'"' {
+        return RawApplyOutcome::Bail;
+    }
+    on_string(&val[1..val.len() - 1])
+}
+
 /// Apply the `.field // fallback` raw-byte fast path on a single JSON
 /// record.
 ///

--- a/tests/fast_path_contract.rs
+++ b/tests/fast_path_contract.rs
@@ -12,9 +12,10 @@ use jq_jit::fast_path::{
     FastPath, FieldAccessPath, RawApplyOutcome, apply_field_access_raw,
     apply_field_alternative_raw, apply_field_field_alternative_raw, apply_field_format_raw,
     apply_field_gsub_raw, apply_field_ltrimstr_tonumber_raw, apply_field_match_raw,
-    apply_field_scan_raw, apply_field_str_concat_raw, apply_field_test_raw,
-    apply_full_object_fields_raw, apply_has_field_raw, apply_has_multi_field_raw,
-    apply_multi_field_access_raw, apply_nested_field_access_raw, apply_object_compute_raw,
+    apply_field_scan_raw, apply_field_str_concat_raw, apply_field_str_reverse_raw,
+    apply_field_test_raw, apply_full_object_fields_raw, apply_has_field_raw,
+    apply_has_multi_field_raw, apply_multi_field_access_raw, apply_nested_field_access_raw,
+    apply_object_compute_raw,
 };
 use jq_jit::interpreter::Filter;
 use jq_jit::ir::BinOp;
@@ -1590,6 +1591,98 @@ fn raw_field_str_concat_non_object_input_bails() {
         assert!(
             matches!(outcome, RawApplyOutcome::Bail),
             "expected Bail for str_concat input {:?}, got {:?}",
+            std::str::from_utf8(raw).unwrap(),
+            outcome,
+        );
+        assert_eq!(called, 0);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// `.field | split("") | reverse | join("")` — structural-only Bail at the
+// helper boundary; the closure receives the raw inner bytes (still possibly
+// containing JSON escapes) and decides between ASCII-fast and decode-rebuild
+// strategies, returning its own `RawApplyOutcome` for failures (e.g. invalid
+// UTF-8 after escape decode).
+
+#[test]
+fn raw_field_str_reverse_hands_inner_bytes_to_closure() {
+    let mut seen: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_field_str_reverse_raw(
+        b"{\"x\":\"hello\"}",
+        "x",
+        |inner| {
+            seen.push(inner.to_vec());
+            RawApplyOutcome::Emit
+        },
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(seen, vec![b"hello".to_vec()]);
+}
+
+#[test]
+fn raw_field_str_reverse_propagates_closure_bail_verdict() {
+    // Closure may signal a per-input Bail — e.g. the apply-site cannot
+    // decode an escape-bearing string; the helper must propagate without
+    // emitting anything.
+    let outcome = apply_field_str_reverse_raw(
+        br#"{"x":"a\u00ZZ"}"#,
+        "x",
+        |_| RawApplyOutcome::Bail,
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+}
+
+#[test]
+fn raw_field_str_reverse_field_missing_bails_without_invoking_closure() {
+    let mut called = 0u32;
+    let outcome = apply_field_str_reverse_raw(
+        b"{\"y\":\"hi\"}",
+        "x",
+        |_| {
+            called += 1;
+            RawApplyOutcome::Emit
+        },
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert_eq!(called, 0);
+}
+
+#[test]
+fn raw_field_str_reverse_non_string_field_bails_without_invoking_closure() {
+    for inner in [&b"{\"x\":42}"[..], &b"{\"x\":null}"[..], &b"{\"x\":[1,2]}"[..]] {
+        let mut called = 0u32;
+        let outcome = apply_field_str_reverse_raw(inner, "x", |_| {
+            called += 1;
+            RawApplyOutcome::Emit
+        });
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "expected Bail for non-string field input {:?}, got {:?}",
+            std::str::from_utf8(inner).unwrap(),
+            outcome,
+        );
+        assert_eq!(called, 0);
+    }
+}
+
+#[test]
+fn raw_field_str_reverse_non_object_input_bails_without_invoking_closure() {
+    for raw in [
+        b"42".as_slice(),
+        b"\"hi\"".as_slice(),
+        b"null".as_slice(),
+        b"true".as_slice(),
+        b"[1,2,3]".as_slice(),
+    ] {
+        let mut called = 0u32;
+        let outcome = apply_field_str_reverse_raw(raw, "x", |_| {
+            called += 1;
+            RawApplyOutcome::Emit
+        });
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "expected Bail for str_reverse input {:?}, got {:?}",
             std::str::from_utf8(raw).unwrap(),
             outcome,
         );

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -3175,3 +3175,52 @@ null
 
 (.x + "_done")?
 [1,2,3]
+
+# #83 Phase B: .x | split("") | reverse | join("") apply-site uses
+# RawApplyOutcome::Bail.
+# ASCII no-escape: byte-reverse fast path.
+.x | split("") | reverse | join("")
+{"x":"hello"}
+"olleh"
+
+# Empty string round-trips cleanly.
+.x | split("") | reverse | join("")
+{"x":""}
+""
+
+# Non-ASCII string: decode + char-reverse + re-encode.
+.x | split("") | reverse | join("")
+{"x":"あいう"}
+"ういあ"
+
+# Escape-bearing string: decode + char-reverse path inside the closure.
+.x | split("") | reverse | join("")
+{"x":"a\nb"}
+"b\na"
+
+# Field absent under `?` bails to generic; jq's null|split raises; `?` swallows.
+(.x | split("") | reverse | join(""))?
+{"y":"hi"}
+
+# Non-string field under `?`
+(.x | split("") | reverse | join(""))?
+{"x":42}
+
+(.x | split("") | reverse | join(""))?
+{"x":null}
+
+(.x | split("") | reverse | join(""))?
+{"x":[1,2,3]}
+
+# Non-object input under `?`
+(.x | split("") | reverse | join(""))?
+42
+
+(.x | split("") | reverse | join(""))?
+"hi"
+
+(.x | split("") | reverse | join(""))?
+null
+
+(.x | split("") | reverse | join(""))?
+[1,2,3]


### PR DESCRIPTION
## Summary
- Migrate `.field | split("") | reverse | join("")` (stdin + file dispatch) to the named-Bail discipline introduced for #83 Phase B.
- New helper `apply_field_str_reverse_raw` does **structural-only** type-guarding (object input + quoted-string field). The closure receives the raw inner bytes (still possibly containing JSON escapes) and picks between ASCII-fast and decode-rebuild strategies, returning its own verdict (`Bail` if escape-decode yields invalid UTF-8).

## Test plan
- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` — 98 fast_path_contract cases + full regression
- [x] `tests/fast_path_contract.rs`: 5 new cases pinning the inner-bytes Emit, closure-Bail propagation, and every helper-side Bail branch
- [x] `tests/regression.test`: 12 new cases including ASCII-fast, multi-byte char round-trip, escape-bearing-string round-trip, and the `?`-wrapped Bail matrix
- [x] `./bench/comprehensive.sh --quick` — `reverse(2M)` and adjacent benchmarks track baseline; no regression

Refs: #251 follow-up checkbox `field_str_reverse`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)