### PR TITLE
refactor: field_str_builtin apply-site uses RawApplyOutcome (#83 Phase B)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -141,10 +141,11 @@ use jq_jit::interpreter::Filter;
 use jq_jit::fast_path::{
     apply_field_access_raw, apply_field_alternative_raw, apply_field_field_alternative_raw,
     apply_field_format_raw, apply_field_gsub_raw, apply_field_ltrimstr_tonumber_raw,
-    apply_field_match_raw, apply_field_scan_raw, apply_field_str_concat_raw,
-    apply_field_str_reverse_raw, apply_field_test_raw, apply_full_object_fields_raw,
-    apply_has_field_raw, apply_has_multi_field_raw, apply_multi_field_access_raw,
-    apply_nested_field_access_raw, apply_object_compute_raw, RawApplyOutcome,
+    apply_field_match_raw, apply_field_scan_raw, apply_field_str_builtin_raw,
+    apply_field_str_concat_raw, apply_field_str_reverse_raw, apply_field_test_raw,
+    apply_full_object_fields_raw, apply_has_field_raw, apply_has_multi_field_raw,
+    apply_multi_field_access_raw, apply_nested_field_access_raw, apply_object_compute_raw,
+    RawApplyOutcome,
 };
 
 fn json_escape_bytes(bytes: &[u8]) -> Vec<u8> {
@@ -6463,142 +6464,135 @@ fn real_main() {
                     let arg_bytes = sb_arg.as_bytes();
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, sb_field) {
-                            let val = &raw[vs..ve];
-                            // Only fast-path quoted strings without backslash escapes
-                            if val.len() >= 2 && val[0] == b'"' && val[val.len()-1] == b'"'
-                                && !val[1..val.len()-1].contains(&b'\\')
-                            {
-                                let content = &val[1..val.len()-1];
-                                match sb_name.as_str() {
-                                    "startswith" => {
-                                        if content.len() >= arg_bytes.len() && &content[..arg_bytes.len()] == arg_bytes {
-                                            compact_buf.extend_from_slice(b"true\n");
-                                        } else {
-                                            compact_buf.extend_from_slice(b"false\n");
-                                        }
+                        let outcome = apply_field_str_builtin_raw(raw, sb_field, |content| {
+                            match sb_name.as_str() {
+                                "startswith" => {
+                                    if content.len() >= arg_bytes.len() && &content[..arg_bytes.len()] == arg_bytes {
+                                        compact_buf.extend_from_slice(b"true\n");
+                                    } else {
+                                        compact_buf.extend_from_slice(b"false\n");
                                     }
-                                    "endswith" => {
-                                        if content.len() >= arg_bytes.len() && &content[content.len()-arg_bytes.len()..] == arg_bytes {
-                                            compact_buf.extend_from_slice(b"true\n");
-                                        } else {
-                                            compact_buf.extend_from_slice(b"false\n");
-                                        }
+                                    RawApplyOutcome::Emit
+                                }
+                                "endswith" => {
+                                    if content.len() >= arg_bytes.len() && &content[content.len()-arg_bytes.len()..] == arg_bytes {
+                                        compact_buf.extend_from_slice(b"true\n");
+                                    } else {
+                                        compact_buf.extend_from_slice(b"false\n");
                                     }
-                                    "ltrimstr" => {
-                                        compact_buf.push(b'"');
-                                        if content.len() >= arg_bytes.len() && &content[..arg_bytes.len()] == arg_bytes {
-                                            compact_buf.extend_from_slice(&content[arg_bytes.len()..]);
-                                        } else {
-                                            compact_buf.extend_from_slice(content);
-                                        }
-                                        compact_buf.push(b'"');
-                                        compact_buf.push(b'\n');
+                                    RawApplyOutcome::Emit
+                                }
+                                "ltrimstr" => {
+                                    compact_buf.push(b'"');
+                                    if content.len() >= arg_bytes.len() && &content[..arg_bytes.len()] == arg_bytes {
+                                        compact_buf.extend_from_slice(&content[arg_bytes.len()..]);
+                                    } else {
+                                        compact_buf.extend_from_slice(content);
                                     }
-                                    "rtrimstr" => {
-                                        compact_buf.push(b'"');
-                                        if content.len() >= arg_bytes.len() && &content[content.len()-arg_bytes.len()..] == arg_bytes {
-                                            compact_buf.extend_from_slice(&content[..content.len()-arg_bytes.len()]);
-                                        } else {
-                                            compact_buf.extend_from_slice(content);
-                                        }
-                                        compact_buf.push(b'"');
-                                        compact_buf.push(b'\n');
+                                    compact_buf.push(b'"');
+                                    compact_buf.push(b'\n');
+                                    RawApplyOutcome::Emit
+                                }
+                                "rtrimstr" => {
+                                    compact_buf.push(b'"');
+                                    if content.len() >= arg_bytes.len() && &content[content.len()-arg_bytes.len()..] == arg_bytes {
+                                        compact_buf.extend_from_slice(&content[..content.len()-arg_bytes.len()]);
+                                    } else {
+                                        compact_buf.extend_from_slice(content);
                                     }
-                                    "split" => {
-                                        // Raw byte split: split JSON string content by separator,
-                                        // output JSON array directly without Value construction
-                                        compact_buf.push(b'[');
-                                        if arg_bytes.is_empty() {
-                                            // split("") = each byte as separate string
-                                            for (j, &byte) in content.iter().enumerate() {
-                                                if j > 0 { compact_buf.push(b','); }
+                                    compact_buf.push(b'"');
+                                    compact_buf.push(b'\n');
+                                    RawApplyOutcome::Emit
+                                }
+                                "split" => {
+                                    compact_buf.push(b'[');
+                                    if arg_bytes.is_empty() {
+                                        for (j, &byte) in content.iter().enumerate() {
+                                            if j > 0 { compact_buf.push(b','); }
+                                            compact_buf.push(b'"');
+                                            compact_buf.push(byte);
+                                            compact_buf.push(b'"');
+                                        }
+                                    } else {
+                                        let mut pos = 0;
+                                        let mut first = true;
+                                        while pos <= content.len() {
+                                            if !first { compact_buf.push(b','); }
+                                            first = false;
+                                            let next = if pos + arg_bytes.len() <= content.len() {
+                                                content[pos..].windows(arg_bytes.len())
+                                                    .position(|w| w == arg_bytes)
+                                                    .map(|i| pos + i)
+                                            } else { None };
+                                            compact_buf.push(b'"');
+                                            if let Some(found) = next {
+                                                compact_buf.extend_from_slice(&content[pos..found]);
                                                 compact_buf.push(b'"');
-                                                compact_buf.push(byte);
+                                                pos = found + arg_bytes.len();
+                                            } else {
+                                                compact_buf.extend_from_slice(&content[pos..]);
                                                 compact_buf.push(b'"');
+                                                break;
                                             }
-                                        } else {
-                                            let mut pos = 0;
-                                            let mut first = true;
-                                            while pos <= content.len() {
+                                        }
+                                    }
+                                    compact_buf.extend_from_slice(b"]\n");
+                                    RawApplyOutcome::Emit
+                                }
+                                "index" => {
+                                    if arg_bytes.is_empty() {
+                                        compact_buf.extend_from_slice(b"null\n");
+                                    } else if let Some(pos) = content.windows(arg_bytes.len()).position(|w| w == arg_bytes) {
+                                        compact_buf.extend_from_slice(itoa::Buffer::new().format(pos as i64).as_bytes());
+                                        compact_buf.push(b'\n');
+                                    } else {
+                                        compact_buf.extend_from_slice(b"null\n");
+                                    }
+                                    RawApplyOutcome::Emit
+                                }
+                                "rindex" => {
+                                    if arg_bytes.is_empty() {
+                                        compact_buf.extend_from_slice(b"null\n");
+                                    } else if let Some(pos) = content.windows(arg_bytes.len()).rposition(|w| w == arg_bytes) {
+                                        compact_buf.extend_from_slice(itoa::Buffer::new().format(pos as i64).as_bytes());
+                                        compact_buf.push(b'\n');
+                                    } else {
+                                        compact_buf.extend_from_slice(b"null\n");
+                                    }
+                                    RawApplyOutcome::Emit
+                                }
+                                "indices" => {
+                                    compact_buf.push(b'[');
+                                    if !arg_bytes.is_empty() {
+                                        let mut first = true;
+                                        let mut start = 0;
+                                        while start + arg_bytes.len() <= content.len() {
+                                            if let Some(pos) = content[start..].windows(arg_bytes.len()).position(|w| w == arg_bytes) {
                                                 if !first { compact_buf.push(b','); }
                                                 first = false;
-                                                // Find next occurrence of separator
-                                                let next = if pos + arg_bytes.len() <= content.len() {
-                                                    content[pos..].windows(arg_bytes.len())
-                                                        .position(|w| w == arg_bytes)
-                                                        .map(|i| pos + i)
-                                                } else { None };
-                                                compact_buf.push(b'"');
-                                                if let Some(found) = next {
-                                                    compact_buf.extend_from_slice(&content[pos..found]);
-                                                    compact_buf.push(b'"');
-                                                    pos = found + arg_bytes.len();
-                                                } else {
-                                                    compact_buf.extend_from_slice(&content[pos..]);
-                                                    compact_buf.push(b'"');
-                                                    break;
-                                                }
+                                                let abs_pos = start + pos;
+                                                compact_buf.extend_from_slice(itoa::Buffer::new().format(abs_pos as i64).as_bytes());
+                                                start = abs_pos + 1;
+                                            } else {
+                                                break;
                                             }
                                         }
-                                        compact_buf.extend_from_slice(b"]\n");
                                     }
-                                    "index" => {
-                                        if arg_bytes.is_empty() {
-                                            compact_buf.extend_from_slice(b"null\n");
-                                        } else if let Some(pos) = content.windows(arg_bytes.len()).position(|w| w == arg_bytes) {
-                                            compact_buf.extend_from_slice(itoa::Buffer::new().format(pos as i64).as_bytes());
-                                            compact_buf.push(b'\n');
-                                        } else {
-                                            compact_buf.extend_from_slice(b"null\n");
-                                        }
-                                    }
-                                    "rindex" => {
-                                        if arg_bytes.is_empty() {
-                                            compact_buf.extend_from_slice(b"null\n");
-                                        } else if let Some(pos) = content.windows(arg_bytes.len()).rposition(|w| w == arg_bytes) {
-                                            compact_buf.extend_from_slice(itoa::Buffer::new().format(pos as i64).as_bytes());
-                                            compact_buf.push(b'\n');
-                                        } else {
-                                            compact_buf.extend_from_slice(b"null\n");
-                                        }
-                                    }
-                                    "indices" => {
-                                        compact_buf.push(b'[');
-                                        if !arg_bytes.is_empty() {
-                                            let mut first = true;
-                                            let mut start = 0;
-                                            while start + arg_bytes.len() <= content.len() {
-                                                if let Some(pos) = content[start..].windows(arg_bytes.len()).position(|w| w == arg_bytes) {
-                                                    if !first { compact_buf.push(b','); }
-                                                    first = false;
-                                                    let abs_pos = start + pos;
-                                                    compact_buf.extend_from_slice(itoa::Buffer::new().format(abs_pos as i64).as_bytes());
-                                                    start = abs_pos + 1;
-                                                } else {
-                                                    break;
-                                                }
-                                            }
-                                        }
-                                        compact_buf.extend_from_slice(b"]\n");
-                                    }
-                                    "contains" => {
-                                        if arg_bytes.is_empty() || content.windows(arg_bytes.len()).any(|w| w == arg_bytes) {
-                                            compact_buf.extend_from_slice(b"true\n");
-                                        } else {
-                                            compact_buf.extend_from_slice(b"false\n");
-                                        }
-                                    }
-                                    _ => {
-                                        let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                        process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                                    }
+                                    compact_buf.extend_from_slice(b"]\n");
+                                    RawApplyOutcome::Emit
                                 }
-                            } else {
-                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                                "contains" => {
+                                    if arg_bytes.is_empty() || content.windows(arg_bytes.len()).any(|w| w == arg_bytes) {
+                                        compact_buf.extend_from_slice(b"true\n");
+                                    } else {
+                                        compact_buf.extend_from_slice(b"false\n");
+                                    }
+                                    RawApplyOutcome::Emit
+                                }
+                                _ => RawApplyOutcome::Bail,
                             }
-                        } else {
+                        });
+                        if let RawApplyOutcome::Bail = outcome {
                             let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                             process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }
@@ -19749,137 +19743,135 @@ fn real_main() {
                 let content_bytes = content.as_bytes();
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, sb_field) {
-                        let val = &raw[vs..ve];
-                        if val.len() >= 2 && val[0] == b'"' && val[val.len()-1] == b'"'
-                            && !val[1..val.len()-1].contains(&b'\\')
-                        {
-                            let content = &val[1..val.len()-1];
-                            match sb_name.as_str() {
-                                "startswith" => {
-                                    if content.len() >= arg_bytes.len() && &content[..arg_bytes.len()] == arg_bytes {
-                                        compact_buf.extend_from_slice(b"true\n");
-                                    } else {
-                                        compact_buf.extend_from_slice(b"false\n");
-                                    }
+                    let outcome = apply_field_str_builtin_raw(raw, sb_field, |content| {
+                        match sb_name.as_str() {
+                            "startswith" => {
+                                if content.len() >= arg_bytes.len() && &content[..arg_bytes.len()] == arg_bytes {
+                                    compact_buf.extend_from_slice(b"true\n");
+                                } else {
+                                    compact_buf.extend_from_slice(b"false\n");
                                 }
-                                "endswith" => {
-                                    if content.len() >= arg_bytes.len() && &content[content.len()-arg_bytes.len()..] == arg_bytes {
-                                        compact_buf.extend_from_slice(b"true\n");
-                                    } else {
-                                        compact_buf.extend_from_slice(b"false\n");
-                                    }
+                                RawApplyOutcome::Emit
+                            }
+                            "endswith" => {
+                                if content.len() >= arg_bytes.len() && &content[content.len()-arg_bytes.len()..] == arg_bytes {
+                                    compact_buf.extend_from_slice(b"true\n");
+                                } else {
+                                    compact_buf.extend_from_slice(b"false\n");
                                 }
-                                "ltrimstr" => {
-                                    compact_buf.push(b'"');
-                                    if content.len() >= arg_bytes.len() && &content[..arg_bytes.len()] == arg_bytes {
-                                        compact_buf.extend_from_slice(&content[arg_bytes.len()..]);
-                                    } else {
-                                        compact_buf.extend_from_slice(content);
-                                    }
-                                    compact_buf.push(b'"');
-                                    compact_buf.push(b'\n');
+                                RawApplyOutcome::Emit
+                            }
+                            "ltrimstr" => {
+                                compact_buf.push(b'"');
+                                if content.len() >= arg_bytes.len() && &content[..arg_bytes.len()] == arg_bytes {
+                                    compact_buf.extend_from_slice(&content[arg_bytes.len()..]);
+                                } else {
+                                    compact_buf.extend_from_slice(content);
                                 }
-                                "rtrimstr" => {
-                                    compact_buf.push(b'"');
-                                    if content.len() >= arg_bytes.len() && &content[content.len()-arg_bytes.len()..] == arg_bytes {
-                                        compact_buf.extend_from_slice(&content[..content.len()-arg_bytes.len()]);
-                                    } else {
-                                        compact_buf.extend_from_slice(content);
-                                    }
-                                    compact_buf.push(b'"');
-                                    compact_buf.push(b'\n');
+                                compact_buf.push(b'"');
+                                compact_buf.push(b'\n');
+                                RawApplyOutcome::Emit
+                            }
+                            "rtrimstr" => {
+                                compact_buf.push(b'"');
+                                if content.len() >= arg_bytes.len() && &content[content.len()-arg_bytes.len()..] == arg_bytes {
+                                    compact_buf.extend_from_slice(&content[..content.len()-arg_bytes.len()]);
+                                } else {
+                                    compact_buf.extend_from_slice(content);
                                 }
-                                "split" => {
-                                    compact_buf.push(b'[');
-                                    if arg_bytes.is_empty() {
-                                        for (j, &byte) in content.iter().enumerate() {
-                                            if j > 0 { compact_buf.push(b','); }
+                                compact_buf.push(b'"');
+                                compact_buf.push(b'\n');
+                                RawApplyOutcome::Emit
+                            }
+                            "split" => {
+                                compact_buf.push(b'[');
+                                if arg_bytes.is_empty() {
+                                    for (j, &byte) in content.iter().enumerate() {
+                                        if j > 0 { compact_buf.push(b','); }
+                                        compact_buf.push(b'"');
+                                        compact_buf.push(byte);
+                                        compact_buf.push(b'"');
+                                    }
+                                } else {
+                                    let mut pos = 0;
+                                    let mut first = true;
+                                    while pos <= content.len() {
+                                        if !first { compact_buf.push(b','); }
+                                        first = false;
+                                        let next = if pos + arg_bytes.len() <= content.len() {
+                                            content[pos..].windows(arg_bytes.len())
+                                                .position(|w| w == arg_bytes)
+                                                .map(|i| pos + i)
+                                        } else { None };
+                                        compact_buf.push(b'"');
+                                        if let Some(found) = next {
+                                            compact_buf.extend_from_slice(&content[pos..found]);
                                             compact_buf.push(b'"');
-                                            compact_buf.push(byte);
+                                            pos = found + arg_bytes.len();
+                                        } else {
+                                            compact_buf.extend_from_slice(&content[pos..]);
                                             compact_buf.push(b'"');
+                                            break;
                                         }
-                                    } else {
-                                        let mut pos = 0;
-                                        let mut first = true;
-                                        while pos <= content.len() {
+                                    }
+                                }
+                                compact_buf.extend_from_slice(b"]\n");
+                                RawApplyOutcome::Emit
+                            }
+                            "index" => {
+                                if arg_bytes.is_empty() {
+                                    compact_buf.extend_from_slice(b"null\n");
+                                } else if let Some(pos) = content.windows(arg_bytes.len()).position(|w| w == arg_bytes) {
+                                    compact_buf.extend_from_slice(itoa::Buffer::new().format(pos as i64).as_bytes());
+                                    compact_buf.push(b'\n');
+                                } else {
+                                    compact_buf.extend_from_slice(b"null\n");
+                                }
+                                RawApplyOutcome::Emit
+                            }
+                            "rindex" => {
+                                if arg_bytes.is_empty() {
+                                    compact_buf.extend_from_slice(b"null\n");
+                                } else if let Some(pos) = content.windows(arg_bytes.len()).rposition(|w| w == arg_bytes) {
+                                    compact_buf.extend_from_slice(itoa::Buffer::new().format(pos as i64).as_bytes());
+                                    compact_buf.push(b'\n');
+                                } else {
+                                    compact_buf.extend_from_slice(b"null\n");
+                                }
+                                RawApplyOutcome::Emit
+                            }
+                            "indices" => {
+                                compact_buf.push(b'[');
+                                if !arg_bytes.is_empty() {
+                                    let mut first = true;
+                                    let mut start = 0;
+                                    while start + arg_bytes.len() <= content.len() {
+                                        if let Some(pos) = content[start..].windows(arg_bytes.len()).position(|w| w == arg_bytes) {
                                             if !first { compact_buf.push(b','); }
                                             first = false;
-                                            let next = if pos + arg_bytes.len() <= content.len() {
-                                                content[pos..].windows(arg_bytes.len())
-                                                    .position(|w| w == arg_bytes)
-                                                    .map(|i| pos + i)
-                                            } else { None };
-                                            compact_buf.push(b'"');
-                                            if let Some(found) = next {
-                                                compact_buf.extend_from_slice(&content[pos..found]);
-                                                compact_buf.push(b'"');
-                                                pos = found + arg_bytes.len();
-                                            } else {
-                                                compact_buf.extend_from_slice(&content[pos..]);
-                                                compact_buf.push(b'"');
-                                                break;
-                                            }
+                                            let abs_pos = start + pos;
+                                            compact_buf.extend_from_slice(itoa::Buffer::new().format(abs_pos as i64).as_bytes());
+                                            start = abs_pos + 1;
+                                        } else {
+                                            break;
                                         }
                                     }
-                                    compact_buf.extend_from_slice(b"]\n");
                                 }
-                                "index" => {
-                                    if arg_bytes.is_empty() {
-                                        compact_buf.extend_from_slice(b"null\n");
-                                    } else if let Some(pos) = content.windows(arg_bytes.len()).position(|w| w == arg_bytes) {
-                                        compact_buf.extend_from_slice(itoa::Buffer::new().format(pos as i64).as_bytes());
-                                        compact_buf.push(b'\n');
-                                    } else {
-                                        compact_buf.extend_from_slice(b"null\n");
-                                    }
-                                }
-                                "rindex" => {
-                                    if arg_bytes.is_empty() {
-                                        compact_buf.extend_from_slice(b"null\n");
-                                    } else if let Some(pos) = content.windows(arg_bytes.len()).rposition(|w| w == arg_bytes) {
-                                        compact_buf.extend_from_slice(itoa::Buffer::new().format(pos as i64).as_bytes());
-                                        compact_buf.push(b'\n');
-                                    } else {
-                                        compact_buf.extend_from_slice(b"null\n");
-                                    }
-                                }
-                                "indices" => {
-                                    compact_buf.push(b'[');
-                                    if !arg_bytes.is_empty() {
-                                        let mut first = true;
-                                        let mut start = 0;
-                                        while start + arg_bytes.len() <= content.len() {
-                                            if let Some(pos) = content[start..].windows(arg_bytes.len()).position(|w| w == arg_bytes) {
-                                                if !first { compact_buf.push(b','); }
-                                                first = false;
-                                                let abs_pos = start + pos;
-                                                compact_buf.extend_from_slice(itoa::Buffer::new().format(abs_pos as i64).as_bytes());
-                                                start = abs_pos + 1;
-                                            } else {
-                                                break;
-                                            }
-                                        }
-                                    }
-                                    compact_buf.extend_from_slice(b"]\n");
-                                }
-                                "contains" => {
-                                    if arg_bytes.is_empty() || content.windows(arg_bytes.len()).any(|w| w == arg_bytes) {
-                                        compact_buf.extend_from_slice(b"true\n");
-                                    } else {
-                                        compact_buf.extend_from_slice(b"false\n");
-                                    }
-                                }
-                                _ => {
-                                    let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                    process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                                }
+                                compact_buf.extend_from_slice(b"]\n");
+                                RawApplyOutcome::Emit
                             }
-                        } else {
-                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                            "contains" => {
+                                if arg_bytes.is_empty() || content.windows(arg_bytes.len()).any(|w| w == arg_bytes) {
+                                    compact_buf.extend_from_slice(b"true\n");
+                                } else {
+                                    compact_buf.extend_from_slice(b"false\n");
+                                }
+                                RawApplyOutcome::Emit
+                            }
+                            _ => RawApplyOutcome::Bail,
                         }
-                    } else {
+                    });
+                    if let RawApplyOutcome::Bail = outcome {
                         let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                         process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                     }

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -670,6 +670,47 @@ where
     on_string(&val[1..val.len() - 1])
 }
 
+/// Apply the `.field | <string-builtin>(arg)` raw-byte fast path on a
+/// single JSON record. The detector (`detect_field_str_builtin`) fuses
+/// nine string builtins under one shape — `startswith`, `endswith`,
+/// `ltrimstr`, `rtrimstr`, `split`, `index`, `rindex`, `indices`,
+/// `contains` — all of which share the same input contract: an object
+/// with a quoted-string field whose content has no `\` escapes.
+///
+/// The helper handles only the structural type-guard and hands the
+/// inner bytes (without quotes) to the closure. The closure dispatches
+/// on builtin name and emits the appropriate output. If the closure
+/// encounters an unknown builtin name (defensive fallback) it returns
+/// [`RawApplyOutcome::Bail`] to delegate to the generic path.
+///
+/// Bail discipline:
+/// * Field absent — [`RawApplyOutcome::Bail`].
+/// * Value isn't a quoted string, or contains any backslash escape —
+///   [`RawApplyOutcome::Bail`] (the generic path decodes escapes and
+///   raises type errors).
+/// * Non-object input — [`RawApplyOutcome::Bail`].
+/// * Closure returns [`RawApplyOutcome::Bail`] — the helper propagates.
+pub fn apply_field_str_builtin_raw<E>(
+    raw: &[u8],
+    field: &str,
+    on_string: E,
+) -> RawApplyOutcome
+where
+    E: FnOnce(&[u8]) -> RawApplyOutcome,
+{
+    let (vs, ve) = match json_object_get_field_raw(raw, 0, field) {
+        Some(r) => r,
+        None => return RawApplyOutcome::Bail,
+    };
+    let val = &raw[vs..ve];
+    if val.len() < 2 || val[0] != b'"' || val[val.len() - 1] != b'"'
+        || val[1..val.len() - 1].contains(&b'\\')
+    {
+        return RawApplyOutcome::Bail;
+    }
+    on_string(&val[1..val.len() - 1])
+}
+
 /// Apply the `.field // fallback` raw-byte fast path on a single JSON
 /// record.
 ///

--- a/tests/fast_path_contract.rs
+++ b/tests/fast_path_contract.rs
@@ -12,10 +12,10 @@ use jq_jit::fast_path::{
     FastPath, FieldAccessPath, RawApplyOutcome, apply_field_access_raw,
     apply_field_alternative_raw, apply_field_field_alternative_raw, apply_field_format_raw,
     apply_field_gsub_raw, apply_field_ltrimstr_tonumber_raw, apply_field_match_raw,
-    apply_field_scan_raw, apply_field_str_concat_raw, apply_field_str_reverse_raw,
-    apply_field_test_raw, apply_full_object_fields_raw, apply_has_field_raw,
-    apply_has_multi_field_raw, apply_multi_field_access_raw, apply_nested_field_access_raw,
-    apply_object_compute_raw,
+    apply_field_scan_raw, apply_field_str_builtin_raw, apply_field_str_concat_raw,
+    apply_field_str_reverse_raw, apply_field_test_raw, apply_full_object_fields_raw,
+    apply_has_field_raw, apply_has_multi_field_raw, apply_multi_field_access_raw,
+    apply_nested_field_access_raw, apply_object_compute_raw,
 };
 use jq_jit::interpreter::Filter;
 use jq_jit::ir::BinOp;
@@ -1683,6 +1683,110 @@ fn raw_field_str_reverse_non_object_input_bails_without_invoking_closure() {
         assert!(
             matches!(outcome, RawApplyOutcome::Bail),
             "expected Bail for str_reverse input {:?}, got {:?}",
+            std::str::from_utf8(raw).unwrap(),
+            outcome,
+        );
+        assert_eq!(called, 0);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// `.field | <string-builtin>(arg)` — the helper enforces the structural
+// type-guard (object input + non-escape quoted-string field) and lets the
+// closure dispatch on builtin name. The closure can return Bail for an
+// unknown name (defensive fallback).
+
+#[test]
+fn raw_field_str_builtin_invokes_closure_with_inner_bytes() {
+    let mut seen: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_field_str_builtin_raw(
+        b"{\"x\":\"banana\"}",
+        "x",
+        |content| {
+            seen.push(content.to_vec());
+            RawApplyOutcome::Emit
+        },
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(seen, vec![b"banana".to_vec()]);
+}
+
+#[test]
+fn raw_field_str_builtin_propagates_closure_bail_verdict() {
+    // The closure can choose to Bail (e.g. unknown builtin name fallback).
+    let outcome = apply_field_str_builtin_raw(
+        b"{\"x\":\"banana\"}",
+        "x",
+        |_| RawApplyOutcome::Bail,
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+}
+
+#[test]
+fn raw_field_str_builtin_field_missing_bails() {
+    let mut called = 0u32;
+    let outcome = apply_field_str_builtin_raw(
+        b"{\"y\":\"hi\"}",
+        "x",
+        |_| {
+            called += 1;
+            RawApplyOutcome::Emit
+        },
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert_eq!(called, 0);
+}
+
+#[test]
+fn raw_field_str_builtin_non_string_field_bails() {
+    for inner in [&b"{\"x\":42}"[..], &b"{\"x\":null}"[..], &b"{\"x\":[1,2]}"[..]] {
+        let mut called = 0u32;
+        let outcome = apply_field_str_builtin_raw(inner, "x", |_| {
+            called += 1;
+            RawApplyOutcome::Emit
+        });
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "expected Bail for non-string field input {:?}, got {:?}",
+            std::str::from_utf8(inner).unwrap(),
+            outcome,
+        );
+        assert_eq!(called, 0);
+    }
+}
+
+#[test]
+fn raw_field_str_builtin_escaped_string_bails() {
+    let mut called = 0u32;
+    let outcome = apply_field_str_builtin_raw(
+        br#"{"x":"a\nb"}"#,
+        "x",
+        |_| {
+            called += 1;
+            RawApplyOutcome::Emit
+        },
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert_eq!(called, 0);
+}
+
+#[test]
+fn raw_field_str_builtin_non_object_input_bails() {
+    for raw in [
+        b"42".as_slice(),
+        b"\"hi\"".as_slice(),
+        b"null".as_slice(),
+        b"true".as_slice(),
+        b"[1,2,3]".as_slice(),
+    ] {
+        let mut called = 0u32;
+        let outcome = apply_field_str_builtin_raw(raw, "x", |_| {
+            called += 1;
+            RawApplyOutcome::Emit
+        });
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "expected Bail for str_builtin input {:?}, got {:?}",
             std::str::from_utf8(raw).unwrap(),
             outcome,
         );

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -3224,3 +3224,70 @@ null
 
 (.x | split("") | reverse | join(""))?
 [1,2,3]
+
+# #83 Phase B: .x | <string-builtin>(arg) apply-site uses RawApplyOutcome::Bail.
+# Happy paths covering all 9 fused builtins.
+.x | startswith("ab")
+{"x":"abcdef"}
+true
+
+.x | endswith("ef")
+{"x":"abcdef"}
+true
+
+.x | ltrimstr("ab")
+{"x":"abcdef"}
+"cdef"
+
+.x | rtrimstr("ef")
+{"x":"abcdef"}
+"abcd"
+
+.x | split(",")
+{"x":"a,b,c"}
+["a","b","c"]
+
+.x | index("c")
+{"x":"abc"}
+2
+
+.x | rindex("c")
+{"x":"abcabc"}
+5
+
+.x | indices("a")
+{"x":"banana"}
+[1,3,5]
+
+.x | contains("an")
+{"x":"banana"}
+true
+
+# Field absent under `?` bails to generic; jq raises null|<builtin>; `?` swallows.
+(.x | startswith("a"))?
+{"y":"hi"}
+
+# Non-string field under `?`
+(.x | startswith("a"))?
+{"x":42}
+
+(.x | endswith("a"))?
+{"x":null}
+
+(.x | ltrimstr("a"))?
+{"x":[1,2,3]}
+
+# Escape-bearing string: bail to generic; jq decodes correctly.
+.x | startswith("a")
+{"x":"a\nb"}
+true
+
+# Non-object input under `?`
+(.x | contains("a"))?
+42
+
+(.x | split(","))?
+"hi"
+
+(.x | endswith("a"))?
+[1,2,3]


### PR DESCRIPTION
## Summary
- Migrate the multi-modal `.field | <string-builtin>(arg)` apply-site (stdin + file dispatch) — fuses 9 builtins (`startswith`, `endswith`, `ltrimstr`, `rtrimstr`, `split`, `index`, `rindex`, `indices`, `contains`) — to the named-Bail discipline introduced for #83 Phase B.
- New helper `apply_field_str_builtin_raw` mirrors `apply_field_test_raw`'s type-guard ladder; closure dispatches on builtin name, returns `Bail` for unknown names (defensive fallback).

## Test plan
- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` — 104 fast_path_contract cases + full regression
- [x] `tests/fast_path_contract.rs`: 6 new cases pinning Emit, closure-Bail propagation, and every helper-side Bail branch
- [x] `tests/regression.test`: 18 new cases covering each of the 9 builtins on the happy path plus the `?`-wrapped Bail matrix
- [x] `./bench/comprehensive.sh --quick` — `startswith`/`endswith`/`split` benchmarks track baseline (0.087-0.157s); no regression

Refs: #251 follow-up checkbox `field_str_builtin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)