### PR TITLE
refactor: field_binop apply-site uses RawApplyOutcome (#83 Phase B)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -139,13 +139,13 @@ fn print_jq_error(msg: &str) {
 use jq_jit::value::{Value, json_to_value, json_stream, json_stream_offsets, json_stream_raw, json_stream_project, json_value_has_duplicate_keys, json_stream_has_duplicate_keys, json_object_get_num, json_object_get_two_nums, json_object_get_field_raw, json_object_get_fields_raw_buf, json_object_get_nested_field_raw, parse_json_num, json_value_length, json_object_keys_to_buf_reuse, json_object_extract_keys_only, json_object_keys_unsorted_to_buf, json_object_keys_join_to_buf, json_object_has_key, json_object_has_all_keys, json_object_has_any_key, json_type_byte, json_object_del_field, json_object_del_fields, json_object_filter_by_key_str, json_object_merge_literal, json_object_sort_keys, json_object_filter_by_value_type, json_each_value_raw, json_each_value_cb, json_to_entries_raw, json_with_entries_select_value_cmp, json_object_set_field_raw, json_object_update_field_num, json_object_update_field_num_chain, json_object_update_field_case, json_object_update_field_gsub, json_object_update_field_split_first, json_object_update_field_split_last, json_object_update_field_trim, json_object_update_field_slice, json_object_update_field_str_map, json_object_update_field_str_concat, json_object_update_field_length, json_object_update_field_tostring, json_object_update_field_test, json_object_assign_field_arith, json_object_assign_two_fields_arith, json_object_select_then_update_num, json_object_select_then_update_str_concat, json_object_select_compound_then_update_num, json_object_select_str_then_update_num, json_object_values_tostring, is_json_compact, push_json_compact_raw, push_tojson_raw, push_json_pretty_raw, push_json_pretty_raw_at, value_to_json_precise, value_to_json_pretty_ext, push_compact_line, push_compact_line_color, push_pretty_line, push_pretty_line_color, push_jq_number_bytes, write_value_compact_ext, write_value_compact_line, write_value_pretty_line_color, value_to_json_pretty_color, walk_json_transform_nums, pool_value, skip_json_value};
 use jq_jit::interpreter::Filter;
 use jq_jit::fast_path::{
-    apply_field_access_raw, apply_field_alternative_raw, apply_field_field_alternative_raw,
-    apply_field_format_raw, apply_field_gsub_raw, apply_field_ltrimstr_tonumber_raw,
-    apply_field_match_raw, apply_field_scan_raw, apply_field_str_builtin_raw,
-    apply_field_str_concat_raw, apply_field_str_reverse_raw, apply_field_test_raw,
-    apply_full_object_fields_raw, apply_has_field_raw, apply_has_multi_field_raw,
-    apply_multi_field_access_raw, apply_nested_field_access_raw, apply_object_compute_raw,
-    RawApplyOutcome,
+    apply_field_access_raw, apply_field_alternative_raw, apply_field_binop_raw,
+    apply_field_field_alternative_raw, apply_field_format_raw, apply_field_gsub_raw,
+    apply_field_ltrimstr_tonumber_raw, apply_field_match_raw, apply_field_scan_raw,
+    apply_field_str_builtin_raw, apply_field_str_concat_raw, apply_field_str_reverse_raw,
+    apply_field_test_raw, apply_full_object_fields_raw, apply_has_field_raw,
+    apply_has_multi_field_raw, apply_multi_field_access_raw, apply_nested_field_access_raw,
+    apply_object_compute_raw, RawApplyOutcome,
 };
 
 fn json_escape_bytes(bytes: &[u8]) -> Vec<u8> {
@@ -5833,27 +5833,13 @@ fn real_main() {
                         Ok(())
                     })
                 } else if let Some((ref f1, ref op, ref f2)) = field_binop {
-                    use jq_jit::ir::BinOp;
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        if let Some((a, b)) = json_object_get_two_nums(raw, 0, f1, f2) {
-                            let result = match op {
-                                BinOp::Add => a + b,
-                                BinOp::Sub => a - b,
-                                BinOp::Mul => a * b,
-                                BinOp::Div => a / b,
-                                BinOp::Mod => jq_jit::runtime::jq_mod_f64(a, b).unwrap_or(f64::NAN),
-                                _ => unreachable!(),
-                            };
-                            if result.is_finite() {
-                                push_jq_number_bytes(&mut compact_buf, result);
-                                compact_buf.push(b'\n');
-                            } else {
-                                // Division by zero or mod edge case: fall back to normal path for error handling
-                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                            }
-                        } else {
+                        let outcome = apply_field_binop_raw(raw, f1, f2, *op, |result| {
+                            push_jq_number_bytes(&mut compact_buf, result);
+                            compact_buf.push(b'\n');
+                        });
+                        if let RawApplyOutcome::Bail = outcome {
                             let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                             process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }
@@ -19145,28 +19131,16 @@ fn real_main() {
                 })
             } else if let Some((ref f1, ref op, ref f2)) = field_binop {
                 // Arithmetic fast path: extract two numeric fields, compute, output.
-                // Falls back to normal JIT if fields are missing or non-numeric.
-                use jq_jit::ir::BinOp;
+                // Falls back to normal JIT if fields are missing or non-numeric or
+                // the result is non-finite (jq raises on div-by-zero etc.).
                 let content_bytes = content.as_bytes();
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    if let Some((a, b)) = json_object_get_two_nums(raw, 0, f1, f2) {
-                        let result = match op {
-                            BinOp::Add => a + b,
-                            BinOp::Sub => a - b,
-                            BinOp::Mul => a * b,
-                            BinOp::Div => if b == 0.0 { f64::NAN } else { a / b },
-                            BinOp::Mod => jq_jit::runtime::jq_mod_f64(a, b).unwrap_or(f64::NAN),
-                            _ => unreachable!(),
-                        };
-                        if result.is_nan() {
-                            compact_buf.extend_from_slice(b"null\n");
-                        } else {
-                            push_jq_number_bytes(&mut compact_buf, result);
-                            compact_buf.push(b'\n');
-                        }
-                    } else {
-                        // Field missing or non-numeric: fall back to parse + JIT
+                    let outcome = apply_field_binop_raw(raw, f1, f2, *op, |result| {
+                        push_jq_number_bytes(&mut compact_buf, result);
+                        compact_buf.push(b'\n');
+                    });
+                    if let RawApplyOutcome::Bail = outcome {
                         let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                         process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                     }

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -66,8 +66,8 @@ use crate::ir::BinOp;
 use crate::runtime::jq_mod_f64;
 use crate::value::{
     KeyStr, Value, ObjInner, json_object_get_field_raw, json_object_get_fields_raw_buf,
-    json_object_get_nested_field_raw, json_object_has_all_keys, json_object_has_any_key,
-    json_object_has_key,
+    json_object_get_nested_field_raw, json_object_get_two_nums, json_object_has_all_keys,
+    json_object_has_any_key, json_object_has_key,
 };
 
 /// A fast path whose type-dispatch obligations are encoded in its
@@ -668,6 +668,55 @@ where
         return RawApplyOutcome::Bail;
     }
     on_string(&val[1..val.len() - 1])
+}
+
+/// Apply the `.x <op> .y` raw-byte arithmetic fast path on a single
+/// JSON record where both `.x` and `.y` resolve to JSON numbers.
+///
+/// Bail discipline:
+/// * Either field is absent, or either value isn't a JSON number —
+///   [`RawApplyOutcome::Bail`] (the generic path raises jq's
+///   `<type> and <type> cannot be added` / similar).
+/// * `op` is anything other than `Add`/`Sub`/`Mul`/`Div`/`Mod` —
+///   [`RawApplyOutcome::Bail`] (the detector should never produce a
+///   non-arithmetic op for this shape, but the helper rejects it
+///   defensively rather than wrap the comparison ops in a coerced
+///   `f64`).
+/// * The arithmetic result is non-finite (div-by-zero, mod-by-zero,
+///   IEEE NaN/∞) — [`RawApplyOutcome::Bail`] so the generic path
+///   produces jq's runtime error (`/ by zero`, etc.).
+/// * Non-object input — [`RawApplyOutcome::Bail`] (number lookup
+///   fails).
+///
+/// On a passing type-guard with a finite result, invokes `emit(n)` so
+/// the apply-site owns JSON-number formatting.
+pub fn apply_field_binop_raw<F>(
+    raw: &[u8],
+    field_a: &str,
+    field_b: &str,
+    op: BinOp,
+    mut emit: F,
+) -> RawApplyOutcome
+where
+    F: FnMut(f64),
+{
+    let (a, b) = match json_object_get_two_nums(raw, 0, field_a, field_b) {
+        Some(p) => p,
+        None => return RawApplyOutcome::Bail,
+    };
+    let result = match op {
+        BinOp::Add => a + b,
+        BinOp::Sub => a - b,
+        BinOp::Mul => a * b,
+        BinOp::Div => a / b,
+        BinOp::Mod => jq_mod_f64(a, b).unwrap_or(f64::NAN),
+        _ => return RawApplyOutcome::Bail,
+    };
+    if !result.is_finite() {
+        return RawApplyOutcome::Bail;
+    }
+    emit(result);
+    RawApplyOutcome::Emit
 }
 
 /// Apply the `.field | <string-builtin>(arg)` raw-byte fast path on a

--- a/tests/fast_path_contract.rs
+++ b/tests/fast_path_contract.rs
@@ -10,12 +10,12 @@
 
 use jq_jit::fast_path::{
     FastPath, FieldAccessPath, RawApplyOutcome, apply_field_access_raw,
-    apply_field_alternative_raw, apply_field_field_alternative_raw, apply_field_format_raw,
-    apply_field_gsub_raw, apply_field_ltrimstr_tonumber_raw, apply_field_match_raw,
-    apply_field_scan_raw, apply_field_str_builtin_raw, apply_field_str_concat_raw,
-    apply_field_str_reverse_raw, apply_field_test_raw, apply_full_object_fields_raw,
-    apply_has_field_raw, apply_has_multi_field_raw, apply_multi_field_access_raw,
-    apply_nested_field_access_raw, apply_object_compute_raw,
+    apply_field_alternative_raw, apply_field_binop_raw, apply_field_field_alternative_raw,
+    apply_field_format_raw, apply_field_gsub_raw, apply_field_ltrimstr_tonumber_raw,
+    apply_field_match_raw, apply_field_scan_raw, apply_field_str_builtin_raw,
+    apply_field_str_concat_raw, apply_field_str_reverse_raw, apply_field_test_raw,
+    apply_full_object_fields_raw, apply_has_field_raw, apply_has_multi_field_raw,
+    apply_multi_field_access_raw, apply_nested_field_access_raw, apply_object_compute_raw,
 };
 use jq_jit::interpreter::Filter;
 use jq_jit::ir::BinOp;
@@ -1791,5 +1791,129 @@ fn raw_field_str_builtin_non_object_input_bails() {
             outcome,
         );
         assert_eq!(called, 0);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// `.x <op> .y` — both fields must be JSON numbers; the helper computes the
+// arithmetic and Bails on missing/non-numeric fields, on a non-arithmetic op
+// (defensive), and on a non-finite result (so the generic path raises jq's
+// `/ by zero` error).
+
+#[test]
+fn raw_field_binop_add_emits_sum() {
+    let mut emitted: Vec<f64> = Vec::new();
+    let outcome = apply_field_binop_raw(
+        b"{\"x\":3,\"y\":4}",
+        "x",
+        "y",
+        BinOp::Add,
+        |n| emitted.push(n),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec![7.0]);
+}
+
+#[test]
+fn raw_field_binop_handles_all_arith_ops() {
+    for (op, expected) in [
+        (BinOp::Add, 13.0),
+        (BinOp::Sub, 7.0),
+        (BinOp::Mul, 30.0),
+        (BinOp::Div, 10.0 / 3.0),
+        (BinOp::Mod, 1.0),
+    ] {
+        let mut emitted: Vec<f64> = Vec::new();
+        let outcome = apply_field_binop_raw(
+            b"{\"x\":10,\"y\":3}",
+            "x",
+            "y",
+            op,
+            |n| emitted.push(n),
+        );
+        assert!(matches!(outcome, RawApplyOutcome::Emit));
+        assert_eq!(emitted, vec![expected], "op={:?}", op);
+    }
+}
+
+#[test]
+fn raw_field_binop_div_by_zero_bails() {
+    let mut emitted: Vec<f64> = Vec::new();
+    let outcome = apply_field_binop_raw(
+        b"{\"x\":1,\"y\":0}",
+        "x",
+        "y",
+        BinOp::Div,
+        |n| emitted.push(n),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_field_binop_non_arith_op_bails() {
+    let mut emitted: Vec<f64> = Vec::new();
+    let outcome = apply_field_binop_raw(
+        b"{\"x\":1,\"y\":2}",
+        "x",
+        "y",
+        BinOp::Eq,
+        |n| emitted.push(n),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_field_binop_field_missing_bails() {
+    let mut emitted: Vec<f64> = Vec::new();
+    let outcome = apply_field_binop_raw(
+        b"{\"x\":1}",
+        "x",
+        "y",
+        BinOp::Add,
+        |n| emitted.push(n),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_field_binop_non_numeric_field_bails() {
+    for inner in [
+        &b"{\"x\":\"hi\",\"y\":1}"[..],
+        &b"{\"x\":1,\"y\":null}"[..],
+        &b"{\"x\":[1],\"y\":2}"[..],
+    ] {
+        let mut emitted: Vec<f64> = Vec::new();
+        let outcome = apply_field_binop_raw(inner, "x", "y", BinOp::Add, |n| emitted.push(n));
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "expected Bail for non-numeric field input {:?}, got {:?}",
+            std::str::from_utf8(inner).unwrap(),
+            outcome,
+        );
+        assert!(emitted.is_empty());
+    }
+}
+
+#[test]
+fn raw_field_binop_non_object_input_bails() {
+    for raw in [
+        b"42".as_slice(),
+        b"\"hi\"".as_slice(),
+        b"null".as_slice(),
+        b"true".as_slice(),
+        b"[1,2,3]".as_slice(),
+    ] {
+        let mut emitted: Vec<f64> = Vec::new();
+        let outcome = apply_field_binop_raw(raw, "x", "y", BinOp::Add, |n| emitted.push(n));
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "expected Bail for binop input {:?}, got {:?}",
+            std::str::from_utf8(raw).unwrap(),
+            outcome,
+        );
+        assert!(emitted.is_empty());
     }
 }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -3291,3 +3291,71 @@ true
 
 (.x | endswith("a"))?
 [1,2,3]
+
+# #83 Phase B: .x <op> .y arithmetic apply-site uses RawApplyOutcome::Bail.
+# Happy path covering all 5 ops.
+.x + .y
+{"x":3,"y":4}
+7
+
+.x - .y
+{"x":10,"y":3}
+7
+
+.x * .y
+{"x":6,"y":7}
+42
+
+.x / .y
+{"x":10,"y":4}
+2.5
+
+.x % .y
+{"x":10,"y":3}
+1
+
+# Div-by-zero: jq raises; bail to generic; `?` swallows.
+(.x / .y)?
+{"x":1,"y":0}
+
+# Mod-by-zero: jq raises; bail to generic; `?` swallows.
+(.x % .y)?
+{"x":5,"y":0}
+
+# Field missing: bail to generic; jq's `null + X == X` holds.
+(.x + .y)?
+{"x":3}
+3
+
+(.x + .y)?
+{"y":4}
+4
+
+# Non-numeric field under `?`: depends on jq's `+` semantics.
+# string + number raises → empty.
+(.x + .y)?
+{"x":"hi","y":1}
+
+# null + 1 == 1 (jq null left-identity).
+.x + .y
+{"x":1,"y":null}
+1
+
+# array + number raises → empty.
+(.x + .y)?
+{"x":[1,2],"y":3}
+
+# Non-object/non-null input under `?`: jq raises "Cannot index <type>".
+(.x + .y)?
+42
+
+(.x + .y)?
+"hi"
+
+(.x + .y)?
+[1,2,3]
+
+# null input: jq returns null (null + null == null).
+.x + .y
+null
+null


### PR DESCRIPTION
## Summary
- Migrate `.x <op> .y` arithmetic apply-site (stdin + file dispatch) to the named-Bail discipline introduced for #83 Phase B.
- New helper `apply_field_binop_raw` covers `Add`/`Sub`/`Mul`/`Div`/`Mod` over two numeric fields. Bails on: missing/non-numeric field, non-arithmetic op (defensive), non-finite result (so the generic path raises jq's `/ by zero`), non-object input.
- Also fixes a pre-existing divergence between the two apply-sites: the file-mode path was silently emitting `null` on div-by-zero (#83-class bug); the stdin path already bailed to generic. Both now go through the helper so the right error fires uniformly.

## Test plan
- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` — 111 fast_path_contract cases + full regression
- [x] `tests/fast_path_contract.rs`: 7 new cases pinning Emit for all 5 ops, div-by-zero Bail, non-arith op Bail, missing/non-numeric/non-object Bail
- [x] `tests/regression.test`: 17 new cases covering arithmetic happy paths, div/mod-by-zero raises, jq's `null + X == X` left-identity, and the `?`-wrapped Bail matrix
- [x] `./bench/comprehensive.sh --quick` — `arithmetic .x + .y` benchmark at 0.064s (in line with baseline)

Refs: #251 follow-up checkbox `field_binop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)