### PR TITLE
refactor: field_field_cmp apply-site uses RawApplyOutcome (#83 Phase B)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -140,12 +140,13 @@ use jq_jit::value::{Value, json_to_value, json_stream, json_stream_offsets, json
 use jq_jit::interpreter::Filter;
 use jq_jit::fast_path::{
     apply_field_access_raw, apply_field_alternative_raw, apply_field_arith_chain_raw,
-    apply_field_binop_raw, apply_field_field_alternative_raw, apply_field_format_raw,
-    apply_field_gsub_raw, apply_field_ltrimstr_tonumber_raw, apply_field_match_raw,
-    apply_field_scan_raw, apply_field_str_builtin_raw, apply_field_str_concat_raw,
-    apply_field_str_reverse_raw, apply_field_test_raw, apply_full_object_fields_raw,
-    apply_has_field_raw, apply_has_multi_field_raw, apply_multi_field_access_raw,
-    apply_nested_field_access_raw, apply_object_compute_raw, RawApplyOutcome,
+    apply_field_binop_raw, apply_field_field_alternative_raw, apply_field_field_cmp_raw,
+    apply_field_format_raw, apply_field_gsub_raw, apply_field_ltrimstr_tonumber_raw,
+    apply_field_match_raw, apply_field_scan_raw, apply_field_str_builtin_raw,
+    apply_field_str_concat_raw, apply_field_str_reverse_raw, apply_field_test_raw,
+    apply_full_object_fields_raw, apply_has_field_raw, apply_has_multi_field_raw,
+    apply_multi_field_access_raw, apply_nested_field_access_raw, apply_object_compute_raw,
+    RawApplyOutcome,
 };
 
 fn json_escape_bytes(bytes: &[u8]) -> Vec<u8> {
@@ -6307,18 +6308,12 @@ fn real_main() {
                         Ok(())
                     })
                 } else if let Some((ref f1, ref cmp_op, ref f2)) = field_field_cmp {
-                    use jq_jit::ir::BinOp;
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        if let Some((n1, n2)) = json_object_get_two_nums(raw, 0, f1, f2) {
-                            let result = match cmp_op {
-                                BinOp::Gt => n1 > n2, BinOp::Lt => n1 < n2,
-                                BinOp::Ge => n1 >= n2, BinOp::Le => n1 <= n2,
-                                BinOp::Eq => n1 == n2, BinOp::Ne => n1 != n2,
-                                _ => unreachable!(),
-                            };
+                        let outcome = apply_field_field_cmp_raw(raw, f1, f2, *cmp_op, |result| {
                             compact_buf.extend_from_slice(if result { b"true\n" } else { b"false\n" });
-                        } else {
+                        });
+                        if let RawApplyOutcome::Bail = outcome {
                             let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                             process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }
@@ -19560,19 +19555,13 @@ fn real_main() {
                     Ok(())
                 })
             } else if let Some((ref f1, ref cmp_op, ref f2)) = field_field_cmp {
-                use jq_jit::ir::BinOp;
                 let content_bytes = content.as_bytes();
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    if let Some((n1, n2)) = json_object_get_two_nums(raw, 0, f1, f2) {
-                        let result = match cmp_op {
-                            BinOp::Gt => n1 > n2, BinOp::Lt => n1 < n2,
-                            BinOp::Ge => n1 >= n2, BinOp::Le => n1 <= n2,
-                            BinOp::Eq => n1 == n2, BinOp::Ne => n1 != n2,
-                            _ => unreachable!(),
-                        };
+                    let outcome = apply_field_field_cmp_raw(raw, f1, f2, *cmp_op, |result| {
                         compact_buf.extend_from_slice(if result { b"true\n" } else { b"false\n" });
-                    } else {
+                    });
+                    if let RawApplyOutcome::Bail = outcome {
                         let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                         process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                     }

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -719,6 +719,50 @@ where
     RawApplyOutcome::Emit
 }
 
+/// Apply the `.x <cmp> .y` raw-byte numeric-comparison fast path on a
+/// single JSON record (`<cmp>` ∈ Gt/Lt/Ge/Le/Eq/Ne) where both fields
+/// resolve to JSON numbers.
+///
+/// jq's `==`/`!=` work on every type (`null == null`, `"a" == "a"`),
+/// but this fast path only commits when both fields are numbers; the
+/// generic path handles every other type combination so cross-type
+/// equality (e.g. `null == null`) doesn't silently take the numeric
+/// branch.
+///
+/// Bail discipline:
+/// * Either field absent or non-numeric — [`RawApplyOutcome::Bail`].
+/// * Non-comparison op (`Add`/`And`/etc.) — [`RawApplyOutcome::Bail`]
+///   (defensive — the detector should never produce these).
+/// * Non-object input — [`RawApplyOutcome::Bail`].
+///
+/// On success, invokes `emit(result)` with the boolean comparison.
+pub fn apply_field_field_cmp_raw<F>(
+    raw: &[u8],
+    field_a: &str,
+    field_b: &str,
+    cmp_op: BinOp,
+    mut emit: F,
+) -> RawApplyOutcome
+where
+    F: FnMut(bool),
+{
+    let (a, b) = match json_object_get_two_nums(raw, 0, field_a, field_b) {
+        Some(p) => p,
+        None => return RawApplyOutcome::Bail,
+    };
+    let result = match cmp_op {
+        BinOp::Gt => a > b,
+        BinOp::Lt => a < b,
+        BinOp::Ge => a >= b,
+        BinOp::Le => a <= b,
+        BinOp::Eq => a == b,
+        BinOp::Ne => a != b,
+        _ => return RawApplyOutcome::Bail,
+    };
+    emit(result);
+    RawApplyOutcome::Emit
+}
+
 /// Apply the `.field <op1> <c1> <op2> <c2> ...` raw-byte arithmetic chain
 /// fast path on a single JSON record (a left-fold of `(BinOp, f64)` pairs
 /// over a single numeric field).

--- a/tests/fast_path_contract.rs
+++ b/tests/fast_path_contract.rs
@@ -11,12 +11,12 @@
 use jq_jit::fast_path::{
     FastPath, FieldAccessPath, RawApplyOutcome, apply_field_access_raw,
     apply_field_alternative_raw, apply_field_arith_chain_raw, apply_field_binop_raw,
-    apply_field_field_alternative_raw, apply_field_format_raw, apply_field_gsub_raw,
-    apply_field_ltrimstr_tonumber_raw, apply_field_match_raw, apply_field_scan_raw,
-    apply_field_str_builtin_raw, apply_field_str_concat_raw, apply_field_str_reverse_raw,
-    apply_field_test_raw, apply_full_object_fields_raw, apply_has_field_raw,
-    apply_has_multi_field_raw, apply_multi_field_access_raw, apply_nested_field_access_raw,
-    apply_object_compute_raw,
+    apply_field_field_alternative_raw, apply_field_field_cmp_raw, apply_field_format_raw,
+    apply_field_gsub_raw, apply_field_ltrimstr_tonumber_raw, apply_field_match_raw,
+    apply_field_scan_raw, apply_field_str_builtin_raw, apply_field_str_concat_raw,
+    apply_field_str_reverse_raw, apply_field_test_raw, apply_full_object_fields_raw,
+    apply_has_field_raw, apply_has_multi_field_raw, apply_multi_field_access_raw,
+    apply_nested_field_access_raw, apply_object_compute_raw,
 };
 use jq_jit::interpreter::Filter;
 use jq_jit::ir::BinOp;
@@ -2015,6 +2015,106 @@ fn raw_field_arith_chain_non_object_input_bails() {
         assert!(
             matches!(outcome, RawApplyOutcome::Bail),
             "expected Bail for arith_chain input {:?}, got {:?}",
+            std::str::from_utf8(raw).unwrap(),
+            outcome,
+        );
+        assert!(emitted.is_empty());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// `.x <cmp> .y` — numeric comparison fast path. Helper Bails on missing /
+// non-numeric / non-comparison-op / non-object so cross-type equality (e.g.
+// `null == null`) doesn't silently take the numeric branch.
+
+#[test]
+fn raw_field_field_cmp_handles_all_ops() {
+    for (op, expected) in [
+        (BinOp::Gt, true),  // 5 > 3
+        (BinOp::Lt, false),
+        (BinOp::Ge, true),
+        (BinOp::Le, false),
+        (BinOp::Eq, false),
+        (BinOp::Ne, true),
+    ] {
+        let mut emitted: Vec<bool> = Vec::new();
+        let outcome = apply_field_field_cmp_raw(
+            b"{\"x\":5,\"y\":3}",
+            "x",
+            "y",
+            op,
+            |b| emitted.push(b),
+        );
+        assert!(matches!(outcome, RawApplyOutcome::Emit));
+        assert_eq!(emitted, vec![expected], "op={:?}", op);
+    }
+}
+
+#[test]
+fn raw_field_field_cmp_non_cmp_op_bails() {
+    let mut emitted: Vec<bool> = Vec::new();
+    let outcome = apply_field_field_cmp_raw(
+        b"{\"x\":1,\"y\":2}",
+        "x",
+        "y",
+        BinOp::Add,
+        |b| emitted.push(b),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_field_field_cmp_field_missing_bails() {
+    let mut emitted: Vec<bool> = Vec::new();
+    let outcome = apply_field_field_cmp_raw(
+        b"{\"x\":1}",
+        "x",
+        "y",
+        BinOp::Eq,
+        |b| emitted.push(b),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_field_field_cmp_non_numeric_field_bails() {
+    // Both nulls would compare equal in jq, but the helper bails so the
+    // generic path takes over (so the fast path doesn't shadow non-numeric
+    // equality semantics).
+    for inner in [
+        &b"{\"x\":\"a\",\"y\":\"a\"}"[..],
+        &b"{\"x\":null,\"y\":null}"[..],
+        &b"{\"x\":[1],\"y\":[1]}"[..],
+        &b"{\"x\":1,\"y\":\"1\"}"[..],
+    ] {
+        let mut emitted: Vec<bool> = Vec::new();
+        let outcome = apply_field_field_cmp_raw(inner, "x", "y", BinOp::Eq, |b| emitted.push(b));
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "expected Bail for non-numeric field input {:?}, got {:?}",
+            std::str::from_utf8(inner).unwrap(),
+            outcome,
+        );
+        assert!(emitted.is_empty());
+    }
+}
+
+#[test]
+fn raw_field_field_cmp_non_object_input_bails() {
+    for raw in [
+        b"42".as_slice(),
+        b"\"hi\"".as_slice(),
+        b"null".as_slice(),
+        b"true".as_slice(),
+        b"[1,2,3]".as_slice(),
+    ] {
+        let mut emitted: Vec<bool> = Vec::new();
+        let outcome = apply_field_field_cmp_raw(raw, "x", "y", BinOp::Eq, |b| emitted.push(b));
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "expected Bail for field_field_cmp input {:?}, got {:?}",
             std::str::from_utf8(raw).unwrap(),
             outcome,
         );

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -3395,3 +3395,50 @@ null
 
 (.x * 2 + 1)?
 [1,2,3]
+
+# #83 Phase B: .x <cmp> .y numeric comparison apply-site uses
+# RawApplyOutcome::Bail.
+.x > .y
+{"x":5,"y":3}
+true
+
+.x < .y
+{"x":5,"y":3}
+false
+
+.x == .y
+{"x":2,"y":2}
+true
+
+.x != .y
+{"x":2,"y":2}
+false
+
+# Field missing: bail to generic; jq's `.x == .y` on missing fields is
+# `null == null == true`.
+.x == .y
+{}
+true
+
+# Cross-type equality routes through generic — fast path bails.
+.x == .y
+{"x":"hi","y":"hi"}
+true
+
+.x == .y
+{"x":null,"y":null}
+true
+
+.x == .y
+{"x":1,"y":"1"}
+false
+
+# Non-object input under `?`
+(.x > .y)?
+42
+
+(.x > .y)?
+"hi"
+
+(.x > .y)?
+[1,2,3]


### PR DESCRIPTION
## Summary
- Migrate `.x <cmp> .y` numeric-comparison apply-site (stdin + file dispatch) to the named-Bail discipline introduced for #83 Phase B.
- New helper `apply_field_field_cmp_raw` covers Gt/Lt/Ge/Le/Eq/Ne. jq's `==`/`!=` work on every type, but this fast path only commits when both fields are numbers — the helper Bails on every other type combination so cross-type equality goes through the generic path.
- Bail branches: missing field, non-numeric field, non-comparison op (defensive), non-object input.

## Test plan
- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` — 122 fast_path_contract cases + full regression
- [x] `tests/fast_path_contract.rs`: 5 new cases pinning all 6 ops, non-cmp-op Bail, missing/non-numeric/non-object Bail
- [x] `tests/regression.test`: 11 new cases including cross-type equality routing through generic and the `?`-wrapped Bail matrix
- [x] `./bench/comprehensive.sh --quick` — adjacent benchmarks track baseline; no regression

Refs: #251 follow-up checkbox `field_field_cmp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)