### PR TITLE
refactor: field_const_cmp apply-site uses RawApplyOutcome (#83 Phase B)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -140,13 +140,13 @@ use jq_jit::value::{Value, json_to_value, json_stream, json_stream_offsets, json
 use jq_jit::interpreter::Filter;
 use jq_jit::fast_path::{
     apply_field_access_raw, apply_field_alternative_raw, apply_field_arith_chain_raw,
-    apply_field_binop_raw, apply_field_field_alternative_raw, apply_field_field_cmp_raw,
-    apply_field_format_raw, apply_field_gsub_raw, apply_field_ltrimstr_tonumber_raw,
-    apply_field_match_raw, apply_field_scan_raw, apply_field_str_builtin_raw,
-    apply_field_str_concat_raw, apply_field_str_reverse_raw, apply_field_test_raw,
-    apply_full_object_fields_raw, apply_has_field_raw, apply_has_multi_field_raw,
-    apply_multi_field_access_raw, apply_nested_field_access_raw, apply_object_compute_raw,
-    RawApplyOutcome,
+    apply_field_binop_raw, apply_field_const_cmp_raw, apply_field_field_alternative_raw,
+    apply_field_field_cmp_raw, apply_field_format_raw, apply_field_gsub_raw,
+    apply_field_ltrimstr_tonumber_raw, apply_field_match_raw, apply_field_scan_raw,
+    apply_field_str_builtin_raw, apply_field_str_concat_raw, apply_field_str_reverse_raw,
+    apply_field_test_raw, apply_full_object_fields_raw, apply_has_field_raw,
+    apply_has_multi_field_raw, apply_multi_field_access_raw, apply_nested_field_access_raw,
+    apply_object_compute_raw, RawApplyOutcome,
 };
 
 fn json_escape_bytes(bytes: &[u8]) -> Vec<u8> {
@@ -6324,18 +6324,12 @@ fn real_main() {
                         Ok(())
                     })
                 } else if let Some((ref field, ref cmp_op, cval)) = field_const_cmp {
-                    use jq_jit::ir::BinOp;
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        if let Some(n) = json_object_get_num(raw, 0, field) {
-                            let result = match cmp_op {
-                                BinOp::Gt => n > cval, BinOp::Lt => n < cval,
-                                BinOp::Ge => n >= cval, BinOp::Le => n <= cval,
-                                BinOp::Eq => n == cval, BinOp::Ne => n != cval,
-                                _ => unreachable!(),
-                            };
+                        let outcome = apply_field_const_cmp_raw(raw, field, *cmp_op, cval, |result| {
                             compact_buf.extend_from_slice(if result { b"true\n" } else { b"false\n" });
-                        } else {
+                        });
+                        if let RawApplyOutcome::Bail = outcome {
                             let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                             process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }
@@ -19572,19 +19566,13 @@ fn real_main() {
                     Ok(())
                 })
             } else if let Some((ref field, ref cmp_op, cval)) = field_const_cmp {
-                use jq_jit::ir::BinOp;
                 let content_bytes = content.as_bytes();
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    if let Some(n) = json_object_get_num(raw, 0, field) {
-                        let result = match cmp_op {
-                            BinOp::Gt => n > cval, BinOp::Lt => n < cval,
-                            BinOp::Ge => n >= cval, BinOp::Le => n <= cval,
-                            BinOp::Eq => n == cval, BinOp::Ne => n != cval,
-                            _ => unreachable!(),
-                        };
+                    let outcome = apply_field_const_cmp_raw(raw, field, *cmp_op, cval, |result| {
                         compact_buf.extend_from_slice(if result { b"true\n" } else { b"false\n" });
-                    } else {
+                    });
+                    if let RawApplyOutcome::Bail = outcome {
                         let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                         process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                     }

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -763,6 +763,45 @@ where
     RawApplyOutcome::Emit
 }
 
+/// Apply the `.field <cmp> <const>` raw-byte numeric-comparison fast
+/// path on a single JSON record (`<cmp>` ∈ Gt/Lt/Ge/Le/Eq/Ne) where
+/// the field resolves to a JSON number and the right-hand side is a
+/// compile-time numeric constant.
+///
+/// Bail discipline mirrors [`apply_field_field_cmp_raw`]:
+/// * Field absent or non-numeric — [`RawApplyOutcome::Bail`].
+/// * Non-comparison op (`Add`/`And`/etc.) — [`RawApplyOutcome::Bail`]
+///   (defensive — the detector should never produce these).
+/// * Non-object input — [`RawApplyOutcome::Bail`].
+///
+/// On success, invokes `emit(result)` with the boolean comparison.
+pub fn apply_field_const_cmp_raw<F>(
+    raw: &[u8],
+    field: &str,
+    cmp_op: BinOp,
+    cval: f64,
+    mut emit: F,
+) -> RawApplyOutcome
+where
+    F: FnMut(bool),
+{
+    let n = match json_object_get_num(raw, 0, field) {
+        Some(n) => n,
+        None => return RawApplyOutcome::Bail,
+    };
+    let result = match cmp_op {
+        BinOp::Gt => n > cval,
+        BinOp::Lt => n < cval,
+        BinOp::Ge => n >= cval,
+        BinOp::Le => n <= cval,
+        BinOp::Eq => n == cval,
+        BinOp::Ne => n != cval,
+        _ => return RawApplyOutcome::Bail,
+    };
+    emit(result);
+    RawApplyOutcome::Emit
+}
+
 /// Apply the `.field <op1> <c1> <op2> <c2> ...` raw-byte arithmetic chain
 /// fast path on a single JSON record (a left-fold of `(BinOp, f64)` pairs
 /// over a single numeric field).

--- a/tests/fast_path_contract.rs
+++ b/tests/fast_path_contract.rs
@@ -11,12 +11,12 @@
 use jq_jit::fast_path::{
     FastPath, FieldAccessPath, RawApplyOutcome, apply_field_access_raw,
     apply_field_alternative_raw, apply_field_arith_chain_raw, apply_field_binop_raw,
-    apply_field_field_alternative_raw, apply_field_field_cmp_raw, apply_field_format_raw,
-    apply_field_gsub_raw, apply_field_ltrimstr_tonumber_raw, apply_field_match_raw,
-    apply_field_scan_raw, apply_field_str_builtin_raw, apply_field_str_concat_raw,
-    apply_field_str_reverse_raw, apply_field_test_raw, apply_full_object_fields_raw,
-    apply_has_field_raw, apply_has_multi_field_raw, apply_multi_field_access_raw,
-    apply_nested_field_access_raw, apply_object_compute_raw,
+    apply_field_const_cmp_raw, apply_field_field_alternative_raw, apply_field_field_cmp_raw,
+    apply_field_format_raw, apply_field_gsub_raw, apply_field_ltrimstr_tonumber_raw,
+    apply_field_match_raw, apply_field_scan_raw, apply_field_str_builtin_raw,
+    apply_field_str_concat_raw, apply_field_str_reverse_raw, apply_field_test_raw,
+    apply_full_object_fields_raw, apply_has_field_raw, apply_has_multi_field_raw,
+    apply_multi_field_access_raw, apply_nested_field_access_raw, apply_object_compute_raw,
 };
 use jq_jit::interpreter::Filter;
 use jq_jit::ir::BinOp;
@@ -2115,6 +2115,104 @@ fn raw_field_field_cmp_non_object_input_bails() {
         assert!(
             matches!(outcome, RawApplyOutcome::Bail),
             "expected Bail for field_field_cmp input {:?}, got {:?}",
+            std::str::from_utf8(raw).unwrap(),
+            outcome,
+        );
+        assert!(emitted.is_empty());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// `.field <cmp> N` — numeric comparison vs compile-time constant. Same Bail
+// surface as `apply_field_field_cmp_raw` but only one field needs to be
+// numeric.
+
+#[test]
+fn raw_field_const_cmp_handles_all_ops() {
+    for (op, expected) in [
+        (BinOp::Gt, true),
+        (BinOp::Lt, false),
+        (BinOp::Ge, true),
+        (BinOp::Le, false),
+        (BinOp::Eq, false),
+        (BinOp::Ne, true),
+    ] {
+        let mut emitted: Vec<bool> = Vec::new();
+        let outcome = apply_field_const_cmp_raw(
+            b"{\"x\":5}",
+            "x",
+            op,
+            3.0,
+            |b| emitted.push(b),
+        );
+        assert!(matches!(outcome, RawApplyOutcome::Emit));
+        assert_eq!(emitted, vec![expected], "op={:?}", op);
+    }
+}
+
+#[test]
+fn raw_field_const_cmp_non_cmp_op_bails() {
+    let mut emitted: Vec<bool> = Vec::new();
+    let outcome = apply_field_const_cmp_raw(
+        b"{\"x\":1}",
+        "x",
+        BinOp::Add,
+        2.0,
+        |b| emitted.push(b),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_field_const_cmp_field_missing_bails() {
+    let mut emitted: Vec<bool> = Vec::new();
+    let outcome = apply_field_const_cmp_raw(
+        b"{\"y\":1}",
+        "x",
+        BinOp::Eq,
+        1.0,
+        |b| emitted.push(b),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_field_const_cmp_non_numeric_field_bails() {
+    for inner in [
+        &b"{\"x\":\"hi\"}"[..],
+        &b"{\"x\":null}"[..],
+        &b"{\"x\":[1]}"[..],
+    ] {
+        let mut emitted: Vec<bool> = Vec::new();
+        let outcome =
+            apply_field_const_cmp_raw(inner, "x", BinOp::Eq, 1.0, |b| emitted.push(b));
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "expected Bail for non-numeric field input {:?}, got {:?}",
+            std::str::from_utf8(inner).unwrap(),
+            outcome,
+        );
+        assert!(emitted.is_empty());
+    }
+}
+
+#[test]
+fn raw_field_const_cmp_non_object_input_bails() {
+    for raw in [
+        b"42".as_slice(),
+        b"\"hi\"".as_slice(),
+        b"null".as_slice(),
+        b"true".as_slice(),
+        b"[1,2,3]".as_slice(),
+    ] {
+        let mut emitted: Vec<bool> = Vec::new();
+        let outcome =
+            apply_field_const_cmp_raw(raw, "x", BinOp::Eq, 1.0, |b| emitted.push(b));
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "expected Bail for field_const_cmp input {:?}, got {:?}",
             std::str::from_utf8(raw).unwrap(),
             outcome,
         );

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -3442,3 +3442,52 @@ false
 
 (.x > .y)?
 [1,2,3]
+
+# #83 Phase B: .field <cmp> N apply-site uses RawApplyOutcome::Bail.
+.x > 3
+{"x":5}
+true
+
+.x < 3
+{"x":5}
+false
+
+.x == 5
+{"x":5}
+true
+
+.x != 5
+{"x":5}
+false
+
+# Field missing: bail to generic; jq's `null > 3` is false (null orders
+# below everything in jq's mixed-type ordering).
+.x > 3
+{"y":1}
+false
+
+# null == N is false in jq.
+.x == 5
+{"y":1}
+false
+
+# Non-numeric field: bail; jq orders string > number.
+.x > 3
+{"x":"hi"}
+true
+
+# null input: bail; jq's `.x | (.x == N)` on null treats . as null;
+# `null == 5` is false (no raise).
+.x == 5
+null
+false
+
+# Non-object input under `?`: jq raises "Cannot index <type>".
+(.x > 3)?
+42
+
+(.x > 3)?
+"hi"
+
+(.x > 3)?
+[1,2,3]


### PR DESCRIPTION
## Summary
- Migrate `.field <cmp> <const>` numeric-comparison apply-site (stdin + file dispatch) to the named-Bail discipline introduced for #83 Phase B.
- New helper `apply_field_const_cmp_raw` covers Gt/Lt/Ge/Le/Eq/Ne. Same Bail surface as `apply_field_field_cmp_raw`, just with a single field + constant.
- Bail branches: missing field, non-numeric field, non-comparison op (defensive), non-object input. The generic path handles cross-type ordering correctly (null < everything, string > number, etc.).

## Test plan
- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` — 127 fast_path_contract cases + full regression
- [x] `tests/fast_path_contract.rs`: 5 new cases pinning all 6 ops, non-cmp-op Bail, missing/non-numeric/non-object Bail
- [x] `tests/regression.test`: 11 new cases including jq's mixed-type ordering routing through generic, and the `?`-wrapped Bail matrix
- [x] `./bench/comprehensive.sh --quick` — adjacent benchmarks track baseline

Refs: #251 follow-up checkbox `field_const_cmp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)