### PR TITLE
refactor: select_field_null apply-site uses RawApplyOutcome (#83 Phase B)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -147,7 +147,7 @@ use jq_jit::fast_path::{
     apply_field_str_reverse_raw, apply_field_test_raw, apply_full_object_fields_raw,
     apply_has_field_raw, apply_has_multi_field_raw, apply_multi_field_access_raw,
     apply_nested_field_access_raw, apply_object_compute_raw, apply_select_cmp_raw,
-    RawApplyOutcome,
+    apply_select_field_null_raw, RawApplyOutcome,
 };
 
 fn json_escape_bytes(bytes: &[u8]) -> Vec<u8> {
@@ -7485,23 +7485,16 @@ fn real_main() {
                     // `.field` surfaces (#199 sibling).
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        if raw.is_empty() || raw[0] != b'{' {
+                        let outcome = apply_select_field_null_raw(raw, field, is_eq, |record| {
+                            emit_raw_ln!(&mut compact_buf, record);
+                        });
+                        if let RawApplyOutcome::Bail = outcome {
                             let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                             process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                            return Ok(());
                         }
-                        let is_null = if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, field) {
-                            &raw[vs..ve] == b"null"
-                        } else {
-                            true // missing field is null
-                        };
-                        let pass = if is_eq { is_null } else { !is_null };
-                        if pass {
-                            emit_raw_ln!(&mut compact_buf, raw);
-                            if compact_buf.len() >= 1 << 17 {
-                                let _ = out.write_all(&compact_buf);
-                                compact_buf.clear();
-                            }
+                        if compact_buf.len() >= 1 << 17 {
+                            let _ = out.write_all(&compact_buf);
+                            compact_buf.clear();
                         }
                         Ok(())
                     })
@@ -15201,23 +15194,16 @@ fn real_main() {
                 let content_bytes = content.as_bytes();
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    if raw.is_empty() || raw[0] != b'{' {
+                    let outcome = apply_select_field_null_raw(raw, field, is_eq, |record| {
+                        emit_raw_ln!(&mut compact_buf, record);
+                    });
+                    if let RawApplyOutcome::Bail = outcome {
                         let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                         process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                        return Ok(());
                     }
-                    let is_null = if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, field) {
-                        &raw[vs..ve] == b"null"
-                    } else {
-                        true
-                    };
-                    let pass = if is_eq { is_null } else { !is_null };
-                    if pass {
-                        emit_raw_ln!(&mut compact_buf, raw);
-                        if compact_buf.len() >= 1 << 17 {
-                            let _ = out.write_all(&compact_buf);
-                            compact_buf.clear();
-                        }
+                    if compact_buf.len() >= 1 << 17 {
+                        let _ = out.write_all(&compact_buf);
+                        compact_buf.clear();
                     }
                     Ok(())
                 })

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -904,6 +904,43 @@ where
     RawApplyOutcome::Emit
 }
 
+/// Apply the `select(.field == null)` / `select(.field != null)` raw-byte
+/// fast path on a single JSON record.
+///
+/// `is_eq = true` corresponds to `== null`; `is_eq = false` to `!= null`.
+/// A missing field counts as null (jq's `null | .x == null` is true).
+///
+/// Bail discipline:
+/// * Non-object input — [`RawApplyOutcome::Bail`] so jq's
+///   `Cannot index <type>` surfaces (#199 sibling).
+///
+/// On a passing type-guard the helper returns
+/// [`RawApplyOutcome::Emit`] regardless of whether the predicate
+/// fires; the closure is invoked only when it does.
+pub fn apply_select_field_null_raw<F>(
+    raw: &[u8],
+    field: &str,
+    is_eq: bool,
+    mut emit_match: F,
+) -> RawApplyOutcome
+where
+    F: FnMut(&[u8]),
+{
+    if raw.first() != Some(&b'{') {
+        return RawApplyOutcome::Bail;
+    }
+    let is_null = if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, field) {
+        &raw[vs..ve] == b"null"
+    } else {
+        true
+    };
+    let pass = if is_eq { is_null } else { !is_null };
+    if pass {
+        emit_match(raw);
+    }
+    RawApplyOutcome::Emit
+}
+
 /// Apply the `.field <arith_chain> <cmp> <threshold>` raw-byte fast path
 /// on a single JSON record — fold a `(BinOp, f64)` arithmetic chain over
 /// a numeric field, then compare the result against `threshold`.

--- a/tests/fast_path_contract.rs
+++ b/tests/fast_path_contract.rs
@@ -17,7 +17,7 @@ use jq_jit::fast_path::{
     apply_field_str_concat_raw, apply_field_str_reverse_raw, apply_field_test_raw,
     apply_full_object_fields_raw, apply_has_field_raw, apply_has_multi_field_raw,
     apply_multi_field_access_raw, apply_nested_field_access_raw, apply_object_compute_raw,
-    apply_select_cmp_raw,
+    apply_select_cmp_raw, apply_select_field_null_raw,
 };
 use jq_jit::interpreter::Filter;
 use jq_jit::ir::BinOp;
@@ -2431,4 +2431,83 @@ fn raw_select_cmp_non_cmp_op_bails() {
     );
     assert!(matches!(outcome, RawApplyOutcome::Bail));
     assert!(seen.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// `select(.field == null)` / `select(.field != null)` — null-equality
+// predicate fast path. Missing field counts as null.
+
+#[test]
+fn raw_select_field_null_eq_emits_when_null_or_missing() {
+    for input in [&b"{\"x\":null}"[..], &b"{\"y\":1}"[..]] {
+        let mut seen: Vec<Vec<u8>> = Vec::new();
+        let outcome =
+            apply_select_field_null_raw(input, "x", true, |r| seen.push(r.to_vec()));
+        assert!(matches!(outcome, RawApplyOutcome::Emit));
+        assert_eq!(
+            seen,
+            vec![input.to_vec()],
+            "input {:?}",
+            std::str::from_utf8(input).unwrap()
+        );
+    }
+}
+
+#[test]
+fn raw_select_field_null_eq_skips_when_field_present_non_null() {
+    let mut seen: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_select_field_null_raw(
+        b"{\"x\":1}",
+        "x",
+        true,
+        |r| seen.push(r.to_vec()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert!(seen.is_empty());
+}
+
+#[test]
+fn raw_select_field_null_ne_emits_when_field_present_non_null() {
+    let mut seen: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_select_field_null_raw(
+        b"{\"x\":1}",
+        "x",
+        false,
+        |r| seen.push(r.to_vec()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(seen, vec![b"{\"x\":1}".to_vec()]);
+}
+
+#[test]
+fn raw_select_field_null_ne_skips_when_null_or_missing() {
+    for input in [&b"{\"x\":null}"[..], &b"{\"y\":1}"[..]] {
+        let mut seen: Vec<Vec<u8>> = Vec::new();
+        let outcome =
+            apply_select_field_null_raw(input, "x", false, |r| seen.push(r.to_vec()));
+        assert!(matches!(outcome, RawApplyOutcome::Emit));
+        assert!(seen.is_empty());
+    }
+}
+
+#[test]
+fn raw_select_field_null_non_object_bails_for_type_error() {
+    for raw in [
+        b"42".as_slice(),
+        b"\"hi\"".as_slice(),
+        b"null".as_slice(),
+        b"true".as_slice(),
+        b"[1,2,3]".as_slice(),
+    ] {
+        let mut seen: Vec<Vec<u8>> = Vec::new();
+        let outcome =
+            apply_select_field_null_raw(raw, "x", true, |r| seen.push(r.to_vec()));
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "expected Bail for select_field_null input {:?}, got {:?}",
+            std::str::from_utf8(raw).unwrap(),
+            outcome,
+        );
+        assert!(seen.is_empty());
+    }
 }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -3571,3 +3571,38 @@ select(.x > 3)
 [ (select(.x > 3))? ]
 [1,2,3]
 []
+
+# #83 Phase B: select(.field == null) / select(.field != null) apply-site
+# uses RawApplyOutcome::Bail. Missing field counts as null in the predicate.
+select(.x == null)
+{"x":null}
+{"x":null}
+
+select(.x == null)
+{"y":1}
+{"y":1}
+
+[ select(.x == null) ]
+{"x":1}
+[]
+
+select(.x != null)
+{"x":1}
+{"x":1}
+
+[ select(.x != null) ]
+{"x":null}
+[]
+
+# Non-object input under `?`: jq raises "Cannot index <type>".
+[ (select(.x == null))? ]
+42
+[]
+
+[ (select(.x != null))? ]
+"hi"
+[]
+
+[ (select(.x == null))? ]
+[1,2,3]
+[]


### PR DESCRIPTION
## Summary
- Migrate `select(.field == null)` / `select(.field != null)` apply-site (stdin + file dispatch) to the named-Bail discipline introduced for #83 Phase B.
- New helper `apply_select_field_null_raw` treats a missing field as null (matching jq's semantics). On a passing predicate it hands raw record bytes to the closure.
- Bail branch: non-object input → `Cannot index <type>` via generic (#199 sibling).

## Test plan
- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` — 144 fast_path_contract cases + full regression
- [x] `tests/fast_path_contract.rs`: 5 new cases pinning eq/ne emit + skip + non-object Bail
- [x] `tests/regression.test`: 8 new cases covering missing-field-as-null, the `?`-wrapped Bail matrix
- [x] `./bench/comprehensive.sh --quick` — `select` benchmarks track baseline (0.067s/0.073s/0.105s/0.021s)

Refs: #251 follow-up checkbox `select_field_null`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)