### PR TITLE
refactor: select_field_str_test apply-site uses RawApplyOutcome (#83 Phase B)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -147,7 +147,8 @@ use jq_jit::fast_path::{
     apply_field_str_reverse_raw, apply_field_test_raw, apply_full_object_fields_raw,
     apply_has_field_raw, apply_has_multi_field_raw, apply_multi_field_access_raw,
     apply_nested_field_access_raw, apply_object_compute_raw, apply_select_arith_cmp_raw,
-    apply_select_cmp_raw, apply_select_field_null_raw, apply_select_str_raw, RawApplyOutcome,
+    apply_select_cmp_raw, apply_select_field_null_raw, apply_select_str_raw,
+    apply_select_str_test_raw, RawApplyOutcome,
 };
 
 fn json_escape_bytes(bytes: &[u8]) -> Vec<u8> {
@@ -7537,21 +7538,12 @@ fn real_main() {
                     // select(.field | startswith/endswith/contains("str")) — raw byte test
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, field) {
-                            let val = &raw[vs..ve];
-                            // Only handle simple quoted strings (no backslash escapes)
-                            if val.len() >= 2 && val[0] == b'"' && val[ve-vs-1] == b'"' && !val[1..ve-vs-1].contains(&b'\\') {
-                                let inner = &val[1..ve-vs-1];
-                                let pass = match builtin.as_str() {
-                                    "startswith" => inner.starts_with(arg.as_bytes()),
-                                    "endswith" => inner.ends_with(arg.as_bytes()),
-                                    "contains" => bytes_contains(inner, arg.as_bytes()),
-                                    _ => false,
-                                };
-                                if pass {
-                                    emit_raw_ln!(&mut compact_buf, raw);
-                                }
-                            }
+                        let outcome = apply_select_str_test_raw(raw, field, builtin, arg, |record| {
+                            emit_raw_ln!(&mut compact_buf, record);
+                        });
+                        if let RawApplyOutcome::Bail = outcome {
+                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }
                         if compact_buf.len() >= 1 << 17 {
                             let _ = out.write_all(&compact_buf);
@@ -15214,20 +15206,12 @@ fn real_main() {
                 let content_bytes = content.as_bytes();
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, field) {
-                        let val = &raw[vs..ve];
-                        if val.len() >= 2 && val[0] == b'"' && val[ve-vs-1] == b'"' && !val[1..ve-vs-1].contains(&b'\\') {
-                            let inner = &val[1..ve-vs-1];
-                            let pass = match builtin.as_str() {
-                                "startswith" => inner.starts_with(arg.as_bytes()),
-                                "endswith" => inner.ends_with(arg.as_bytes()),
-                                "contains" => bytes_contains(inner, arg.as_bytes()),
-                                _ => false,
-                            };
-                            if pass {
-                                emit_raw_ln!(&mut compact_buf, raw);
-                            }
-                        }
+                    let outcome = apply_select_str_test_raw(raw, field, builtin, arg, |record| {
+                        emit_raw_ln!(&mut compact_buf, record);
+                    });
+                    if let RawApplyOutcome::Bail = outcome {
+                        let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                        process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                     }
                     if compact_buf.len() >= 1 << 17 {
                         let _ = out.write_all(&compact_buf);

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -1027,6 +1027,70 @@ where
     RawApplyOutcome::Emit
 }
 
+/// Apply the `select(.field | startswith/endswith/contains("arg"))`
+/// raw-byte fast path on a single JSON record.
+///
+/// All three jq builtins require string inputs; jq raises
+/// `<builtin>() requires string inputs` on a non-string. The helper
+/// therefore bails on every non-string-no-escape shape so the generic
+/// path can produce the real error.
+///
+/// Bail discipline:
+/// * Non-object input — [`RawApplyOutcome::Bail`].
+/// * Field absent, value isn't a quoted string, or contains any
+///   `\` escape — [`RawApplyOutcome::Bail`].
+/// * Unknown builtin name (defensive — only `startswith`, `endswith`,
+///   `contains` are handled) — [`RawApplyOutcome::Bail`].
+///
+/// On a passing predicate the helper invokes `emit_match(raw)` with
+/// the original record bytes.
+pub fn apply_select_str_test_raw<F>(
+    raw: &[u8],
+    field: &str,
+    builtin: &str,
+    arg: &str,
+    mut emit_match: F,
+) -> RawApplyOutcome
+where
+    F: FnMut(&[u8]),
+{
+    if raw.first() != Some(&b'{') {
+        return RawApplyOutcome::Bail;
+    }
+    let (vs, ve) = match json_object_get_field_raw(raw, 0, field) {
+        Some(r) => r,
+        None => return RawApplyOutcome::Bail,
+    };
+    let val = &raw[vs..ve];
+    if val.len() < 2 || val[0] != b'"' || val[val.len() - 1] != b'"'
+        || val[1..val.len() - 1].contains(&b'\\')
+    {
+        return RawApplyOutcome::Bail;
+    }
+    let inner = &val[1..val.len() - 1];
+    let arg_bytes = arg.as_bytes();
+    let pass = match builtin {
+        "startswith" => inner.starts_with(arg_bytes),
+        "endswith" => inner.ends_with(arg_bytes),
+        "contains" => {
+            if arg_bytes.is_empty() {
+                true
+            } else if arg_bytes.len() == 1 {
+                memchr::memchr(arg_bytes[0], inner).is_some()
+            } else {
+                inner
+                    .windows(arg_bytes.len())
+                    .any(|w| w == arg_bytes)
+            }
+        }
+        _ => return RawApplyOutcome::Bail,
+    };
+    if pass {
+        emit_match(raw);
+    }
+    RawApplyOutcome::Emit
+}
+
 /// Apply the `select(.field <arith_chain> <cmp> N)` raw-byte fast path
 /// on a single JSON record.
 ///

--- a/tests/fast_path_contract.rs
+++ b/tests/fast_path_contract.rs
@@ -18,7 +18,7 @@ use jq_jit::fast_path::{
     apply_full_object_fields_raw, apply_has_field_raw, apply_has_multi_field_raw,
     apply_multi_field_access_raw, apply_nested_field_access_raw, apply_object_compute_raw,
     apply_select_arith_cmp_raw, apply_select_cmp_raw, apply_select_field_null_raw,
-    apply_select_str_raw,
+    apply_select_str_raw, apply_select_str_test_raw,
 };
 use jq_jit::interpreter::Filter;
 use jq_jit::ir::BinOp;
@@ -2799,4 +2799,144 @@ fn raw_select_str_non_cmp_op_bails() {
     );
     assert!(matches!(outcome, RawApplyOutcome::Bail));
     assert!(seen.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// `select(.field | startswith/endswith/contains("arg"))` — string-test
+// predicate fast path. jq raises `<builtin>() requires string inputs` on
+// non-string fields, so the helper bails on every non-string-no-escape shape
+// (fixing the silent-skip bug in the old apply-site).
+
+#[test]
+fn raw_select_str_test_startswith_emits_match() {
+    let mut seen: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_select_str_test_raw(
+        b"{\"x\":\"foobar\"}",
+        "x",
+        "startswith",
+        "foo",
+        |r| seen.push(r.to_vec()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(seen, vec![b"{\"x\":\"foobar\"}".to_vec()]);
+}
+
+#[test]
+fn raw_select_str_test_endswith_emits_match() {
+    let mut seen: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_select_str_test_raw(
+        b"{\"x\":\"foobar\"}",
+        "x",
+        "endswith",
+        "bar",
+        |r| seen.push(r.to_vec()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(seen, vec![b"{\"x\":\"foobar\"}".to_vec()]);
+}
+
+#[test]
+fn raw_select_str_test_contains_emits_match() {
+    let mut seen: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_select_str_test_raw(
+        b"{\"x\":\"foobar\"}",
+        "x",
+        "contains",
+        "oba",
+        |r| seen.push(r.to_vec()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(seen, vec![b"{\"x\":\"foobar\"}".to_vec()]);
+}
+
+#[test]
+fn raw_select_str_test_skips_when_predicate_fails() {
+    let mut seen: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_select_str_test_raw(
+        b"{\"x\":\"foobar\"}",
+        "x",
+        "startswith",
+        "zzz",
+        |r| seen.push(r.to_vec()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert!(seen.is_empty());
+}
+
+#[test]
+fn raw_select_str_test_unknown_builtin_bails() {
+    let mut seen: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_select_str_test_raw(
+        b"{\"x\":\"foo\"}",
+        "x",
+        "test",
+        "foo",
+        |r| seen.push(r.to_vec()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(seen.is_empty());
+}
+
+#[test]
+fn raw_select_str_test_field_missing_bails() {
+    let mut seen: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_select_str_test_raw(
+        b"{\"y\":\"hi\"}",
+        "x",
+        "startswith",
+        "h",
+        |r| seen.push(r.to_vec()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(seen.is_empty());
+}
+
+#[test]
+fn raw_select_str_test_non_string_field_bails() {
+    for inner in [&b"{\"x\":42}"[..], &b"{\"x\":null}"[..], &b"{\"x\":[1]}"[..]] {
+        let mut seen: Vec<Vec<u8>> = Vec::new();
+        let outcome = apply_select_str_test_raw(inner, "x", "startswith", "h", |r| {
+            seen.push(r.to_vec())
+        });
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "expected Bail for non-string field input {:?}, got {:?}",
+            std::str::from_utf8(inner).unwrap(),
+            outcome,
+        );
+        assert!(seen.is_empty());
+    }
+}
+
+#[test]
+fn raw_select_str_test_escape_bearing_field_bails() {
+    let raw: Vec<u8> = b"{\"x\":\"a\\nb\"}".to_vec();
+    let mut seen: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_select_str_test_raw(&raw, "x", "startswith", "a", |r| {
+        seen.push(r.to_vec())
+    });
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(seen.is_empty());
+}
+
+#[test]
+fn raw_select_str_test_non_object_input_bails() {
+    for raw in [
+        b"42".as_slice(),
+        b"\"hi\"".as_slice(),
+        b"null".as_slice(),
+        b"[1,2,3]".as_slice(),
+    ] {
+        let mut seen: Vec<Vec<u8>> = Vec::new();
+        let outcome = apply_select_str_test_raw(raw, "x", "startswith", "h", |r| {
+            seen.push(r.to_vec())
+        });
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "expected Bail for select_str_test input {:?}, got {:?}",
+            std::str::from_utf8(raw).unwrap(),
+            outcome,
+        );
+        assert!(seen.is_empty());
+    }
 }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -3687,3 +3687,53 @@ select(.x < "foo")
 [ (select(.x < "foo"))? ]
 [1,2,3]
 []
+
+# #83 Phase B: select(.field | startswith/endswith/contains("arg"))
+# apply-site uses RawApplyOutcome::Bail.
+select(.x | startswith("foo"))
+{"x":"foobar"}
+{"x":"foobar"}
+
+select(.x | endswith("bar"))
+{"x":"foobar"}
+{"x":"foobar"}
+
+select(.x | contains("oba"))
+{"x":"foobar"}
+{"x":"foobar"}
+
+[ select(.x | startswith("zzz")) ]
+{"x":"foobar"}
+[]
+
+# Field missing under `?`: bail to generic; jq raises (null|startswith).
+[ (select(.x | startswith("h")))? ]
+{"y":"hi"}
+[]
+
+# Non-string field under `?`: bail; jq raises.
+[ (select(.x | startswith("h")))? ]
+{"x":42}
+[]
+
+[ (select(.x | endswith("h")))? ]
+{"x":null}
+[]
+
+# Escape-bearing string: bail to generic, which decodes correctly.
+select(.x | startswith("a"))
+{"x":"a\nb"}
+{"x":"a\nb"}
+
+# Non-object input under `?`
+[ (select(.x | startswith("h")))? ]
+42
+[]
+
+[ (select(.x | endswith("h")))? ]
+"hi"
+[]
+
+[ (select(.x | contains("h")))? ]
+[1,2,3]
+[]


### PR DESCRIPTION
## Summary
- Migrate `select(.field | startswith/endswith/contains("arg"))` apply-site (stdin + file dispatch) to the named-Bail discipline introduced for #83 Phase B.
- New helper `apply_select_str_test_raw` covers the three string-test builtins.
- Fixes a pre-existing #83-class bug: the old apply-site silently skipped output when field was missing or non-string; jq raises `<builtin>() requires string inputs`. Both apply-sites now bail to generic.

## Test plan
- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` — 170 fast_path_contract cases + full regression
- [x] `tests/fast_path_contract.rs`: 9 new cases pinning each builtin's Emit, predicate-fail skip, and every Bail branch
- [x] `tests/regression.test`: 11 new cases including escape-bearing string decode through generic and the `?`-wrapped Bail matrix
- [x] `./bench/comprehensive.sh --quick` — `select` benchmarks track baseline (0.067s/0.073s/0.107s/0.021s)

Refs: #251 follow-up checkbox `select_field_str_test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)