### PR TITLE
refactor: field_update_tostring apply-site uses RawApplyOutcome (#83 Phase B)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -136,7 +136,7 @@ fn print_jq_error(msg: &str) {
     }
 }
 
-use jq_jit::value::{Value, json_to_value, json_stream, json_stream_offsets, json_stream_raw, json_stream_project, json_value_has_duplicate_keys, json_stream_has_duplicate_keys, json_object_get_num, json_object_get_two_nums, json_object_get_field_raw, json_object_get_fields_raw_buf, json_object_get_nested_field_raw, parse_json_num, json_value_length, json_object_keys_to_buf_reuse, json_object_extract_keys_only, json_object_keys_unsorted_to_buf, json_object_keys_join_to_buf, json_object_has_key, json_object_has_all_keys, json_object_has_any_key, json_type_byte, json_object_del_field, json_object_del_fields, json_object_filter_by_key_str, json_object_merge_literal, json_object_sort_keys, json_object_filter_by_value_type, json_each_value_raw, json_each_value_cb, json_to_entries_raw, json_with_entries_select_value_cmp, json_object_set_field_raw, json_object_update_field_num, json_object_update_field_num_chain, json_object_update_field_case, json_object_update_field_gsub, json_object_update_field_split_first, json_object_update_field_split_last, json_object_update_field_trim, json_object_update_field_slice, json_object_update_field_str_map, json_object_update_field_str_concat, json_object_update_field_tostring, json_object_update_field_test, json_object_assign_field_arith, json_object_assign_two_fields_arith, json_object_select_then_update_num, json_object_select_then_update_str_concat, json_object_select_compound_then_update_num, json_object_select_str_then_update_num, json_object_values_tostring, is_json_compact, push_json_compact_raw, push_tojson_raw, push_json_pretty_raw, push_json_pretty_raw_at, value_to_json_precise, value_to_json_pretty_ext, push_compact_line, push_compact_line_color, push_pretty_line, push_pretty_line_color, push_jq_number_bytes, write_value_compact_ext, write_value_compact_line, write_value_pretty_line_color, value_to_json_pretty_color, walk_json_transform_nums, pool_value, skip_json_value};
+use jq_jit::value::{Value, json_to_value, json_stream, json_stream_offsets, json_stream_raw, json_stream_project, json_value_has_duplicate_keys, json_stream_has_duplicate_keys, json_object_get_num, json_object_get_two_nums, json_object_get_field_raw, json_object_get_fields_raw_buf, json_object_get_nested_field_raw, parse_json_num, json_value_length, json_object_keys_to_buf_reuse, json_object_extract_keys_only, json_object_keys_unsorted_to_buf, json_object_keys_join_to_buf, json_object_has_key, json_object_has_all_keys, json_object_has_any_key, json_type_byte, json_object_del_field, json_object_del_fields, json_object_filter_by_key_str, json_object_merge_literal, json_object_sort_keys, json_object_filter_by_value_type, json_each_value_raw, json_each_value_cb, json_to_entries_raw, json_with_entries_select_value_cmp, json_object_set_field_raw, json_object_update_field_num, json_object_update_field_num_chain, json_object_update_field_case, json_object_update_field_gsub, json_object_update_field_split_first, json_object_update_field_split_last, json_object_update_field_trim, json_object_update_field_slice, json_object_update_field_str_map, json_object_update_field_str_concat, json_object_update_field_test, json_object_assign_field_arith, json_object_assign_two_fields_arith, json_object_select_then_update_num, json_object_select_then_update_str_concat, json_object_select_compound_then_update_num, json_object_select_str_then_update_num, json_object_values_tostring, is_json_compact, push_json_compact_raw, push_tojson_raw, push_json_pretty_raw, push_json_pretty_raw_at, value_to_json_precise, value_to_json_pretty_ext, push_compact_line, push_compact_line_color, push_pretty_line, push_pretty_line_color, push_jq_number_bytes, write_value_compact_ext, write_value_compact_line, write_value_pretty_line_color, value_to_json_pretty_color, walk_json_transform_nums, pool_value, skip_json_value};
 use jq_jit::interpreter::Filter;
 use jq_jit::fast_path::{
     apply_arith_chain_cmp_raw, apply_field_access_raw, apply_field_alternative_raw,
@@ -148,7 +148,8 @@ use jq_jit::fast_path::{
     apply_has_field_raw, apply_has_multi_field_raw, apply_multi_field_access_raw,
     apply_nested_field_access_raw, apply_object_compute_raw, apply_select_arith_cmp_raw,
     apply_select_cmp_raw, apply_select_field_null_raw, apply_select_str_raw,
-    apply_select_str_test_raw, apply_field_update_length_raw, RawApplyOutcome,
+    apply_select_str_test_raw, apply_field_update_length_raw, apply_field_update_tostring_raw,
+    RawApplyOutcome,
 };
 
 fn json_escape_bytes(bytes: &[u8]) -> Vec<u8> {
@@ -5134,18 +5135,26 @@ fn real_main() {
                         let raw = &input_bytes[start..end];
                         if use_pretty_buf {
                             tmp.clear();
-                            if json_object_update_field_tostring(raw, 0, ts_field, &mut tmp) {
-                                push_json_pretty_raw(&mut compact_buf, &tmp, 2, false);
-                                compact_buf.push(b'\n');
-                            } else {
-                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                            let outcome = apply_field_update_tostring_raw(raw, ts_field, &mut tmp);
+                            match outcome {
+                                RawApplyOutcome::Emit => {
+                                    push_json_pretty_raw(&mut compact_buf, &tmp, 2, false);
+                                    compact_buf.push(b'\n');
+                                }
+                                RawApplyOutcome::Bail => {
+                                    let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                                    process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                                }
                             }
-                        } else if !json_object_update_field_tostring(raw, 0, ts_field, &mut compact_buf) {
-                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         } else {
-                            compact_buf.push(b'\n');
+                            let outcome = apply_field_update_tostring_raw(raw, ts_field, &mut compact_buf);
+                            match outcome {
+                                RawApplyOutcome::Emit => compact_buf.push(b'\n'),
+                                RawApplyOutcome::Bail => {
+                                    let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                                    process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                                }
+                            }
                         }
                         if compact_buf.len() >= 1 << 17 {
                             let _ = out.write_all(&compact_buf);
@@ -14701,18 +14710,26 @@ fn real_main() {
                     let raw = &content_bytes[start..end];
                     if use_pretty_buf {
                         tmp.clear();
-                        if json_object_update_field_tostring(raw, 0, ts_field, &mut tmp) {
-                            push_json_pretty_raw(&mut compact_buf, &tmp, 2, false);
-                            compact_buf.push(b'\n');
-                        } else {
-                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                        let outcome = apply_field_update_tostring_raw(raw, ts_field, &mut tmp);
+                        match outcome {
+                            RawApplyOutcome::Emit => {
+                                push_json_pretty_raw(&mut compact_buf, &tmp, 2, false);
+                                compact_buf.push(b'\n');
+                            }
+                            RawApplyOutcome::Bail => {
+                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                            }
                         }
-                    } else if !json_object_update_field_tostring(raw, 0, ts_field, &mut compact_buf) {
-                        let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                        process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                     } else {
-                        compact_buf.push(b'\n');
+                        let outcome = apply_field_update_tostring_raw(raw, ts_field, &mut compact_buf);
+                        match outcome {
+                            RawApplyOutcome::Emit => compact_buf.push(b'\n'),
+                            RawApplyOutcome::Bail => {
+                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                            }
+                        }
                     }
                     if compact_buf.len() >= 1 << 17 {
                         let _ = out.write_all(&compact_buf);

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -68,7 +68,7 @@ use crate::value::{
     KeyStr, Value, ObjInner, json_object_get_field_raw, json_object_get_fields_raw_buf,
     json_object_get_nested_field_raw, json_object_get_num, json_object_get_two_nums,
     json_object_has_all_keys, json_object_has_any_key, json_object_has_key,
-    json_object_update_field_length,
+    json_object_update_field_length, json_object_update_field_tostring,
 };
 
 /// A fast path whose type-dispatch obligations are encoded in its
@@ -1048,6 +1048,33 @@ where
 /// compact output).
 pub fn apply_field_update_length_raw(raw: &[u8], field: &str, buf: &mut Vec<u8>) -> RawApplyOutcome {
     if json_object_update_field_length(raw, 0, field, buf) {
+        RawApplyOutcome::Emit
+    } else {
+        RawApplyOutcome::Bail
+    }
+}
+
+/// Apply the `.field |= tostring` raw-byte update fast path on a single
+/// JSON record, writing the updated object bytes to `buf`.
+///
+/// jq's `tostring` is identity on strings and JSON-stringifies every
+/// other type (numbers → `"42"`, booleans → `"true"`, `null` → `"null"`,
+/// arrays/objects → their pretty/compact JSON representation). The
+/// underlying value-side function handles strings + scalars; arrays and
+/// objects bail to generic since stringifying them requires the full
+/// recursive JSON encoder.
+///
+/// Bail discipline:
+/// * Non-object input — [`RawApplyOutcome::Bail`].
+/// * Field absent — [`RawApplyOutcome::Bail`].
+/// * Field value is an array or object literal —
+///   [`RawApplyOutcome::Bail`] (generic does the recursive
+///   stringification).
+///
+/// On success, `buf` is appended the updated object bytes (without a
+/// trailing newline).
+pub fn apply_field_update_tostring_raw(raw: &[u8], field: &str, buf: &mut Vec<u8>) -> RawApplyOutcome {
+    if json_object_update_field_tostring(raw, 0, field, buf) {
         RawApplyOutcome::Emit
     } else {
         RawApplyOutcome::Bail

--- a/tests/fast_path_contract.rs
+++ b/tests/fast_path_contract.rs
@@ -17,8 +17,9 @@ use jq_jit::fast_path::{
     apply_field_str_concat_raw, apply_field_str_reverse_raw, apply_field_test_raw,
     apply_full_object_fields_raw, apply_has_field_raw, apply_has_multi_field_raw,
     apply_multi_field_access_raw, apply_nested_field_access_raw, apply_object_compute_raw,
-    apply_field_update_length_raw, apply_select_arith_cmp_raw, apply_select_cmp_raw,
-    apply_select_field_null_raw, apply_select_str_raw, apply_select_str_test_raw,
+    apply_field_update_length_raw, apply_field_update_tostring_raw, apply_select_arith_cmp_raw,
+    apply_select_cmp_raw, apply_select_field_null_raw, apply_select_str_raw,
+    apply_select_str_test_raw,
 };
 use jq_jit::interpreter::Filter;
 use jq_jit::ir::BinOp;
@@ -3005,6 +3006,61 @@ fn raw_field_update_length_non_object_input_bails() {
         assert!(
             matches!(outcome, RawApplyOutcome::Bail),
             "expected Bail for field_update_length input {:?}, got {:?}",
+            std::str::from_utf8(raw).unwrap(),
+            outcome,
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// `.field |= tostring` — string-coerce update fast path. Strings pass
+// through; numbers / booleans / null are wrapped in quotes. Arrays and
+// objects bail since their stringification needs the recursive JSON encoder.
+
+#[test]
+fn raw_field_update_tostring_string_passthrough() {
+    let mut buf = Vec::new();
+    let outcome = apply_field_update_tostring_raw(b"{\"x\":\"hi\"}", "x", &mut buf);
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(buf.as_slice(), b"{\"x\":\"hi\"}");
+}
+
+#[test]
+fn raw_field_update_tostring_number_wraps_in_quotes() {
+    let mut buf = Vec::new();
+    let outcome = apply_field_update_tostring_raw(b"{\"x\":42}", "x", &mut buf);
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(buf.as_slice(), b"{\"x\":\"42\"}");
+}
+
+#[test]
+fn raw_field_update_tostring_null_wraps_in_quotes() {
+    let mut buf = Vec::new();
+    let outcome = apply_field_update_tostring_raw(b"{\"x\":null}", "x", &mut buf);
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(buf.as_slice(), b"{\"x\":\"null\"}");
+}
+
+#[test]
+fn raw_field_update_tostring_field_missing_bails() {
+    let mut buf = Vec::new();
+    let outcome = apply_field_update_tostring_raw(b"{\"y\":\"hi\"}", "x", &mut buf);
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+}
+
+#[test]
+fn raw_field_update_tostring_non_object_input_bails() {
+    for raw in [
+        b"42".as_slice(),
+        b"\"hi\"".as_slice(),
+        b"null".as_slice(),
+        b"[1,2,3]".as_slice(),
+    ] {
+        let mut buf = Vec::new();
+        let outcome = apply_field_update_tostring_raw(raw, "x", &mut buf);
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "expected Bail for field_update_tostring input {:?}, got {:?}",
             std::str::from_utf8(raw).unwrap(),
             outcome,
         );

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -3779,3 +3779,47 @@ select(.x | startswith("a"))
 [ (.x |= length)? ]
 [1,2,3]
 []
+
+# #83 Phase B: .field |= tostring apply-site uses RawApplyOutcome::Bail.
+# String passthrough.
+.x |= tostring
+{"x":"hi"}
+{"x":"hi"}
+
+# Number → "N".
+.x |= tostring
+{"x":42}
+{"x":"42"}
+
+# Boolean → "true" / "false".
+.x |= tostring
+{"x":true}
+{"x":"true"}
+
+# null → "null".
+.x |= tostring
+{"x":null}
+{"x":"null"}
+
+# Field absent: bail to generic; jq's null|tostring = "null".
+.x |= tostring
+{"y":1}
+{"y":1,"x":"null"}
+
+# Array: bail to generic; jq stringifies recursively.
+.x |= tostring
+{"x":[1,2]}
+{"x":"[1,2]"}
+
+# Non-object input under `?`
+[ (.x |= tostring)? ]
+42
+[]
+
+[ (.x |= tostring)? ]
+"hi"
+[]
+
+[ (.x |= tostring)? ]
+[1,2,3]
+[]


### PR DESCRIPTION
## Summary
- Migrate `.field |= tostring` apply-site (stdin + file dispatch) to the named-Bail discipline introduced for #83 Phase B.
- New helper `apply_field_update_tostring_raw` is a thin wrapper translating `json_object_update_field_tostring`'s bool to `RawApplyOutcome`.
- Fast path commits on strings (passthrough) and scalar non-strings (number/bool/null wrapped in quotes). Arrays/objects bail to generic for recursive stringification.

## Test plan
- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` — 180 fast_path_contract cases + full regression
- [x] `tests/fast_path_contract.rs`: 5 new cases pinning string/number/null Emit, missing-field Bail, non-object Bail
- [x] `tests/regression.test`: 9 new cases covering array recursive stringify through generic
- [x] `./bench/comprehensive.sh --quick` — `tostring` at 0.043s (baseline preserved)

Refs: #251 follow-up checkbox `field_update_tostring`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)