### PR TITLE
refactor: 6 more field_update_* apply-sites use RawApplyOutcome (#83 Phase B)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -136,7 +136,7 @@ fn print_jq_error(msg: &str) {
     }
 }
 
-use jq_jit::value::{Value, json_to_value, json_stream, json_stream_offsets, json_stream_raw, json_stream_project, json_value_has_duplicate_keys, json_stream_has_duplicate_keys, json_object_get_num, json_object_get_two_nums, json_object_get_field_raw, json_object_get_fields_raw_buf, json_object_get_nested_field_raw, parse_json_num, json_value_length, json_object_keys_to_buf_reuse, json_object_extract_keys_only, json_object_keys_unsorted_to_buf, json_object_keys_join_to_buf, json_object_has_key, json_object_has_all_keys, json_object_has_any_key, json_type_byte, json_object_del_field, json_object_del_fields, json_object_filter_by_key_str, json_object_merge_literal, json_object_sort_keys, json_object_filter_by_value_type, json_each_value_raw, json_each_value_cb, json_to_entries_raw, json_with_entries_select_value_cmp, json_object_set_field_raw, json_object_update_field_num, json_object_update_field_num_chain, json_object_update_field_split_first, json_object_update_field_split_last, json_object_update_field_trim, json_object_update_field_slice, json_object_update_field_str_map, json_object_update_field_str_concat, json_object_assign_field_arith, json_object_assign_two_fields_arith, json_object_select_then_update_num, json_object_select_then_update_str_concat, json_object_select_compound_then_update_num, json_object_select_str_then_update_num, json_object_values_tostring, is_json_compact, push_json_compact_raw, push_tojson_raw, push_json_pretty_raw, push_json_pretty_raw_at, value_to_json_precise, value_to_json_pretty_ext, push_compact_line, push_compact_line_color, push_pretty_line, push_pretty_line_color, push_jq_number_bytes, write_value_compact_ext, write_value_compact_line, write_value_pretty_line_color, value_to_json_pretty_color, walk_json_transform_nums, pool_value, skip_json_value};
+use jq_jit::value::{Value, json_to_value, json_stream, json_stream_offsets, json_stream_raw, json_stream_project, json_value_has_duplicate_keys, json_stream_has_duplicate_keys, json_object_get_num, json_object_get_two_nums, json_object_get_field_raw, json_object_get_fields_raw_buf, json_object_get_nested_field_raw, parse_json_num, json_value_length, json_object_keys_to_buf_reuse, json_object_extract_keys_only, json_object_keys_unsorted_to_buf, json_object_keys_join_to_buf, json_object_has_key, json_object_has_all_keys, json_object_has_any_key, json_type_byte, json_object_del_field, json_object_del_fields, json_object_filter_by_key_str, json_object_merge_literal, json_object_sort_keys, json_object_filter_by_value_type, json_each_value_raw, json_each_value_cb, json_to_entries_raw, json_with_entries_select_value_cmp, json_object_set_field_raw, json_object_update_field_num, json_object_update_field_num_chain,  json_object_assign_field_arith, json_object_assign_two_fields_arith, json_object_select_then_update_num, json_object_select_then_update_str_concat, json_object_select_compound_then_update_num, json_object_select_str_then_update_num, json_object_values_tostring, is_json_compact, push_json_compact_raw, push_tojson_raw, push_json_pretty_raw, push_json_pretty_raw_at, value_to_json_precise, value_to_json_pretty_ext, push_compact_line, push_compact_line_color, push_pretty_line, push_pretty_line_color, push_jq_number_bytes, write_value_compact_ext, write_value_compact_line, write_value_pretty_line_color, value_to_json_pretty_color, walk_json_transform_nums, pool_value, skip_json_value};
 use jq_jit::interpreter::Filter;
 use jq_jit::fast_path::{
     apply_arith_chain_cmp_raw, apply_field_access_raw, apply_field_alternative_raw,
@@ -149,8 +149,11 @@ use jq_jit::fast_path::{
     apply_nested_field_access_raw, apply_object_compute_raw, apply_select_arith_cmp_raw,
     apply_select_cmp_raw, apply_select_field_null_raw, apply_select_str_raw,
     apply_select_str_test_raw, apply_field_update_case_raw, apply_field_update_gsub_raw,
-    apply_field_update_length_raw, apply_field_update_test_raw, apply_field_update_tostring_raw,
-    RawApplyOutcome,
+    apply_field_update_length_raw, apply_field_update_slice_raw,
+    apply_field_update_split_first_raw, apply_field_update_split_last_raw,
+    apply_field_update_str_concat_raw, apply_field_update_str_map_raw,
+    apply_field_update_test_raw, apply_field_update_tostring_raw,
+    apply_field_update_trim_raw, RawApplyOutcome,
 };
 
 fn json_escape_bytes(bytes: &[u8]) -> Vec<u8> {
@@ -4956,18 +4959,26 @@ fn real_main() {
                         let raw = &input_bytes[start..end];
                         if use_pretty_buf {
                             tmp.clear();
-                            if json_object_update_field_split_first(raw, 0, sf_field, sf_sep, &mut tmp) {
-                                push_json_pretty_raw(&mut compact_buf, &tmp, 2, false);
-                                compact_buf.push(b'\n');
-                            } else {
-                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                            let outcome = apply_field_update_split_first_raw(raw, sf_field, sf_sep, &mut tmp);
+                            match outcome {
+                                RawApplyOutcome::Emit => {
+                                    push_json_pretty_raw(&mut compact_buf, &tmp, 2, false);
+                                    compact_buf.push(b'\n');
+                                }
+                                RawApplyOutcome::Bail => {
+                                    let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                                    process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                                }
                             }
-                        } else if !json_object_update_field_split_first(raw, 0, sf_field, sf_sep, &mut compact_buf) {
-                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         } else {
-                            compact_buf.push(b'\n');
+                            let outcome = apply_field_update_split_first_raw(raw, sf_field, sf_sep, &mut compact_buf);
+                            match outcome {
+                                RawApplyOutcome::Emit => compact_buf.push(b'\n'),
+                                RawApplyOutcome::Bail => {
+                                    let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                                    process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                                }
+                            }
                         }
                         if compact_buf.len() >= 1 << 17 {
                             let _ = out.write_all(&compact_buf);
@@ -4981,18 +4992,26 @@ fn real_main() {
                         let raw = &input_bytes[start..end];
                         if use_pretty_buf {
                             tmp.clear();
-                            if json_object_update_field_split_last(raw, 0, sl_field, sl_sep, &mut tmp) {
-                                push_json_pretty_raw(&mut compact_buf, &tmp, 2, false);
-                                compact_buf.push(b'\n');
-                            } else {
-                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                            let outcome = apply_field_update_split_last_raw(raw, sl_field, sl_sep, &mut tmp);
+                            match outcome {
+                                RawApplyOutcome::Emit => {
+                                    push_json_pretty_raw(&mut compact_buf, &tmp, 2, false);
+                                    compact_buf.push(b'\n');
+                                }
+                                RawApplyOutcome::Bail => {
+                                    let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                                    process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                                }
                             }
-                        } else if !json_object_update_field_split_last(raw, 0, sl_field, sl_sep, &mut compact_buf) {
-                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         } else {
-                            compact_buf.push(b'\n');
+                            let outcome = apply_field_update_split_last_raw(raw, sl_field, sl_sep, &mut compact_buf);
+                            match outcome {
+                                RawApplyOutcome::Emit => compact_buf.push(b'\n'),
+                                RawApplyOutcome::Bail => {
+                                    let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                                    process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                                }
+                            }
                         }
                         if compact_buf.len() >= 1 << 17 {
                             let _ = out.write_all(&compact_buf);
@@ -5006,18 +5025,26 @@ fn real_main() {
                         let raw = &input_bytes[start..end];
                         if use_pretty_buf {
                             tmp.clear();
-                            if json_object_update_field_trim(raw, 0, tr_field, tr_str, tr_is_rtrim, &mut tmp) {
-                                push_json_pretty_raw(&mut compact_buf, &tmp, 2, false);
-                                compact_buf.push(b'\n');
-                            } else {
-                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                            let outcome = apply_field_update_trim_raw(raw, tr_field, tr_str, tr_is_rtrim, &mut tmp);
+                            match outcome {
+                                RawApplyOutcome::Emit => {
+                                    push_json_pretty_raw(&mut compact_buf, &tmp, 2, false);
+                                    compact_buf.push(b'\n');
+                                }
+                                RawApplyOutcome::Bail => {
+                                    let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                                    process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                                }
                             }
-                        } else if !json_object_update_field_trim(raw, 0, tr_field, tr_str, tr_is_rtrim, &mut compact_buf) {
-                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         } else {
-                            compact_buf.push(b'\n');
+                            let outcome = apply_field_update_trim_raw(raw, tr_field, tr_str, tr_is_rtrim, &mut compact_buf);
+                            match outcome {
+                                RawApplyOutcome::Emit => compact_buf.push(b'\n'),
+                                RawApplyOutcome::Bail => {
+                                    let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                                    process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                                }
+                            }
                         }
                         if compact_buf.len() >= 1 << 17 {
                             let _ = out.write_all(&compact_buf);
@@ -5031,18 +5058,26 @@ fn real_main() {
                         let raw = &input_bytes[start..end];
                         if use_pretty_buf {
                             tmp.clear();
-                            if json_object_update_field_slice(raw, 0, us_field, us_from, us_to, &mut tmp) {
-                                push_json_pretty_raw(&mut compact_buf, &tmp, 2, false);
-                                compact_buf.push(b'\n');
-                            } else {
-                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                            let outcome = apply_field_update_slice_raw(raw, us_field, us_from, us_to, &mut tmp);
+                            match outcome {
+                                RawApplyOutcome::Emit => {
+                                    push_json_pretty_raw(&mut compact_buf, &tmp, 2, false);
+                                    compact_buf.push(b'\n');
+                                }
+                                RawApplyOutcome::Bail => {
+                                    let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                                    process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                                }
                             }
-                        } else if !json_object_update_field_slice(raw, 0, us_field, us_from, us_to, &mut compact_buf) {
-                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         } else {
-                            compact_buf.push(b'\n');
+                            let outcome = apply_field_update_slice_raw(raw, us_field, us_from, us_to, &mut compact_buf);
+                            match outcome {
+                                RawApplyOutcome::Emit => compact_buf.push(b'\n'),
+                                RawApplyOutcome::Bail => {
+                                    let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                                    process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                                }
+                            }
                         }
                         if compact_buf.len() >= 1 << 17 {
                             let _ = out.write_all(&compact_buf);
@@ -5059,18 +5094,26 @@ fn real_main() {
                         let raw = &input_bytes[start..end];
                         if use_pretty_buf {
                             tmp.clear();
-                            if json_object_update_field_str_map(raw, 0, sm_field, cond_json, then_bytes, else_bytes, &mut tmp) {
-                                push_json_pretty_raw(&mut compact_buf, &tmp, 2, false);
-                                compact_buf.push(b'\n');
-                            } else {
-                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                            let outcome = apply_field_update_str_map_raw(raw, sm_field, cond_json, then_bytes, else_bytes, &mut tmp);
+                            match outcome {
+                                RawApplyOutcome::Emit => {
+                                    push_json_pretty_raw(&mut compact_buf, &tmp, 2, false);
+                                    compact_buf.push(b'\n');
+                                }
+                                RawApplyOutcome::Bail => {
+                                    let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                                    process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                                }
                             }
-                        } else if !json_object_update_field_str_map(raw, 0, sm_field, cond_json, then_bytes, else_bytes, &mut compact_buf) {
-                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         } else {
-                            compact_buf.push(b'\n');
+                            let outcome = apply_field_update_str_map_raw(raw, sm_field, cond_json, then_bytes, else_bytes, &mut compact_buf);
+                            match outcome {
+                                RawApplyOutcome::Emit => compact_buf.push(b'\n'),
+                                RawApplyOutcome::Bail => {
+                                    let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                                    process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                                }
+                            }
                         }
                         if compact_buf.len() >= 1 << 17 {
                             let _ = out.write_all(&compact_buf);
@@ -5086,18 +5129,26 @@ fn real_main() {
                         let raw = &input_bytes[start..end];
                         if use_pretty_buf {
                             tmp.clear();
-                            if json_object_update_field_str_concat(raw, 0, sc_field, &prefix_json, &suffix_json, &mut tmp) {
-                                push_json_pretty_raw(&mut compact_buf, &tmp, 2, false);
-                                compact_buf.push(b'\n');
-                            } else {
-                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                            let outcome = apply_field_update_str_concat_raw(raw, sc_field, &prefix_json, &suffix_json, &mut tmp);
+                            match outcome {
+                                RawApplyOutcome::Emit => {
+                                    push_json_pretty_raw(&mut compact_buf, &tmp, 2, false);
+                                    compact_buf.push(b'\n');
+                                }
+                                RawApplyOutcome::Bail => {
+                                    let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                                    process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                                }
                             }
-                        } else if !json_object_update_field_str_concat(raw, 0, sc_field, &prefix_json, &suffix_json, &mut compact_buf) {
-                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         } else {
-                            compact_buf.push(b'\n');
+                            let outcome = apply_field_update_str_concat_raw(raw, sc_field, &prefix_json, &suffix_json, &mut compact_buf);
+                            match outcome {
+                                RawApplyOutcome::Emit => compact_buf.push(b'\n'),
+                                RawApplyOutcome::Bail => {
+                                    let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                                    process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                                }
+                            }
                         }
                         if compact_buf.len() >= 1 << 17 {
                             let _ = out.write_all(&compact_buf);
@@ -14548,18 +14599,26 @@ fn real_main() {
                     let raw = &content_bytes[start..end];
                     if use_pretty_buf {
                         tmp.clear();
-                        if json_object_update_field_split_first(raw, 0, sf_field, sf_sep, &mut tmp) {
-                            push_json_pretty_raw(&mut compact_buf, &tmp, 2, false);
-                            compact_buf.push(b'\n');
-                        } else {
-                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                        let outcome = apply_field_update_split_first_raw(raw, sf_field, sf_sep, &mut tmp);
+                        match outcome {
+                            RawApplyOutcome::Emit => {
+                                push_json_pretty_raw(&mut compact_buf, &tmp, 2, false);
+                                compact_buf.push(b'\n');
+                            }
+                            RawApplyOutcome::Bail => {
+                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                            }
                         }
-                    } else if !json_object_update_field_split_first(raw, 0, sf_field, sf_sep, &mut compact_buf) {
-                        let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                        process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                     } else {
-                        compact_buf.push(b'\n');
+                        let outcome = apply_field_update_split_first_raw(raw, sf_field, sf_sep, &mut compact_buf);
+                        match outcome {
+                            RawApplyOutcome::Emit => compact_buf.push(b'\n'),
+                            RawApplyOutcome::Bail => {
+                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                            }
+                        }
                     }
                     if compact_buf.len() >= 1 << 17 {
                         let _ = out.write_all(&compact_buf);
@@ -14574,18 +14633,26 @@ fn real_main() {
                     let raw = &content_bytes[start..end];
                     if use_pretty_buf {
                         tmp.clear();
-                        if json_object_update_field_split_last(raw, 0, sl_field, sl_sep, &mut tmp) {
-                            push_json_pretty_raw(&mut compact_buf, &tmp, 2, false);
-                            compact_buf.push(b'\n');
-                        } else {
-                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                        let outcome = apply_field_update_split_last_raw(raw, sl_field, sl_sep, &mut tmp);
+                        match outcome {
+                            RawApplyOutcome::Emit => {
+                                push_json_pretty_raw(&mut compact_buf, &tmp, 2, false);
+                                compact_buf.push(b'\n');
+                            }
+                            RawApplyOutcome::Bail => {
+                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                            }
                         }
-                    } else if !json_object_update_field_split_last(raw, 0, sl_field, sl_sep, &mut compact_buf) {
-                        let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                        process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                     } else {
-                        compact_buf.push(b'\n');
+                        let outcome = apply_field_update_split_last_raw(raw, sl_field, sl_sep, &mut compact_buf);
+                        match outcome {
+                            RawApplyOutcome::Emit => compact_buf.push(b'\n'),
+                            RawApplyOutcome::Bail => {
+                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                            }
+                        }
                     }
                     if compact_buf.len() >= 1 << 17 {
                         let _ = out.write_all(&compact_buf);
@@ -14600,18 +14667,26 @@ fn real_main() {
                     let raw = &content_bytes[start..end];
                     if use_pretty_buf {
                         tmp.clear();
-                        if json_object_update_field_trim(raw, 0, tr_field, tr_str, tr_is_rtrim, &mut tmp) {
-                            push_json_pretty_raw(&mut compact_buf, &tmp, 2, false);
-                            compact_buf.push(b'\n');
-                        } else {
-                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                        let outcome = apply_field_update_trim_raw(raw, tr_field, tr_str, tr_is_rtrim, &mut tmp);
+                        match outcome {
+                            RawApplyOutcome::Emit => {
+                                push_json_pretty_raw(&mut compact_buf, &tmp, 2, false);
+                                compact_buf.push(b'\n');
+                            }
+                            RawApplyOutcome::Bail => {
+                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                            }
                         }
-                    } else if !json_object_update_field_trim(raw, 0, tr_field, tr_str, tr_is_rtrim, &mut compact_buf) {
-                        let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                        process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                     } else {
-                        compact_buf.push(b'\n');
+                        let outcome = apply_field_update_trim_raw(raw, tr_field, tr_str, tr_is_rtrim, &mut compact_buf);
+                        match outcome {
+                            RawApplyOutcome::Emit => compact_buf.push(b'\n'),
+                            RawApplyOutcome::Bail => {
+                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                            }
+                        }
                     }
                     if compact_buf.len() >= 1 << 17 {
                         let _ = out.write_all(&compact_buf);
@@ -14626,18 +14701,26 @@ fn real_main() {
                     let raw = &content_bytes[start..end];
                     if use_pretty_buf {
                         tmp.clear();
-                        if json_object_update_field_slice(raw, 0, us_field, us_from, us_to, &mut tmp) {
-                            push_json_pretty_raw(&mut compact_buf, &tmp, 2, false);
-                            compact_buf.push(b'\n');
-                        } else {
-                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                        let outcome = apply_field_update_slice_raw(raw, us_field, us_from, us_to, &mut tmp);
+                        match outcome {
+                            RawApplyOutcome::Emit => {
+                                push_json_pretty_raw(&mut compact_buf, &tmp, 2, false);
+                                compact_buf.push(b'\n');
+                            }
+                            RawApplyOutcome::Bail => {
+                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                            }
                         }
-                    } else if !json_object_update_field_slice(raw, 0, us_field, us_from, us_to, &mut compact_buf) {
-                        let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                        process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                     } else {
-                        compact_buf.push(b'\n');
+                        let outcome = apply_field_update_slice_raw(raw, us_field, us_from, us_to, &mut compact_buf);
+                        match outcome {
+                            RawApplyOutcome::Emit => compact_buf.push(b'\n'),
+                            RawApplyOutcome::Bail => {
+                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                            }
+                        }
                     }
                     if compact_buf.len() >= 1 << 17 {
                         let _ = out.write_all(&compact_buf);
@@ -14655,18 +14738,26 @@ fn real_main() {
                     let raw = &content_bytes[start..end];
                     if use_pretty_buf {
                         tmp.clear();
-                        if json_object_update_field_str_map(raw, 0, sm_field, cond_json, then_bytes, else_bytes, &mut tmp) {
-                            push_json_pretty_raw(&mut compact_buf, &tmp, 2, false);
-                            compact_buf.push(b'\n');
-                        } else {
-                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                        let outcome = apply_field_update_str_map_raw(raw, sm_field, cond_json, then_bytes, else_bytes, &mut tmp);
+                        match outcome {
+                            RawApplyOutcome::Emit => {
+                                push_json_pretty_raw(&mut compact_buf, &tmp, 2, false);
+                                compact_buf.push(b'\n');
+                            }
+                            RawApplyOutcome::Bail => {
+                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                            }
                         }
-                    } else if !json_object_update_field_str_map(raw, 0, sm_field, cond_json, then_bytes, else_bytes, &mut compact_buf) {
-                        let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                        process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                     } else {
-                        compact_buf.push(b'\n');
+                        let outcome = apply_field_update_str_map_raw(raw, sm_field, cond_json, then_bytes, else_bytes, &mut compact_buf);
+                        match outcome {
+                            RawApplyOutcome::Emit => compact_buf.push(b'\n'),
+                            RawApplyOutcome::Bail => {
+                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                            }
+                        }
                     }
                     if compact_buf.len() >= 1 << 17 {
                         let _ = out.write_all(&compact_buf);
@@ -14683,18 +14774,26 @@ fn real_main() {
                     let raw = &content_bytes[start..end];
                     if use_pretty_buf {
                         tmp.clear();
-                        if json_object_update_field_str_concat(raw, 0, sc_field, &prefix_json, &suffix_json, &mut tmp) {
-                            push_json_pretty_raw(&mut compact_buf, &tmp, 2, false);
-                            compact_buf.push(b'\n');
-                        } else {
-                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                        let outcome = apply_field_update_str_concat_raw(raw, sc_field, &prefix_json, &suffix_json, &mut tmp);
+                        match outcome {
+                            RawApplyOutcome::Emit => {
+                                push_json_pretty_raw(&mut compact_buf, &tmp, 2, false);
+                                compact_buf.push(b'\n');
+                            }
+                            RawApplyOutcome::Bail => {
+                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                            }
                         }
-                    } else if !json_object_update_field_str_concat(raw, 0, sc_field, &prefix_json, &suffix_json, &mut compact_buf) {
-                        let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                        process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                     } else {
-                        compact_buf.push(b'\n');
+                        let outcome = apply_field_update_str_concat_raw(raw, sc_field, &prefix_json, &suffix_json, &mut compact_buf);
+                        match outcome {
+                            RawApplyOutcome::Emit => compact_buf.push(b'\n'),
+                            RawApplyOutcome::Bail => {
+                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                            }
+                        }
                     }
                     if compact_buf.len() >= 1 << 17 {
                         let _ = out.write_all(&compact_buf);

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -69,8 +69,11 @@ use crate::value::{
     json_object_get_nested_field_raw, json_object_get_num, json_object_get_two_nums,
     json_object_has_all_keys, json_object_has_any_key, json_object_has_key,
     json_object_update_field_case, json_object_update_field_gsub,
-    json_object_update_field_length, json_object_update_field_test,
-    json_object_update_field_tostring,
+    json_object_update_field_length, json_object_update_field_slice,
+    json_object_update_field_split_first, json_object_update_field_split_last,
+    json_object_update_field_str_concat, json_object_update_field_str_map,
+    json_object_update_field_test, json_object_update_field_tostring,
+    json_object_update_field_trim,
 };
 
 /// A fast path whose type-dispatch obligations are encoded in its
@@ -1154,6 +1157,118 @@ pub fn apply_field_update_case_raw(
     buf: &mut Vec<u8>,
 ) -> RawApplyOutcome {
     if json_object_update_field_case(raw, 0, field, is_upcase, buf) {
+        RawApplyOutcome::Emit
+    } else {
+        RawApplyOutcome::Bail
+    }
+}
+
+/// Apply the `.field |= split("sep") | .[0]` raw-byte update fast path
+/// on a single JSON record (drop everything after the first `sep`,
+/// keeping the prefix as the new field value).
+///
+/// Bails on non-object input, missing/non-string field. The generic
+/// path handles other shapes and any escape-decode quirks.
+pub fn apply_field_update_split_first_raw(
+    raw: &[u8],
+    field: &str,
+    sep: &str,
+    buf: &mut Vec<u8>,
+) -> RawApplyOutcome {
+    if json_object_update_field_split_first(raw, 0, field, sep, buf) {
+        RawApplyOutcome::Emit
+    } else {
+        RawApplyOutcome::Bail
+    }
+}
+
+/// Apply the `.field |= split("sep") | .[-1]` raw-byte update fast path
+/// (keep everything after the last `sep`).
+///
+/// Bails on non-object input, missing/non-string field.
+pub fn apply_field_update_split_last_raw(
+    raw: &[u8],
+    field: &str,
+    sep: &str,
+    buf: &mut Vec<u8>,
+) -> RawApplyOutcome {
+    if json_object_update_field_split_last(raw, 0, field, sep, buf) {
+        RawApplyOutcome::Emit
+    } else {
+        RawApplyOutcome::Bail
+    }
+}
+
+/// Apply the `.field |= ltrimstr/rtrimstr("s")` raw-byte update fast
+/// path. `is_rtrim` selects between left- and right-trim.
+///
+/// Bails on non-object input, missing/non-string field.
+pub fn apply_field_update_trim_raw(
+    raw: &[u8],
+    field: &str,
+    trim_str: &str,
+    is_rtrim: bool,
+    buf: &mut Vec<u8>,
+) -> RawApplyOutcome {
+    if json_object_update_field_trim(raw, 0, field, trim_str, is_rtrim, buf) {
+        RawApplyOutcome::Emit
+    } else {
+        RawApplyOutcome::Bail
+    }
+}
+
+/// Apply the `.field |= .[from:to]` raw-byte update fast path.
+///
+/// Bails on non-object input, missing/non-string field; the generic
+/// path handles arrays and other types.
+pub fn apply_field_update_slice_raw(
+    raw: &[u8],
+    field: &str,
+    from: Option<i64>,
+    to: Option<i64>,
+    buf: &mut Vec<u8>,
+) -> RawApplyOutcome {
+    if json_object_update_field_slice(raw, 0, field, from, to, buf) {
+        RawApplyOutcome::Emit
+    } else {
+        RawApplyOutcome::Bail
+    }
+}
+
+/// Apply the fused `.field |= if . == "cond" then THEN else ELSE end`
+/// raw-byte update fast path (`json_object_update_field_str_map`).
+/// `cond_str` is the literal-string condition; `then_json` / `else_json`
+/// are pre-encoded JSON values.
+///
+/// Bails on non-object input, missing/non-string field.
+pub fn apply_field_update_str_map_raw(
+    raw: &[u8],
+    field: &str,
+    cond_str: &[u8],
+    then_json: &[u8],
+    else_json: &[u8],
+    buf: &mut Vec<u8>,
+) -> RawApplyOutcome {
+    if json_object_update_field_str_map(raw, 0, field, cond_str, then_json, else_json, buf) {
+        RawApplyOutcome::Emit
+    } else {
+        RawApplyOutcome::Bail
+    }
+}
+
+/// Apply the fused `.field |= "PREFIX" + . + "SUFFIX"` raw-byte update
+/// fast path. `prefix` and `suffix` are JSON-escaped strings (without
+/// surrounding quotes).
+///
+/// Bails on non-object input, missing/non-string field.
+pub fn apply_field_update_str_concat_raw(
+    raw: &[u8],
+    field: &str,
+    prefix: &[u8],
+    suffix: &[u8],
+    buf: &mut Vec<u8>,
+) -> RawApplyOutcome {
+    if json_object_update_field_str_concat(raw, 0, field, prefix, suffix, buf) {
         RawApplyOutcome::Emit
     } else {
         RawApplyOutcome::Bail

--- a/tests/fast_path_contract.rs
+++ b/tests/fast_path_contract.rs
@@ -18,9 +18,11 @@ use jq_jit::fast_path::{
     apply_full_object_fields_raw, apply_has_field_raw, apply_has_multi_field_raw,
     apply_multi_field_access_raw, apply_nested_field_access_raw, apply_object_compute_raw,
     apply_field_update_case_raw, apply_field_update_gsub_raw, apply_field_update_length_raw,
-    apply_field_update_test_raw, apply_field_update_tostring_raw, apply_select_arith_cmp_raw,
-    apply_select_cmp_raw, apply_select_field_null_raw, apply_select_str_raw,
-    apply_select_str_test_raw,
+    apply_field_update_slice_raw, apply_field_update_split_first_raw,
+    apply_field_update_split_last_raw, apply_field_update_str_concat_raw,
+    apply_field_update_str_map_raw, apply_field_update_test_raw, apply_field_update_tostring_raw,
+    apply_field_update_trim_raw, apply_select_arith_cmp_raw, apply_select_cmp_raw,
+    apply_select_field_null_raw, apply_select_str_raw, apply_select_str_test_raw,
 };
 use jq_jit::interpreter::Filter;
 use jq_jit::ir::BinOp;
@@ -3202,4 +3204,148 @@ fn raw_field_update_case_non_object_input_bails() {
         let outcome = apply_field_update_case_raw(raw, "x", false, &mut buf);
         assert!(matches!(outcome, RawApplyOutcome::Bail));
     }
+}
+
+// ---------------------------------------------------------------------------
+// Six more `.field |=` thin-wrappers: split_first / split_last / trim /
+// slice / str_map / str_concat. All share the same Bail discipline:
+// non-object, missing/non-string field.
+
+#[test]
+fn raw_field_update_split_first_emits_prefix() {
+    let mut buf = Vec::new();
+    let outcome = apply_field_update_split_first_raw(b"{\"x\":\"a/b/c\"}", "x", "/", &mut buf);
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(buf.as_slice(), b"{\"x\":\"a\"}");
+}
+
+#[test]
+fn raw_field_update_split_first_non_object_bails() {
+    for raw in [b"42".as_slice(), b"null".as_slice(), b"[1]".as_slice()] {
+        let mut buf = Vec::new();
+        let outcome = apply_field_update_split_first_raw(raw, "x", "/", &mut buf);
+        assert!(matches!(outcome, RawApplyOutcome::Bail));
+    }
+}
+
+#[test]
+fn raw_field_update_split_last_emits_suffix() {
+    let mut buf = Vec::new();
+    let outcome = apply_field_update_split_last_raw(b"{\"x\":\"a/b/c\"}", "x", "/", &mut buf);
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(buf.as_slice(), b"{\"x\":\"c\"}");
+}
+
+#[test]
+fn raw_field_update_split_last_non_string_field_bails() {
+    let mut buf = Vec::new();
+    let outcome = apply_field_update_split_last_raw(b"{\"x\":42}", "x", "/", &mut buf);
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+}
+
+#[test]
+fn raw_field_update_trim_ltrim_emits() {
+    let mut buf = Vec::new();
+    let outcome = apply_field_update_trim_raw(b"{\"x\":\"abcabc\"}", "x", "ab", false, &mut buf);
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(buf.as_slice(), b"{\"x\":\"cabc\"}");
+}
+
+#[test]
+fn raw_field_update_trim_rtrim_emits() {
+    let mut buf = Vec::new();
+    let outcome = apply_field_update_trim_raw(b"{\"x\":\"abcabc\"}", "x", "bc", true, &mut buf);
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(buf.as_slice(), b"{\"x\":\"abca\"}");
+}
+
+#[test]
+fn raw_field_update_trim_non_object_bails() {
+    let mut buf = Vec::new();
+    let outcome = apply_field_update_trim_raw(b"42", "x", "ab", false, &mut buf);
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+}
+
+#[test]
+fn raw_field_update_slice_emits() {
+    let mut buf = Vec::new();
+    let outcome =
+        apply_field_update_slice_raw(b"{\"x\":\"abcdef\"}", "x", Some(1), Some(4), &mut buf);
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(buf.as_slice(), b"{\"x\":\"bcd\"}");
+}
+
+#[test]
+fn raw_field_update_slice_non_string_field_bails() {
+    let mut buf = Vec::new();
+    let outcome =
+        apply_field_update_slice_raw(b"{\"x\":[1,2,3]}", "x", Some(1), Some(2), &mut buf);
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+}
+
+#[test]
+fn raw_field_update_str_map_emits_then_branch() {
+    // .x |= if . == "yes" then "Y" else "N" end
+    let mut buf = Vec::new();
+    let outcome = apply_field_update_str_map_raw(
+        b"{\"x\":\"yes\"}",
+        "x",
+        b"yes",
+        b"\"Y\"",
+        b"\"N\"",
+        &mut buf,
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(buf.as_slice(), b"{\"x\":\"Y\"}");
+}
+
+#[test]
+fn raw_field_update_str_map_emits_else_branch() {
+    let mut buf = Vec::new();
+    let outcome = apply_field_update_str_map_raw(
+        b"{\"x\":\"no\"}",
+        "x",
+        b"yes",
+        b"\"Y\"",
+        b"\"N\"",
+        &mut buf,
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(buf.as_slice(), b"{\"x\":\"N\"}");
+}
+
+#[test]
+fn raw_field_update_str_map_non_object_bails() {
+    let mut buf = Vec::new();
+    let outcome = apply_field_update_str_map_raw(
+        b"\"yes\"",
+        "x",
+        b"yes",
+        b"\"Y\"",
+        b"\"N\"",
+        &mut buf,
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+}
+
+#[test]
+fn raw_field_update_str_concat_wraps_value() {
+    let mut buf = Vec::new();
+    let outcome = apply_field_update_str_concat_raw(
+        b"{\"x\":\"hi\"}",
+        "x",
+        b"<",
+        b">",
+        &mut buf,
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(buf.as_slice(), b"{\"x\":\"<hi>\"}");
+}
+
+#[test]
+fn raw_field_update_str_concat_non_string_field_bails() {
+    let mut buf = Vec::new();
+    let outcome =
+        apply_field_update_str_concat_raw(b"{\"x\":42}", "x", b"<", b">", &mut buf);
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
 }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -3875,3 +3875,52 @@ select(.x | startswith("a"))
 [ (.x |= ascii_upcase)? ]
 [1,2,3]
 []
+
+# #83 Phase B: split_first / split_last / trim / slice / str_map / str_concat
+# updates use RawApplyOutcome::Bail.
+.x |= split("/") | .x |= .[0]
+{"x":"a/b/c"}
+{"x":"a"}
+
+.x |= split("/") | .x |= .[-1]
+{"x":"a/b/c"}
+{"x":"c"}
+
+.x |= ltrimstr("ab")
+{"x":"abcabc"}
+{"x":"cabc"}
+
+.x |= rtrimstr("bc")
+{"x":"abcabc"}
+{"x":"abca"}
+
+.x |= .[1:4]
+{"x":"abcdef"}
+{"x":"bcd"}
+
+.x |= "<" + . + ">"
+{"x":"hi"}
+{"x":"<hi>"}
+
+# Non-string field under `?`
+[ (.x |= ltrimstr("a"))? ]
+{"x":42}
+[]
+
+# null is sliceable in jq — slice of null is null.
+[ (.x |= .[0:2])? ]
+{"x":null}
+[{"x":null}]
+
+# Non-object input under `?`
+[ (.x |= ltrimstr("a"))? ]
+42
+[]
+
+[ (.x |= .[0:2])? ]
+"hi"
+[]
+
+[ (.x |= "<" + . + ">")? ]
+[1,2,3]
+[]


### PR DESCRIPTION
## Summary
Final batch of `.field |= <op>` apply-site migrations to the named-Bail discipline. All six follow the same thin-wrapper shape.

New helpers:
- `apply_field_update_split_first_raw` — `.field |= split("s")|.[0]`
- `apply_field_update_split_last_raw` — `.field |= split("s")|.[-1]`
- `apply_field_update_trim_raw` — `.field |= ltrimstr/rtrimstr("s")`
- `apply_field_update_slice_raw` — `.field |= .[from:to]`
- `apply_field_update_str_map_raw` — fused `.field |= if . == cond then THEN else ELSE end`
- `apply_field_update_str_concat_raw` — `.field |= "PRE" + . + "SUF"`

Bail discipline (uniform): non-object input, missing/non-string field.

## Test plan
- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` — 206 fast_path_contract cases + full regression (681 cases)
- [x] `tests/fast_path_contract.rs`: 14 new cases (2-3 per helper) pinning Emit and Bail
- [x] `tests/regression.test`: 11 new cases including jq's null-slicing edge case routed through generic
- [x] `./bench/comprehensive.sh --quick` — `ltrimstr`/`rtrimstr`/`split`/`case+split` track baseline

Refs: #251 follow-up checkboxes `field_update_split_first`, `field_update_split_last`, `field_update_trim`, `field_update_slice`, `field_update_str_map`, `field_update_str_concat`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)