### PR TITLE
refactor: field_case_test / field_case_gsub apply-sites use RawApplyOutcome (#83 Phase B)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -140,7 +140,8 @@ use jq_jit::value::{Value, json_to_value, json_stream, json_stream_offsets, json
 use jq_jit::interpreter::Filter;
 use jq_jit::fast_path::{
     apply_arith_chain_cmp_raw, apply_field_access_raw, apply_field_alternative_raw,
-    apply_field_arith_chain_raw, apply_field_binop_raw, apply_field_const_cmp_raw,
+    apply_field_arith_chain_raw, apply_field_binop_raw, apply_field_case_gsub_raw,
+    apply_field_case_test_raw, apply_field_const_cmp_raw,
     apply_field_field_alternative_raw, apply_field_field_cmp_raw, apply_field_format_raw,
     apply_field_gsub_raw, apply_field_ltrimstr_tonumber_raw, apply_field_match_raw,
     apply_field_scan_raw, apply_field_str_builtin_raw, apply_field_str_concat_raw,
@@ -6824,26 +6825,9 @@ fn real_main() {
                         let repl = cg_replacement.as_str();
                         json_stream_raw(&input_str, |start, end| {
                             let raw = &input_bytes[start..end];
-                            if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, cg_field) {
-                                let val = &raw[vs..ve];
-                                if val.len() >= 2 && val[0] == b'"' && val[val.len()-1] == b'"'
-                                    && !val[1..val.len()-1].contains(&b'\\')
-                                {
-                                    let inner = &val[1..val.len()-1];
-                                    // Case-convert
-                                    let converted: Vec<u8> = inner.iter().map(|&b| {
-                                        if cg_upper {
-                                            if b >= b'a' && b <= b'z' { b - 32 } else { b }
-                                        } else {
-                                            if b >= b'A' && b <= b'Z' { b + 32 } else { b }
-                                        }
-                                    }).collect();
-                                    let content = unsafe { std::str::from_utf8_unchecked(&converted) };
-                                    let result = if cg_global {
-                                        re.replace_all(content, repl)
-                                    } else {
-                                        re.replace(content, repl)
-                                    };
+                            let outcome = apply_field_case_gsub_raw(
+                                raw, cg_field, cg_upper, &re, repl, cg_global,
+                                |result| {
                                     compact_buf.push(b'"');
                                     for &b in result.as_bytes() {
                                         match b {
@@ -6857,11 +6841,9 @@ fn real_main() {
                                         }
                                     }
                                     compact_buf.extend_from_slice(b"\"\n");
-                                } else {
-                                    let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                    process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                                }
-                            } else {
+                                },
+                            );
+                            if let RawApplyOutcome::Bail = outcome {
                                 let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                                 process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                             }
@@ -6884,30 +6866,11 @@ fn real_main() {
                     if let Ok(re) = regex::Regex::new(ct_pattern) {
                         json_stream_raw(&input_str, |start, end| {
                             let raw = &input_bytes[start..end];
-                            if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, ct_field) {
-                                let val = &raw[vs..ve];
-                                if val.len() >= 2 && val[0] == b'"' && val[val.len()-1] == b'"'
-                                    && !val[1..val.len()-1].contains(&b'\\')
-                                {
-                                    let inner = &val[1..val.len()-1];
-                                    let converted: Vec<u8> = inner.iter().map(|&b| {
-                                        if ct_upper {
-                                            if b >= b'a' && b <= b'z' { b - 32 } else { b }
-                                        } else {
-                                            if b >= b'A' && b <= b'Z' { b + 32 } else { b }
-                                        }
-                                    }).collect();
-                                    let content = unsafe { std::str::from_utf8_unchecked(&converted) };
-                                    if re.is_match(content) {
-                                        compact_buf.extend_from_slice(b"true\n");
-                                    } else {
-                                        compact_buf.extend_from_slice(b"false\n");
-                                    }
-                                } else {
-                                    let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                    process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                                }
-                            } else {
+                            let outcome = apply_field_case_test_raw(raw, ct_field, ct_upper, &re, |bytes| {
+                                compact_buf.extend_from_slice(bytes);
+                                compact_buf.push(b'\n');
+                            });
+                            if let RawApplyOutcome::Bail = outcome {
                                 let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                                 process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                             }
@@ -20025,25 +19988,9 @@ fn real_main() {
                     let content_bytes = content.as_bytes();
                     json_stream_raw(content, |start, end| {
                         let raw = &content_bytes[start..end];
-                        if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, cg_field) {
-                            let val = &raw[vs..ve];
-                            if val.len() >= 2 && val[0] == b'"' && val[val.len()-1] == b'"'
-                                && !val[1..val.len()-1].contains(&b'\\')
-                            {
-                                let inner = &val[1..val.len()-1];
-                                let converted: Vec<u8> = inner.iter().map(|&b| {
-                                    if cg_upper {
-                                        if b >= b'a' && b <= b'z' { b - 32 } else { b }
-                                    } else {
-                                        if b >= b'A' && b <= b'Z' { b + 32 } else { b }
-                                    }
-                                }).collect();
-                                let content_str = unsafe { std::str::from_utf8_unchecked(&converted) };
-                                let result = if cg_global {
-                                    re.replace_all(content_str, repl)
-                                } else {
-                                    re.replace(content_str, repl)
-                                };
+                        let outcome = apply_field_case_gsub_raw(
+                            raw, cg_field, cg_upper, &re, repl, cg_global,
+                            |result| {
                                 compact_buf.push(b'"');
                                 for &b in result.as_bytes() {
                                     match b {
@@ -20057,11 +20004,9 @@ fn real_main() {
                                     }
                                 }
                                 compact_buf.extend_from_slice(b"\"\n");
-                            } else {
-                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                            }
-                        } else {
+                            },
+                        );
+                        if let RawApplyOutcome::Bail = outcome {
                             let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                             process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }
@@ -20086,30 +20031,11 @@ fn real_main() {
                     let content_bytes = content.as_bytes();
                     json_stream_raw(content, |start, end| {
                         let raw = &content_bytes[start..end];
-                        if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, ct_field) {
-                            let val = &raw[vs..ve];
-                            if val.len() >= 2 && val[0] == b'"' && val[val.len()-1] == b'"'
-                                && !val[1..val.len()-1].contains(&b'\\')
-                            {
-                                let inner = &val[1..val.len()-1];
-                                let converted: Vec<u8> = inner.iter().map(|&b| {
-                                    if ct_upper {
-                                        if b >= b'a' && b <= b'z' { b - 32 } else { b }
-                                    } else {
-                                        if b >= b'A' && b <= b'Z' { b + 32 } else { b }
-                                    }
-                                }).collect();
-                                let content_str = unsafe { std::str::from_utf8_unchecked(&converted) };
-                                if re.is_match(content_str) {
-                                    compact_buf.extend_from_slice(b"true\n");
-                                } else {
-                                    compact_buf.extend_from_slice(b"false\n");
-                                }
-                            } else {
-                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                            }
-                        } else {
+                        let outcome = apply_field_case_test_raw(raw, ct_field, ct_upper, &re, |bytes| {
+                            compact_buf.extend_from_slice(bytes);
+                            compact_buf.push(b'\n');
+                        });
+                        if let RawApplyOutcome::Bail = outcome {
                             let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                             process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -377,6 +377,100 @@ where
     RawApplyOutcome::Emit
 }
 
+/// Apply the `.field | ascii_downcase|ascii_upcase | test("pattern")`
+/// raw-byte fast path on a single JSON record.
+///
+/// `upper = true` selects `ascii_upcase`, `false` selects `ascii_downcase`.
+/// The case fold is byte-wise ASCII (`a..z` ↔ `A..Z`), matching jq's
+/// behaviour for ASCII characters in the no-escape lane.
+///
+/// Bail discipline matches [`apply_field_test_raw`]. Strings with any `\`
+/// escape Bail because the raw scanner can't decode them, and the case
+/// fold is only safe on bytes the scanner can already see verbatim. Non-
+/// object input or missing field also Bail so the generic path produces
+/// jq's verdict.
+pub fn apply_field_case_test_raw<E>(
+    raw: &[u8],
+    field: &str,
+    upper: bool,
+    re: &regex::Regex,
+    mut emit: E,
+) -> RawApplyOutcome
+where
+    E: FnMut(&[u8]),
+{
+    let (vs, ve) = match json_object_get_field_raw(raw, 0, field) {
+        Some(r) => r,
+        None => return RawApplyOutcome::Bail,
+    };
+    let val = &raw[vs..ve];
+    if val.len() < 2 || val[0] != b'"' || val[val.len() - 1] != b'"'
+        || val[1..val.len() - 1].contains(&b'\\')
+    {
+        return RawApplyOutcome::Bail;
+    }
+    let inner = &val[1..val.len() - 1];
+    let converted: Vec<u8> = inner.iter().map(|&b| {
+        if upper {
+            if b.is_ascii_lowercase() { b - 32 } else { b }
+        } else if b.is_ascii_uppercase() { b + 32 } else { b }
+    }).collect();
+    let content = unsafe { std::str::from_utf8_unchecked(&converted) };
+    if re.is_match(content) {
+        emit(b"true");
+    } else {
+        emit(b"false");
+    }
+    RawApplyOutcome::Emit
+}
+
+/// Apply the `.field | ascii_downcase|ascii_upcase | gsub/sub("pattern";
+/// "replacement"; flags)` raw-byte fast path on a single JSON record.
+///
+/// `upper = true` selects `ascii_upcase`, `false` selects `ascii_downcase`.
+/// `is_global` selects between `replace_all` (gsub) and `replace` (sub).
+///
+/// Bail discipline matches [`apply_field_gsub_raw`]. Only the no-escape
+/// quoted-string lane is handled; everything else returns
+/// [`RawApplyOutcome::Bail`] for the generic path.
+pub fn apply_field_case_gsub_raw<E>(
+    raw: &[u8],
+    field: &str,
+    upper: bool,
+    re: &regex::Regex,
+    replacement: &str,
+    is_global: bool,
+    mut emit: E,
+) -> RawApplyOutcome
+where
+    E: FnMut(&str),
+{
+    let (vs, ve) = match json_object_get_field_raw(raw, 0, field) {
+        Some(r) => r,
+        None => return RawApplyOutcome::Bail,
+    };
+    let val = &raw[vs..ve];
+    if val.len() < 2 || val[0] != b'"' || val[val.len() - 1] != b'"'
+        || val[1..val.len() - 1].contains(&b'\\')
+    {
+        return RawApplyOutcome::Bail;
+    }
+    let inner = &val[1..val.len() - 1];
+    let converted: Vec<u8> = inner.iter().map(|&b| {
+        if upper {
+            if b.is_ascii_lowercase() { b - 32 } else { b }
+        } else if b.is_ascii_uppercase() { b + 32 } else { b }
+    }).collect();
+    let content = unsafe { std::str::from_utf8_unchecked(&converted) };
+    let result = if is_global {
+        re.replace_all(content, replacement)
+    } else {
+        re.replace(content, replacement)
+    };
+    emit(&result);
+    RawApplyOutcome::Emit
+}
+
 /// Apply a single-call `.field | re.captures(content)` raw-byte fast path
 /// on one JSON record. Used by both `match` and `capture` apply-sites:
 /// both run a single `captures()` call (not an iterator), emit one output

--- a/tests/fast_path_contract.rs
+++ b/tests/fast_path_contract.rs
@@ -11,7 +11,8 @@
 use jq_jit::fast_path::{
     FastPath, FieldAccessPath, RawApplyOutcome, apply_arith_chain_cmp_raw, apply_field_access_raw,
     apply_field_alternative_raw, apply_field_arith_chain_raw, apply_field_binop_raw,
-    apply_field_const_cmp_raw, apply_field_field_alternative_raw, apply_field_field_cmp_raw,
+    apply_field_case_gsub_raw, apply_field_case_test_raw, apply_field_const_cmp_raw,
+    apply_field_field_alternative_raw, apply_field_field_cmp_raw,
     apply_field_format_raw, apply_field_gsub_raw, apply_field_ltrimstr_tonumber_raw,
     apply_field_match_raw, apply_field_scan_raw, apply_field_str_builtin_raw,
     apply_field_str_concat_raw, apply_field_str_reverse_raw, apply_field_test_raw,
@@ -1019,6 +1020,244 @@ fn raw_field_gsub_non_object_input_bails() {
         let mut emitted: Vec<String> = Vec::new();
         let outcome =
             apply_field_gsub_raw(raw, "x", &re, "X", true, |s| emitted.push(s.to_string()));
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "expected Bail for input {:?}, got {:?}",
+            std::str::from_utf8(raw).unwrap(),
+            outcome,
+        );
+        assert!(emitted.is_empty());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// `.field | ascii_downcase|ascii_upcase | test("p")` — case fold then regex
+// test. Same Bail discipline as `apply_field_test_raw`; the case fold is
+// byte-wise ASCII over the un-decoded string content.
+
+#[test]
+fn raw_field_case_test_downcase_match_emits_true() {
+    let re = regex::Regex::new("^foo").unwrap();
+    let mut emitted: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_field_case_test_raw(
+        b"{\"x\":\"FOObar\"}",
+        "x",
+        false,
+        &re,
+        |b| emitted.push(b.to_vec()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec![b"true".to_vec()]);
+}
+
+#[test]
+fn raw_field_case_test_upcase_match_emits_true() {
+    let re = regex::Regex::new("^FOO").unwrap();
+    let mut emitted: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_field_case_test_raw(
+        b"{\"x\":\"foobar\"}",
+        "x",
+        true,
+        &re,
+        |b| emitted.push(b.to_vec()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec![b"true".to_vec()]);
+}
+
+#[test]
+fn raw_field_case_test_no_match_emits_false() {
+    let re = regex::Regex::new("^foo").unwrap();
+    let mut emitted: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_field_case_test_raw(
+        b"{\"x\":\"BARbaz\"}",
+        "x",
+        false,
+        &re,
+        |b| emitted.push(b.to_vec()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec![b"false".to_vec()]);
+}
+
+#[test]
+fn raw_field_case_test_field_missing_bails() {
+    let re = regex::Regex::new("^foo").unwrap();
+    let mut emitted: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_field_case_test_raw(
+        b"{\"y\":\"FOO\"}",
+        "x",
+        false,
+        &re,
+        |b| emitted.push(b.to_vec()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_field_case_test_non_string_field_bails() {
+    let re = regex::Regex::new(".*").unwrap();
+    for inner in [&b"{\"x\":42}"[..], &b"{\"x\":null}"[..], &b"{\"x\":[1,2]}"[..]] {
+        let mut emitted: Vec<Vec<u8>> = Vec::new();
+        let outcome =
+            apply_field_case_test_raw(inner, "x", false, &re, |b| emitted.push(b.to_vec()));
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "expected Bail for non-string field input {:?}, got {:?}",
+            std::str::from_utf8(inner).unwrap(),
+            outcome,
+        );
+        assert!(emitted.is_empty());
+    }
+}
+
+#[test]
+fn raw_field_case_test_escaped_string_bails() {
+    let re = regex::Regex::new(".*").unwrap();
+    let mut emitted: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_field_case_test_raw(
+        br#"{"x":"a\nb"}"#,
+        "x",
+        false,
+        &re,
+        |b| emitted.push(b.to_vec()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_field_case_test_non_object_input_bails() {
+    let re = regex::Regex::new(".*").unwrap();
+    for raw in [
+        b"42".as_slice(),
+        b"\"hi\"".as_slice(),
+        b"null".as_slice(),
+        b"[1,2,3]".as_slice(),
+    ] {
+        let mut emitted: Vec<Vec<u8>> = Vec::new();
+        let outcome =
+            apply_field_case_test_raw(raw, "x", false, &re, |b| emitted.push(b.to_vec()));
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "expected Bail for input {:?}, got {:?}",
+            std::str::from_utf8(raw).unwrap(),
+            outcome,
+        );
+        assert!(emitted.is_empty());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// `.field | ascii_downcase|ascii_upcase | gsub/sub("p"; "r")` — same Bail
+// discipline as `apply_field_gsub_raw`; case fold runs first, then regex
+// replacement on the folded bytes.
+
+#[test]
+fn raw_field_case_gsub_downcase_global_replaces_all() {
+    let re = regex::Regex::new("a").unwrap();
+    let mut emitted: Vec<String> = Vec::new();
+    let outcome = apply_field_case_gsub_raw(
+        b"{\"x\":\"BAnAnA\"}",
+        "x",
+        false,
+        &re,
+        "X",
+        true,
+        |s| emitted.push(s.to_string()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec!["bXnXnX".to_string()]);
+}
+
+#[test]
+fn raw_field_case_gsub_upcase_first_match_only() {
+    let re = regex::Regex::new("A").unwrap();
+    let mut emitted: Vec<String> = Vec::new();
+    let outcome = apply_field_case_gsub_raw(
+        b"{\"x\":\"banana\"}",
+        "x",
+        true,
+        &re,
+        "X",
+        false,
+        |s| emitted.push(s.to_string()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec!["BXNANA".to_string()]);
+}
+
+#[test]
+fn raw_field_case_gsub_no_match_emits_folded_string() {
+    let re = regex::Regex::new("z").unwrap();
+    let mut emitted: Vec<String> = Vec::new();
+    let outcome = apply_field_case_gsub_raw(
+        b"{\"x\":\"BANANA\"}",
+        "x",
+        false,
+        &re,
+        "X",
+        true,
+        |s| emitted.push(s.to_string()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec!["banana".to_string()]);
+}
+
+#[test]
+fn raw_field_case_gsub_field_missing_or_non_string_bails() {
+    let re = regex::Regex::new("a").unwrap();
+    for inner in [
+        &b"{\"y\":\"hi\"}"[..],
+        &b"{\"x\":42}"[..],
+        &b"{\"x\":null}"[..],
+        &b"{\"x\":[1,2,3]}"[..],
+    ] {
+        let mut emitted: Vec<String> = Vec::new();
+        let outcome = apply_field_case_gsub_raw(
+            inner, "x", false, &re, "X", true, |s| emitted.push(s.to_string()),
+        );
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "expected Bail for input {:?}, got {:?}",
+            std::str::from_utf8(inner).unwrap(),
+            outcome,
+        );
+        assert!(emitted.is_empty());
+    }
+}
+
+#[test]
+fn raw_field_case_gsub_escaped_string_bails() {
+    let re = regex::Regex::new("a").unwrap();
+    let mut emitted: Vec<String> = Vec::new();
+    let outcome = apply_field_case_gsub_raw(
+        br#"{"x":"a\nb"}"#,
+        "x",
+        false,
+        &re,
+        "X",
+        true,
+        |s| emitted.push(s.to_string()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_field_case_gsub_non_object_input_bails() {
+    let re = regex::Regex::new(".*").unwrap();
+    for raw in [
+        b"42".as_slice(),
+        b"\"hi\"".as_slice(),
+        b"null".as_slice(),
+        b"[1,2,3]".as_slice(),
+    ] {
+        let mut emitted: Vec<String> = Vec::new();
+        let outcome = apply_field_case_gsub_raw(
+            raw, "x", false, &re, "X", true, |s| emitted.push(s.to_string()),
+        );
         assert!(
             matches!(outcome, RawApplyOutcome::Bail),
             "expected Bail for input {:?}, got {:?}",

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -3957,3 +3957,58 @@ null
 [ (del(.x))? ]
 [1,2,3]
 []
+
+# Issue #251: field_case_test apply-site uses RawApplyOutcome (#83 Phase B).
+# Happy path: object input + plain string field → case-fold then regex test.
+.x | ascii_upcase | test("FOO")
+{"x":"foobar"}
+true
+
+.x | ascii_downcase | test("^bar")
+{"x":"BARbaz"}
+true
+
+# `?`-wrapped non-string field → Bail to generic, jq raises, ? swallows.
+[ (.x | ascii_upcase | test("FOO"))? ]
+{"x":42}
+[]
+
+[ (.x | ascii_upcase | test("FOO"))? ]
+{"x":null}
+[]
+
+# `?`-wrapped non-object input → Bail to generic.
+[ (.x | ascii_upcase | test("FOO"))? ]
+"plain"
+[]
+
+# Escaped string field: raw scanner Bails, generic path decodes the escape
+# and runs the regex against the upcase'd decoded content.
+.x | ascii_upcase | test("A\\nB")
+{"x":"a\nb"}
+true
+
+# Issue #251: field_case_gsub apply-site uses RawApplyOutcome (#83 Phase B).
+.x | ascii_downcase | gsub("a"; "X")
+{"x":"BANANA"}
+"bXnXnX"
+
+.x | ascii_upcase | sub("A"; "X")
+{"x":"banana"}
+"BXNANA"
+
+# `?`-wrapped non-string field → Bail to generic.
+[ (.x | ascii_downcase | gsub("a"; "X"))? ]
+{"x":42}
+[]
+
+# `?`-wrapped non-object input → Bail to generic.
+[ (.x | ascii_downcase | gsub("a"; "X"))? ]
+[1,2,3]
+[]
+
+# Escaped string field: raw scanner Bails, generic path runs the replacement
+# on the decoded content (so the result has the literal newline back, not "\n").
+.x | ascii_downcase | gsub("a"; "X")
+{"x":"a\nb"}
+"X\nb"


### PR DESCRIPTION
## Summary
- Add `apply_field_case_test_raw` / `apply_field_case_gsub_raw` to `src/fast_path.rs`. Both helpers fold ASCII case (`a..z` ↔ `A..Z`) over the un-decoded string content, then run the regex test/replacement.
- Migrate the `detect_field_case_test` / `detect_field_case_gsub` apply-sites in `bin/jq-jit.rs` (stdin and file dispatch) to the named `RawApplyOutcome::{Emit, Bail}` discipline.
- 13 new contract cases pin the verdict surface; 11 new regression cases cover the `?`-wrapped Bail matrix and the escape-bearing string round-trip through the generic path.

Bail discipline matches the underlying `apply_field_test_raw` / `apply_field_gsub_raw`: missing field, non-string field, escape-bearing string, or non-object input all return `Bail` so the generic path produces jq's verdict.

Refs #251.

## Test plan
- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (passes including new contract + regression cases)
- [x] `./bench/comprehensive.sh --quick` (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)