### PR TITLE
refactor: two_field_binop_const apply-site uses RawApplyOutcome (#83 Phase B)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -146,6 +146,7 @@ use jq_jit::fast_path::{
     apply_field_gsub_raw, apply_field_ltrimstr_tonumber_raw, apply_field_match_raw,
     apply_field_scan_raw, apply_field_str_builtin_raw, apply_field_str_concat_raw,
     apply_field_str_reverse_raw, apply_field_test_raw, apply_full_object_fields_raw,
+    apply_two_field_binop_const_raw,
     apply_has_field_raw, apply_has_multi_field_raw, apply_multi_field_access_raw,
     apply_nested_field_access_raw, apply_object_compute_raw, apply_select_arith_cmp_raw,
     apply_select_cmp_raw, apply_select_field_null_raw, apply_select_str_raw,
@@ -5948,30 +5949,16 @@ fn real_main() {
                         Ok(())
                     })
                 } else if let Some((ref f1, ref op1, ref f2, ref op2, const_val)) = two_field_binop_const {
-                    use jq_jit::ir::BinOp;
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        if let Some((a, b)) = json_object_get_two_nums(raw, 0, f1, f2) {
-                            let inner = match op1 {
-                                BinOp::Add => a + b, BinOp::Sub => a - b,
-                                BinOp::Mul => a * b, BinOp::Div => a / b,
-                                BinOp::Mod => jq_jit::runtime::jq_mod_f64(a, b).unwrap_or(f64::NAN),
-                                _ => unreachable!(),
-                            };
-                            let result = match op2 {
-                                BinOp::Add => inner + const_val, BinOp::Sub => inner - const_val,
-                                BinOp::Mul => inner * const_val, BinOp::Div => inner / const_val,
-                                BinOp::Mod => jq_jit::runtime::jq_mod_f64(inner, const_val).unwrap_or(f64::NAN),
-                                _ => unreachable!(),
-                            };
-                            if result.is_finite() {
+                        let outcome = apply_two_field_binop_const_raw(
+                            raw, f1, f2, *op1, *op2, const_val,
+                            |result| {
                                 push_jq_number_bytes(&mut compact_buf, result);
                                 compact_buf.push(b'\n');
-                            } else {
-                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                            }
-                        } else {
+                            },
+                        );
+                        if let RawApplyOutcome::Bail = outcome {
                             let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                             process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }
@@ -19121,30 +19108,17 @@ fn real_main() {
                     Ok(())
                 })
             } else if let Some((ref f1, ref op1, ref f2, ref op2, const_val)) = two_field_binop_const {
-                use jq_jit::ir::BinOp;
                 let content_bytes = content.as_bytes();
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    if let Some((a, b)) = json_object_get_two_nums(raw, 0, f1, f2) {
-                        let inner = match op1 {
-                            BinOp::Add => a + b, BinOp::Sub => a - b,
-                            BinOp::Mul => a * b, BinOp::Div => a / b,
-                            BinOp::Mod => jq_jit::runtime::jq_mod_f64(a, b).unwrap_or(f64::NAN),
-                            _ => unreachable!(),
-                        };
-                        let result = match op2 {
-                            BinOp::Add => inner + const_val, BinOp::Sub => inner - const_val,
-                            BinOp::Mul => inner * const_val, BinOp::Div => inner / const_val,
-                            BinOp::Mod => jq_jit::runtime::jq_mod_f64(inner, const_val).unwrap_or(f64::NAN),
-                            _ => unreachable!(),
-                        };
-                        if result.is_finite() {
+                    let outcome = apply_two_field_binop_const_raw(
+                        raw, f1, f2, *op1, *op2, const_val,
+                        |result| {
                             push_jq_number_bytes(&mut compact_buf, result);
                             compact_buf.push(b'\n');
-                        } else {
-                            compact_buf.extend_from_slice(b"null\n");
-                        }
-                    } else {
+                        },
+                    );
+                    if let RawApplyOutcome::Bail = outcome {
                         let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                         process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                     }

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -903,6 +903,63 @@ where
     RawApplyOutcome::Emit
 }
 
+/// Apply the `(.x <op1> .y) <op2> <const>` raw-byte two-field-and-const
+/// arithmetic fast path on a single JSON record. Both `.x` and `.y`
+/// must resolve to JSON numbers; `<op1>` and `<op2>` are arithmetic
+/// (`Add`/`Sub`/`Mul`/`Div`/`Mod`).
+///
+/// Bail discipline:
+/// * Either field absent or non-numeric — [`RawApplyOutcome::Bail`]
+///   so the generic path raises jq's type error.
+/// * Either op is non-arithmetic (`Eq`/`And`/etc.) —
+///   [`RawApplyOutcome::Bail`] (defensive — the detector should never
+///   produce these, but the helper rejects them at the boundary).
+/// * Inner or final result non-finite (div-by-zero / mod-by-zero,
+///   IEEE NaN/∞) — [`RawApplyOutcome::Bail`] so the generic path
+///   raises jq's `/ by zero` etc.
+/// * Non-object input — [`RawApplyOutcome::Bail`].
+///
+/// On success, invokes `emit(result)` so the apply-site owns
+/// JSON-number formatting.
+pub fn apply_two_field_binop_const_raw<F>(
+    raw: &[u8],
+    field_a: &str,
+    field_b: &str,
+    op1: BinOp,
+    op2: BinOp,
+    cval: f64,
+    mut emit: F,
+) -> RawApplyOutcome
+where
+    F: FnMut(f64),
+{
+    let (a, b) = match json_object_get_two_nums(raw, 0, field_a, field_b) {
+        Some(p) => p,
+        None => return RawApplyOutcome::Bail,
+    };
+    let inner = match op1 {
+        BinOp::Add => a + b,
+        BinOp::Sub => a - b,
+        BinOp::Mul => a * b,
+        BinOp::Div => a / b,
+        BinOp::Mod => jq_mod_f64(a, b).unwrap_or(f64::NAN),
+        _ => return RawApplyOutcome::Bail,
+    };
+    let result = match op2 {
+        BinOp::Add => inner + cval,
+        BinOp::Sub => inner - cval,
+        BinOp::Mul => inner * cval,
+        BinOp::Div => inner / cval,
+        BinOp::Mod => jq_mod_f64(inner, cval).unwrap_or(f64::NAN),
+        _ => return RawApplyOutcome::Bail,
+    };
+    if !result.is_finite() {
+        return RawApplyOutcome::Bail;
+    }
+    emit(result);
+    RawApplyOutcome::Emit
+}
+
 /// Apply the `.field <op1> <c1> <op2> <c2> ...` raw-byte arithmetic chain
 /// fast path on a single JSON record (a left-fold of `(BinOp, f64)` pairs
 /// over a single numeric field).

--- a/tests/fast_path_contract.rs
+++ b/tests/fast_path_contract.rs
@@ -25,6 +25,7 @@ use jq_jit::fast_path::{
     apply_field_update_test_raw, apply_field_update_tostring_raw,
     apply_field_update_trim_raw, apply_select_arith_cmp_raw, apply_select_cmp_raw,
     apply_select_field_null_raw, apply_select_str_raw, apply_select_str_test_raw,
+    apply_two_field_binop_const_raw,
 };
 use jq_jit::interpreter::Filter;
 use jq_jit::ir::BinOp;
@@ -2261,6 +2262,123 @@ fn raw_field_arith_chain_non_object_input_bails() {
         assert!(
             matches!(outcome, RawApplyOutcome::Bail),
             "expected Bail for arith_chain input {:?}, got {:?}",
+            std::str::from_utf8(raw).unwrap(),
+            outcome,
+        );
+        assert!(emitted.is_empty());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// `(.x <op1> .y) <op2> <const>` — two-field-and-const arithmetic. Helper
+// Bails on missing / non-numeric / non-arith op / non-finite result /
+// non-object so cross-type and runtime errors route through the generic
+// path.
+
+#[test]
+fn raw_two_field_binop_const_emits_finite_result() {
+    let mut emitted: Vec<f64> = Vec::new();
+    // (3 + 4) * 2 = 14
+    let outcome = apply_two_field_binop_const_raw(
+        b"{\"x\":3,\"y\":4}",
+        "x", "y", BinOp::Add, BinOp::Mul, 2.0,
+        |n| emitted.push(n),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec![14.0]);
+}
+
+#[test]
+fn raw_two_field_binop_const_field_missing_bails() {
+    let mut emitted: Vec<f64> = Vec::new();
+    let outcome = apply_two_field_binop_const_raw(
+        b"{\"x\":3}",
+        "x", "y", BinOp::Add, BinOp::Mul, 2.0,
+        |n| emitted.push(n),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_two_field_binop_const_non_numeric_field_bails() {
+    for inner in [&b"{\"x\":3,\"y\":\"hi\"}"[..], &b"{\"x\":null,\"y\":4}"[..]] {
+        let mut emitted: Vec<f64> = Vec::new();
+        let outcome = apply_two_field_binop_const_raw(
+            inner, "x", "y", BinOp::Add, BinOp::Mul, 2.0, |n| emitted.push(n),
+        );
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "expected Bail for non-numeric input {:?}, got {:?}",
+            std::str::from_utf8(inner).unwrap(),
+            outcome,
+        );
+        assert!(emitted.is_empty());
+    }
+}
+
+#[test]
+fn raw_two_field_binop_const_non_arith_op_bails() {
+    for op in [BinOp::Eq, BinOp::Lt, BinOp::And] {
+        let mut emitted: Vec<f64> = Vec::new();
+        // op1 is non-arith
+        let outcome = apply_two_field_binop_const_raw(
+            b"{\"x\":3,\"y\":4}",
+            "x", "y", op, BinOp::Mul, 2.0, |n| emitted.push(n),
+        );
+        assert!(matches!(outcome, RawApplyOutcome::Bail), "op1={:?}", op);
+        // op2 is non-arith
+        let mut emitted2: Vec<f64> = Vec::new();
+        let outcome2 = apply_two_field_binop_const_raw(
+            b"{\"x\":3,\"y\":4}",
+            "x", "y", BinOp::Add, op, 2.0, |n| emitted2.push(n),
+        );
+        assert!(matches!(outcome2, RawApplyOutcome::Bail), "op2={:?}", op);
+    }
+}
+
+#[test]
+fn raw_two_field_binop_const_div_by_zero_bails() {
+    let mut emitted: Vec<f64> = Vec::new();
+    // (1 / 0) * 2 = inf → Bail
+    let outcome = apply_two_field_binop_const_raw(
+        b"{\"x\":1,\"y\":0}",
+        "x", "y", BinOp::Div, BinOp::Mul, 2.0,
+        |n| emitted.push(n),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_two_field_binop_const_inner_finite_outer_div_zero_bails() {
+    let mut emitted: Vec<f64> = Vec::new();
+    // (3 + 4) / 0 = inf → Bail
+    let outcome = apply_two_field_binop_const_raw(
+        b"{\"x\":3,\"y\":4}",
+        "x", "y", BinOp::Add, BinOp::Div, 0.0,
+        |n| emitted.push(n),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_two_field_binop_const_non_object_input_bails() {
+    for raw in [
+        b"42".as_slice(),
+        b"\"hi\"".as_slice(),
+        b"null".as_slice(),
+        b"true".as_slice(),
+        b"[1,2,3]".as_slice(),
+    ] {
+        let mut emitted: Vec<f64> = Vec::new();
+        let outcome = apply_two_field_binop_const_raw(
+            raw, "x", "y", BinOp::Add, BinOp::Mul, 2.0, |n| emitted.push(n),
+        );
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "expected Bail for two_field_binop_const input {:?}, got {:?}",
             std::str::from_utf8(raw).unwrap(),
             outcome,
         );

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -4058,3 +4058,45 @@ true
 [ (((.x + 1) * 2) | tostring)? ]
 "plain"
 []
+
+# Issue #251: two_field_binop_const apply-site uses RawApplyOutcome (#83 Phase B).
+# Helper Bails on missing/non-numeric/non-arith/non-finite/non-object so jq's
+# error semantics surface through `?`. Also fixes a pre-existing #83-class bug
+# where the file-mode apply-site silently emitted `null\n` on non-finite.
+(.x + .y) * 2
+{"x":3,"y":4}
+14
+
+(.x - .y) + 10
+{"x":7,"y":2}
+15
+
+# Missing field — generic resolves missing as null; null + 3 = 3, * 2 = 6.
+[ ((.x + .y) * 2)? ]
+{"x":3}
+[6]
+
+# Non-numeric field — generic raises type error, ? swallows.
+[ ((.x + .y) * 2)? ]
+{"x":3,"y":"hi"}
+[]
+
+# Non-object input — generic raises indexing error, ? swallows.
+[ ((.x + .y) * 2)? ]
+"plain"
+[]
+
+[ ((.x + .y) * 2)? ]
+null
+[]
+
+# Inner div-by-zero — helper Bails on non-finite, generic raises.
+[ ((.x / .y) * 2)? ]
+{"x":1,"y":0}
+[]
+
+# Outer div-by-zero — helper Bails on non-finite (was previously emitting `null`
+# in file mode pre-#83-Phase-B).
+[ ((.x + .y) / 0)? ]
+{"x":3,"y":4}
+[]


### PR DESCRIPTION
## Summary
- Add `apply_two_field_binop_const_raw` to `src/fast_path.rs` for `(.x op1 .y) op2 const` over two numeric fields and a compile-time constant.
- Migrate the `detect_two_field_binop_const` apply-sites in `bin/jq-jit.rs` (stdin + file-mode) to the named `RawApplyOutcome::{Emit, Bail}` discipline.
- Bail discipline: missing field, non-numeric field, non-arithmetic op (defensive), non-finite inner or final result, or non-object input.

**Bug fix:** The file-mode apply-site previously silently emitted `null\n` on non-finite results (e.g. div-by-zero), while the stdin counterpart correctly routed through generic eval. After migration both share the structural Bail at the helper boundary.

7 new contract cases pin the verdict surface; 8 new regression cases cover the `?`-wrapped Bail matrix including inner and outer div-by-zero.

Refs #251.

## Test plan
- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (840 regression cases pass, +8 over main; 232 contract cases, +7)
- [x] `./bench/comprehensive.sh --quick` (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)