### PR TITLE
refactor: field_binop_const_unary apply-site uses RawApplyOutcome (#83 Phase B)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -145,8 +145,8 @@ use jq_jit::fast_path::{
     apply_field_field_alternative_raw, apply_field_field_cmp_raw, apply_field_format_raw,
     apply_field_gsub_raw, apply_field_ltrimstr_tonumber_raw, apply_field_match_raw,
     apply_field_scan_raw, apply_field_str_builtin_raw, apply_field_str_concat_raw,
-    apply_field_str_reverse_raw, apply_field_test_raw, apply_full_object_fields_raw,
-    apply_two_field_binop_const_raw,
+    apply_field_binop_const_unary_raw, apply_field_str_reverse_raw, apply_field_test_raw,
+    apply_full_object_fields_raw, apply_two_field_binop_const_raw,
     apply_has_field_raw, apply_has_multi_field_raw, apply_multi_field_access_raw,
     apply_nested_field_access_raw, apply_object_compute_raw, apply_select_arith_cmp_raw,
     apply_select_cmp_raw, apply_select_field_null_raw, apply_select_str_raw,
@@ -6207,32 +6207,16 @@ fn real_main() {
                         Ok(())
                     })
                 } else if let Some((ref field, ref bop, cval, ref uop_opt, const_left)) = field_binop_const_unary {
-                    use jq_jit::ir::BinOp;
-                    use jq_jit::ir::UnaryOp;
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        if let Some(n) = json_object_get_num(raw, 0, field) {
-                            let (a, b) = if const_left { (cval, n) } else { (n, cval) };
-                            let mid = match bop {
-                                BinOp::Add => a + b,
-                                BinOp::Sub => a - b,
-                                BinOp::Mul => a * b,
-                                BinOp::Div => a / b,
-                                BinOp::Mod => jq_jit::runtime::jq_mod_f64(a, b).unwrap_or(f64::NAN),
-                                _ => unreachable!(),
-                            };
-                            let result = if let Some(uop) = uop_opt {
-                                match uop {
-                                    UnaryOp::Floor => mid.floor(),
-                                    UnaryOp::Ceil => mid.ceil(),
-                                    UnaryOp::Sqrt => mid.sqrt(),
-                                    UnaryOp::Fabs | UnaryOp::Abs => mid.abs(),
-                                    _ => unreachable!(),
-                                }
-                            } else { mid };
-                            push_jq_number_bytes(&mut compact_buf, result);
-                            compact_buf.push(b'\n');
-                        } else {
+                        let outcome = apply_field_binop_const_unary_raw(
+                            raw, field, *bop, cval, *uop_opt, const_left,
+                            |result| {
+                                push_jq_number_bytes(&mut compact_buf, result);
+                                compact_buf.push(b'\n');
+                            },
+                        );
+                        if let RawApplyOutcome::Bail = outcome {
                             let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                             process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }
@@ -19327,33 +19311,17 @@ fn real_main() {
                     Ok(())
                 })
             } else if let Some((ref field, ref bop, cval, ref uop_opt, const_left)) = field_binop_const_unary {
-                use jq_jit::ir::BinOp;
-                use jq_jit::ir::UnaryOp;
                 let content_bytes = content.as_bytes();
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    if let Some(n) = json_object_get_num(raw, 0, field) {
-                        let (a, b) = if const_left { (cval, n) } else { (n, cval) };
-                        let mid = match bop {
-                            BinOp::Add => a + b,
-                            BinOp::Sub => a - b,
-                            BinOp::Mul => a * b,
-                            BinOp::Div => a / b,
-                            BinOp::Mod => jq_jit::runtime::jq_mod_f64(a, b).unwrap_or(f64::NAN),
-                            _ => unreachable!(),
-                        };
-                        let result = if let Some(uop) = uop_opt {
-                            match uop {
-                                UnaryOp::Floor => mid.floor(),
-                                UnaryOp::Ceil => mid.ceil(),
-                                UnaryOp::Sqrt => mid.sqrt(),
-                                UnaryOp::Fabs | UnaryOp::Abs => mid.abs(),
-                                _ => unreachable!(),
-                            }
-                        } else { mid };
-                        push_jq_number_bytes(&mut compact_buf, result);
-                        compact_buf.push(b'\n');
-                    } else {
+                    let outcome = apply_field_binop_const_unary_raw(
+                        raw, field, *bop, cval, *uop_opt, const_left,
+                        |result| {
+                            push_jq_number_bytes(&mut compact_buf, result);
+                            compact_buf.push(b'\n');
+                        },
+                    );
+                    if let RawApplyOutcome::Bail = outcome {
                         let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                         process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                     }

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -62,7 +62,7 @@
 
 use anyhow::Result;
 
-use crate::ir::BinOp;
+use crate::ir::{BinOp, UnaryOp};
 use crate::runtime::jq_mod_f64;
 use crate::value::{
     KeyStr, Value, ObjInner, json_object_del_field, json_object_del_fields,
@@ -899,6 +899,73 @@ where
         BinOp::Ne => n != cval,
         _ => return RawApplyOutcome::Bail,
     };
+    emit(result);
+    RawApplyOutcome::Emit
+}
+
+/// Apply the `.field <op> <const>` (or `<const> <op> .field`) raw-byte
+/// fast path on a single JSON record, optionally followed by a unary
+/// math op (`floor`/`ceil`/`sqrt`/`fabs`/`abs`).
+///
+/// `const_left = true` swaps operands so the constant is on the left
+/// (e.g. `2 - .x`). `uop_opt = None` skips the unary stage.
+///
+/// Bail discipline:
+/// * Field absent or non-numeric — [`RawApplyOutcome::Bail`] so the
+///   generic path raises jq's type error.
+/// * Non-arithmetic op (`Eq`/`And`/etc.) — [`RawApplyOutcome::Bail`]
+///   (defensive — the detector should never produce these).
+/// * Unary op not in the supported math set
+///   (`Floor`/`Ceil`/`Sqrt`/`Fabs`/`Abs`) — [`RawApplyOutcome::Bail`]
+///   (defensive — same reason).
+/// * Final result non-finite (div-by-zero, sqrt of negative, etc.) —
+///   [`RawApplyOutcome::Bail`] so the generic path raises jq's
+///   `/ by zero` etc. Without this guard the fast path silently emits
+///   `Infinity`/`NaN`-formatted bytes (#83-class bug in the prior
+///   apply-site).
+/// * Non-object input — [`RawApplyOutcome::Bail`].
+///
+/// On success, invokes `emit(result)` so the apply-site owns
+/// JSON-number formatting.
+pub fn apply_field_binop_const_unary_raw<F>(
+    raw: &[u8],
+    field: &str,
+    bop: BinOp,
+    cval: f64,
+    uop_opt: Option<UnaryOp>,
+    const_left: bool,
+    mut emit: F,
+) -> RawApplyOutcome
+where
+    F: FnMut(f64),
+{
+    let n = match json_object_get_num(raw, 0, field) {
+        Some(v) => v,
+        None => return RawApplyOutcome::Bail,
+    };
+    let (a, b) = if const_left { (cval, n) } else { (n, cval) };
+    let mid = match bop {
+        BinOp::Add => a + b,
+        BinOp::Sub => a - b,
+        BinOp::Mul => a * b,
+        BinOp::Div => a / b,
+        BinOp::Mod => jq_mod_f64(a, b).unwrap_or(f64::NAN),
+        _ => return RawApplyOutcome::Bail,
+    };
+    let result = if let Some(uop) = uop_opt {
+        match uop {
+            UnaryOp::Floor => mid.floor(),
+            UnaryOp::Ceil => mid.ceil(),
+            UnaryOp::Sqrt => mid.sqrt(),
+            UnaryOp::Fabs | UnaryOp::Abs => mid.abs(),
+            _ => return RawApplyOutcome::Bail,
+        }
+    } else {
+        mid
+    };
+    if !result.is_finite() {
+        return RawApplyOutcome::Bail;
+    }
     emit(result);
     RawApplyOutcome::Emit
 }

--- a/tests/fast_path_contract.rs
+++ b/tests/fast_path_contract.rs
@@ -23,12 +23,13 @@ use jq_jit::fast_path::{
     apply_field_update_split_first_raw, apply_field_update_split_last_raw,
     apply_field_update_str_concat_raw, apply_field_update_str_map_raw,
     apply_field_update_test_raw, apply_field_update_tostring_raw,
+    apply_field_binop_const_unary_raw,
     apply_field_update_trim_raw, apply_select_arith_cmp_raw, apply_select_cmp_raw,
     apply_select_field_null_raw, apply_select_str_raw, apply_select_str_test_raw,
     apply_two_field_binop_const_raw,
 };
 use jq_jit::interpreter::Filter;
-use jq_jit::ir::BinOp;
+use jq_jit::ir::{BinOp, UnaryOp};
 use jq_jit::value::Value;
 
 #[test]
@@ -2379,6 +2380,152 @@ fn raw_two_field_binop_const_non_object_input_bails() {
         assert!(
             matches!(outcome, RawApplyOutcome::Bail),
             "expected Bail for two_field_binop_const input {:?}, got {:?}",
+            std::str::from_utf8(raw).unwrap(),
+            outcome,
+        );
+        assert!(emitted.is_empty());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// `.field <op> <const> [| unary]` — single-field-with-const arithmetic,
+// optional final unary math op. Helper Bails on missing / non-numeric /
+// non-arith op / unsupported unary / non-finite / non-object so jq's runtime
+// errors (div-by-zero, type errors) surface through the generic path.
+
+#[test]
+fn raw_field_binop_const_unary_no_unary() {
+    let mut emitted: Vec<f64> = Vec::new();
+    let outcome = apply_field_binop_const_unary_raw(
+        b"{\"x\":5}", "x", BinOp::Add, 3.0, None, false, |n| emitted.push(n),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec![8.0]);
+}
+
+#[test]
+fn raw_field_binop_const_unary_const_left_subtraction() {
+    let mut emitted: Vec<f64> = Vec::new();
+    // 2 - .x with x=5 → -3, then abs → 3
+    let outcome = apply_field_binop_const_unary_raw(
+        b"{\"x\":5}", "x", BinOp::Sub, 2.0, Some(UnaryOp::Abs), true,
+        |n| emitted.push(n),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec![3.0]);
+}
+
+#[test]
+fn raw_field_binop_const_unary_floor_ceil() {
+    let mut floored: Vec<f64> = Vec::new();
+    let outcome = apply_field_binop_const_unary_raw(
+        b"{\"x\":3.7}", "x", BinOp::Add, 0.0, Some(UnaryOp::Floor), false,
+        |n| floored.push(n),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(floored, vec![3.0]);
+
+    let mut ceilinged: Vec<f64> = Vec::new();
+    let outcome = apply_field_binop_const_unary_raw(
+        b"{\"x\":3.2}", "x", BinOp::Add, 0.0, Some(UnaryOp::Ceil), false,
+        |n| ceilinged.push(n),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(ceilinged, vec![4.0]);
+}
+
+#[test]
+fn raw_field_binop_const_unary_field_missing_bails() {
+    let mut emitted: Vec<f64> = Vec::new();
+    let outcome = apply_field_binop_const_unary_raw(
+        b"{\"y\":3}", "x", BinOp::Add, 1.0, None, false, |n| emitted.push(n),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_field_binop_const_unary_non_numeric_field_bails() {
+    for inner in [&b"{\"x\":\"hi\"}"[..], &b"{\"x\":null}"[..], &b"{\"x\":[1]}"[..]] {
+        let mut emitted: Vec<f64> = Vec::new();
+        let outcome = apply_field_binop_const_unary_raw(
+            inner, "x", BinOp::Add, 1.0, None, false, |n| emitted.push(n),
+        );
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "expected Bail for non-numeric input {:?}, got {:?}",
+            std::str::from_utf8(inner).unwrap(),
+            outcome,
+        );
+        assert!(emitted.is_empty());
+    }
+}
+
+#[test]
+fn raw_field_binop_const_unary_non_arith_op_bails() {
+    for op in [BinOp::Eq, BinOp::Lt, BinOp::And] {
+        let mut emitted: Vec<f64> = Vec::new();
+        let outcome = apply_field_binop_const_unary_raw(
+            b"{\"x\":5}", "x", op, 3.0, None, false, |n| emitted.push(n),
+        );
+        assert!(matches!(outcome, RawApplyOutcome::Bail), "op={:?}", op);
+    }
+}
+
+#[test]
+fn raw_field_binop_const_unary_unsupported_unary_bails() {
+    // Detector should never produce these for this shape, but defensive Bail.
+    for uop in [UnaryOp::Length, UnaryOp::ToString, UnaryOp::Type] {
+        let mut emitted: Vec<f64> = Vec::new();
+        let outcome = apply_field_binop_const_unary_raw(
+            b"{\"x\":5}", "x", BinOp::Add, 3.0, Some(uop), false,
+            |n| emitted.push(n),
+        );
+        assert!(matches!(outcome, RawApplyOutcome::Bail), "uop={:?}", uop);
+    }
+}
+
+#[test]
+fn raw_field_binop_const_unary_div_by_zero_bails() {
+    // .x / 0 → inf → Bail (fixes #83-class divergence: prior fast path
+    // emitted "1.7976931348623157e+308" instead of jq's "/ by zero" error).
+    let mut emitted: Vec<f64> = Vec::new();
+    let outcome = apply_field_binop_const_unary_raw(
+        b"{\"x\":4}", "x", BinOp::Div, 0.0, None, false, |n| emitted.push(n),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_field_binop_const_unary_sqrt_negative_bails() {
+    // (.x + 0) | sqrt with x=-1 → NaN → Bail (generic produces null,
+    // matching jq).
+    let mut emitted: Vec<f64> = Vec::new();
+    let outcome = apply_field_binop_const_unary_raw(
+        b"{\"x\":-1}", "x", BinOp::Add, 0.0, Some(UnaryOp::Sqrt), false,
+        |n| emitted.push(n),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_field_binop_const_unary_non_object_input_bails() {
+    for raw in [
+        b"42".as_slice(),
+        b"\"hi\"".as_slice(),
+        b"null".as_slice(),
+        b"true".as_slice(),
+        b"[1,2,3]".as_slice(),
+    ] {
+        let mut emitted: Vec<f64> = Vec::new();
+        let outcome = apply_field_binop_const_unary_raw(
+            raw, "x", BinOp::Add, 1.0, None, false, |n| emitted.push(n),
+        );
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "expected Bail for input {:?}, got {:?}",
             std::str::from_utf8(raw).unwrap(),
             outcome,
         );

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -4100,3 +4100,51 @@ null
 [ ((.x + .y) / 0)? ]
 {"x":3,"y":4}
 []
+
+# Issue #251: field_binop_const_unary apply-site uses RawApplyOutcome (#83
+# Phase B). Helper Bails on missing/non-numeric/non-arith/unsupported-unary/
+# non-finite/non-object. Also fixes a pre-existing #83-class bug where the
+# apply-site silently emitted `1.7976931348623157e+308` for non-finite results
+# (e.g. `.x / 0`) instead of jq's `/ by zero` error.
+(.x + 1) | floor
+{"x":3.7}
+4
+
+(2 - .x) | abs
+{"x":5}
+3
+
+(.x * 0.5) | ceil
+{"x":7}
+4
+
+(.x + 0) | sqrt
+{"x":4}
+2
+
+# `?`-wrapped: missing field — generic resolves missing as null, null + 1 = 1.
+[ ((.x + 1) | floor)? ]
+{"y":3}
+[1]
+
+# `?`-wrapped: non-numeric field — generic raises type error, ? swallows.
+[ ((.x + 1) | floor)? ]
+{"x":"hi"}
+[]
+
+# `?`-wrapped: non-object input — generic raises indexing error.
+[ ((.x + 1) | floor)? ]
+"plain"
+[]
+
+# `?`-wrapped: div-by-zero — helper Bails on non-finite, generic raises (was
+# emitting `1.7976931348623157e+308` pre-#83-Phase-B).
+[ (.x / 0)? ]
+{"x":4}
+[]
+
+# sqrt of negative produces NaN → helper Bails, generic produces null
+# (matching jq's behaviour for sqrt of negative).
+(.x + 0) | sqrt
+{"x":-1}
+null


### PR DESCRIPTION
## Summary
- Add `apply_field_binop_const_unary_raw` to `src/fast_path.rs` for `.field op cval [| floor|ceil|sqrt|abs|fabs]` (and `cval op .field` via `const_left`).
- Migrate the `detect_field_binop_const_unary` apply-sites in `bin/jq-jit.rs` (stdin + file-mode) to the named `RawApplyOutcome::{Emit, Bail}` discipline.
- Bail discipline: missing field, non-numeric field, non-arith op, unsupported unary op (defensive), non-finite final result (div-by-zero, sqrt of negative), or non-object input.

**Bug fix:** The prior fast-path emitted `1.7976931348623157e+308` (the saturating output for ±Infinity) on non-finite results, while jq raises `/ by zero` etc. After migration the structural Bail at the helper boundary routes through the generic path so the right error surfaces.

10 new contract cases pin the verdict surface; 9 new regression cases cover the `?`-wrapped Bail matrix.

Refs #251.

## Test plan
- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (849 regression cases pass, +9 over main; 242 contract cases, +10)
- [x] `./bench/comprehensive.sh --quick` (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)