### PR TITLE
refactor: field_unary_arith apply-site uses RawApplyOutcome (#83 Phase B)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -146,7 +146,7 @@ use jq_jit::fast_path::{
     apply_field_gsub_raw, apply_field_ltrimstr_tonumber_raw, apply_field_match_raw,
     apply_field_scan_raw, apply_field_str_builtin_raw, apply_field_str_concat_raw,
     apply_field_binop_const_unary_raw, apply_field_str_reverse_raw, apply_field_test_raw,
-    apply_full_object_fields_raw, apply_two_field_binop_const_raw,
+    apply_field_unary_arith_raw, apply_full_object_fields_raw, apply_two_field_binop_const_raw,
     apply_has_field_raw, apply_has_multi_field_raw, apply_multi_field_access_raw,
     apply_nested_field_access_raw, apply_object_compute_raw, apply_select_arith_cmp_raw,
     apply_select_cmp_raw, apply_select_field_null_raw, apply_select_str_raw,
@@ -6146,57 +6146,16 @@ fn real_main() {
                         Ok(())
                     })
                 } else if let Some((ref field, ref uop, ref arith_steps)) = field_unary_arith {
-                    use jq_jit::ir::{BinOp, UnaryOp};
-                    let is_length = matches!(uop, UnaryOp::Length);
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        let base_val = if is_length {
-                            // Length: get field raw bytes and compute length
-                            if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, field) {
-                                let val = &raw[vs..ve];
-                                match val[0] {
-                                    b'"' => {
-                                        let inner = &val[1..ve-vs-1];
-                                        if !inner.contains(&b'\\') {
-                                            if inner.is_ascii() {
-                                                Some(inner.len() as f64)
-                                            } else {
-                                                Some(unsafe { std::str::from_utf8_unchecked(inner) }.chars().count() as f64)
-                                            }
-                                        } else { None }
-                                    }
-                                    b'[' | b'{' => {
-                                        json_value_length(val, 0).map(|l| l as f64)
-                                    }
-                                    b'n' => Some(0.0), // null length = 0
-                                    _ => json_object_get_num(raw, 0, field).map(|n| n.abs()),
-                                }
-                            } else { Some(0.0) } // missing field = null length = 0
-                        } else {
-                            json_object_get_num(raw, 0, field).map(|n| match uop {
-                                UnaryOp::Floor => n.floor(),
-                                UnaryOp::Ceil => n.ceil(),
-                                UnaryOp::Sqrt => n.sqrt(),
-                                UnaryOp::Fabs | UnaryOp::Abs => n.abs(),
-                                UnaryOp::Round => n.round(),
-                                _ => n,
-                            })
-                        };
-                        if let Some(base) = base_val {
-                            let mut v = base;
-                            for (op, c) in arith_steps {
-                                v = match op {
-                                    BinOp::Add => v + c,
-                                    BinOp::Sub => v - c,
-                                    BinOp::Mul => v * c,
-                                    BinOp::Div => v / c,
-                                    BinOp::Mod => jq_jit::runtime::jq_mod_f64(v, *c).unwrap_or(f64::NAN),
-                                    _ => v,
-                                };
-                            }
-                            push_jq_number_bytes(&mut compact_buf, v);
-                            compact_buf.push(b'\n');
-                        } else {
+                        let outcome = apply_field_unary_arith_raw(
+                            raw, field, *uop, arith_steps,
+                            |result| {
+                                push_jq_number_bytes(&mut compact_buf, result);
+                                compact_buf.push(b'\n');
+                            },
+                        );
+                        if let RawApplyOutcome::Bail = outcome {
                             let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                             process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }
@@ -19258,49 +19217,17 @@ fn real_main() {
                     Ok(())
                 })
             } else if let Some((ref field, ref uop, ref arith_steps)) = field_unary_arith {
-                use jq_jit::ir::{BinOp, UnaryOp};
                 let content_bytes = content.as_bytes();
-                let is_length = matches!(uop, UnaryOp::Length);
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    let base_val = if is_length {
-                        if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, field) {
-                            let val = &raw[vs..ve];
-                            match val[0] {
-                                b'"' => {
-                                    let inner = &val[1..ve-vs-1];
-                                    if !inner.contains(&b'\\') {
-                                        if inner.is_ascii() { Some(inner.len() as f64) }
-                                        else { Some(unsafe { std::str::from_utf8_unchecked(inner) }.chars().count() as f64) }
-                                    } else { None }
-                                }
-                                b'[' | b'{' => json_value_length(val, 0).map(|l| l as f64),
-                                b'n' => Some(0.0),
-                                _ => json_object_get_num(raw, 0, field).map(|n| n.abs()),
-                            }
-                        } else { Some(0.0) }
-                    } else {
-                        json_object_get_num(raw, 0, field).map(|n| match uop {
-                            UnaryOp::Floor => n.floor(), UnaryOp::Ceil => n.ceil(),
-                            UnaryOp::Sqrt => n.sqrt(), UnaryOp::Fabs | UnaryOp::Abs => n.abs(),
-                            UnaryOp::Round => n.round(), _ => n,
-                        })
-                    };
-                    if let Some(base) = base_val {
-                        let mut v = base;
-                        for (op, c) in arith_steps {
-                            v = match op {
-                                BinOp::Add => v + c,
-                                BinOp::Sub => v - c,
-                                BinOp::Mul => v * c,
-                                BinOp::Div => v / c,
-                                BinOp::Mod => jq_jit::runtime::jq_mod_f64(v, *c).unwrap_or(f64::NAN),
-                                _ => v,
-                            };
-                        }
-                        push_jq_number_bytes(&mut compact_buf, v);
-                        compact_buf.push(b'\n');
-                    } else {
+                    let outcome = apply_field_unary_arith_raw(
+                        raw, field, *uop, arith_steps,
+                        |result| {
+                            push_jq_number_bytes(&mut compact_buf, result);
+                            compact_buf.push(b'\n');
+                        },
+                    );
+                    if let RawApplyOutcome::Bail = outcome {
                         let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                         process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                     }

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -74,7 +74,7 @@ use crate::value::{
     json_object_update_field_split_first, json_object_update_field_split_last,
     json_object_update_field_str_concat, json_object_update_field_str_map,
     json_object_update_field_test, json_object_update_field_tostring,
-    json_object_update_field_trim,
+    json_object_update_field_trim, json_value_length,
 };
 
 /// A fast path whose type-dispatch obligations are encoded in its
@@ -900,6 +900,111 @@ where
         _ => return RawApplyOutcome::Bail,
     };
     emit(result);
+    RawApplyOutcome::Emit
+}
+
+/// Apply the `(.field | <unary>) <op1> <c1> <op2> <c2> ...` raw-byte
+/// fast path on a single JSON record. The unary op is applied to the
+/// field value first, then a left-fold of `(BinOp, f64)` arithmetic
+/// pairs runs on the result.
+///
+/// Supported unary ops:
+/// * `Length` — works on string/array/object/null/number (matches jq's
+///   polymorphic `length`). On a numeric field, evaluates to `abs(n)`
+///   per jq semantics.
+/// * `Floor`/`Ceil`/`Sqrt`/`Fabs`/`Abs`/`Round` — numeric, requires a
+///   number-valued field (Bail otherwise).
+///
+/// Bail discipline:
+/// * Non-object input — [`RawApplyOutcome::Bail`]. The prior fast path
+///   silently emitted `0` when invoked on `(.x | length)` against a
+///   number/string root (a #83-class divergence; jq raises
+///   `Cannot index <type> with "x"`).
+/// * For `Length` on a string field: backslash-escaped strings Bail
+///   (the raw scanner can't decode the escape to count code points).
+/// * For `Length` on an array/object field: malformed value Bails
+///   (`json_value_length` returns None).
+/// * For numeric unary ops on a non-numeric field — Bail.
+/// * Unsupported unary op (defensive — detector should never produce
+///   these for this shape) — Bail.
+/// * Non-arith op in `arith_steps` — Bail (defensive).
+/// * Non-finite final result (div-by-zero / overflow / NaN) — Bail so
+///   the generic path raises jq's `/ by zero` etc.
+///
+/// On success, invokes `emit(result)` so the apply-site owns
+/// JSON-number formatting.
+pub fn apply_field_unary_arith_raw<F>(
+    raw: &[u8],
+    field: &str,
+    uop: UnaryOp,
+    arith_steps: &[(BinOp, f64)],
+    mut emit: F,
+) -> RawApplyOutcome
+where
+    F: FnMut(f64),
+{
+    if raw.is_empty() || raw[0] != b'{' {
+        return RawApplyOutcome::Bail;
+    }
+    let is_length = matches!(uop, UnaryOp::Length);
+    let base = if is_length {
+        if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, field) {
+            let val = &raw[vs..ve];
+            match val[0] {
+                b'"' => {
+                    let inner = &val[1..val.len() - 1];
+                    if inner.contains(&b'\\') {
+                        return RawApplyOutcome::Bail;
+                    }
+                    if inner.is_ascii() {
+                        inner.len() as f64
+                    } else {
+                        unsafe { std::str::from_utf8_unchecked(inner) }.chars().count() as f64
+                    }
+                }
+                b'[' | b'{' => match json_value_length(val, 0) {
+                    Some(l) => l as f64,
+                    None => return RawApplyOutcome::Bail,
+                },
+                b'n' => 0.0,
+                _ => match json_object_get_num(raw, 0, field) {
+                    Some(n) => n.abs(),
+                    None => return RawApplyOutcome::Bail,
+                },
+            }
+        } else {
+            // Object input + missing field: jq's `null | length = 0`.
+            0.0
+        }
+    } else {
+        let n = match json_object_get_num(raw, 0, field) {
+            Some(v) => v,
+            None => return RawApplyOutcome::Bail,
+        };
+        match uop {
+            UnaryOp::Floor => n.floor(),
+            UnaryOp::Ceil => n.ceil(),
+            UnaryOp::Sqrt => n.sqrt(),
+            UnaryOp::Fabs | UnaryOp::Abs => n.abs(),
+            UnaryOp::Round => n.round(),
+            _ => return RawApplyOutcome::Bail,
+        }
+    };
+    let mut v = base;
+    for (op, c) in arith_steps {
+        v = match op {
+            BinOp::Add => v + c,
+            BinOp::Sub => v - c,
+            BinOp::Mul => v * c,
+            BinOp::Div => v / c,
+            BinOp::Mod => jq_mod_f64(v, *c).unwrap_or(f64::NAN),
+            _ => return RawApplyOutcome::Bail,
+        };
+    }
+    if !v.is_finite() {
+        return RawApplyOutcome::Bail;
+    }
+    emit(v);
     RawApplyOutcome::Emit
 }
 

--- a/tests/fast_path_contract.rs
+++ b/tests/fast_path_contract.rs
@@ -23,7 +23,7 @@ use jq_jit::fast_path::{
     apply_field_update_split_first_raw, apply_field_update_split_last_raw,
     apply_field_update_str_concat_raw, apply_field_update_str_map_raw,
     apply_field_update_test_raw, apply_field_update_tostring_raw,
-    apply_field_binop_const_unary_raw,
+    apply_field_binop_const_unary_raw, apply_field_unary_arith_raw,
     apply_field_update_trim_raw, apply_select_arith_cmp_raw, apply_select_cmp_raw,
     apply_select_field_null_raw, apply_select_str_raw, apply_select_str_test_raw,
     apply_two_field_binop_const_raw,
@@ -2522,6 +2522,162 @@ fn raw_field_binop_const_unary_non_object_input_bails() {
         let mut emitted: Vec<f64> = Vec::new();
         let outcome = apply_field_binop_const_unary_raw(
             raw, "x", BinOp::Add, 1.0, None, false, |n| emitted.push(n),
+        );
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "expected Bail for input {:?}, got {:?}",
+            std::str::from_utf8(raw).unwrap(),
+            outcome,
+        );
+        assert!(emitted.is_empty());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// `(.field | <unary>) <op1> <c1> ...` — unary then arith chain. Helper Bails
+// on non-object / unsupported unary / non-numeric-for-numeric-unary /
+// escape-bearing string for length / non-finite final.
+
+#[test]
+fn raw_field_unary_arith_length_string() {
+    // (.x | length) + 5 with x="abc" → 3 + 5 = 8
+    let mut emitted: Vec<f64> = Vec::new();
+    let outcome = apply_field_unary_arith_raw(
+        b"{\"x\":\"abc\"}", "x", UnaryOp::Length, &[(BinOp::Add, 5.0)],
+        |n| emitted.push(n),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec![8.0]);
+}
+
+#[test]
+fn raw_field_unary_arith_length_array() {
+    // (.x | length) * 2 with x=[1,2,3] → 3 * 2 = 6
+    let mut emitted: Vec<f64> = Vec::new();
+    let outcome = apply_field_unary_arith_raw(
+        b"{\"x\":[1,2,3]}", "x", UnaryOp::Length, &[(BinOp::Mul, 2.0)],
+        |n| emitted.push(n),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec![6.0]);
+}
+
+#[test]
+fn raw_field_unary_arith_length_null_value() {
+    // jq: `null | length = 0`. (.x | length) + 1 with x=null → 1
+    let mut emitted: Vec<f64> = Vec::new();
+    let outcome = apply_field_unary_arith_raw(
+        b"{\"x\":null}", "x", UnaryOp::Length, &[(BinOp::Add, 1.0)],
+        |n| emitted.push(n),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec![1.0]);
+}
+
+#[test]
+fn raw_field_unary_arith_length_missing_field_is_zero() {
+    // jq: missing field is null, null | length = 0. (.x | length) + 7 → 7
+    let mut emitted: Vec<f64> = Vec::new();
+    let outcome = apply_field_unary_arith_raw(
+        b"{\"y\":1}", "x", UnaryOp::Length, &[(BinOp::Add, 7.0)],
+        |n| emitted.push(n),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec![7.0]);
+}
+
+#[test]
+fn raw_field_unary_arith_length_number_field_uses_abs() {
+    // jq: number | length = abs. (.x | length) + 0 with x=-7 → 7
+    let mut emitted: Vec<f64> = Vec::new();
+    let outcome = apply_field_unary_arith_raw(
+        b"{\"x\":-7}", "x", UnaryOp::Length, &[(BinOp::Add, 0.0)],
+        |n| emitted.push(n),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec![7.0]);
+}
+
+#[test]
+fn raw_field_unary_arith_length_escape_bearing_string_bails() {
+    // Raw scanner can't decode `\n` to count code points correctly.
+    let mut emitted: Vec<f64> = Vec::new();
+    let outcome = apply_field_unary_arith_raw(
+        br#"{"x":"a\nb"}"#, "x", UnaryOp::Length, &[(BinOp::Add, 0.0)],
+        |n| emitted.push(n),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_field_unary_arith_floor_then_chain() {
+    // (.x | floor) + 1 with x=3.7 → 4
+    let mut emitted: Vec<f64> = Vec::new();
+    let outcome = apply_field_unary_arith_raw(
+        b"{\"x\":3.7}", "x", UnaryOp::Floor, &[(BinOp::Add, 1.0)],
+        |n| emitted.push(n),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec![4.0]);
+}
+
+#[test]
+fn raw_field_unary_arith_numeric_op_non_numeric_field_bails() {
+    let mut emitted: Vec<f64> = Vec::new();
+    let outcome = apply_field_unary_arith_raw(
+        b"{\"x\":\"hi\"}", "x", UnaryOp::Floor, &[(BinOp::Add, 1.0)],
+        |n| emitted.push(n),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_field_unary_arith_unsupported_unary_bails() {
+    for uop in [UnaryOp::ToString, UnaryOp::Type, UnaryOp::Explode] {
+        let mut emitted: Vec<f64> = Vec::new();
+        let outcome = apply_field_unary_arith_raw(
+            b"{\"x\":1}", "x", uop, &[(BinOp::Add, 0.0)], |n| emitted.push(n),
+        );
+        assert!(matches!(outcome, RawApplyOutcome::Bail), "uop={:?}", uop);
+    }
+}
+
+#[test]
+fn raw_field_unary_arith_non_arith_step_bails() {
+    let mut emitted: Vec<f64> = Vec::new();
+    let outcome = apply_field_unary_arith_raw(
+        b"{\"x\":1}", "x", UnaryOp::Abs, &[(BinOp::Eq, 1.0)], |n| emitted.push(n),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+}
+
+#[test]
+fn raw_field_unary_arith_div_by_zero_bails() {
+    // ((.x | abs) / 0) → inf → Bail (was emitting saturated 1.797e+308 pre-fix)
+    let mut emitted: Vec<f64> = Vec::new();
+    let outcome = apply_field_unary_arith_raw(
+        b"{\"x\":4}", "x", UnaryOp::Abs, &[(BinOp::Div, 0.0)], |n| emitted.push(n),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_field_unary_arith_non_object_input_bails() {
+    // Pre-existing #83-class bug: prior fast path returned `0` for length on
+    // non-object roots instead of jq's `Cannot index <type>` error.
+    for raw in [
+        b"42".as_slice(),
+        b"\"hi\"".as_slice(),
+        b"null".as_slice(),
+        b"true".as_slice(),
+        b"[1,2,3]".as_slice(),
+    ] {
+        let mut emitted: Vec<f64> = Vec::new();
+        let outcome = apply_field_unary_arith_raw(
+            raw, "x", UnaryOp::Length, &[(BinOp::Add, 0.0)], |n| emitted.push(n),
         );
         assert!(
             matches!(outcome, RawApplyOutcome::Bail),

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -4148,3 +4148,52 @@ null
 (.x + 0) | sqrt
 {"x":-1}
 null
+
+# Issue #251: field_unary_arith apply-site uses RawApplyOutcome (#83 Phase B).
+# Helper Bails on non-object/unsupported-unary/non-numeric-for-numeric-unary/
+# escape-bearing-string-for-length/non-finite. Also fixes a pre-existing
+# #83-class bug where the apply-site silently treated non-object roots as
+# `null|length=0` instead of jq's `Cannot index <type> with "x"` error.
+(.x | length) + 5
+{"x":"abc"}
+8
+
+(.x | length) * 2
+{"x":[1,2,3]}
+6
+
+(.x | length) + 1
+{"x":null}
+1
+
+(.x | length) + 7
+{"y":1}
+7
+
+(.x | length) + 0
+{"x":-7}
+7
+
+(.x | floor) + 1
+{"x":3.7}
+4
+
+# `?`-wrapped: numeric unary on non-numeric field — generic raises, ? swallows.
+[ (((.x | floor) + 1))? ]
+{"x":"hi"}
+[]
+
+# `?`-wrapped: div-by-zero — helper Bails on non-finite, generic raises.
+[ ((.x | abs) / 0)? ]
+{"x":4}
+[]
+
+# `?`-wrapped: non-object input — generic raises `Cannot index <type>` (was
+# silently emitting `0` pre-#83-Phase-B).
+[ ((.x | length) + 0)? ]
+42
+[]
+
+[ ((.x | length) + 0)? ]
+"hi"
+[]


### PR DESCRIPTION
## Summary
- Add `apply_field_unary_arith_raw` to `src/fast_path.rs` for `(.field | <unary>) op1 c1 op2 c2 ...` (polymorphic `Length` plus numeric unary set: `Floor`/`Ceil`/`Sqrt`/`Fabs`/`Abs`/`Round`).
- Migrate the `detect_field_unary_arith` apply-sites in `bin/jq-jit.rs` (stdin + file-mode) to the named `RawApplyOutcome::{Emit, Bail}` discipline.
- Bail discipline: non-object input, escape-bearing string for length, non-numeric field for numeric unary, malformed array/object for length, unsupported unary op (defensive), non-arith chain step (defensive), non-finite final result.

**Bug fix:** The prior fast path silently emitted `0` (treating input as `null | length`) when called on non-object roots like numbers/strings/booleans/arrays, instead of jq's `Cannot index <type>` error. Also fixes the saturated `1.797e+308` output on non-finite chain results.

12 new contract cases pin the verdict surface; 10 new regression cases cover the `?`-wrapped Bail matrix and Length on each base type.

Refs #251.

## Test plan
- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (859 regression cases pass, +10 over main; 254 contract cases, +12)
- [x] `./bench/comprehensive.sh --quick` (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)