### PR TITLE
refactor: field_index_arith apply-site uses RawApplyOutcome (#83 Phase B)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -145,9 +145,9 @@ use jq_jit::fast_path::{
     apply_field_field_alternative_raw, apply_field_field_cmp_raw, apply_field_format_raw,
     apply_field_gsub_raw, apply_field_ltrimstr_tonumber_raw, apply_field_match_raw,
     apply_field_scan_raw, apply_field_str_builtin_raw, apply_field_str_concat_raw,
-    apply_field_binop_const_unary_raw, apply_field_str_reverse_raw, apply_field_test_raw,
-    apply_field_unary_arith_raw, apply_field_unary_num_raw, apply_full_object_fields_raw,
-    apply_two_field_binop_const_raw,
+    apply_field_binop_const_unary_raw, apply_field_index_arith_raw, apply_field_str_reverse_raw,
+    apply_field_test_raw, apply_field_unary_arith_raw, apply_field_unary_num_raw,
+    apply_full_object_fields_raw, apply_two_field_binop_const_raw,
     apply_has_field_raw, apply_has_multi_field_raw, apply_multi_field_access_raw,
     apply_nested_field_access_raw, apply_object_compute_raw, apply_select_arith_cmp_raw,
     apply_select_cmp_raw, apply_select_field_null_raw, apply_select_str_raw,
@@ -6420,55 +6420,17 @@ fn real_main() {
                         Ok(())
                     })
                 } else if let Some((ref fia_field, ref fia_search, fia_is_rindex, fia_op, fia_n)) = field_index_arith {
-                    // .field | index/rindex("str") op N — raw byte
-                    use jq_jit::ir::BinOp;
                     let search_bytes = fia_search.as_bytes();
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, fia_field) {
-                            let val = &raw[vs..ve];
-                            if val.len() >= 2 && val[0] == b'"' && val[val.len()-1] == b'"'
-                                && !val[1..val.len()-1].contains(&b'\\')
-                            {
-                                let inner = &val[1..val.len()-1];
-                                let pos = if search_bytes.is_empty() {
-                                    None
-                                } else if fia_is_rindex {
-                                    inner.windows(search_bytes.len()).rposition(|w| w == search_bytes)
-                                } else {
-                                    inner.windows(search_bytes.len()).position(|w| w == search_bytes)
-                                };
-                                if let Some(p) = pos {
-                                    // UTF-8 codepoint position, not byte position
-                                    let cp_pos = inner[..p].iter().filter(|&&b| (b & 0xC0) != 0x80).count() as f64;
-                                    let result = match fia_op {
-                                        BinOp::Add => cp_pos + fia_n,
-                                        BinOp::Sub => cp_pos - fia_n,
-                                        BinOp::Mul => cp_pos * fia_n,
-                                        BinOp::Div => cp_pos / fia_n,
-                                        _ => cp_pos,
-                                    };
-                                    push_jq_number_bytes(&mut compact_buf, result);
-                                    compact_buf.push(b'\n');
-                                } else if matches!(fia_op, BinOp::Add) {
-                                    // index returned null; jq's `null + N` is N.
-                                    // For Sub/Mul/Div jq errors — bail to generic.
-                                    push_jq_number_bytes(&mut compact_buf, fia_n);
-                                    compact_buf.push(b'\n');
-                                } else {
-                                    let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                    process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                                }
-                            } else {
-                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                            }
-                        } else if matches!(fia_op, BinOp::Add) {
-                            // Field missing → index returns null → `null + N = N` (#167).
-                            push_jq_number_bytes(&mut compact_buf, fia_n);
-                            compact_buf.push(b'\n');
-                        } else {
-                            // For Sub/Mul/Div jq raises a type error on null.
+                        let outcome = apply_field_index_arith_raw(
+                            raw, fia_field, search_bytes, fia_is_rindex, fia_op, fia_n,
+                            |result| {
+                                push_jq_number_bytes(&mut compact_buf, result);
+                                compact_buf.push(b'\n');
+                            },
+                        );
+                        if let RawApplyOutcome::Bail = outcome {
                             let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                             process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }
@@ -19393,52 +19355,18 @@ fn real_main() {
                     Ok(())
                 })
             } else if let Some((ref fia_field, ref fia_search, fia_is_rindex, fia_op, fia_n)) = field_index_arith {
-                // .field | index/rindex("str") op N — file path
-                use jq_jit::ir::BinOp;
                 let content_bytes = content.as_bytes();
                 let search_bytes = fia_search.as_bytes();
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, fia_field) {
-                        let val = &raw[vs..ve];
-                        if val.len() >= 2 && val[0] == b'"' && val[val.len()-1] == b'"'
-                            && !val[1..val.len()-1].contains(&b'\\')
-                        {
-                            let inner = &val[1..val.len()-1];
-                            let pos = if search_bytes.is_empty() {
-                                None
-                            } else if fia_is_rindex {
-                                inner.windows(search_bytes.len()).rposition(|w| w == search_bytes)
-                            } else {
-                                inner.windows(search_bytes.len()).position(|w| w == search_bytes)
-                            };
-                            if let Some(p) = pos {
-                                let cp_pos = inner[..p].iter().filter(|&&b| (b & 0xC0) != 0x80).count() as f64;
-                                let result = match fia_op {
-                                    BinOp::Add => cp_pos + fia_n,
-                                    BinOp::Sub => cp_pos - fia_n,
-                                    BinOp::Mul => cp_pos * fia_n,
-                                    BinOp::Div => cp_pos / fia_n,
-                                    _ => cp_pos,
-                                };
-                                push_jq_number_bytes(&mut compact_buf, result);
-                                compact_buf.push(b'\n');
-                            } else if matches!(fia_op, BinOp::Add) {
-                                // index returned null; jq's `null + N` is N (#167).
-                                push_jq_number_bytes(&mut compact_buf, fia_n);
-                                compact_buf.push(b'\n');
-                            } else {
-                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                            }
-                        } else {
-                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                        }
-                    } else if matches!(fia_op, BinOp::Add) {
-                        push_jq_number_bytes(&mut compact_buf, fia_n);
-                        compact_buf.push(b'\n');
-                    } else {
+                    let outcome = apply_field_index_arith_raw(
+                        raw, fia_field, search_bytes, fia_is_rindex, fia_op, fia_n,
+                        |result| {
+                            push_jq_number_bytes(&mut compact_buf, result);
+                            compact_buf.push(b'\n');
+                        },
+                    );
+                    if let RawApplyOutcome::Bail = outcome {
                         let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                         process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                     }

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -903,6 +903,92 @@ where
     RawApplyOutcome::Emit
 }
 
+/// Apply the `(.field | index/rindex("str")) <op> <const>` raw-byte
+/// fast path on a single JSON record.
+///
+/// `is_rindex = true` selects `rindex` (last match) over `index` (first
+/// match). On a successful match, the helper computes the
+/// **codepoint-position** (jq semantics — not byte position) of the
+/// match in the field's UTF-8 content, then folds the arithmetic
+/// `(op, n)` over it. The helper handles the field-missing /
+/// no-match case with jq's `null + N = N` rule for `Add`; for
+/// `Sub`/`Mul`/`Div` jq raises a type error on `null`, so the
+/// helper Bails to let the generic path produce it.
+///
+/// Bail discipline:
+/// * Non-object input — [`RawApplyOutcome::Bail`] (jq raises
+///   `Cannot index <type> with "<field>"`).
+/// * Field absent and `op` isn't `Add` — Bail.
+/// * Field is non-string or escape-bearing string — Bail (the raw
+///   scanner can't decode escapes; for non-strings jq raises a
+///   type error).
+/// * `op` is non-arithmetic (`Eq`/`And`/etc.) — Bail (defensive).
+///
+/// On Emit, invokes `emit(result)` so the apply-site owns
+/// JSON-number formatting.
+pub fn apply_field_index_arith_raw<F>(
+    raw: &[u8],
+    field: &str,
+    search: &[u8],
+    is_rindex: bool,
+    op: BinOp,
+    n: f64,
+    mut emit: F,
+) -> RawApplyOutcome
+where
+    F: FnMut(f64),
+{
+    if raw.is_empty() || raw[0] != b'{' {
+        return RawApplyOutcome::Bail;
+    }
+    if !matches!(op, BinOp::Add | BinOp::Sub | BinOp::Mul | BinOp::Div | BinOp::Mod) {
+        return RawApplyOutcome::Bail;
+    }
+    if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, field) {
+        let val = &raw[vs..ve];
+        if val.len() < 2 || val[0] != b'"' || val[val.len() - 1] != b'"'
+            || val[1..val.len() - 1].contains(&b'\\')
+        {
+            return RawApplyOutcome::Bail;
+        }
+        let inner = &val[1..val.len() - 1];
+        let pos = if search.is_empty() {
+            None
+        } else if is_rindex {
+            inner.windows(search.len()).rposition(|w| w == search)
+        } else {
+            inner.windows(search.len()).position(|w| w == search)
+        };
+        if let Some(p) = pos {
+            let cp_pos = inner[..p].iter().filter(|&&b| (b & 0xC0) != 0x80).count() as f64;
+            let result = match op {
+                BinOp::Add => cp_pos + n,
+                BinOp::Sub => cp_pos - n,
+                BinOp::Mul => cp_pos * n,
+                BinOp::Div => cp_pos / n,
+                BinOp::Mod => jq_mod_f64(cp_pos, n).unwrap_or(f64::NAN),
+                _ => return RawApplyOutcome::Bail,
+            };
+            if !result.is_finite() {
+                return RawApplyOutcome::Bail;
+            }
+            emit(result);
+        } else if matches!(op, BinOp::Add) {
+            // index returned null; jq's `null + N = N`.
+            emit(n);
+        } else {
+            // For Sub/Mul/Div jq raises on null; Bail to generic.
+            return RawApplyOutcome::Bail;
+        }
+    } else if matches!(op, BinOp::Add) {
+        // Object input + missing field → index returns null → `null + N = N`.
+        emit(n);
+    } else {
+        return RawApplyOutcome::Bail;
+    }
+    RawApplyOutcome::Emit
+}
+
 /// Apply the `.field | <unary>` raw-byte multi-modal fast path on a
 /// single JSON record. Output type depends on the unary op:
 ///

--- a/tests/fast_path_contract.rs
+++ b/tests/fast_path_contract.rs
@@ -23,8 +23,8 @@ use jq_jit::fast_path::{
     apply_field_update_split_first_raw, apply_field_update_split_last_raw,
     apply_field_update_str_concat_raw, apply_field_update_str_map_raw,
     apply_field_update_test_raw, apply_field_update_tostring_raw,
-    apply_field_binop_const_unary_raw, apply_field_unary_arith_raw,
-    apply_field_unary_num_raw,
+    apply_field_binop_const_unary_raw, apply_field_index_arith_raw,
+    apply_field_unary_arith_raw, apply_field_unary_num_raw,
     apply_field_update_trim_raw, apply_select_arith_cmp_raw, apply_select_cmp_raw,
     apply_select_field_null_raw, apply_select_str_raw, apply_select_str_test_raw,
     apply_two_field_binop_const_raw,
@@ -2523,6 +2523,164 @@ fn raw_field_binop_const_unary_non_object_input_bails() {
         let mut emitted: Vec<f64> = Vec::new();
         let outcome = apply_field_binop_const_unary_raw(
             raw, "x", BinOp::Add, 1.0, None, false, |n| emitted.push(n),
+        );
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "expected Bail for input {:?}, got {:?}",
+            std::str::from_utf8(raw).unwrap(),
+            outcome,
+        );
+        assert!(emitted.is_empty());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// `(.field | index/rindex("str")) <op> <const>` — match position + arith.
+// Helper handles jq's `null + N = N` rule on no-match for Add; Bails on
+// non-object / non-string / escape-bearing string / non-arith op /
+// no-match-with-non-Add-op.
+
+#[test]
+fn raw_field_index_arith_index_first_match_codepoint_pos() {
+    let mut emitted: Vec<f64> = Vec::new();
+    // .x | index("ab") + 5 with x="cabd" → match at byte 1, cp=1, +5 = 6
+    let outcome = apply_field_index_arith_raw(
+        b"{\"x\":\"cabd\"}", "x", b"ab", false, BinOp::Add, 5.0,
+        |n| emitted.push(n),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec![6.0]);
+}
+
+#[test]
+fn raw_field_index_arith_rindex_last_match() {
+    let mut emitted: Vec<f64> = Vec::new();
+    // .x | rindex("a") + 0 with x="cabad" → last 'a' at byte 3, cp=3
+    let outcome = apply_field_index_arith_raw(
+        b"{\"x\":\"cabad\"}", "x", b"a", true, BinOp::Add, 0.0,
+        |n| emitted.push(n),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec![3.0]);
+}
+
+#[test]
+fn raw_field_index_arith_no_match_add_emits_n() {
+    let mut emitted: Vec<f64> = Vec::new();
+    // .x | index("zz") + 5 with x="abc" → no match, null+5=5
+    let outcome = apply_field_index_arith_raw(
+        b"{\"x\":\"abc\"}", "x", b"zz", false, BinOp::Add, 5.0,
+        |n| emitted.push(n),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec![5.0]);
+}
+
+#[test]
+fn raw_field_index_arith_no_match_non_add_bails() {
+    // For Sub/Mul/Div on null, jq raises type error; helper Bails.
+    for op in [BinOp::Sub, BinOp::Mul, BinOp::Div] {
+        let mut emitted: Vec<f64> = Vec::new();
+        let outcome = apply_field_index_arith_raw(
+            b"{\"x\":\"abc\"}", "x", b"zz", false, op, 5.0,
+            |n| emitted.push(n),
+        );
+        assert!(matches!(outcome, RawApplyOutcome::Bail), "op={:?}", op);
+        assert!(emitted.is_empty());
+    }
+}
+
+#[test]
+fn raw_field_index_arith_missing_field_add_emits_n() {
+    let mut emitted: Vec<f64> = Vec::new();
+    let outcome = apply_field_index_arith_raw(
+        b"{\"y\":1}", "x", b"ab", false, BinOp::Add, 7.0,
+        |n| emitted.push(n),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec![7.0]);
+}
+
+#[test]
+fn raw_field_index_arith_missing_field_non_add_bails() {
+    let mut emitted: Vec<f64> = Vec::new();
+    let outcome = apply_field_index_arith_raw(
+        b"{\"y\":1}", "x", b"ab", false, BinOp::Sub, 7.0,
+        |n| emitted.push(n),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_field_index_arith_non_string_field_bails() {
+    let mut emitted: Vec<f64> = Vec::new();
+    let outcome = apply_field_index_arith_raw(
+        b"{\"x\":42}", "x", b"a", false, BinOp::Add, 0.0,
+        |n| emitted.push(n),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_field_index_arith_escape_bearing_string_bails() {
+    let mut emitted: Vec<f64> = Vec::new();
+    let outcome = apply_field_index_arith_raw(
+        br#"{"x":"a\nb"}"#, "x", b"b", false, BinOp::Add, 0.0,
+        |n| emitted.push(n),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_field_index_arith_non_arith_op_bails() {
+    for op in [BinOp::Eq, BinOp::Lt, BinOp::And] {
+        let mut emitted: Vec<f64> = Vec::new();
+        let outcome = apply_field_index_arith_raw(
+            b"{\"x\":\"abc\"}", "x", b"a", false, op, 0.0,
+            |n| emitted.push(n),
+        );
+        assert!(matches!(outcome, RawApplyOutcome::Bail), "op={:?}", op);
+    }
+}
+
+#[test]
+fn raw_field_index_arith_div_by_zero_bails() {
+    let mut emitted: Vec<f64> = Vec::new();
+    let outcome = apply_field_index_arith_raw(
+        b"{\"x\":\"abc\"}", "x", b"a", false, BinOp::Div, 0.0,
+        |n| emitted.push(n),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_field_index_arith_codepoint_position_for_multibyte() {
+    // .x | index("c") with x="日本cd" → byte position 6, cp position 2
+    let mut emitted: Vec<f64> = Vec::new();
+    let outcome = apply_field_index_arith_raw(
+        "{\"x\":\"日本cd\"}".as_bytes(), "x", b"c", false, BinOp::Add, 0.0,
+        |n| emitted.push(n),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec![2.0]);
+}
+
+#[test]
+fn raw_field_index_arith_non_object_input_bails() {
+    for raw in [
+        b"42".as_slice(),
+        b"\"hi\"".as_slice(),
+        b"null".as_slice(),
+        b"true".as_slice(),
+        b"[1,2,3]".as_slice(),
+    ] {
+        let mut emitted: Vec<f64> = Vec::new();
+        let outcome = apply_field_index_arith_raw(
+            raw, "x", b"a", false, BinOp::Add, 0.0, |n| emitted.push(n),
         );
         assert!(
             matches!(outcome, RawApplyOutcome::Bail),

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -4283,3 +4283,54 @@ null
 .x | ascii_upcase
 {"x":"a\nb"}
 "A\nB"
+
+# Issue #251: field_index_arith apply-site uses RawApplyOutcome (#83 Phase B).
+# Helper Bails on non-object/non-string/escape-bearing/no-match-non-Add/
+# non-arith op. jq's `null + N = N` rule preserved for missing/no-match Add.
+(.x | index("ab")) + 5
+{"x":"cabd"}
+6
+
+(.x | rindex("a")) + 0
+{"x":"cabad"}
+3
+
+# No match + Add: null + 5 = 5.
+(.x | index("zz")) + 5
+{"x":"abcd"}
+5
+
+# Missing field + Add: null + 7 = 7.
+(.x | index("ab")) + 7
+{"y":1}
+7
+
+# `?`-wrapped: no match + Sub — jq raises null type error, ? swallows.
+[ ((.x | index("zz")) - 5)? ]
+{"x":"abcd"}
+[]
+
+# `?`-wrapped: missing field + Sub.
+[ ((.x | index("ab")) - 5)? ]
+{"y":1}
+[]
+
+# `?`-wrapped: non-string field — generic raises type error.
+[ ((.x | index("ab")) + 5)? ]
+{"x":42}
+[]
+
+# `?`-wrapped: non-object input — generic raises indexing error.
+[ ((.x | index("ab")) + 5)? ]
+"plain"
+[]
+
+# Codepoint (not byte) position for multibyte UTF-8.
+(.x | index("c")) + 0
+{"x":"日本cd"}
+2
+
+# Escaped string field: helper Bails, generic decodes.
+(.x | index("b")) + 0
+{"x":"a\nb"}
+2


### PR DESCRIPTION
## Summary
- Add `apply_field_index_arith_raw` to `src/fast_path.rs` for `(.field | index/rindex("str")) op n`. Computes codepoint position (jq semantics) of the match, then folds arithmetic.
- Migrate the `detect_field_index_arith` apply-sites in `bin/jq-jit.rs` (stdin + file-mode) to the named `RawApplyOutcome::{Emit, Bail}` discipline.
- Preserves jq's `null + N = N` rule on no-match / missing-field for `Add`; for `Sub`/`Mul`/`Div` jq raises on null, so the helper Bails for the generic path to produce it.

Bail discipline: non-object input, non-string field, escape-bearing string, non-arith op (defensive), no-match-with-non-Add, non-finite result.

12 new contract cases pin the verdict surface (codepoint position for multibyte UTF-8, every Bail branch); 10 new regression cases cover the `?`-wrapped Bail matrix.

Refs #251.

## Test plan
- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (887 regression cases pass, +10 over main; 286 contract cases, +12)
- [x] `./bench/comprehensive.sh --quick` (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)