### PR TITLE
refactor: numeric_expr / numeric_expr_unary apply-sites use RawApplyOutcome (#83 Phase B)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -147,7 +147,7 @@ use jq_jit::fast_path::{
     apply_field_scan_raw, apply_field_str_builtin_raw, apply_field_str_concat_raw,
     apply_field_binop_const_unary_raw, apply_field_index_arith_raw, apply_field_str_reverse_raw,
     apply_field_test_raw, apply_field_unary_arith_raw, apply_field_unary_num_raw,
-    apply_full_object_fields_raw, apply_two_field_binop_const_raw,
+    apply_full_object_fields_raw, apply_numeric_expr_raw, apply_two_field_binop_const_raw,
     apply_has_field_raw, apply_has_multi_field_raw, apply_multi_field_access_raw,
     apply_nested_field_access_raw, apply_object_compute_raw, apply_select_arith_cmp_raw,
     apply_select_cmp_raw, apply_select_field_null_raw, apply_select_str_raw,
@@ -6089,37 +6089,20 @@ fn real_main() {
                     })
                 } else if let Some((ref nfields, ref arith)) = numeric_expr {
                     let nf_count = nfields.len();
-                    // Hoist allocations outside the hot loop
                     let field_refs: Vec<&str> = nfields.iter().map(|s| s.as_str()).collect();
                     let mut ranges_buf = vec![(0usize, 0usize); nf_count];
                     let mut vals_buf: Vec<f64> = vec![0.0; nf_count];
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        let ok = if nf_count == 1 {
-                            if let Some(v) = json_object_get_num(raw, 0, &nfields[0]) {
-                                vals_buf[0] = v; true
-                            } else { false }
-                        } else if nf_count == 2 {
-                            if let Some((a, b)) = json_object_get_two_nums(raw, 0, &nfields[0], &nfields[1]) {
-                                vals_buf[0] = a; vals_buf[1] = b; true
-                            } else { false }
-                        } else {
-                            if json_object_get_fields_raw_buf(raw, 0, &field_refs, &mut ranges_buf) {
-                                let mut all_ok = true;
-                                for (i, &(s, e)) in ranges_buf.iter().enumerate() {
-                                    match fast_float::parse::<f64, _>(unsafe { std::str::from_utf8_unchecked(&raw[s..e]) }) {
-                                        Ok(n) => vals_buf[i] = n,
-                                        Err(_) => { all_ok = false; break; }
-                                    }
-                                }
-                                all_ok
-                            } else { false }
-                        };
-                        if ok {
-                            let result = arith.eval(&vals_buf);
-                            push_jq_number_bytes(&mut compact_buf, result);
-                            compact_buf.push(b'\n');
-                        } else {
+                        let outcome = apply_numeric_expr_raw(
+                            raw, &field_refs, arith, None,
+                            &mut ranges_buf, &mut vals_buf,
+                            |result| {
+                                push_jq_number_bytes(&mut compact_buf, result);
+                                compact_buf.push(b'\n');
+                            },
+                        );
+                        if let RawApplyOutcome::Bail = outcome {
                             let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                             process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }
@@ -6136,31 +6119,15 @@ fn real_main() {
                     let mut vals_buf: Vec<f64> = vec![0.0; nf_count];
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        let ok = if nf_count == 1 {
-                            if let Some(v) = json_object_get_num(raw, 0, &nfields[0]) {
-                                vals_buf[0] = v; true
-                            } else { false }
-                        } else if nf_count == 2 {
-                            if let Some((a, b)) = json_object_get_two_nums(raw, 0, &nfields[0], &nfields[1]) {
-                                vals_buf[0] = a; vals_buf[1] = b; true
-                            } else { false }
-                        } else {
-                            if json_object_get_fields_raw_buf(raw, 0, &field_refs, &mut ranges_buf) {
-                                let mut all_ok = true;
-                                for (i, &(s, e)) in ranges_buf.iter().enumerate() {
-                                    match fast_float::parse::<f64, _>(unsafe { std::str::from_utf8_unchecked(&raw[s..e]) }) {
-                                        Ok(n) => vals_buf[i] = n,
-                                        Err(_) => { all_ok = false; break; }
-                                    }
-                                }
-                                all_ok
-                            } else { false }
-                        };
-                        if ok {
-                            let result = apply_math_unary(math_op, arith.eval(&vals_buf));
-                            push_jq_number_bytes(&mut compact_buf, result);
-                            compact_buf.push(b'\n');
-                        } else {
+                        let outcome = apply_numeric_expr_raw(
+                            raw, &field_refs, arith, Some(math_op),
+                            &mut ranges_buf, &mut vals_buf,
+                            |result| {
+                                push_jq_number_bytes(&mut compact_buf, result);
+                                compact_buf.push(b'\n');
+                            },
+                        );
+                        if let RawApplyOutcome::Bail = outcome {
                             let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                             process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }
@@ -19026,31 +18993,15 @@ fn real_main() {
                 let mut vals_buf: Vec<f64> = vec![0.0; nf_count];
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    let ok = if nf_count == 1 {
-                        if let Some(v) = json_object_get_num(raw, 0, &nfields[0]) {
-                            vals_buf[0] = v; true
-                        } else { false }
-                    } else if nf_count == 2 {
-                        if let Some((a, b)) = json_object_get_two_nums(raw, 0, &nfields[0], &nfields[1]) {
-                            vals_buf[0] = a; vals_buf[1] = b; true
-                        } else { false }
-                    } else {
-                        if json_object_get_fields_raw_buf(raw, 0, &field_refs, &mut ranges_buf) {
-                            let mut all_ok = true;
-                            for (i, &(s, e)) in ranges_buf.iter().enumerate() {
-                                match fast_float::parse::<f64, _>(unsafe { std::str::from_utf8_unchecked(&raw[s..e]) }) {
-                                    Ok(n) => vals_buf[i] = n,
-                                    Err(_) => { all_ok = false; break; }
-                                }
-                            }
-                            all_ok
-                        } else { false }
-                    };
-                    if ok {
-                        let result = arith.eval(&vals_buf);
-                        push_jq_number_bytes(&mut compact_buf, result);
-                        compact_buf.push(b'\n');
-                    } else {
+                    let outcome = apply_numeric_expr_raw(
+                        raw, &field_refs, arith, None,
+                        &mut ranges_buf, &mut vals_buf,
+                        |result| {
+                            push_jq_number_bytes(&mut compact_buf, result);
+                            compact_buf.push(b'\n');
+                        },
+                    );
+                    if let RawApplyOutcome::Bail = outcome {
                         let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                         process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                     }
@@ -19068,31 +19019,15 @@ fn real_main() {
                 let mut vals_buf: Vec<f64> = vec![0.0; nf_count];
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    let ok = if nf_count == 1 {
-                        if let Some(v) = json_object_get_num(raw, 0, &nfields[0]) {
-                            vals_buf[0] = v; true
-                        } else { false }
-                    } else if nf_count == 2 {
-                        if let Some((a, b)) = json_object_get_two_nums(raw, 0, &nfields[0], &nfields[1]) {
-                            vals_buf[0] = a; vals_buf[1] = b; true
-                        } else { false }
-                    } else {
-                        if json_object_get_fields_raw_buf(raw, 0, &field_refs, &mut ranges_buf) {
-                            let mut all_ok = true;
-                            for (i, &(s, e)) in ranges_buf.iter().enumerate() {
-                                match fast_float::parse::<f64, _>(unsafe { std::str::from_utf8_unchecked(&raw[s..e]) }) {
-                                    Ok(n) => vals_buf[i] = n,
-                                    Err(_) => { all_ok = false; break; }
-                                }
-                            }
-                            all_ok
-                        } else { false }
-                    };
-                    if ok {
-                        let result = apply_math_unary(math_op, arith.eval(&vals_buf));
-                        push_jq_number_bytes(&mut compact_buf, result);
-                        compact_buf.push(b'\n');
-                    } else {
+                    let outcome = apply_numeric_expr_raw(
+                        raw, &field_refs, arith, Some(math_op),
+                        &mut ranges_buf, &mut vals_buf,
+                        |result| {
+                            push_jq_number_bytes(&mut compact_buf, result);
+                            compact_buf.push(b'\n');
+                        },
+                    );
+                    if let RawApplyOutcome::Bail = outcome {
                         let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                         process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                     }

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -62,6 +62,7 @@
 
 use anyhow::Result;
 
+use crate::interpreter::{ArithExpr, MathUnary};
 use crate::ir::{BinOp, UnaryOp};
 use crate::runtime::jq_mod_f64;
 use crate::value::{
@@ -1430,6 +1431,94 @@ where
             BinOp::Mod => jq_mod_f64(result, *c).unwrap_or(f64::NAN),
             _ => return RawApplyOutcome::Bail,
         };
+    }
+    emit(result);
+    RawApplyOutcome::Emit
+}
+
+/// Apply a generic `ArithExpr` (a pure numeric expression over named
+/// fields and constants) raw-byte fast path on a single JSON record,
+/// optionally followed by a math unary op (`floor`/`ceil`/`sqrt`/
+/// `fabs`/`round`).
+///
+/// Covers both `detect_numeric_expr` (no unary) and
+/// `detect_numeric_expr_unary`. Caller provides:
+/// * `fields` — list of field names referenced by the expression
+///   (`ArithExpr::Field(idx)` resolves into this slice).
+/// * `arith` — the compiled expression (built by `simplify_expr`).
+/// * `math_op` — `Some(_)` to apply the trailing unary op, `None` to
+///   skip it.
+/// * `ranges_buf` and `vals_buf` — reusable scratch buffers sized
+///   to `fields.len()`. Hoisting them across the input stream avoids
+///   per-record allocation; required for the 3-or-more-fields
+///   path that uses `json_object_get_fields_raw_buf`.
+///
+/// Bail discipline:
+/// * Non-object input — [`RawApplyOutcome::Bail`].
+/// * Any field absent or non-numeric — Bail.
+/// * Buffer length mismatch (caller bug) — Bail (defensive).
+/// * Non-finite final result — Bail so the generic path raises
+///   jq's `/ by zero` etc. (The prior fast path silently emitted
+///   `1.7976931348623157e+308` / `null` for ±Infinity / NaN —
+///   another #83-class divergence the structural Bail closes.)
+///
+/// On Emit, invokes `emit(result)` so the apply-site owns
+/// JSON-number formatting.
+pub fn apply_numeric_expr_raw<F>(
+    raw: &[u8],
+    fields: &[&str],
+    arith: &ArithExpr,
+    math_op: Option<MathUnary>,
+    ranges_buf: &mut [(usize, usize)],
+    vals_buf: &mut [f64],
+    mut emit: F,
+) -> RawApplyOutcome
+where
+    F: FnMut(f64),
+{
+    if raw.is_empty() || raw[0] != b'{' {
+        return RawApplyOutcome::Bail;
+    }
+    let nf = fields.len();
+    if ranges_buf.len() < nf || vals_buf.len() < nf {
+        return RawApplyOutcome::Bail;
+    }
+    let ok = if nf == 1 {
+        match json_object_get_num(raw, 0, fields[0]) {
+            Some(v) => { vals_buf[0] = v; true }
+            None => false,
+        }
+    } else if nf == 2 {
+        match json_object_get_two_nums(raw, 0, fields[0], fields[1]) {
+            Some((a, b)) => { vals_buf[0] = a; vals_buf[1] = b; true }
+            None => false,
+        }
+    } else if json_object_get_fields_raw_buf(raw, 0, fields, ranges_buf) {
+        let mut all_ok = true;
+        for (i, &(s, e)) in ranges_buf[..nf].iter().enumerate() {
+            match fast_float::parse::<f64, _>(unsafe { std::str::from_utf8_unchecked(&raw[s..e]) }) {
+                Ok(n) => vals_buf[i] = n,
+                Err(_) => { all_ok = false; break; }
+            }
+        }
+        all_ok
+    } else {
+        false
+    };
+    if !ok {
+        return RawApplyOutcome::Bail;
+    }
+    let base = arith.eval(&vals_buf[..nf]);
+    let result = match math_op {
+        Some(MathUnary::Sqrt) => base.sqrt(),
+        Some(MathUnary::Floor) => base.floor(),
+        Some(MathUnary::Ceil) => base.ceil(),
+        Some(MathUnary::Fabs) => base.abs(),
+        Some(MathUnary::Round) => base.round(),
+        None => base,
+    };
+    if !result.is_finite() {
+        return RawApplyOutcome::Bail;
     }
     emit(result);
     RawApplyOutcome::Emit

--- a/tests/fast_path_contract.rs
+++ b/tests/fast_path_contract.rs
@@ -25,11 +25,12 @@ use jq_jit::fast_path::{
     apply_field_update_test_raw, apply_field_update_tostring_raw,
     apply_field_binop_const_unary_raw, apply_field_index_arith_raw,
     apply_field_unary_arith_raw, apply_field_unary_num_raw,
-    apply_field_update_trim_raw, apply_select_arith_cmp_raw, apply_select_cmp_raw,
+    apply_field_update_trim_raw, apply_numeric_expr_raw,
+    apply_select_arith_cmp_raw, apply_select_cmp_raw,
     apply_select_field_null_raw, apply_select_str_raw, apply_select_str_test_raw,
     apply_two_field_binop_const_raw,
 };
-use jq_jit::interpreter::Filter;
+use jq_jit::interpreter::{ArithExpr, Filter, MathUnary};
 use jq_jit::ir::{BinOp, UnaryOp};
 use jq_jit::value::Value;
 
@@ -2532,6 +2533,182 @@ fn raw_field_binop_const_unary_non_object_input_bails() {
         );
         assert!(emitted.is_empty());
     }
+}
+
+// ---------------------------------------------------------------------------
+// `apply_numeric_expr_raw` — generic ArithExpr over named fields, optional
+// trailing math unary. Bails on non-object / missing-or-non-numeric field /
+// non-finite final result / buffer-mismatch.
+
+#[test]
+fn raw_numeric_expr_two_fields_add() {
+    // .x + .y with x=3, y=4
+    let arith = ArithExpr::BinOp(
+        BinOp::Add,
+        Box::new(ArithExpr::Field(0)),
+        Box::new(ArithExpr::Field(1)),
+    );
+    let fields = ["x", "y"];
+    let mut ranges = vec![(0, 0); 2];
+    let mut vals = vec![0.0; 2];
+    let mut emitted: Vec<f64> = Vec::new();
+    let outcome = apply_numeric_expr_raw(
+        b"{\"x\":3,\"y\":4}", &fields, &arith, None,
+        &mut ranges, &mut vals, |n| emitted.push(n),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec![7.0]);
+}
+
+#[test]
+fn raw_numeric_expr_three_fields() {
+    // .a * .b + .c with a=2, b=3, c=4 → 10
+    let arith = ArithExpr::BinOp(
+        BinOp::Add,
+        Box::new(ArithExpr::BinOp(
+            BinOp::Mul,
+            Box::new(ArithExpr::Field(0)),
+            Box::new(ArithExpr::Field(1)),
+        )),
+        Box::new(ArithExpr::Field(2)),
+    );
+    let fields = ["a", "b", "c"];
+    let mut ranges = vec![(0, 0); 3];
+    let mut vals = vec![0.0; 3];
+    let mut emitted: Vec<f64> = Vec::new();
+    let outcome = apply_numeric_expr_raw(
+        b"{\"a\":2,\"b\":3,\"c\":4}", &fields, &arith, None,
+        &mut ranges, &mut vals, |n| emitted.push(n),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec![10.0]);
+}
+
+#[test]
+fn raw_numeric_expr_with_unary_floor() {
+    // floor((.x + .y) / 2) with x=3, y=4 → floor(3.5) = 3
+    let arith = ArithExpr::BinOp(
+        BinOp::Div,
+        Box::new(ArithExpr::BinOp(
+            BinOp::Add,
+            Box::new(ArithExpr::Field(0)),
+            Box::new(ArithExpr::Field(1)),
+        )),
+        Box::new(ArithExpr::Const(2.0)),
+    );
+    let fields = ["x", "y"];
+    let mut ranges = vec![(0, 0); 2];
+    let mut vals = vec![0.0; 2];
+    let mut emitted: Vec<f64> = Vec::new();
+    let outcome = apply_numeric_expr_raw(
+        b"{\"x\":3,\"y\":4}", &fields, &arith, Some(MathUnary::Floor),
+        &mut ranges, &mut vals, |n| emitted.push(n),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec![3.0]);
+}
+
+#[test]
+fn raw_numeric_expr_field_missing_bails() {
+    let arith = ArithExpr::Field(0);
+    let fields = ["x"];
+    let mut ranges = vec![(0, 0); 1];
+    let mut vals = vec![0.0; 1];
+    let mut emitted: Vec<f64> = Vec::new();
+    let outcome = apply_numeric_expr_raw(
+        b"{\"y\":1}", &fields, &arith, None,
+        &mut ranges, &mut vals, |n| emitted.push(n),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_numeric_expr_non_numeric_field_bails() {
+    let arith = ArithExpr::Field(0);
+    let fields = ["x"];
+    let mut ranges = vec![(0, 0); 1];
+    let mut vals = vec![0.0; 1];
+    for inner in [&b"{\"x\":\"hi\"}"[..], &b"{\"x\":null}"[..], &b"{\"x\":[1]}"[..]] {
+        let mut emitted: Vec<f64> = Vec::new();
+        let outcome = apply_numeric_expr_raw(
+            inner, &fields, &arith, None,
+            &mut ranges, &mut vals, |n| emitted.push(n),
+        );
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "expected Bail for non-numeric input {:?}, got {:?}",
+            std::str::from_utf8(inner).unwrap(),
+            outcome,
+        );
+    }
+}
+
+#[test]
+fn raw_numeric_expr_div_by_zero_bails() {
+    // .x / .y with x=1, y=0 → inf → Bail
+    let arith = ArithExpr::BinOp(
+        BinOp::Div,
+        Box::new(ArithExpr::Field(0)),
+        Box::new(ArithExpr::Field(1)),
+    );
+    let fields = ["x", "y"];
+    let mut ranges = vec![(0, 0); 2];
+    let mut vals = vec![0.0; 2];
+    let mut emitted: Vec<f64> = Vec::new();
+    let outcome = apply_numeric_expr_raw(
+        b"{\"x\":1,\"y\":0}", &fields, &arith, None,
+        &mut ranges, &mut vals, |n| emitted.push(n),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_numeric_expr_non_object_input_bails() {
+    let arith = ArithExpr::Field(0);
+    let fields = ["x"];
+    let mut ranges = vec![(0, 0); 1];
+    let mut vals = vec![0.0; 1];
+    for raw in [
+        b"42".as_slice(),
+        b"\"hi\"".as_slice(),
+        b"null".as_slice(),
+        b"true".as_slice(),
+        b"[1,2,3]".as_slice(),
+    ] {
+        let mut emitted: Vec<f64> = Vec::new();
+        let outcome = apply_numeric_expr_raw(
+            raw, &fields, &arith, None,
+            &mut ranges, &mut vals, |n| emitted.push(n),
+        );
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "expected Bail for input {:?}, got {:?}",
+            std::str::from_utf8(raw).unwrap(),
+            outcome,
+        );
+    }
+}
+
+#[test]
+fn raw_numeric_expr_buffer_too_small_bails() {
+    // Defensive: caller bug
+    let arith = ArithExpr::BinOp(
+        BinOp::Add,
+        Box::new(ArithExpr::Field(0)),
+        Box::new(ArithExpr::Field(1)),
+    );
+    let fields = ["x", "y"];
+    let mut ranges = vec![(0, 0); 1];
+    let mut vals = vec![0.0; 1];
+    let mut emitted: Vec<f64> = Vec::new();
+    let outcome = apply_numeric_expr_raw(
+        b"{\"x\":3,\"y\":4}", &fields, &arith, None,
+        &mut ranges, &mut vals, |n| emitted.push(n),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -4334,3 +4334,40 @@ null
 (.x | index("b")) + 0
 {"x":"a\nb"}
 2
+
+# Issue #251: numeric_expr / numeric_expr_unary apply-sites use RawApplyOutcome
+# (#83 Phase B). Helper Bails on non-object/missing-or-non-numeric/non-finite/
+# buffer-mismatch. Also fixes pre-existing #83-class non-finite divergence
+# (was emitting saturated `1.797e+308` for ±Infinity).
+.x + .y * 2
+{"x":3,"y":4}
+11
+
+(.a + .b) * (.c - .d)
+{"a":1,"b":2,"c":5,"d":1}
+12
+
+# Unary trailing op
+(.x + .y) | sqrt
+{"x":2,"y":7}
+3
+
+# `?`-wrapped: non-numeric field — generic raises type error, ? swallows.
+[ ((.x + .y) * 2)? ]
+{"x":3,"y":"hi"}
+[]
+
+# `?`-wrapped: div-by-zero — helper Bails, generic raises.
+[ (.x / .y)? ]
+{"x":1,"y":0}
+[]
+
+# sqrt of negative produces NaN → helper Bails, generic produces null.
+(.x + .y) | sqrt
+{"x":-5,"y":-5}
+null
+
+# `?`-wrapped: non-object input — generic raises.
+[ ((.x + .y) | sqrt)? ]
+"plain"
+[]


### PR DESCRIPTION
## Summary
- Add `apply_numeric_expr_raw` to `src/fast_path.rs` covering both `detect_numeric_expr` and `detect_numeric_expr_unary` via `Option<MathUnary>`. Callers hoist `ranges_buf` / `vals_buf` outside the stream loop; the helper picks the right field-extraction lane (1, 2, or N+) based on `fields.len()`.
- Migrate the 4 apply-sites in `bin/jq-jit.rs` (stdin × 2, file-mode × 2) to the named `RawApplyOutcome::{Emit, Bail}` discipline.
- Bail discipline: non-object input, any field absent or non-numeric, buffer length mismatch (defensive), non-finite final result.

**Bug fix:** Prior fast path emitted saturated `1.7976931348623157e+308` for ±Infinity (e.g. `.x / 0`) instead of jq's `/ by zero` error. Structural Bail now routes through the generic path. NaN→null already worked correctly via `push_jq_number_bytes`.

8 new contract cases pin the verdict surface (1/2/N-field lanes, with/without unary, every Bail branch); 7 new regression cases cover the `?`-wrapped Bail matrix.

Closes the final two items in the "Arithmetic & numeric chains" section. Refs #251.

## Test plan
- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (894 regression cases pass, +7 over main; 294 contract cases, +8)
- [x] `./bench/comprehensive.sh --quick` (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)