### PR TITLE
refactor: compound_field_cmp apply-site uses RawApplyOutcome (#83 Phase B)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -145,9 +145,10 @@ use jq_jit::fast_path::{
     apply_field_field_alternative_raw, apply_field_field_cmp_raw, apply_field_format_raw,
     apply_field_gsub_raw, apply_field_ltrimstr_tonumber_raw, apply_field_match_raw,
     apply_field_scan_raw, apply_field_str_builtin_raw, apply_field_str_concat_raw,
-    apply_field_binop_const_unary_raw, apply_field_index_arith_raw, apply_field_str_reverse_raw,
-    apply_field_test_raw, apply_field_unary_arith_raw, apply_field_unary_num_raw,
-    apply_full_object_fields_raw, apply_numeric_expr_raw, apply_two_field_binop_const_raw,
+    apply_compound_field_cmp_raw, apply_field_binop_const_unary_raw, apply_field_index_arith_raw,
+    apply_field_str_reverse_raw, apply_field_test_raw, apply_field_unary_arith_raw,
+    apply_field_unary_num_raw, apply_full_object_fields_raw, apply_numeric_expr_raw,
+    apply_two_field_binop_const_raw,
     apply_has_field_raw, apply_has_multi_field_raw, apply_multi_field_access_raw,
     apply_nested_field_access_raw, apply_object_compute_raw, apply_select_arith_cmp_raw,
     apply_select_cmp_raw, apply_select_field_null_raw, apply_select_str_raw,
@@ -6190,7 +6191,6 @@ fn real_main() {
                     })
                 } else if let Some((ref conjunct, ref cmps)) = compound_field_cmp {
                     use jq_jit::ir::BinOp;
-                    let is_and = matches!(conjunct, BinOp::And);
                     // Collect unique field names for lookup
                     let mut field_names: Vec<String> = Vec::new();
                     let mut field_idx: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
@@ -6200,41 +6200,18 @@ fn real_main() {
                             field_names.push(f.clone());
                         }
                     }
+                    let field_refs: Vec<&str> = field_names.iter().map(|s| s.as_str()).collect();
                     let cmp_spec: Vec<(usize, BinOp, f64)> = cmps.iter().map(|(f, op, n)| (field_idx[f], *op, *n)).collect();
+                    let mut vals_buf: Vec<f64> = vec![0.0; field_names.len()];
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        // Fast path for exactly 2 unique fields
-                        let got = if field_names.len() == 2 {
-                            json_object_get_two_nums(raw, 0, &field_names[0], &field_names[1])
-                                .map(|(a, b)| vec![a, b])
-                        } else {
-                            let mut vals = vec![f64::NAN; field_names.len()];
-                            let mut ok = true;
-                            for (i, fname) in field_names.iter().enumerate() {
-                                if let Some(n) = json_object_get_num(raw, 0, fname) {
-                                    vals[i] = n;
-                                } else { ok = false; break; }
-                            }
-                            if ok { Some(vals) } else { None }
-                        };
-                        if let Some(vals) = got {
-                            let mut result = is_and;
-                            for (idx, op, threshold) in &cmp_spec {
-                                let v = vals[*idx];
-                                let cmp_result = match op {
-                                    BinOp::Gt => v > *threshold, BinOp::Lt => v < *threshold,
-                                    BinOp::Ge => v >= *threshold, BinOp::Le => v <= *threshold,
-                                    BinOp::Eq => v == *threshold, BinOp::Ne => v != *threshold,
-                                    _ => unreachable!(),
-                                };
-                                if is_and {
-                                    if !cmp_result { result = false; break; }
-                                } else {
-                                    if cmp_result { result = true; break; }
-                                }
-                            }
-                            compact_buf.extend_from_slice(if result { b"true\n" } else { b"false\n" });
-                        } else {
+                        let outcome = apply_compound_field_cmp_raw(
+                            raw, &field_refs, &cmp_spec, *conjunct, &mut vals_buf,
+                            |result| {
+                                compact_buf.extend_from_slice(if result { b"true\n" } else { b"false\n" });
+                            },
+                        );
+                        if let RawApplyOutcome::Bail = outcome {
                             let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                             process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }
@@ -19093,7 +19070,6 @@ fn real_main() {
                 })
             } else if let Some((ref conjunct, ref cmps)) = compound_field_cmp {
                 use jq_jit::ir::BinOp;
-                let is_and = matches!(conjunct, BinOp::And);
                 let mut field_names: Vec<String> = Vec::new();
                 let mut field_idx: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
                 for (f, _, _) in cmps {
@@ -19102,41 +19078,19 @@ fn real_main() {
                         field_names.push(f.clone());
                     }
                 }
+                let field_refs: Vec<&str> = field_names.iter().map(|s| s.as_str()).collect();
                 let cmp_spec: Vec<(usize, BinOp, f64)> = cmps.iter().map(|(f, op, n)| (field_idx[f], *op, *n)).collect();
+                let mut vals_buf: Vec<f64> = vec![0.0; field_names.len()];
                 let content_bytes = content.as_bytes();
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    let got = if field_names.len() == 2 {
-                        json_object_get_two_nums(raw, 0, &field_names[0], &field_names[1])
-                            .map(|(a, b)| vec![a, b])
-                    } else {
-                        let mut vals = vec![f64::NAN; field_names.len()];
-                        let mut ok = true;
-                        for (i, fname) in field_names.iter().enumerate() {
-                            if let Some(n) = json_object_get_num(raw, 0, fname) {
-                                vals[i] = n;
-                            } else { ok = false; break; }
-                        }
-                        if ok { Some(vals) } else { None }
-                    };
-                    if let Some(vals) = got {
-                        let mut result = is_and;
-                        for (idx, op, threshold) in &cmp_spec {
-                            let v = vals[*idx];
-                            let cmp_result = match op {
-                                BinOp::Gt => v > *threshold, BinOp::Lt => v < *threshold,
-                                BinOp::Ge => v >= *threshold, BinOp::Le => v <= *threshold,
-                                BinOp::Eq => v == *threshold, BinOp::Ne => v != *threshold,
-                                _ => unreachable!(),
-                            };
-                            if is_and {
-                                if !cmp_result { result = false; break; }
-                            } else {
-                                if cmp_result { result = true; break; }
-                            }
-                        }
-                        compact_buf.extend_from_slice(if result { b"true\n" } else { b"false\n" });
-                    } else {
+                    let outcome = apply_compound_field_cmp_raw(
+                        raw, &field_refs, &cmp_spec, *conjunct, &mut vals_buf,
+                        |result| {
+                            compact_buf.extend_from_slice(if result { b"true\n" } else { b"false\n" });
+                        },
+                    );
+                    if let RawApplyOutcome::Bail = outcome {
                         let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                         process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                     }

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -865,6 +865,85 @@ where
     RawApplyOutcome::Emit
 }
 
+/// Apply the `(.x cmp1 N1) <conjunct> (.y cmp2 N2) <conjunct> ...`
+/// raw-byte compound numeric-comparison fast path on a single JSON
+/// record. Each comparison is a `<field> <cmp> <const>` predicate
+/// against a single numeric field; the predicates are joined by a
+/// single conjunct (`And` for `and`, `Or` for `or`) with short-
+/// circuiting.
+///
+/// Caller passes pre-deduplicated buffers:
+/// * `field_names` — unique field names referenced by the
+///   comparisons (`json_object_get_num` is called once per name).
+/// * `cmp_spec` — `(field_index, cmp_op, threshold)`. The
+///   `field_index` is into `field_names`.
+/// * `vals_buf` — reusable scratch sized to `field_names.len()`.
+///
+/// Bail discipline:
+/// * Non-object input — [`RawApplyOutcome::Bail`].
+/// * Any referenced field absent or non-numeric — Bail.
+/// * Any `cmp_op` is not `Gt`/`Lt`/`Ge`/`Le`/`Eq`/`Ne` — Bail
+///   (defensive — the detector should never produce these).
+/// * `conjunct` is not `And`/`Or` — Bail (defensive).
+/// * Buffer length mismatch — Bail (defensive).
+///
+/// On Emit, invokes `emit(result)` with the boolean conjunction.
+pub fn apply_compound_field_cmp_raw<F>(
+    raw: &[u8],
+    field_names: &[&str],
+    cmp_spec: &[(usize, BinOp, f64)],
+    conjunct: BinOp,
+    vals_buf: &mut [f64],
+    mut emit: F,
+) -> RawApplyOutcome
+where
+    F: FnMut(bool),
+{
+    if raw.is_empty() || raw[0] != b'{' {
+        return RawApplyOutcome::Bail;
+    }
+    let is_and = match conjunct {
+        BinOp::And => true,
+        BinOp::Or => false,
+        _ => return RawApplyOutcome::Bail,
+    };
+    let nf = field_names.len();
+    if vals_buf.len() < nf {
+        return RawApplyOutcome::Bail;
+    }
+    if nf == 2 {
+        match json_object_get_two_nums(raw, 0, field_names[0], field_names[1]) {
+            Some((a, b)) => { vals_buf[0] = a; vals_buf[1] = b; }
+            None => return RawApplyOutcome::Bail,
+        }
+    } else {
+        for (i, fname) in field_names.iter().enumerate() {
+            match json_object_get_num(raw, 0, fname) {
+                Some(n) => vals_buf[i] = n,
+                None => return RawApplyOutcome::Bail,
+            }
+        }
+    }
+    let mut result = is_and;
+    for (idx, op, threshold) in cmp_spec {
+        let v = vals_buf[*idx];
+        let cmp_result = match op {
+            BinOp::Gt => v > *threshold,
+            BinOp::Lt => v < *threshold,
+            BinOp::Ge => v >= *threshold,
+            BinOp::Le => v <= *threshold,
+            BinOp::Eq => v == *threshold,
+            BinOp::Ne => v != *threshold,
+            _ => return RawApplyOutcome::Bail,
+        };
+        if is_and {
+            if !cmp_result { result = false; break; }
+        } else if cmp_result { result = true; break; }
+    }
+    emit(result);
+    RawApplyOutcome::Emit
+}
+
 /// Apply the `.field <cmp> <const>` raw-byte numeric-comparison fast
 /// path on a single JSON record (`<cmp>` ∈ Gt/Lt/Ge/Le/Eq/Ne) where
 /// the field resolves to a JSON number and the right-hand side is a

--- a/tests/fast_path_contract.rs
+++ b/tests/fast_path_contract.rs
@@ -23,6 +23,7 @@ use jq_jit::fast_path::{
     apply_field_update_split_first_raw, apply_field_update_split_last_raw,
     apply_field_update_str_concat_raw, apply_field_update_str_map_raw,
     apply_field_update_test_raw, apply_field_update_tostring_raw,
+    apply_compound_field_cmp_raw,
     apply_field_binop_const_unary_raw, apply_field_index_arith_raw,
     apply_field_unary_arith_raw, apply_field_unary_num_raw,
     apply_field_update_trim_raw, apply_numeric_expr_raw,
@@ -2532,6 +2533,168 @@ fn raw_field_binop_const_unary_non_object_input_bails() {
             outcome,
         );
         assert!(emitted.is_empty());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// `(.x cmp1 N1) and/or (.y cmp2 N2) ...` — compound numeric predicate.
+// Helper short-circuits AND/OR; Bails on non-object / missing-or-non-numeric
+// field / non-cmp-op / non-and-or conjunct / buffer-mismatch.
+
+#[test]
+fn raw_compound_field_cmp_and_short_circuits() {
+    // (.x > 0) and (.y > 0) with x=5, y=3 → true
+    let mut emitted: Vec<bool> = Vec::new();
+    let fields = ["x", "y"];
+    let spec = vec![(0, BinOp::Gt, 0.0), (1, BinOp::Gt, 0.0)];
+    let mut vals = vec![0.0; 2];
+    let outcome = apply_compound_field_cmp_raw(
+        b"{\"x\":5,\"y\":3}", &fields, &spec, BinOp::And, &mut vals,
+        |b| emitted.push(b),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec![true]);
+}
+
+#[test]
+fn raw_compound_field_cmp_and_short_circuit_false() {
+    // (.x > 0) and (.y > 0) with x=5, y=-3 → false (short-circuits at second)
+    let mut emitted: Vec<bool> = Vec::new();
+    let fields = ["x", "y"];
+    let spec = vec![(0, BinOp::Gt, 0.0), (1, BinOp::Gt, 0.0)];
+    let mut vals = vec![0.0; 2];
+    let outcome = apply_compound_field_cmp_raw(
+        b"{\"x\":5,\"y\":-3}", &fields, &spec, BinOp::And, &mut vals,
+        |b| emitted.push(b),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec![false]);
+}
+
+#[test]
+fn raw_compound_field_cmp_or_short_circuits_true() {
+    // (.x > 100) or (.y < 0) with x=5, y=-3 → true (second matches)
+    let mut emitted: Vec<bool> = Vec::new();
+    let fields = ["x", "y"];
+    let spec = vec![(0, BinOp::Gt, 100.0), (1, BinOp::Lt, 0.0)];
+    let mut vals = vec![0.0; 2];
+    let outcome = apply_compound_field_cmp_raw(
+        b"{\"x\":5,\"y\":-3}", &fields, &spec, BinOp::Or, &mut vals,
+        |b| emitted.push(b),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec![true]);
+}
+
+#[test]
+fn raw_compound_field_cmp_or_all_false() {
+    // (.x > 100) or (.y > 100) with x=5, y=3 → false
+    let mut emitted: Vec<bool> = Vec::new();
+    let fields = ["x", "y"];
+    let spec = vec![(0, BinOp::Gt, 100.0), (1, BinOp::Gt, 100.0)];
+    let mut vals = vec![0.0; 2];
+    let outcome = apply_compound_field_cmp_raw(
+        b"{\"x\":5,\"y\":3}", &fields, &spec, BinOp::Or, &mut vals,
+        |b| emitted.push(b),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec![false]);
+}
+
+#[test]
+fn raw_compound_field_cmp_three_fields() {
+    // (.a > 0) and (.b > 0) and (.c > 0) with a=1, b=2, c=3 → true
+    let mut emitted: Vec<bool> = Vec::new();
+    let fields = ["a", "b", "c"];
+    let spec = vec![(0, BinOp::Gt, 0.0), (1, BinOp::Gt, 0.0), (2, BinOp::Gt, 0.0)];
+    let mut vals = vec![0.0; 3];
+    let outcome = apply_compound_field_cmp_raw(
+        b"{\"a\":1,\"b\":2,\"c\":3}", &fields, &spec, BinOp::And, &mut vals,
+        |b| emitted.push(b),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec![true]);
+}
+
+#[test]
+fn raw_compound_field_cmp_field_missing_bails() {
+    let mut emitted: Vec<bool> = Vec::new();
+    let fields = ["x", "y"];
+    let spec = vec![(0, BinOp::Gt, 0.0), (1, BinOp::Gt, 0.0)];
+    let mut vals = vec![0.0; 2];
+    let outcome = apply_compound_field_cmp_raw(
+        b"{\"x\":5}", &fields, &spec, BinOp::And, &mut vals,
+        |b| emitted.push(b),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_compound_field_cmp_non_numeric_bails() {
+    let mut emitted: Vec<bool> = Vec::new();
+    let fields = ["x", "y"];
+    let spec = vec![(0, BinOp::Gt, 0.0), (1, BinOp::Gt, 0.0)];
+    let mut vals = vec![0.0; 2];
+    let outcome = apply_compound_field_cmp_raw(
+        b"{\"x\":5,\"y\":\"hi\"}", &fields, &spec, BinOp::And, &mut vals,
+        |b| emitted.push(b),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_compound_field_cmp_non_cmp_op_bails() {
+    for op in [BinOp::Add, BinOp::Mul] {
+        let mut emitted: Vec<bool> = Vec::new();
+        let fields = ["x"];
+        let spec = vec![(0, op, 0.0)];
+        let mut vals = vec![0.0; 1];
+        let outcome = apply_compound_field_cmp_raw(
+            b"{\"x\":5}", &fields, &spec, BinOp::And, &mut vals,
+            |b| emitted.push(b),
+        );
+        assert!(matches!(outcome, RawApplyOutcome::Bail), "op={:?}", op);
+    }
+}
+
+#[test]
+fn raw_compound_field_cmp_non_and_or_conjunct_bails() {
+    for conj in [BinOp::Add, BinOp::Eq] {
+        let mut emitted: Vec<bool> = Vec::new();
+        let fields = ["x"];
+        let spec = vec![(0, BinOp::Gt, 0.0)];
+        let mut vals = vec![0.0; 1];
+        let outcome = apply_compound_field_cmp_raw(
+            b"{\"x\":5}", &fields, &spec, conj, &mut vals, |b| emitted.push(b),
+        );
+        assert!(matches!(outcome, RawApplyOutcome::Bail), "conj={:?}", conj);
+    }
+}
+
+#[test]
+fn raw_compound_field_cmp_non_object_input_bails() {
+    let fields = ["x"];
+    let spec = vec![(0, BinOp::Gt, 0.0)];
+    for raw in [
+        b"42".as_slice(),
+        b"\"hi\"".as_slice(),
+        b"null".as_slice(),
+        b"true".as_slice(),
+        b"[1,2,3]".as_slice(),
+    ] {
+        let mut emitted: Vec<bool> = Vec::new();
+        let mut vals = vec![0.0; 1];
+        let outcome = apply_compound_field_cmp_raw(
+            raw, &fields, &spec, BinOp::And, &mut vals, |b| emitted.push(b),
+        );
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "expected Bail for input {:?}, got {:?}",
+            std::str::from_utf8(raw).unwrap(),
+            outcome,
+        );
     }
 }
 

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -4371,3 +4371,37 @@ null
 [ ((.x + .y) | sqrt)? ]
 "plain"
 []
+
+# Issue #251: compound_field_cmp apply-site uses RawApplyOutcome (#83 Phase B).
+# Helper Bails on non-object/missing-or-non-numeric/non-cmp-op/non-and-or
+# conjunct/buffer-mismatch.
+(.x > 0) and (.y > 0)
+{"x":5,"y":3}
+true
+
+(.x > 100) or (.y < 0)
+{"x":5,"y":-3}
+true
+
+(.a > 0) and (.b > 0) and (.c > 0)
+{"a":1,"b":2,"c":3}
+true
+
+# Missing field — helper Bails, generic compares null to 0 (false).
+(.x > 0) and (.y > 0)
+{"x":5}
+false
+
+# Non-numeric — helper Bails, generic uses cross-type ordering ("hi" > 0 is true).
+(.x > 0) and (.y > 0)
+{"x":5,"y":"hi"}
+true
+
+# `?`-wrapped: non-object input — generic raises indexing error.
+[ ((.x > 0) and (.y > 0))? ]
+"plain"
+[]
+
+[ ((.x > 0) and (.y > 0))? ]
+42
+[]


### PR DESCRIPTION
## Summary
- Add `apply_compound_field_cmp_raw` to `src/fast_path.rs` for `(.x cmp1 N1) <and|or> (.y cmp2 N2) ...`. Caller pre-deduplicates field names and provides a reusable `vals_buf`; the helper short-circuits AND/OR.
- Migrate the `detect_compound_field_cmp` apply-sites in `bin/jq-jit.rs` (stdin + file-mode) to the named `RawApplyOutcome::{Emit, Bail}` discipline.
- Bail discipline: non-object input, any referenced field absent or non-numeric (so jq's cross-type ordering surfaces via generic — e.g. `"hi" > 0` is `true`), non-cmp op, non-and-or conjunct, or buffer length mismatch.

10 new contract cases pin the verdict surface; 7 new regression cases cover the `?`-wrapped Bail matrix and cross-type-ordering routing.

Refs #251.

## Test plan
- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (901 regression cases pass, +7 over main; 304 contract cases, +10)
- [x] `./bench/comprehensive.sh --quick` (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)