### PR TITLE
refactor: field_field_cmp_branch apply-site uses RawApplyOutcome (#83 Phase B)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -8520,19 +8520,13 @@ fn real_main() {
                         Ok(())
                     })
                 } else if let Some((ref f1, ref cmp_op, ref f2, ref t_bytes, ref f_bytes)) = field_field_cmp_branch {
-                    use jq_jit::ir::BinOp;
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        if let Some((v1, v2)) = json_object_get_two_nums(raw, 0, f1, f2) {
-                            let pass = match cmp_op {
-                                BinOp::Gt => v1 > v2, BinOp::Lt => v1 < v2,
-                                BinOp::Ge => v1 >= v2, BinOp::Le => v1 <= v2,
-                                BinOp::Eq => v1 == v2, BinOp::Ne => v1 != v2,
-                                _ => false,
-                            };
+                        let outcome = apply_field_field_cmp_raw(raw, f1, f2, *cmp_op, |pass| {
                             compact_buf.extend_from_slice(if pass { t_bytes } else { f_bytes });
                             compact_buf.push(b'\n');
-                        } else {
+                        });
+                        if let RawApplyOutcome::Bail = outcome {
                             let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                             process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }
@@ -16188,20 +16182,14 @@ fn real_main() {
                     Ok(())
                 })
             } else if let Some((ref f1, ref cmp_op, ref f2, ref t_bytes, ref f_bytes)) = field_field_cmp_branch {
-                use jq_jit::ir::BinOp;
                 let content_bytes = content.as_bytes();
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    if let Some((v1, v2)) = json_object_get_two_nums(raw, 0, f1, f2) {
-                        let pass = match cmp_op {
-                            BinOp::Gt => v1 > v2, BinOp::Lt => v1 < v2,
-                            BinOp::Ge => v1 >= v2, BinOp::Le => v1 <= v2,
-                            BinOp::Eq => v1 == v2, BinOp::Ne => v1 != v2,
-                            _ => false,
-                        };
+                    let outcome = apply_field_field_cmp_raw(raw, f1, f2, *cmp_op, |pass| {
                         compact_buf.extend_from_slice(if pass { t_bytes } else { f_bytes });
                         compact_buf.push(b'\n');
-                    } else {
+                    });
+                    if let RawApplyOutcome::Bail = outcome {
                         let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                         process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                     }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -4405,3 +4405,32 @@ true
 [ ((.x > 0) and (.y > 0))? ]
 42
 []
+
+# Issue #251: field_field_cmp_branch apply-site uses RawApplyOutcome (#83
+# Phase B, reusing apply_field_field_cmp_raw — same Bail discipline).
+if .x > .y then "a" else "b" end
+{"x":3,"y":2}
+"a"
+
+if .x == .y then 1 else 0 end
+{"x":5,"y":5}
+1
+
+if .x <= .y then "yes" else "no" end
+{"x":2,"y":3}
+"yes"
+
+# Non-numeric field — helper Bails, generic uses cross-type ordering ("hi" > 3 = true).
+if .x > .y then "a" else "b" end
+{"x":3,"y":"hi"}
+"b"
+
+# `?`-wrapped: non-object input — generic raises.
+[ (if .x > .y then "a" else "b" end)? ]
+"plain"
+[]
+
+# Missing field — generic resolves null comparisons (null < anything = true).
+if .x > .y then "a" else "b" end
+{"x":5}
+"a"


### PR DESCRIPTION
## Summary
- Migrate the `detect_field_field_cmp_branch` apply-sites in `bin/jq-jit.rs` (stdin + file-mode) to the named `RawApplyOutcome::{Emit, Bail}` discipline.
- Shape: `if .x cmp .y then T else F end` with pre-encoded byte literals on both branches. Same comparison logic as `field_field_cmp`, just a different emit closure that picks T or F by the boolean — so the apply-site reuses `apply_field_field_cmp_raw` with no new helper (same pattern as #254 / #276).

Bail discipline matches the parent: missing field, non-numeric field, non-cmp op, non-object input return Bail.

6 new regression cases cover happy paths, cross-type ordering routing through generic (`"hi" > 3 == true` in jq), null comparison routing (null < anything is true), and `?`-wrapped non-object input.

Refs #251.

## Test plan
- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (907 regression cases pass, +6 over main)
- [x] `./bench/comprehensive.sh --quick` (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)