### PR TITLE
refactor: is_type / is_length apply-sites use RawApplyOutcome (#83 Phase B)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -136,7 +136,7 @@ fn print_jq_error(msg: &str) {
     }
 }
 
-use jq_jit::value::{Value, json_to_value, json_stream, json_stream_offsets, json_stream_raw, json_stream_project, json_value_has_duplicate_keys, json_stream_has_duplicate_keys, json_object_get_num, json_object_get_two_nums, json_object_get_field_raw, json_object_get_fields_raw_buf, json_object_get_nested_field_raw, parse_json_num, json_value_length, json_object_keys_to_buf_reuse, json_object_extract_keys_only, json_object_keys_unsorted_to_buf, json_object_keys_join_to_buf, json_object_has_key, json_object_has_all_keys, json_object_has_any_key, json_type_byte, json_object_del_field, json_object_del_fields, json_object_filter_by_key_str, json_object_merge_literal, json_object_sort_keys, json_object_filter_by_value_type, json_each_value_raw, json_each_value_cb, json_to_entries_raw, json_with_entries_select_value_cmp, json_object_set_field_raw, json_object_update_field_num, json_object_update_field_num_chain,  json_object_assign_field_arith, json_object_assign_two_fields_arith, json_object_select_then_update_num, json_object_select_then_update_str_concat, json_object_select_compound_then_update_num, json_object_select_str_then_update_num, json_object_values_tostring, is_json_compact, push_json_compact_raw, push_tojson_raw, push_json_pretty_raw, push_json_pretty_raw_at, value_to_json_precise, value_to_json_pretty_ext, push_compact_line, push_compact_line_color, push_pretty_line, push_pretty_line_color, push_jq_number_bytes, write_value_compact_ext, write_value_compact_line, write_value_pretty_line_color, value_to_json_pretty_color, walk_json_transform_nums, pool_value, skip_json_value};
+use jq_jit::value::{Value, json_to_value, json_stream, json_stream_offsets, json_stream_raw, json_stream_project, json_value_has_duplicate_keys, json_stream_has_duplicate_keys, json_object_get_num, json_object_get_two_nums, json_object_get_field_raw, json_object_get_fields_raw_buf, json_object_get_nested_field_raw, parse_json_num, json_value_length, json_object_keys_to_buf_reuse, json_object_extract_keys_only, json_object_keys_unsorted_to_buf, json_object_keys_join_to_buf, json_object_has_key, json_object_has_all_keys, json_object_has_any_key, json_object_del_field, json_object_del_fields, json_object_filter_by_key_str, json_object_merge_literal, json_object_sort_keys, json_object_filter_by_value_type, json_each_value_raw, json_each_value_cb, json_to_entries_raw, json_with_entries_select_value_cmp, json_object_set_field_raw, json_object_update_field_num, json_object_update_field_num_chain,  json_object_assign_field_arith, json_object_assign_two_fields_arith, json_object_select_then_update_num, json_object_select_then_update_str_concat, json_object_select_compound_then_update_num, json_object_select_str_then_update_num, json_object_values_tostring, is_json_compact, push_json_compact_raw, push_tojson_raw, push_json_pretty_raw, push_json_pretty_raw_at, value_to_json_precise, value_to_json_pretty_ext, push_compact_line, push_compact_line_color, push_pretty_line, push_pretty_line_color, push_jq_number_bytes, write_value_compact_ext, write_value_compact_line, write_value_pretty_line_color, value_to_json_pretty_color, walk_json_transform_nums, pool_value, skip_json_value};
 use jq_jit::interpreter::Filter;
 use jq_jit::fast_path::{
     apply_arith_chain_cmp_raw, apply_field_access_raw, apply_field_alternative_raw,
@@ -147,8 +147,8 @@ use jq_jit::fast_path::{
     apply_field_scan_raw, apply_field_str_builtin_raw, apply_field_str_concat_raw,
     apply_compound_field_cmp_raw, apply_field_binop_const_unary_raw, apply_field_index_arith_raw,
     apply_field_str_reverse_raw, apply_field_test_raw, apply_field_unary_arith_raw,
-    apply_field_unary_num_raw, apply_full_object_fields_raw, apply_numeric_expr_raw,
-    apply_two_field_binop_const_raw,
+    apply_field_unary_num_raw, apply_full_object_fields_raw, apply_is_length_raw,
+    apply_is_type_raw, apply_numeric_expr_raw, apply_two_field_binop_const_raw,
     apply_has_field_raw, apply_has_multi_field_raw, apply_multi_field_access_raw,
     apply_nested_field_access_raw, apply_object_compute_raw, apply_select_arith_cmp_raw,
     apply_select_cmp_raw, apply_select_field_null_raw, apply_select_str_raw,
@@ -11019,10 +11019,8 @@ fn real_main() {
                 } else if is_length {
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        if let Some(len) = json_value_length(raw, 0) {
-                            push_jq_number_bytes(&mut compact_buf, len as f64);
-                            compact_buf.push(b'\n');
-                        } else {
+                        let outcome = apply_is_length_raw(raw, &mut compact_buf);
+                        if let RawApplyOutcome::Bail = outcome {
                             let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                             process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }
@@ -11192,8 +11190,7 @@ fn real_main() {
                 } else if is_type {
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        compact_buf.extend_from_slice(json_type_byte(raw[0]));
-                        compact_buf.push(b'\n');
+                        let _ = apply_is_type_raw(raw, &mut compact_buf);
                         if compact_buf.len() >= 1 << 17 {
                             let _ = out.write_all(&compact_buf);
                             compact_buf.clear();
@@ -20050,10 +20047,8 @@ fn real_main() {
                 let content_bytes = content.as_bytes();
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    if let Some(len) = json_value_length(raw, 0) {
-                        push_jq_number_bytes(&mut compact_buf, len as f64);
-                        compact_buf.push(b'\n');
-                    } else {
+                    let outcome = apply_is_length_raw(raw, &mut compact_buf);
+                    if let RawApplyOutcome::Bail = outcome {
                         let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                         process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                     }
@@ -20219,8 +20214,7 @@ fn real_main() {
                 let content_bytes = content.as_bytes();
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    compact_buf.extend_from_slice(json_type_byte(raw[0]));
-                    compact_buf.push(b'\n');
+                    let _ = apply_is_type_raw(raw, &mut compact_buf);
                     if compact_buf.len() >= 1 << 17 {
                         let _ = out.write_all(&compact_buf);
                         compact_buf.clear();

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -75,7 +75,7 @@ use crate::value::{
     json_object_update_field_split_first, json_object_update_field_split_last,
     json_object_update_field_str_concat, json_object_update_field_str_map,
     json_object_update_field_test, json_object_update_field_tostring,
-    json_object_update_field_trim, json_value_length, push_jq_number_bytes,
+    json_object_update_field_trim, json_type_byte, json_value_length, push_jq_number_bytes,
 };
 
 /// A fast path whose type-dispatch obligations are encoded in its
@@ -863,6 +863,56 @@ where
     };
     emit(result);
     RawApplyOutcome::Emit
+}
+
+/// Apply the `type` raw-byte fast path on a single JSON record.
+///
+/// jq's `type` returns the static type name (`"object"` / `"array"` /
+/// `"string"` / `"boolean"` / `"null"` / `"number"`) of the input.
+/// The output is determined entirely by the first byte of the parsed
+/// JSON value, which `json_stream_raw` guarantees is one of the
+/// valid JSON-value starts.
+///
+/// **No-Bail helper.** Unlike most apply helpers in this module, this
+/// one never returns [`RawApplyOutcome::Bail`] for well-formed input
+/// — the first byte uniquely determines the output, and there is no
+/// type-error case for `type` in jq. The structural shape is pinned
+/// here so a future reader doesn't add a Bail branch and accidentally
+/// route some input through the generic path with a different
+/// behaviour.
+///
+/// Writes the type-name bytes (with surrounding `"` quotes) plus a
+/// trailing newline to `buf`.
+pub fn apply_is_type_raw(raw: &[u8], buf: &mut Vec<u8>) -> RawApplyOutcome {
+    if raw.is_empty() {
+        return RawApplyOutcome::Bail;
+    }
+    buf.extend_from_slice(json_type_byte(raw[0]));
+    buf.push(b'\n');
+    RawApplyOutcome::Emit
+}
+
+/// Apply the `length` raw-byte fast path on a single JSON record.
+///
+/// The raw scanner only handles container and null lengths directly:
+/// * Object — number of keys.
+/// * Array — number of elements.
+/// * Null — `0`.
+///
+/// Strings, numbers, booleans, and any malformed input return
+/// [`RawApplyOutcome::Bail`] so the generic path produces jq's
+/// verdict (unicode-aware string length, `abs(n)` for numbers,
+/// `boolean has no length` error). Adding fast-path support for
+/// strings/numbers is a separate optimisation.
+pub fn apply_is_length_raw(raw: &[u8], buf: &mut Vec<u8>) -> RawApplyOutcome {
+    match json_value_length(raw, 0) {
+        Some(len) => {
+            push_jq_number_bytes(buf, len as f64);
+            buf.push(b'\n');
+            RawApplyOutcome::Emit
+        }
+        None => RawApplyOutcome::Bail,
+    }
 }
 
 /// Apply the `(.x cmp1 N1) <conjunct> (.y cmp2 N2) <conjunct> ...`

--- a/tests/fast_path_contract.rs
+++ b/tests/fast_path_contract.rs
@@ -26,7 +26,8 @@ use jq_jit::fast_path::{
     apply_compound_field_cmp_raw,
     apply_field_binop_const_unary_raw, apply_field_index_arith_raw,
     apply_field_unary_arith_raw, apply_field_unary_num_raw,
-    apply_field_update_trim_raw, apply_numeric_expr_raw,
+    apply_field_update_trim_raw, apply_is_length_raw, apply_is_type_raw,
+    apply_numeric_expr_raw,
     apply_select_arith_cmp_raw, apply_select_cmp_raw,
     apply_select_field_null_raw, apply_select_str_raw, apply_select_str_test_raw,
     apply_two_field_binop_const_raw,
@@ -2533,6 +2534,112 @@ fn raw_field_binop_const_unary_non_object_input_bails() {
             outcome,
         );
         assert!(emitted.is_empty());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// `type` — no-Bail helper. The output is uniquely determined by the first
+// byte of the parsed JSON value, with no type-error case in jq.
+
+#[test]
+fn raw_is_type_object() {
+    let mut buf = Vec::new();
+    let outcome = apply_is_type_raw(b"{\"x\":1}", &mut buf);
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(buf, b"\"object\"\n");
+}
+
+#[test]
+fn raw_is_type_each_kind() {
+    for (raw, expected) in [
+        (&b"[1,2]"[..], &b"\"array\"\n"[..]),
+        (&b"\"hi\""[..], &b"\"string\"\n"[..]),
+        (&b"true"[..], &b"\"boolean\"\n"[..]),
+        (&b"false"[..], &b"\"boolean\"\n"[..]),
+        (&b"null"[..], &b"\"null\"\n"[..]),
+        (&b"42"[..], &b"\"number\"\n"[..]),
+        (&b"-3.14"[..], &b"\"number\"\n"[..]),
+    ] {
+        let mut buf = Vec::new();
+        let outcome = apply_is_type_raw(raw, &mut buf);
+        assert!(matches!(outcome, RawApplyOutcome::Emit));
+        assert_eq!(buf, expected, "input={:?}", std::str::from_utf8(raw).unwrap());
+    }
+}
+
+#[test]
+fn raw_is_type_empty_input_bails() {
+    let mut buf = Vec::new();
+    let outcome = apply_is_type_raw(b"", &mut buf);
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(buf.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// `length` — polymorphic. The raw scanner only handles container/null lengths
+// directly; strings and numbers Bail to the generic path (which has the
+// unicode-aware string-length and abs-of-number paths). Booleans Bail too —
+// jq raises `boolean has no length` and the generic path produces it.
+
+#[test]
+fn raw_is_length_array() {
+    let mut buf = Vec::new();
+    let outcome = apply_is_length_raw(b"[1,2,3]", &mut buf);
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(buf, b"3\n");
+}
+
+#[test]
+fn raw_is_length_array_empty() {
+    let mut buf = Vec::new();
+    let outcome = apply_is_length_raw(b"[]", &mut buf);
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(buf, b"0\n");
+}
+
+#[test]
+fn raw_is_length_object() {
+    let mut buf = Vec::new();
+    let outcome = apply_is_length_raw(b"{\"a\":1,\"b\":2}", &mut buf);
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(buf, b"2\n");
+}
+
+#[test]
+fn raw_is_length_null_is_zero() {
+    let mut buf = Vec::new();
+    let outcome = apply_is_length_raw(b"null", &mut buf);
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(buf, b"0\n");
+}
+
+#[test]
+fn raw_is_length_string_bails() {
+    // The raw scanner punts on strings (`json_value_length` only handles
+    // containers + null); generic path counts unicode code points.
+    let mut buf = Vec::new();
+    let outcome = apply_is_length_raw(b"\"hello\"", &mut buf);
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(buf.is_empty());
+}
+
+#[test]
+fn raw_is_length_number_bails() {
+    // Same — generic path produces `abs(n)` for number length.
+    let mut buf = Vec::new();
+    let outcome = apply_is_length_raw(b"-7", &mut buf);
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(buf.is_empty());
+}
+
+#[test]
+fn raw_is_length_boolean_bails() {
+    // jq: `boolean (true) has no length`
+    for raw in [&b"true"[..], &b"false"[..]] {
+        let mut buf = Vec::new();
+        let outcome = apply_is_length_raw(raw, &mut buf);
+        assert!(matches!(outcome, RawApplyOutcome::Bail), "raw={:?}", std::str::from_utf8(raw).unwrap());
+        assert!(buf.is_empty());
     }
 }
 

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -4434,3 +4434,51 @@ if .x > .y then "a" else "b" end
 if .x > .y then "a" else "b" end
 {"x":5}
 "a"
+
+# Issue #251: is_type / is_length apply-sites use RawApplyOutcome (#83 Phase B).
+# `is_type` is a no-Bail helper (output is uniquely determined by the first
+# byte of the JSON value). `is_length` Bails for strings/numbers/booleans
+# so the generic path handles them.
+type
+{"a":1}
+"object"
+
+type
+[1,2]
+"array"
+
+type
+"hi"
+"string"
+
+type
+42
+"number"
+
+type
+true
+"boolean"
+
+type
+null
+"null"
+
+length
+[1,2,3]
+3
+
+length
+{"a":1,"b":2}
+2
+
+length
+null
+0
+
+length
+"hello"
+5
+
+length
+-7
+7


### PR DESCRIPTION
## Summary
- Add `apply_is_type_raw` and `apply_is_length_raw` to `src/fast_path.rs`.
- Migrate the `is_type` and `is_length` apply-sites in `bin/jq-jit.rs` (stdin + file-mode) to the named `RawApplyOutcome::{Emit, Bail}` discipline.

`apply_is_type_raw` is a **no-Bail helper**: `type`'s output is uniquely determined by the first byte of the parsed JSON value, with no type-error case in jq. The shape is pinned at the helper boundary so a future reader doesn't add a Bail branch and accidentally route some input through the generic path with different behaviour.

`apply_is_length_raw` Bails for strings, numbers, booleans, and malformed input — `json_value_length` only covers container/null lengths directly. The generic path produces the right verdict for the rest (unicode-aware string length, `abs(n)` for numbers, `boolean has no length` error). Adding fast-path string/number length is a separate optimisation.

10 new contract cases pin the verdict surface; 11 new regression cases cover happy paths for both helpers.

Closes `is_type` and `is_length` from issue #251. `is_keys` left for a follow-up (per-stream key cache layer makes a thin helper non-trivial).

## Test plan
- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (918 regression cases pass, +11 over main; 314 contract cases, +10)
- [x] `./bench/comprehensive.sh --quick` (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)