### PR TITLE
refactor: obj_assign_field_arith / obj_assign_two_fields_arith apply-sites use RawApplyOutcome (#83 Phase B)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -136,7 +136,7 @@ fn print_jq_error(msg: &str) {
     }
 }
 
-use jq_jit::value::{Value, json_to_value, json_stream, json_stream_offsets, json_stream_raw, json_stream_project, json_value_has_duplicate_keys, json_stream_has_duplicate_keys, json_object_get_num, json_object_get_two_nums, json_object_get_field_raw, json_object_get_fields_raw_buf, json_object_get_nested_field_raw, parse_json_num, json_value_length, json_object_keys_to_buf_reuse, json_object_extract_keys_only, json_object_keys_unsorted_to_buf, json_object_keys_join_to_buf, json_object_has_key, json_object_has_all_keys, json_object_has_any_key, json_object_del_field, json_object_del_fields, json_object_filter_by_key_str, json_object_merge_literal, json_object_sort_keys, json_object_filter_by_value_type, json_each_value_raw, json_each_value_cb, json_to_entries_raw, json_with_entries_select_value_cmp, json_object_set_field_raw, json_object_update_field_num, json_object_update_field_num_chain,  json_object_assign_field_arith, json_object_assign_two_fields_arith, json_object_select_then_update_num, json_object_select_then_update_str_concat, json_object_select_compound_then_update_num, json_object_select_str_then_update_num, json_object_values_tostring, is_json_compact, push_json_compact_raw, push_tojson_raw, push_json_pretty_raw, push_json_pretty_raw_at, value_to_json_precise, value_to_json_pretty_ext, push_compact_line, push_compact_line_color, push_pretty_line, push_pretty_line_color, push_jq_number_bytes, write_value_compact_ext, write_value_compact_line, write_value_pretty_line_color, value_to_json_pretty_color, walk_json_transform_nums, pool_value, skip_json_value};
+use jq_jit::value::{Value, json_to_value, json_stream, json_stream_offsets, json_stream_raw, json_stream_project, json_value_has_duplicate_keys, json_stream_has_duplicate_keys, json_object_get_num, json_object_get_two_nums, json_object_get_field_raw, json_object_get_fields_raw_buf, json_object_get_nested_field_raw, parse_json_num, json_value_length, json_object_keys_to_buf_reuse, json_object_extract_keys_only, json_object_keys_unsorted_to_buf, json_object_keys_join_to_buf, json_object_has_key, json_object_has_all_keys, json_object_has_any_key, json_object_del_field, json_object_del_fields, json_object_filter_by_key_str, json_object_merge_literal, json_object_sort_keys, json_object_filter_by_value_type, json_each_value_raw, json_each_value_cb, json_to_entries_raw, json_with_entries_select_value_cmp, json_object_set_field_raw, json_object_update_field_num, json_object_update_field_num_chain,json_object_select_then_update_num, json_object_select_then_update_str_concat, json_object_select_compound_then_update_num, json_object_select_str_then_update_num, json_object_values_tostring, is_json_compact, push_json_compact_raw, push_tojson_raw, push_json_pretty_raw, push_json_pretty_raw_at, value_to_json_precise, value_to_json_pretty_ext, push_compact_line, push_compact_line_color, push_pretty_line, push_pretty_line_color, push_jq_number_bytes, write_value_compact_ext, write_value_compact_line, write_value_pretty_line_color, value_to_json_pretty_color, walk_json_transform_nums, pool_value, skip_json_value};
 use jq_jit::interpreter::Filter;
 use jq_jit::fast_path::{
     apply_arith_chain_cmp_raw, apply_field_access_raw, apply_field_alternative_raw,
@@ -148,7 +148,8 @@ use jq_jit::fast_path::{
     apply_compound_field_cmp_raw, apply_field_binop_const_unary_raw, apply_field_index_arith_raw,
     apply_field_str_reverse_raw, apply_field_test_raw, apply_field_unary_arith_raw,
     apply_field_unary_num_raw, apply_full_object_fields_raw, apply_is_length_raw,
-    apply_is_type_raw, apply_numeric_expr_raw, apply_two_field_binop_const_raw,
+    apply_is_type_raw, apply_numeric_expr_raw, apply_obj_assign_field_arith_raw,
+    apply_obj_assign_two_fields_arith_raw, apply_two_field_binop_const_raw,
     apply_has_field_raw, apply_has_multi_field_raw, apply_multi_field_access_raw,
     apply_nested_field_access_raw, apply_object_compute_raw, apply_select_arith_cmp_raw,
     apply_select_cmp_raw, apply_select_field_null_raw, apply_select_str_raw,
@@ -5264,20 +5265,21 @@ fn real_main() {
                     let mut tmp = Vec::with_capacity(256);
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        if use_pretty_buf {
+                        let (target_buf, is_pretty) = if use_pretty_buf {
                             tmp.clear();
-                            if json_object_assign_field_arith(raw, 0, faf_dest, faf_src, faf_op, faf_n, &mut tmp) {
-                                let len = tmp.len();
-                                if len > 0 && tmp[len-1] == b'\n' { tmp.truncate(len-1); }
-                                push_json_pretty_raw(&mut compact_buf, &tmp, 2, false);
-                                compact_buf.push(b'\n');
-                            } else {
-                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                            }
-                        } else if !json_object_assign_field_arith(raw, 0, faf_dest, faf_src, faf_op, faf_n, &mut compact_buf) {
+                            (&mut tmp, true)
+                        } else {
+                            (&mut compact_buf, false)
+                        };
+                        let outcome = apply_obj_assign_field_arith_raw(
+                            raw, faf_dest, faf_src, faf_op, faf_n, target_buf,
+                        );
+                        if let RawApplyOutcome::Bail = outcome {
                             let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                             process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                        } else if is_pretty {
+                            push_json_pretty_raw(&mut compact_buf, &tmp, 2, false);
+                            compact_buf.push(b'\n');
                         } else {
                             compact_buf.push(b'\n');
                         }
@@ -5291,20 +5293,21 @@ fn real_main() {
                     let mut tmp = Vec::with_capacity(256);
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        if use_pretty_buf {
+                        let (target_buf, is_pretty) = if use_pretty_buf {
                             tmp.clear();
-                            if json_object_assign_two_fields_arith(raw, 0, tf_dest, tf_src1, tf_src2, tf_op, &mut tmp) {
-                                let len = tmp.len();
-                                if len > 0 && tmp[len-1] == b'\n' { tmp.truncate(len-1); }
-                                push_json_pretty_raw(&mut compact_buf, &tmp, 2, false);
-                                compact_buf.push(b'\n');
-                            } else {
-                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                            }
-                        } else if !json_object_assign_two_fields_arith(raw, 0, tf_dest, tf_src1, tf_src2, tf_op, &mut compact_buf) {
+                            (&mut tmp, true)
+                        } else {
+                            (&mut compact_buf, false)
+                        };
+                        let outcome = apply_obj_assign_two_fields_arith_raw(
+                            raw, tf_dest, tf_src1, tf_src2, tf_op, target_buf,
+                        );
+                        if let RawApplyOutcome::Bail = outcome {
                             let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                             process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                        } else if is_pretty {
+                            push_json_pretty_raw(&mut compact_buf, &tmp, 2, false);
+                            compact_buf.push(b'\n');
                         } else {
                             compact_buf.push(b'\n');
                         }
@@ -14551,20 +14554,21 @@ fn real_main() {
                 let mut tmp = Vec::with_capacity(256);
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    if use_pretty_buf {
+                    let (target_buf, is_pretty) = if use_pretty_buf {
                         tmp.clear();
-                        if json_object_assign_field_arith(raw, 0, faf_dest, faf_src, faf_op, faf_n, &mut tmp) {
-                            let len = tmp.len();
-                            if len > 0 && tmp[len-1] == b'\n' { tmp.truncate(len-1); }
-                            push_json_pretty_raw(&mut compact_buf, &tmp, 2, false);
-                            compact_buf.push(b'\n');
-                        } else {
-                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                        }
-                    } else if !json_object_assign_field_arith(raw, 0, faf_dest, faf_src, faf_op, faf_n, &mut compact_buf) {
+                        (&mut tmp, true)
+                    } else {
+                        (&mut compact_buf, false)
+                    };
+                    let outcome = apply_obj_assign_field_arith_raw(
+                        raw, faf_dest, faf_src, faf_op, faf_n, target_buf,
+                    );
+                    if let RawApplyOutcome::Bail = outcome {
                         let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                         process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                    } else if is_pretty {
+                        push_json_pretty_raw(&mut compact_buf, &tmp, 2, false);
+                        compact_buf.push(b'\n');
                     } else {
                         compact_buf.push(b'\n');
                     }
@@ -14579,20 +14583,21 @@ fn real_main() {
                 let mut tmp = Vec::with_capacity(256);
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    if use_pretty_buf {
+                    let (target_buf, is_pretty) = if use_pretty_buf {
                         tmp.clear();
-                        if json_object_assign_two_fields_arith(raw, 0, tf_dest, tf_src1, tf_src2, tf_op, &mut tmp) {
-                            let len = tmp.len();
-                            if len > 0 && tmp[len-1] == b'\n' { tmp.truncate(len-1); }
-                            push_json_pretty_raw(&mut compact_buf, &tmp, 2, false);
-                            compact_buf.push(b'\n');
-                        } else {
-                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                        }
-                    } else if !json_object_assign_two_fields_arith(raw, 0, tf_dest, tf_src1, tf_src2, tf_op, &mut compact_buf) {
+                        (&mut tmp, true)
+                    } else {
+                        (&mut compact_buf, false)
+                    };
+                    let outcome = apply_obj_assign_two_fields_arith_raw(
+                        raw, tf_dest, tf_src1, tf_src2, tf_op, target_buf,
+                    );
+                    if let RawApplyOutcome::Bail = outcome {
                         let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                         process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                    } else if is_pretty {
+                        push_json_pretty_raw(&mut compact_buf, &tmp, 2, false);
+                        compact_buf.push(b'\n');
                     } else {
                         compact_buf.push(b'\n');
                     }

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -66,7 +66,8 @@ use crate::interpreter::{ArithExpr, MathUnary};
 use crate::ir::{BinOp, UnaryOp};
 use crate::runtime::jq_mod_f64;
 use crate::value::{
-    KeyStr, Value, ObjInner, json_object_del_field, json_object_del_fields,
+    KeyStr, Value, ObjInner, json_object_assign_field_arith, json_object_assign_two_fields_arith,
+    json_object_del_field, json_object_del_fields,
     json_object_get_field_raw, json_object_get_fields_raw_buf,
     json_object_get_nested_field_raw, json_object_get_num, json_object_get_two_nums,
     json_object_has_all_keys, json_object_has_any_key, json_object_has_key,
@@ -863,6 +864,70 @@ where
     };
     emit(result);
     RawApplyOutcome::Emit
+}
+
+/// Apply the `.dest = (.src <op> N)` raw-byte object-assign fast path
+/// on a single JSON record. Reads `.src`'s numeric value, applies the
+/// arithmetic, and writes the result to `.dest` (creating the field
+/// if absent), preserving the rest of the object's structure.
+///
+/// Bail discipline (delegates to `json_object_assign_field_arith`):
+/// * Non-object input — Bail.
+/// * `.src` absent or non-numeric — Bail (jq raises type error).
+/// * `op` is `Mod` with divisor zero — Bail (jq raises).
+/// * Non-finite arithmetic result — Bail.
+/// * Non-arithmetic op (defensive) — Bail (the underlying call falls
+///   through to a no-op for non-arith ops, but the structural shape
+///   is documented).
+///
+/// Writes the rewritten object bytes (without trailing `\n`) to `buf`
+/// on Emit. Caller appends the newline.
+pub fn apply_obj_assign_field_arith_raw(
+    raw: &[u8],
+    dest_field: &str,
+    src_field: &str,
+    op: BinOp,
+    n: f64,
+    buf: &mut Vec<u8>,
+) -> RawApplyOutcome {
+    if !matches!(op, BinOp::Add | BinOp::Sub | BinOp::Mul | BinOp::Div | BinOp::Mod) {
+        return RawApplyOutcome::Bail;
+    }
+    if json_object_assign_field_arith(raw, 0, dest_field, src_field, op, n, buf) {
+        RawApplyOutcome::Emit
+    } else {
+        RawApplyOutcome::Bail
+    }
+}
+
+/// Apply the `.dest = (.src1 <op> .src2)` raw-byte object-assign fast
+/// path on a single JSON record. Reads two source fields' numeric
+/// values, applies the arithmetic, and writes the result to `.dest`.
+///
+/// Bail discipline (delegates to `json_object_assign_two_fields_arith`):
+/// * Non-object input — Bail.
+/// * Either source field absent or non-numeric — Bail.
+/// * Non-finite arithmetic result — Bail (div-by-zero etc.).
+/// * Non-arithmetic op — Bail (defensive).
+///
+/// Writes the rewritten object bytes (without trailing `\n`) to `buf`
+/// on Emit.
+pub fn apply_obj_assign_two_fields_arith_raw(
+    raw: &[u8],
+    dest_field: &str,
+    src1_field: &str,
+    src2_field: &str,
+    op: BinOp,
+    buf: &mut Vec<u8>,
+) -> RawApplyOutcome {
+    if !matches!(op, BinOp::Add | BinOp::Sub | BinOp::Mul | BinOp::Div | BinOp::Mod) {
+        return RawApplyOutcome::Bail;
+    }
+    if json_object_assign_two_fields_arith(raw, 0, dest_field, src1_field, src2_field, op, buf) {
+        RawApplyOutcome::Emit
+    } else {
+        RawApplyOutcome::Bail
+    }
 }
 
 /// Apply the `type` raw-byte fast path on a single JSON record.

--- a/tests/fast_path_contract.rs
+++ b/tests/fast_path_contract.rs
@@ -27,7 +27,8 @@ use jq_jit::fast_path::{
     apply_field_binop_const_unary_raw, apply_field_index_arith_raw,
     apply_field_unary_arith_raw, apply_field_unary_num_raw,
     apply_field_update_trim_raw, apply_is_length_raw, apply_is_type_raw,
-    apply_numeric_expr_raw,
+    apply_numeric_expr_raw, apply_obj_assign_field_arith_raw,
+    apply_obj_assign_two_fields_arith_raw,
     apply_select_arith_cmp_raw, apply_select_cmp_raw,
     apply_select_field_null_raw, apply_select_str_raw, apply_select_str_test_raw,
     apply_two_field_binop_const_raw,
@@ -2534,6 +2535,135 @@ fn raw_field_binop_const_unary_non_object_input_bails() {
             outcome,
         );
         assert!(emitted.is_empty());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// `.dest = (.src op N)` — object-assign single-field arithmetic. Thin
+// wrapper around `json_object_assign_field_arith`. Bails on missing/non-
+// numeric src, non-finite result, or non-arith op.
+
+#[test]
+fn raw_obj_assign_field_arith_emits_rewritten_object() {
+    // .y = (.x + 1) on {"x":3,"y":0} → {"x":3,"y":4}
+    let mut buf = Vec::new();
+    let outcome = apply_obj_assign_field_arith_raw(
+        b"{\"x\":3,\"y\":0}", "y", "x", BinOp::Add, 1.0, &mut buf,
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(buf, b"{\"x\":3,\"y\":4}");
+}
+
+#[test]
+fn raw_obj_assign_field_arith_missing_src_bails() {
+    let mut buf = Vec::new();
+    let outcome = apply_obj_assign_field_arith_raw(
+        b"{\"y\":0}", "y", "x", BinOp::Add, 1.0, &mut buf,
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(buf.is_empty());
+}
+
+#[test]
+fn raw_obj_assign_field_arith_non_numeric_src_bails() {
+    let mut buf = Vec::new();
+    let outcome = apply_obj_assign_field_arith_raw(
+        b"{\"x\":\"hi\",\"y\":0}", "y", "x", BinOp::Add, 1.0, &mut buf,
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(buf.is_empty());
+}
+
+#[test]
+fn raw_obj_assign_field_arith_div_by_zero_bails() {
+    let mut buf = Vec::new();
+    let outcome = apply_obj_assign_field_arith_raw(
+        b"{\"x\":3,\"y\":0}", "y", "x", BinOp::Div, 0.0, &mut buf,
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(buf.is_empty());
+}
+
+#[test]
+fn raw_obj_assign_field_arith_non_arith_op_bails() {
+    for op in [BinOp::Eq, BinOp::Lt, BinOp::And] {
+        let mut buf = Vec::new();
+        let outcome = apply_obj_assign_field_arith_raw(
+            b"{\"x\":3,\"y\":0}", "y", "x", op, 1.0, &mut buf,
+        );
+        assert!(matches!(outcome, RawApplyOutcome::Bail), "op={:?}", op);
+    }
+}
+
+#[test]
+fn raw_obj_assign_field_arith_non_object_input_bails() {
+    for raw in [b"42".as_slice(), b"\"hi\"".as_slice(), b"null".as_slice(), b"[1,2]".as_slice()] {
+        let mut buf = Vec::new();
+        let outcome = apply_obj_assign_field_arith_raw(
+            raw, "y", "x", BinOp::Add, 1.0, &mut buf,
+        );
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "raw={:?}", std::str::from_utf8(raw).unwrap(),
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// `.dest = (.src1 op .src2)` — object-assign two-field arithmetic.
+
+#[test]
+fn raw_obj_assign_two_fields_arith_emits_rewritten() {
+    // .z = (.x + .y) on {"x":3,"y":4,"z":0} → {"x":3,"y":4,"z":7}
+    let mut buf = Vec::new();
+    let outcome = apply_obj_assign_two_fields_arith_raw(
+        b"{\"x\":3,\"y\":4,\"z\":0}", "z", "x", "y", BinOp::Add, &mut buf,
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(buf, b"{\"x\":3,\"y\":4,\"z\":7}");
+}
+
+#[test]
+fn raw_obj_assign_two_fields_arith_missing_field_bails() {
+    let mut buf = Vec::new();
+    let outcome = apply_obj_assign_two_fields_arith_raw(
+        b"{\"x\":3,\"z\":0}", "z", "x", "y", BinOp::Add, &mut buf,
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(buf.is_empty());
+}
+
+#[test]
+fn raw_obj_assign_two_fields_arith_div_by_zero_bails() {
+    let mut buf = Vec::new();
+    let outcome = apply_obj_assign_two_fields_arith_raw(
+        b"{\"x\":3,\"y\":0,\"z\":0}", "z", "x", "y", BinOp::Div, &mut buf,
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(buf.is_empty());
+}
+
+#[test]
+fn raw_obj_assign_two_fields_arith_non_arith_op_bails() {
+    let mut buf = Vec::new();
+    let outcome = apply_obj_assign_two_fields_arith_raw(
+        b"{\"x\":3,\"y\":4,\"z\":0}", "z", "x", "y", BinOp::Eq, &mut buf,
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(buf.is_empty());
+}
+
+#[test]
+fn raw_obj_assign_two_fields_arith_non_object_input_bails() {
+    for raw in [b"42".as_slice(), b"null".as_slice(), b"[1,2,3]".as_slice()] {
+        let mut buf = Vec::new();
+        let outcome = apply_obj_assign_two_fields_arith_raw(
+            raw, "z", "x", "y", BinOp::Add, &mut buf,
+        );
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "raw={:?}", std::str::from_utf8(raw).unwrap(),
+        );
     }
 }
 

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -4482,3 +4482,48 @@ length
 length
 -7
 7
+
+# Issue #251: obj_assign_field_arith / obj_assign_two_fields_arith apply-sites
+# use RawApplyOutcome (#83 Phase B). Helpers Bail on non-object/missing-or-
+# non-numeric src/non-finite/non-arith op.
+.y = (.x + 1)
+{"x":3,"y":0}
+{"x":3,"y":4}
+
+.z = (.x + .y)
+{"x":3,"y":4,"z":0}
+{"x":3,"y":4,"z":7}
+
+.dest = (.src * 2)
+{"src":7,"dest":0}
+{"src":7,"dest":14}
+
+# Missing src — helper Bails, generic resolves null+1=1.
+[ (.y = (.x + 1))? ]
+{"y":0}
+[{"y":1}]
+
+# Non-numeric src — generic raises type error, ? swallows.
+[ (.y = (.x + 1))? ]
+{"x":"hi","y":0}
+[]
+
+# Div-by-zero — helper Bails, generic raises.
+[ (.y = (.x / 0))? ]
+{"x":3,"y":0}
+[]
+
+# Non-object input — generic raises.
+[ (.y = (.x + 1))? ]
+"plain"
+[]
+
+# Two-field: missing field.
+[ (.z = (.x + .y))? ]
+{"x":3,"z":0}
+[{"x":3,"z":3}]
+
+# Two-field: div-by-zero (.x / .y where y=0).
+[ (.z = (.x / .y))? ]
+{"x":3,"y":0,"z":0}
+[]


### PR DESCRIPTION
## Summary
- Add `apply_obj_assign_field_arith_raw` and `apply_obj_assign_two_fields_arith_raw` to `src/fast_path.rs` as thin wrappers around the existing `json_object_assign_field_arith` / `json_object_assign_two_fields_arith` functions in `value.rs`.
- Migrate the `field_assign_field_arith` and `field_assign_two_fields` apply-sites in `bin/jq-jit.rs` (stdin + file-mode) to the named `RawApplyOutcome::{Emit, Bail}` discipline.
- The underlying value.rs implementations already encode the right Bail conditions; the wrappers add a defensive non-arith-op check at the helper boundary so the structural shape is documented.

11 new contract cases pin the verdict surface; 9 new regression cases cover the `?`-wrapped Bail matrix (missing field → null+N=N, non-numeric, div-by-zero, non-object).

Closes the final two items in the "Object update" section of issue #251.

## Test plan
- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (927 regression cases pass, +9 over main; 325 contract cases, +11)
- [x] `./bench/comprehensive.sh --quick` (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)