### PR TITLE
refactor: obj_merge_lit / obj_merge_computed apply-sites use RawApplyOutcome (#83 Phase B)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -149,7 +149,8 @@ use jq_jit::fast_path::{
     apply_field_str_reverse_raw, apply_field_test_raw, apply_field_unary_arith_raw,
     apply_field_unary_num_raw, apply_full_object_fields_raw, apply_is_length_raw,
     apply_is_type_raw, apply_numeric_expr_raw, apply_obj_assign_field_arith_raw,
-    apply_obj_assign_two_fields_arith_raw, apply_two_field_binop_const_raw,
+    apply_obj_assign_two_fields_arith_raw, apply_obj_merge_computed_raw,
+    apply_obj_merge_lit_raw, apply_two_field_binop_const_raw,
     apply_has_field_raw, apply_has_multi_field_raw, apply_multi_field_access_raw,
     apply_nested_field_access_raw, apply_object_compute_raw, apply_select_arith_cmp_raw,
     apply_select_cmp_raw, apply_select_field_null_raw, apply_select_str_raw,
@@ -11474,20 +11475,21 @@ fn real_main() {
                     let mut tmp = Vec::new();
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        if use_pretty_buf {
+                        let (target_buf, is_pretty) = if use_pretty_buf {
                             tmp.clear();
-                            if json_object_merge_literal(raw, 0, merge_pairs, &mut tmp) {
-                                push_json_pretty_raw(&mut compact_buf, &tmp, 2, false);
-                                compact_buf.push(b'\n');
-                            } else {
-                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                            }
-                        } else if json_object_merge_literal(raw, 0, merge_pairs, &mut compact_buf) {
-                            compact_buf.push(b'\n');
+                            (&mut tmp, true)
                         } else {
+                            (&mut compact_buf, false)
+                        };
+                        let outcome = apply_obj_merge_lit_raw(raw, merge_pairs, target_buf);
+                        if let RawApplyOutcome::Bail = outcome {
                             let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                             process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                        } else if is_pretty {
+                            push_json_pretty_raw(&mut compact_buf, &tmp, 2, false);
+                            compact_buf.push(b'\n');
+                        } else {
+                            compact_buf.push(b'\n');
                         }
                         if compact_buf.len() >= 1 << 17 {
                             let _ = out.write_all(&compact_buf);
@@ -11498,43 +11500,27 @@ fn real_main() {
                 } else if let Some((ref out_key, ref nfields, ref arith)) = obj_merge_computed {
                     let mut tmp = Vec::new();
                     let mut merge_pair = vec![(out_key.clone(), Vec::new())];
+                    let nfield_refs: Vec<&str> = nfields.iter().map(|s| s.as_str()).collect();
+                    let mut vals_buf = vec![0.0f64; nfield_refs.len()];
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        let nf_count = nfields.len();
-                        let ok = if nf_count == 1 {
-                            if let Some(v) = json_object_get_num(raw, 0, &nfields[0]) {
-                                let result = arith.eval(&[v]);
-                                merge_pair[0].1.clear();
-                                push_jq_number_bytes(&mut merge_pair[0].1, result);
-                                true
-                            } else { false }
-                        } else if nf_count == 2 {
-                            if let Some((a, b)) = json_object_get_two_nums(raw, 0, &nfields[0], &nfields[1]) {
-                                let result = arith.eval(&[a, b]);
-                                merge_pair[0].1.clear();
-                                push_jq_number_bytes(&mut merge_pair[0].1, result);
-                                true
-                            } else { false }
-                        } else { false };
-                        if ok {
-                            if use_pretty_buf {
-                                tmp.clear();
-                                if json_object_merge_literal(raw, 0, &merge_pair, &mut tmp) {
-                                    push_json_pretty_raw(&mut compact_buf, &tmp, 2, false);
-                                    compact_buf.push(b'\n');
-                                } else {
-                                    let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                    process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                                }
-                            } else if json_object_merge_literal(raw, 0, &merge_pair, &mut compact_buf) {
-                                compact_buf.push(b'\n');
-                            } else {
-                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                            }
+                        let (target_buf, is_pretty) = if use_pretty_buf {
+                            tmp.clear();
+                            (&mut tmp, true)
                         } else {
+                            (&mut compact_buf, false)
+                        };
+                        let outcome = apply_obj_merge_computed_raw(
+                            raw, &nfield_refs, arith, &mut vals_buf, &mut merge_pair, target_buf,
+                        );
+                        if let RawApplyOutcome::Bail = outcome {
                             let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                             process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                        } else if is_pretty {
+                            push_json_pretty_raw(&mut compact_buf, &tmp, 2, false);
+                            compact_buf.push(b'\n');
+                        } else {
+                            compact_buf.push(b'\n');
                         }
                         if compact_buf.len() >= 1 << 17 {
                             let _ = out.write_all(&compact_buf);
@@ -20489,20 +20475,21 @@ fn real_main() {
                 let mut tmp = Vec::new();
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    if use_pretty_buf {
+                    let (target_buf, is_pretty) = if use_pretty_buf {
                         tmp.clear();
-                        if json_object_merge_literal(raw, 0, merge_pairs, &mut tmp) {
-                            push_json_pretty_raw(&mut compact_buf, &tmp, 2, false);
-                            compact_buf.push(b'\n');
-                        } else {
-                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                        }
-                    } else if json_object_merge_literal(raw, 0, merge_pairs, &mut compact_buf) {
-                        compact_buf.push(b'\n');
+                        (&mut tmp, true)
                     } else {
+                        (&mut compact_buf, false)
+                    };
+                    let outcome = apply_obj_merge_lit_raw(raw, merge_pairs, target_buf);
+                    if let RawApplyOutcome::Bail = outcome {
                         let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                         process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                    } else if is_pretty {
+                        push_json_pretty_raw(&mut compact_buf, &tmp, 2, false);
+                        compact_buf.push(b'\n');
+                    } else {
+                        compact_buf.push(b'\n');
                     }
                     if compact_buf.len() >= 1 << 17 {
                         let _ = out.write_all(&compact_buf);
@@ -20514,43 +20501,27 @@ fn real_main() {
                 let content_bytes = content.as_bytes();
                 let mut tmp = Vec::new();
                 let mut merge_pair = vec![(out_key.clone(), Vec::new())];
+                let nfield_refs: Vec<&str> = nfields.iter().map(|s| s.as_str()).collect();
+                let mut vals_buf = vec![0.0f64; nfield_refs.len()];
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    let nf_count = nfields.len();
-                    let ok = if nf_count == 1 {
-                        if let Some(v) = json_object_get_num(raw, 0, &nfields[0]) {
-                            let result = arith.eval(&[v]);
-                            merge_pair[0].1.clear();
-                            push_jq_number_bytes(&mut merge_pair[0].1, result);
-                            true
-                        } else { false }
-                    } else if nf_count == 2 {
-                        if let Some((a, b)) = json_object_get_two_nums(raw, 0, &nfields[0], &nfields[1]) {
-                            let result = arith.eval(&[a, b]);
-                            merge_pair[0].1.clear();
-                            push_jq_number_bytes(&mut merge_pair[0].1, result);
-                            true
-                        } else { false }
-                    } else { false };
-                    if ok {
-                        if use_pretty_buf {
-                            tmp.clear();
-                            if json_object_merge_literal(raw, 0, &merge_pair, &mut tmp) {
-                                push_json_pretty_raw(&mut compact_buf, &tmp, 2, false);
-                                compact_buf.push(b'\n');
-                            } else {
-                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                            }
-                        } else if json_object_merge_literal(raw, 0, &merge_pair, &mut compact_buf) {
-                            compact_buf.push(b'\n');
-                        } else {
-                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                        }
+                    let (target_buf, is_pretty) = if use_pretty_buf {
+                        tmp.clear();
+                        (&mut tmp, true)
                     } else {
+                        (&mut compact_buf, false)
+                    };
+                    let outcome = apply_obj_merge_computed_raw(
+                        raw, &nfield_refs, arith, &mut vals_buf, &mut merge_pair, target_buf,
+                    );
+                    if let RawApplyOutcome::Bail = outcome {
                         let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                         process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                    } else if is_pretty {
+                        push_json_pretty_raw(&mut compact_buf, &tmp, 2, false);
+                        compact_buf.push(b'\n');
+                    } else {
+                        compact_buf.push(b'\n');
                     }
                     if compact_buf.len() >= 1 << 17 {
                         let _ = out.write_all(&compact_buf);

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -68,7 +68,7 @@ use crate::runtime::jq_mod_f64;
 use crate::value::{
     KeyStr, Value, ObjInner, json_object_assign_field_arith, json_object_assign_two_fields_arith,
     json_object_del_field, json_object_del_fields,
-    json_object_get_field_raw, json_object_get_fields_raw_buf,
+    json_object_get_field_raw, json_object_get_fields_raw_buf, json_object_merge_literal,
     json_object_get_nested_field_raw, json_object_get_num, json_object_get_two_nums,
     json_object_has_all_keys, json_object_has_any_key, json_object_has_key,
     json_object_update_field_case, json_object_update_field_gsub,
@@ -864,6 +864,100 @@ where
     };
     emit(result);
     RawApplyOutcome::Emit
+}
+
+/// Apply the `. + {key: <arith>}` raw-byte object-merge fast path on
+/// a single JSON record. Reads numeric fields, evaluates the
+/// `ArithExpr`, formats the result as JSON-number bytes, and merges
+/// `{key: <result>}` into the input object.
+///
+/// Caller provides:
+/// * `out_key` — the merge key.
+/// * `nfields` — fields referenced by the arith expression.
+/// * `arith` — the compiled numeric expression.
+/// * `vals_buf` — scratch sized to `nfields.len()`.
+/// * `merge_pair_buf` — single-element scratch (shape:
+///   `[(out_key.clone(), Vec::new())]`); element 0's value is
+///   overwritten each call with the JSON-number bytes.
+///
+/// Bail discipline:
+/// * Non-object input — Bail.
+/// * Any referenced field absent or non-numeric — Bail.
+/// * Non-finite result (div-by-zero / overflow / NaN) — Bail so
+///   `null` / saturating numbers don't leak into the merged object.
+/// * `merge_pair_buf` has wrong shape (defensive) — Bail.
+/// * Underlying `json_object_merge_literal` returning false — Bail.
+///
+/// Writes the merged-object bytes (without trailing `\n`) to `buf` on
+/// Emit.
+pub fn apply_obj_merge_computed_raw(
+    raw: &[u8],
+    nfields: &[&str],
+    arith: &ArithExpr,
+    vals_buf: &mut [f64],
+    merge_pair_buf: &mut [(String, Vec<u8>)],
+    buf: &mut Vec<u8>,
+) -> RawApplyOutcome {
+    if raw.is_empty() || raw[0] != b'{' {
+        return RawApplyOutcome::Bail;
+    }
+    if merge_pair_buf.len() != 1 || vals_buf.len() < nfields.len() {
+        return RawApplyOutcome::Bail;
+    }
+    let nf = nfields.len();
+    let ok = if nf == 1 {
+        match json_object_get_num(raw, 0, nfields[0]) {
+            Some(v) => { vals_buf[0] = v; true }
+            None => false,
+        }
+    } else if nf == 2 {
+        match json_object_get_two_nums(raw, 0, nfields[0], nfields[1]) {
+            Some((a, b)) => { vals_buf[0] = a; vals_buf[1] = b; true }
+            None => false,
+        }
+    } else {
+        // 3+ fields not supported by the existing apply-site; the
+        // detector should never produce this shape, but Bail
+        // defensively rather than emit garbage.
+        false
+    };
+    if !ok {
+        return RawApplyOutcome::Bail;
+    }
+    let result = arith.eval(&vals_buf[..nf]);
+    if !result.is_finite() {
+        return RawApplyOutcome::Bail;
+    }
+    merge_pair_buf[0].1.clear();
+    push_jq_number_bytes(&mut merge_pair_buf[0].1, result);
+    if json_object_merge_literal(raw, 0, merge_pair_buf, buf) {
+        RawApplyOutcome::Emit
+    } else {
+        RawApplyOutcome::Bail
+    }
+}
+
+/// Apply the `. + {k1: v1, k2: v2, ...}` raw-byte object-merge fast
+/// path on a single JSON record. Each `(k, v)` is a literal key-name
+/// + JSON-encoded value-bytes pair (the parser pre-encodes each
+/// branch's JSON value).
+///
+/// Bail discipline: delegates to `json_object_merge_literal`, which
+/// returns `false` on non-object input. The wrapper documents the
+/// structural shape at the helper boundary.
+///
+/// Writes the merged-object bytes (without trailing `\n`) to `buf` on
+/// Emit. Caller appends the newline.
+pub fn apply_obj_merge_lit_raw(
+    raw: &[u8],
+    merge_pairs: &[(String, Vec<u8>)],
+    buf: &mut Vec<u8>,
+) -> RawApplyOutcome {
+    if json_object_merge_literal(raw, 0, merge_pairs, buf) {
+        RawApplyOutcome::Emit
+    } else {
+        RawApplyOutcome::Bail
+    }
 }
 
 /// Apply the `.dest = (.src <op> N)` raw-byte object-assign fast path

--- a/tests/fast_path_contract.rs
+++ b/tests/fast_path_contract.rs
@@ -28,7 +28,8 @@ use jq_jit::fast_path::{
     apply_field_unary_arith_raw, apply_field_unary_num_raw,
     apply_field_update_trim_raw, apply_is_length_raw, apply_is_type_raw,
     apply_numeric_expr_raw, apply_obj_assign_field_arith_raw,
-    apply_obj_assign_two_fields_arith_raw,
+    apply_obj_assign_two_fields_arith_raw, apply_obj_merge_computed_raw,
+    apply_obj_merge_lit_raw,
     apply_select_arith_cmp_raw, apply_select_cmp_raw,
     apply_select_field_null_raw, apply_select_str_raw, apply_select_str_test_raw,
     apply_two_field_binop_const_raw,
@@ -2536,6 +2537,129 @@ fn raw_field_binop_const_unary_non_object_input_bails() {
         );
         assert!(emitted.is_empty());
     }
+}
+
+// ---------------------------------------------------------------------------
+// `. + {k: v}` — object-merge-literal. Thin wrapper around
+// `json_object_merge_literal`; Bails on non-object input.
+
+#[test]
+fn raw_obj_merge_lit_appends_new_key() {
+    let mut buf = Vec::new();
+    let pairs = vec![("y".to_string(), b"42".to_vec())];
+    let outcome = apply_obj_merge_lit_raw(b"{\"x\":1}", &pairs, &mut buf);
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(buf, b"{\"x\":1,\"y\":42}");
+}
+
+#[test]
+fn raw_obj_merge_lit_replaces_existing_key() {
+    let mut buf = Vec::new();
+    let pairs = vec![("x".to_string(), b"99".to_vec())];
+    let outcome = apply_obj_merge_lit_raw(b"{\"x\":1,\"y\":2}", &pairs, &mut buf);
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(buf, b"{\"x\":99,\"y\":2}");
+}
+
+#[test]
+fn raw_obj_merge_lit_non_object_bails() {
+    for raw in [b"42".as_slice(), b"\"hi\"".as_slice(), b"null".as_slice(), b"[1]".as_slice()] {
+        let mut buf = Vec::new();
+        let pairs = vec![("y".to_string(), b"42".to_vec())];
+        let outcome = apply_obj_merge_lit_raw(raw, &pairs, &mut buf);
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "raw={:?}", std::str::from_utf8(raw).unwrap(),
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// `. + {key: <arith>}` — object-merge-computed. Reads numeric fields,
+// evaluates the ArithExpr, formats as JSON-number bytes, merges. Bails on
+// non-object/missing-or-non-numeric/non-finite/buffer-shape mismatch.
+
+#[test]
+fn raw_obj_merge_computed_emits_merged() {
+    // . + {sum: .x + .y} on {"x":3,"y":4} → {"x":3,"y":4,"sum":7}
+    let arith = ArithExpr::BinOp(
+        BinOp::Add,
+        Box::new(ArithExpr::Field(0)),
+        Box::new(ArithExpr::Field(1)),
+    );
+    let nfields = ["x", "y"];
+    let mut vals = vec![0.0; 2];
+    let mut merge_pair = vec![("sum".to_string(), Vec::new())];
+    let mut buf = Vec::new();
+    let outcome = apply_obj_merge_computed_raw(
+        b"{\"x\":3,\"y\":4}", &nfields, &arith, &mut vals, &mut merge_pair, &mut buf,
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(buf, b"{\"x\":3,\"y\":4,\"sum\":7}");
+}
+
+#[test]
+fn raw_obj_merge_computed_missing_field_bails() {
+    let arith = ArithExpr::Field(0);
+    let nfields = ["x"];
+    let mut vals = vec![0.0; 1];
+    let mut merge_pair = vec![("dbl".to_string(), Vec::new())];
+    let mut buf = Vec::new();
+    let outcome = apply_obj_merge_computed_raw(
+        b"{\"y\":1}", &nfields, &arith, &mut vals, &mut merge_pair, &mut buf,
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(buf.is_empty());
+}
+
+#[test]
+fn raw_obj_merge_computed_div_by_zero_bails() {
+    let arith = ArithExpr::BinOp(
+        BinOp::Div,
+        Box::new(ArithExpr::Field(0)),
+        Box::new(ArithExpr::Field(1)),
+    );
+    let nfields = ["x", "y"];
+    let mut vals = vec![0.0; 2];
+    let mut merge_pair = vec![("q".to_string(), Vec::new())];
+    let mut buf = Vec::new();
+    let outcome = apply_obj_merge_computed_raw(
+        b"{\"x\":1,\"y\":0}", &nfields, &arith, &mut vals, &mut merge_pair, &mut buf,
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(buf.is_empty());
+}
+
+#[test]
+fn raw_obj_merge_computed_non_object_bails() {
+    let arith = ArithExpr::Field(0);
+    let nfields = ["x"];
+    for raw in [b"42".as_slice(), b"null".as_slice(), b"[1]".as_slice()] {
+        let mut vals = vec![0.0; 1];
+        let mut merge_pair = vec![("dbl".to_string(), Vec::new())];
+        let mut buf = Vec::new();
+        let outcome = apply_obj_merge_computed_raw(
+            raw, &nfields, &arith, &mut vals, &mut merge_pair, &mut buf,
+        );
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "raw={:?}", std::str::from_utf8(raw).unwrap(),
+        );
+    }
+}
+
+#[test]
+fn raw_obj_merge_computed_buffer_shape_mismatch_bails() {
+    let arith = ArithExpr::Field(0);
+    let nfields = ["x"];
+    let mut vals = vec![0.0; 1];
+    // merge_pair_buf must have exactly 1 element
+    let mut merge_pair: Vec<(String, Vec<u8>)> = vec![];
+    let mut buf = Vec::new();
+    let outcome = apply_obj_merge_computed_raw(
+        b"{\"x\":3}", &nfields, &arith, &mut vals, &mut merge_pair, &mut buf,
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -4527,3 +4527,40 @@ length
 [ (.z = (.x / .y))? ]
 {"x":3,"y":0,"z":0}
 []
+
+# Issue #251: obj_merge_lit / obj_merge_computed apply-sites use RawApplyOutcome
+# (#83 Phase B). Helpers Bail on non-object/missing-or-non-numeric/non-finite.
+. + {y:42}
+{"x":1}
+{"x":1,"y":42}
+
+. + {x:99}
+{"x":1,"y":2}
+{"x":99,"y":2}
+
+. + {sum: (.x + .y)}
+{"x":3,"y":4}
+{"x":3,"y":4,"sum":7}
+
+. + {dbl: (.x * 2)}
+{"x":7}
+{"x":7,"dbl":14}
+
+# Missing field — helper Bails, generic resolves null+3=3.
+[ (. + {sum: (.x + .y)})? ]
+{"x":3}
+[{"x":3,"sum":3}]
+
+# Div-by-zero — helper Bails, generic raises.
+[ (. + {q: (.x / .y)})? ]
+{"x":1,"y":0}
+[]
+
+# Non-object input — helper Bails, generic raises.
+[ (. + {y:42})? ]
+"plain"
+[]
+
+[ (. + {sum: (.x + .y)})? ]
+"plain"
+[]


### PR DESCRIPTION
## Summary
- Add `apply_obj_merge_lit_raw` (thin wrapper around `json_object_merge_literal` for `. + {k1: v1, k2: v2, ...}`) and `apply_obj_merge_computed_raw` (`. + {key: <ArithExpr>}`).
- Migrate the `obj_merge_lit` and `obj_merge_computed` apply-sites in `bin/jq-jit.rs` (stdin + file-mode) to the named `RawApplyOutcome::{Emit, Bail}` discipline.

`apply_obj_merge_computed_raw` Bails on non-finite arithmetic results — a structural fix for the prior apply-site, which fed ±Infinity / NaN through `push_jq_number_bytes`'s saturating / `null` outputs into the merged object, while jq raises `/ by zero` on the underlying arithmetic.

8 new contract cases pin the verdict surface (key-append, key-replace, every Bail branch including buffer-shape mismatch); 8 new regression cases cover the `?`-wrapped Bail matrix.

Closes the first two items in the "Object construction / mutation" section. Refs #251.

## Test plan
- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (935 regression cases pass, +8 over main; 333 contract cases, +8)
- [x] `./bench/comprehensive.sh --quick` (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)