### PR TITLE
refactor: select_num_str apply-site uses RawApplyOutcome (#83 Phase B)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -150,7 +150,7 @@ use jq_jit::fast_path::{
     apply_field_unary_num_raw, apply_full_object_fields_raw, apply_is_length_raw,
     apply_is_type_raw, apply_numeric_expr_raw, apply_obj_assign_field_arith_raw,
     apply_obj_assign_two_fields_arith_raw, apply_obj_merge_computed_raw,
-    apply_obj_merge_lit_raw, apply_two_field_binop_const_raw,
+    apply_obj_merge_lit_raw, apply_select_num_str_raw, apply_two_field_binop_const_raw,
     apply_has_field_raw, apply_has_multi_field_raw, apply_multi_field_access_raw,
     apply_nested_field_access_raw, apply_object_compute_raw, apply_select_arith_cmp_raw,
     apply_select_cmp_raw, apply_select_field_null_raw, apply_select_str_raw,
@@ -8948,46 +8948,17 @@ fn real_main() {
                         Ok(())
                     })
                 } else if let Some((ref nf, ref nop, nth, ref sf, ref sop, ref sarg)) = select_num_str {
-                    use jq_jit::ir::BinOp;
-                    let re = if sop == "test" { Some(regex::Regex::new(sarg).ok()).flatten() } else { None };
+                    let re = if sop == "test" { regex::Regex::new(sarg).ok() } else { None };
                     let sarg_bytes = sarg.as_bytes();
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        let num_pass = if let Some(val) = json_object_get_num(raw, 0, nf) {
-                            match nop {
-                                BinOp::Gt => val > nth, BinOp::Lt => val < nth,
-                                BinOp::Ge => val >= nth, BinOp::Le => val <= nth,
-                                BinOp::Eq => val == nth, BinOp::Ne => val != nth,
-                                _ => false,
-                            }
-                        } else { false };
-                        if num_pass {
-                            let str_pass = if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, sf) {
-                                let fval = &raw[vs..ve];
-                                if fval.len() >= 2 && fval[0] == b'"' {
-                                    let inner = &fval[1..fval.len()-1];
-                                    match sop.as_str() {
-                                        "startswith" => inner.starts_with(sarg_bytes),
-                                        "endswith" => inner.ends_with(sarg_bytes),
-                                        "contains" => {
-                                            if sarg_bytes.len() <= inner.len() {
-                                                memchr::memmem::find(inner, sarg_bytes).is_some()
-                                            } else { false }
-                                        }
-                                        "test" => {
-                                            if let Some(ref r) = re {
-                                                let s = unsafe { std::str::from_utf8_unchecked(inner) };
-                                                r.is_match(s)
-                                            } else { false }
-                                        }
-                                        "eq" => inner == sarg_bytes,
-                                        _ => false,
-                                    }
-                                } else { false }
-                            } else { false };
-                            if str_pass {
-                                emit_raw_ln!(&mut compact_buf, raw);
-                            }
+                        let outcome = apply_select_num_str_raw(
+                            raw, nf, *nop, nth, sf, sop, sarg_bytes, re.as_ref(),
+                            |bytes| { emit_raw_ln!(&mut compact_buf, bytes); },
+                        );
+                        if let RawApplyOutcome::Bail = outcome {
+                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }
                         if compact_buf.len() >= 1 << 17 {
                             let _ = out.write_all(&compact_buf);
@@ -16592,43 +16563,18 @@ fn real_main() {
                     Ok(())
                 })
             } else if let Some((ref nf, ref nop, nth, ref sf, ref sop, ref sarg)) = select_num_str {
-                use jq_jit::ir::BinOp;
                 let content_bytes = content.as_bytes();
-                let re = if sop == "test" { Some(regex::Regex::new(sarg).ok()).flatten() } else { None };
+                let re = if sop == "test" { regex::Regex::new(sarg).ok() } else { None };
                 let sarg_bytes = sarg.as_bytes();
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    let num_pass = if let Some(val) = json_object_get_num(raw, 0, nf) {
-                        match nop {
-                            BinOp::Gt => val > nth, BinOp::Lt => val < nth,
-                            BinOp::Ge => val >= nth, BinOp::Le => val <= nth,
-                            BinOp::Eq => val == nth, BinOp::Ne => val != nth,
-                            _ => false,
-                        }
-                    } else { false };
-                    if num_pass {
-                        let str_pass = if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, sf) {
-                            let fval = &raw[vs..ve];
-                            if fval.len() >= 2 && fval[0] == b'"' {
-                                let inner = &fval[1..fval.len()-1];
-                                match sop.as_str() {
-                                    "startswith" => inner.starts_with(sarg_bytes),
-                                    "endswith" => inner.ends_with(sarg_bytes),
-                                    "contains" => memchr::memmem::find(inner, sarg_bytes).is_some(),
-                                    "test" => {
-                                        if let Some(ref r) = re {
-                                            let s = unsafe { std::str::from_utf8_unchecked(inner) };
-                                            r.is_match(s)
-                                        } else { false }
-                                    }
-                                    "eq" => inner == sarg_bytes,
-                                    _ => false,
-                                }
-                            } else { false }
-                        } else { false };
-                        if str_pass {
-                            emit_raw_ln!(&mut compact_buf, raw);
-                        }
+                    let outcome = apply_select_num_str_raw(
+                        raw, nf, *nop, nth, sf, sop, sarg_bytes, re.as_ref(),
+                        |bytes| { emit_raw_ln!(&mut compact_buf, bytes); },
+                    );
+                    if let RawApplyOutcome::Bail = outcome {
+                        let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                        process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                     }
                     if compact_buf.len() >= 1 << 17 {
                         let _ = out.write_all(&compact_buf);

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -1074,6 +1074,117 @@ pub fn apply_is_length_raw(raw: &[u8], buf: &mut Vec<u8>) -> RawApplyOutcome {
     }
 }
 
+/// Apply the `select((.numfield <cmp> N) and (.strfield <op_str> arg))`
+/// raw-byte fast path on a single JSON record. Combines a numeric
+/// comparison on one field with a string predicate
+/// (`startswith`/`endswith`/`contains`/`test`/`eq`) on another.
+///
+/// `select` semantics: emit the input record unchanged on a passing
+/// conjunction; emit nothing on a failing predicate. The helper
+/// passes the raw bytes to `emit_match` only when both predicates
+/// pass.
+///
+/// Bail discipline:
+/// * Non-object input — [`RawApplyOutcome::Bail`] (jq raises
+///   `Cannot index <type>`).
+/// * Numeric field absent or non-numeric — Bail (so jq's cross-type
+///   ordering / type error surfaces via the generic path).
+/// * String field absent, non-string, or escape-bearing — Bail (raw
+///   scanner can't decode escapes; for non-strings jq raises a type
+///   error from the string predicate).
+/// * `num_op` is non-comparison (`Add`/`And`/etc.) — Bail (defensive).
+/// * `str_op` is not a known string op (`startswith`/`endswith`/
+///   `contains`/`test`/`eq`) — Bail (defensive).
+/// * `str_op == "test"` with `str_re` is `None` — Bail (regex
+///   compilation failed; generic path will raise the right error).
+///
+/// On a passing predicate, calls `emit_match(raw)` so the caller
+/// emits the matching record. On a failing predicate, returns
+/// `RawApplyOutcome::Emit` without invoking the closure.
+pub fn apply_select_num_str_raw<F>(
+    raw: &[u8],
+    num_field: &str,
+    num_op: BinOp,
+    num_threshold: f64,
+    str_field: &str,
+    str_op: &str,
+    str_arg: &[u8],
+    str_re: Option<&regex::Regex>,
+    mut emit_match: F,
+) -> RawApplyOutcome
+where
+    F: FnMut(&[u8]),
+{
+    if raw.is_empty() || raw[0] != b'{' {
+        return RawApplyOutcome::Bail;
+    }
+    if !matches!(
+        num_op,
+        BinOp::Gt | BinOp::Lt | BinOp::Ge | BinOp::Le | BinOp::Eq | BinOp::Ne,
+    ) {
+        return RawApplyOutcome::Bail;
+    }
+    let known_str_op = matches!(str_op, "startswith" | "endswith" | "contains" | "test" | "eq");
+    if !known_str_op {
+        return RawApplyOutcome::Bail;
+    }
+    if str_op == "test" && str_re.is_none() {
+        return RawApplyOutcome::Bail;
+    }
+    let n = match json_object_get_num(raw, 0, num_field) {
+        Some(v) => v,
+        None => return RawApplyOutcome::Bail,
+    };
+    let num_pass = match num_op {
+        BinOp::Gt => n > num_threshold,
+        BinOp::Lt => n < num_threshold,
+        BinOp::Ge => n >= num_threshold,
+        BinOp::Le => n <= num_threshold,
+        BinOp::Eq => n == num_threshold,
+        BinOp::Ne => n != num_threshold,
+        _ => unreachable!(),
+    };
+    if !num_pass {
+        return RawApplyOutcome::Emit;
+    }
+    let (vs, ve) = match json_object_get_field_raw(raw, 0, str_field) {
+        Some(r) => r,
+        None => return RawApplyOutcome::Bail,
+    };
+    let val = &raw[vs..ve];
+    if val.len() < 2 || val[0] != b'"' || val[val.len() - 1] != b'"' {
+        return RawApplyOutcome::Bail;
+    }
+    let inner = &val[1..val.len() - 1];
+    if str_op == "test" {
+        if inner.contains(&b'\\') {
+            return RawApplyOutcome::Bail;
+        }
+    }
+    let str_pass = match str_op {
+        "startswith" => inner.starts_with(str_arg),
+        "endswith" => inner.ends_with(str_arg),
+        "contains" => {
+            if str_arg.len() <= inner.len() {
+                memchr::memmem::find(inner, str_arg).is_some()
+            } else {
+                false
+            }
+        }
+        "test" => {
+            let re = str_re.unwrap();
+            let s = unsafe { std::str::from_utf8_unchecked(inner) };
+            re.is_match(s)
+        }
+        "eq" => inner == str_arg,
+        _ => unreachable!(),
+    };
+    if str_pass {
+        emit_match(raw);
+    }
+    RawApplyOutcome::Emit
+}
+
 /// Apply the `(.x cmp1 N1) <conjunct> (.y cmp2 N2) <conjunct> ...`
 /// raw-byte compound numeric-comparison fast path on a single JSON
 /// record. Each comparison is a `<field> <cmp> <const>` predicate

--- a/tests/fast_path_contract.rs
+++ b/tests/fast_path_contract.rs
@@ -29,7 +29,7 @@ use jq_jit::fast_path::{
     apply_field_update_trim_raw, apply_is_length_raw, apply_is_type_raw,
     apply_numeric_expr_raw, apply_obj_assign_field_arith_raw,
     apply_obj_assign_two_fields_arith_raw, apply_obj_merge_computed_raw,
-    apply_obj_merge_lit_raw,
+    apply_obj_merge_lit_raw, apply_select_num_str_raw,
     apply_select_arith_cmp_raw, apply_select_cmp_raw,
     apply_select_field_null_raw, apply_select_str_raw, apply_select_str_test_raw,
     apply_two_field_binop_const_raw,
@@ -2894,6 +2894,166 @@ fn raw_is_length_boolean_bails() {
         let outcome = apply_is_length_raw(raw, &mut buf);
         assert!(matches!(outcome, RawApplyOutcome::Bail), "raw={:?}", std::str::from_utf8(raw).unwrap());
         assert!(buf.is_empty());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// `select((.numfield cmp N) and (.strfield op_str arg))` — numeric+string
+// compound predicate. Bails on non-object/missing-or-non-numeric/non-string/
+// escape-bearing-with-test/unknown-op.
+
+#[test]
+fn raw_select_num_str_emits_match_startswith() {
+    let mut emitted: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_select_num_str_raw(
+        b"{\"n\":5,\"s\":\"hello\"}", "n", BinOp::Gt, 0.0, "s", "startswith", b"he", None,
+        |raw| emitted.push(raw.to_vec()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec![b"{\"n\":5,\"s\":\"hello\"}".to_vec()]);
+}
+
+#[test]
+fn raw_select_num_str_no_emit_on_num_fail() {
+    let mut emitted: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_select_num_str_raw(
+        b"{\"n\":-1,\"s\":\"hello\"}", "n", BinOp::Gt, 0.0, "s", "startswith", b"he", None,
+        |raw| emitted.push(raw.to_vec()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_select_num_str_no_emit_on_str_fail() {
+    let mut emitted: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_select_num_str_raw(
+        b"{\"n\":5,\"s\":\"world\"}", "n", BinOp::Gt, 0.0, "s", "startswith", b"he", None,
+        |raw| emitted.push(raw.to_vec()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_select_num_str_contains_eq_endswith() {
+    for (op, arg, expected) in [
+        ("contains", &b"ell"[..], true),
+        ("endswith", &b"llo"[..], true),
+        ("eq", &b"hello"[..], true),
+        ("eq", &b"world"[..], false),
+    ] {
+        let mut emitted: Vec<Vec<u8>> = Vec::new();
+        let outcome = apply_select_num_str_raw(
+            b"{\"n\":5,\"s\":\"hello\"}", "n", BinOp::Gt, 0.0, "s", op, arg, None,
+            |raw| emitted.push(raw.to_vec()),
+        );
+        assert!(matches!(outcome, RawApplyOutcome::Emit));
+        assert_eq!(emitted.len(), if expected { 1 } else { 0 }, "op={} arg={:?}", op, std::str::from_utf8(arg).unwrap());
+    }
+}
+
+#[test]
+fn raw_select_num_str_test_with_regex() {
+    let re = regex::Regex::new("^h.l").unwrap();
+    let mut emitted: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_select_num_str_raw(
+        b"{\"n\":5,\"s\":\"hello\"}", "n", BinOp::Gt, 0.0, "s", "test", b"^h.l", Some(&re),
+        |raw| emitted.push(raw.to_vec()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted.len(), 1);
+}
+
+#[test]
+fn raw_select_num_str_test_without_regex_bails() {
+    let mut emitted: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_select_num_str_raw(
+        b"{\"n\":5,\"s\":\"hello\"}", "n", BinOp::Gt, 0.0, "s", "test", b"^h.l", None,
+        |raw| emitted.push(raw.to_vec()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_select_num_str_num_field_missing_bails() {
+    let mut emitted: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_select_num_str_raw(
+        b"{\"s\":\"hello\"}", "n", BinOp::Gt, 0.0, "s", "startswith", b"he", None,
+        |raw| emitted.push(raw.to_vec()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_select_num_str_str_field_missing_bails() {
+    let mut emitted: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_select_num_str_raw(
+        b"{\"n\":5}", "n", BinOp::Gt, 0.0, "s", "startswith", b"he", None,
+        |raw| emitted.push(raw.to_vec()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_select_num_str_str_field_non_string_bails() {
+    let mut emitted: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_select_num_str_raw(
+        b"{\"n\":5,\"s\":42}", "n", BinOp::Gt, 0.0, "s", "startswith", b"he", None,
+        |raw| emitted.push(raw.to_vec()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_select_num_str_test_escape_bearing_string_bails() {
+    let re = regex::Regex::new("a").unwrap();
+    let mut emitted: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_select_num_str_raw(
+        br#"{"n":5,"s":"a\nb"}"#, "n", BinOp::Gt, 0.0, "s", "test", b"a", Some(&re),
+        |raw| emitted.push(raw.to_vec()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_select_num_str_unknown_str_op_bails() {
+    let mut emitted: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_select_num_str_raw(
+        b"{\"n\":5,\"s\":\"hello\"}", "n", BinOp::Gt, 0.0, "s", "unknown", b"he", None,
+        |raw| emitted.push(raw.to_vec()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_select_num_str_non_cmp_op_bails() {
+    let mut emitted: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_select_num_str_raw(
+        b"{\"n\":5,\"s\":\"hello\"}", "n", BinOp::Add, 0.0, "s", "startswith", b"he", None,
+        |raw| emitted.push(raw.to_vec()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+}
+
+#[test]
+fn raw_select_num_str_non_object_input_bails() {
+    for raw in [b"42".as_slice(), b"\"hi\"".as_slice(), b"null".as_slice(), b"[1,2]".as_slice()] {
+        let mut emitted: Vec<Vec<u8>> = Vec::new();
+        let outcome = apply_select_num_str_raw(
+            raw, "n", BinOp::Gt, 0.0, "s", "startswith", b"he", None,
+            |raw| emitted.push(raw.to_vec()),
+        );
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "raw={:?}", std::str::from_utf8(raw).unwrap(),
+        );
     }
 }
 

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -4564,3 +4564,49 @@ length
 [ (. + {sum: (.x + .y)})? ]
 "plain"
 []
+
+# Issue #251: select_num_str apply-site uses RawApplyOutcome (#83 Phase B).
+# Helper Bails on non-object/missing-or-non-numeric/non-string/escape-bearing-
+# with-test/unknown-op, so jq's error semantics surface.
+select((.n > 0) and (.s | startswith("he")))
+{"n":5,"s":"hello"}
+{"n":5,"s":"hello"}
+
+select((.n > 0) and (.s | endswith("llo")))
+{"n":5,"s":"hello"}
+{"n":5,"s":"hello"}
+
+select((.n > 0) and (.s | contains("ell")))
+{"n":5,"s":"hello"}
+{"n":5,"s":"hello"}
+
+select((.n > 0) and (.s | test("^h.l")))
+{"n":5,"s":"hello"}
+{"n":5,"s":"hello"}
+
+# Numeric predicate fails — no output (select semantics).
+[ (select((.n > 0) and (.s | startswith("he"))))? ]
+{"n":-1,"s":"hello"}
+[]
+
+# String predicate fails — no output.
+[ (select((.n > 0) and (.s | startswith("he"))))? ]
+{"n":5,"s":"world"}
+[]
+
+# Non-string field for str predicate — generic raises type error, ? swallows.
+[ (select((.n > 0) and (.s | startswith("he"))))? ]
+{"n":5,"s":42}
+[]
+
+# Non-object input — generic raises indexing error.
+[ (select((.n > 0) and (.s | startswith("he"))))? ]
+"plain"
+[]
+
+# NOTE: select_num_str is currently shadowed by select_mixed_compound for
+# user-facing filters (mixed_compound's detector matches the same shape and
+# fires earlier in the dispatch chain). The contract tests pin the helper's
+# behaviour directly; once select_mixed_compound is migrated under issue
+# #251, additional regression cases can verify the helper at the apply-site
+# entry too.


### PR DESCRIPTION
## Summary
- Add `apply_select_num_str_raw` to `src/fast_path.rs` for `select((.numfield cmp N) and (.strfield op_str arg))` (combines a numeric comparison with a string predicate).
- Migrate the `select_num_str` apply-sites in `bin/jq-jit.rs` (stdin + file-mode) to the named `RawApplyOutcome::{Emit, Bail}` discipline.
- Bail discipline: non-object, missing/non-numeric/non-string/escape-bearing-with-test, unknown str_op, non-cmp num_op, `test` without compiled regex.

**Practical note:** `detect_select_mixed_compound` (more permissive) precedes `detect_select_num_and_str` in the dispatch chain and shadows it for user-facing filters. The migrated apply-site is defensive — its structural Bail discipline is pinned regardless of dispatch reachability. Regression coverage at the apply-site entry will land once `select_mixed_compound` is migrated.

13 new contract cases pin the verdict surface (every str_op variant, every Bail branch).

Refs #251.

## Test plan
- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (943 regression cases pass; 346 contract cases, +13)
- [x] `./bench/comprehensive.sh --quick` (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)