### PR TITLE
refactor: each_type_filter family apply-sites use RawApplyOutcome (#83 Phase B)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -149,6 +149,8 @@ use jq_jit::fast_path::{
     apply_field_str_reverse_raw, apply_field_test_raw, apply_field_unary_arith_raw,
     apply_field_unary_num_raw, apply_full_object_fields_raw, apply_is_length_raw,
     apply_is_type_raw, apply_numeric_expr_raw, apply_obj_assign_field_arith_raw,
+    apply_collect_each_select_type_raw, apply_each_type_filter_raw,
+    apply_first_each_select_type_raw,
     apply_obj_assign_two_fields_arith_raw, apply_obj_merge_computed_raw,
     apply_obj_merge_lit_raw, apply_select_num_str_raw, apply_two_field_binop_const_raw,
     apply_has_field_raw, apply_has_multi_field_raw, apply_multi_field_access_raw,
@@ -11632,42 +11634,10 @@ fn real_main() {
                         Ok(())
                     })
                 } else if let Some(ref sel_type) = collect_each_select_type {
-                    // [.[] | select(type == "T")] — collect values of specific type
-                    let type_byte = match sel_type.as_str() {
-                        "string" => Some(b'"'),
-                        "object" => Some(b'{'),
-                        "array" => Some(b'['),
-                        "null" => Some(b'n'),
-                        "boolean" => None, // t or f
-                        "number" => None, // digit, -, or .
-                        _ => None,
-                    };
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        let save_len = compact_buf.len();
-                        compact_buf.push(b'[');
-                        let mut first_elem = true;
-                        let ok = json_each_value_cb(raw, 0, |vs, ve| {
-                            let val = &raw[vs..ve];
-                            if val.is_empty() { return; }
-                            let matches = match sel_type.as_str() {
-                                "number" => val[0] == b'-' || (val[0] >= b'0' && val[0] <= b'9'),
-                                "boolean" => val[0] == b't' || val[0] == b'f',
-                                "null" => val[0] == b'n',
-                                _ => {
-                                    if let Some(tb) = type_byte { val[0] == tb } else { false }
-                                }
-                            };
-                            if matches {
-                                if !first_elem { compact_buf.push(b','); }
-                                first_elem = false;
-                                compact_buf.extend_from_slice(val);
-                            }
-                        });
-                        if ok {
-                            compact_buf.extend_from_slice(b"]\n");
-                        } else {
-                            compact_buf.truncate(save_len);
+                        let outcome = apply_collect_each_select_type_raw(raw, sel_type, &mut compact_buf);
+                        if let RawApplyOutcome::Bail = outcome {
                             let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                             process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }
@@ -11708,41 +11678,12 @@ fn real_main() {
                         Ok(())
                     })
                 } else if let Some(ref first_type) = first_each_select_type {
-                    // first(.[] | select(type == "T")) — first value of given type
-                    let type_byte = match first_type.as_str() {
-                        "string" => Some(b'"'),
-                        "object" => Some(b'{'),
-                        "array" => Some(b'['),
-                        "null" => Some(b'n'),
-                        _ => None,
-                    };
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        let mut found = false;
-                        let ok = json_each_value_cb(raw, 0, |vs, ve| {
-                            if found { return; }
-                            let val = &raw[vs..ve];
-                            if val.is_empty() { return; }
-                            let matches = match first_type.as_str() {
-                                "number" => val[0] == b'-' || (val[0] >= b'0' && val[0] <= b'9'),
-                                "boolean" => val[0] == b't' || val[0] == b'f',
-                                "null" => val[0] == b'n',
-                                _ => {
-                                    if let Some(tb) = type_byte { val[0] == tb } else { false }
-                                }
-                            };
-                            if matches {
-                                compact_buf.extend_from_slice(val);
-                                compact_buf.push(b'\n');
-                                found = true;
-                            }
-                        });
-                        if !ok || !found {
-                            // If !ok, fallback. If !found, no match → no output (which is correct for first with empty)
-                            if !ok {
-                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                            }
+                        let outcome = apply_first_each_select_type_raw(raw, first_type, &mut compact_buf);
+                        if let RawApplyOutcome::Bail = outcome {
+                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }
                         if compact_buf.len() >= 1 << 17 {
                             let _ = out.write_all(&compact_buf);
@@ -11969,24 +11910,10 @@ fn real_main() {
                         })
                     }
                 } else if let Some(ref type_name) = each_type_filter {
-                    // .[] | strings/numbers/booleans/nulls/arrays/objects
-                    let type_check: Box<dyn Fn(u8) -> bool> = match type_name.as_str() {
-                        "string" => Box::new(|b: u8| b == b'"'),
-                        "number" => Box::new(|b: u8| b == b'-' || b.is_ascii_digit()),
-                        "boolean" => Box::new(|b: u8| b == b't' || b == b'f'),
-                        "null" => Box::new(|b: u8| b == b'n'),
-                        "object" => Box::new(|b: u8| b == b'{'),
-                        "array" => Box::new(|b: u8| b == b'['),
-                        _ => Box::new(|_: u8| false),
-                    };
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        if !json_each_value_cb(raw, 0, |vs, ve| {
-                            let val = &raw[vs..ve];
-                            if !val.is_empty() && type_check(val[0]) {
-                                emit_raw_ln!(&mut compact_buf, val);
-                            }
-                        }) {
+                        let outcome = apply_each_type_filter_raw(raw, type_name, &mut compact_buf);
+                        if let RawApplyOutcome::Bail = outcome {
                             let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                             process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }
@@ -20610,41 +20537,11 @@ fn real_main() {
                     Ok(())
                 })
             } else if let Some(ref sel_type) = collect_each_select_type {
-                // [.[] | select(type == "T")] — collect values of specific type (stdin)
                 let content_bytes = content.as_bytes();
-                let type_byte = match sel_type.as_str() {
-                    "string" => Some(b'"'),
-                    "object" => Some(b'{'),
-                    "array" => Some(b'['),
-                    "null" => Some(b'n'),
-                    _ => None,
-                };
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    let save_len = compact_buf.len();
-                    compact_buf.push(b'[');
-                    let mut first_elem = true;
-                    let ok = json_each_value_cb(raw, 0, |vs, ve| {
-                        let val = &raw[vs..ve];
-                        if val.is_empty() { return; }
-                        let matches = match sel_type.as_str() {
-                            "number" => val[0] == b'-' || (val[0] >= b'0' && val[0] <= b'9'),
-                            "boolean" => val[0] == b't' || val[0] == b'f',
-                            "null" => val[0] == b'n',
-                            _ => {
-                                if let Some(tb) = type_byte { val[0] == tb } else { false }
-                            }
-                        };
-                        if matches {
-                            if !first_elem { compact_buf.push(b','); }
-                            first_elem = false;
-                            compact_buf.extend_from_slice(val);
-                        }
-                    });
-                    if ok {
-                        compact_buf.extend_from_slice(b"]\n");
-                    } else {
-                        compact_buf.truncate(save_len);
+                    let outcome = apply_collect_each_select_type_raw(raw, sel_type, &mut compact_buf);
+                    if let RawApplyOutcome::Bail = outcome {
                         let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                         process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                     }
@@ -20686,37 +20583,11 @@ fn real_main() {
                     Ok(())
                 })
             } else if let Some(ref first_type) = first_each_select_type {
-                // first(.[] | select(type == "T")) — first value of given type (stdin)
                 let content_bytes = content.as_bytes();
-                let type_byte = match first_type.as_str() {
-                    "string" => Some(b'"'),
-                    "object" => Some(b'{'),
-                    "array" => Some(b'['),
-                    "null" => Some(b'n'),
-                    _ => None,
-                };
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    let mut found = false;
-                    let ok = json_each_value_cb(raw, 0, |vs, ve| {
-                        if found { return; }
-                        let val = &raw[vs..ve];
-                        if val.is_empty() { return; }
-                        let matches = match first_type.as_str() {
-                            "number" => val[0] == b'-' || (val[0] >= b'0' && val[0] <= b'9'),
-                            "boolean" => val[0] == b't' || val[0] == b'f',
-                            "null" => val[0] == b'n',
-                            _ => {
-                                if let Some(tb) = type_byte { val[0] == tb } else { false }
-                            }
-                        };
-                        if matches {
-                            compact_buf.extend_from_slice(val);
-                            compact_buf.push(b'\n');
-                            found = true;
-                        }
-                    });
-                    if !ok {
+                    let outcome = apply_first_each_select_type_raw(raw, first_type, &mut compact_buf);
+                    if let RawApplyOutcome::Bail = outcome {
                         let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                         process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                     }
@@ -20932,25 +20803,11 @@ fn real_main() {
                     })
                 }
             } else if let Some(ref type_name) = each_type_filter {
-                // .[] | strings/numbers/... — file path
                 let content_bytes = content.as_bytes();
-                let type_check: Box<dyn Fn(u8) -> bool> = match type_name.as_str() {
-                    "string" => Box::new(|b: u8| b == b'"'),
-                    "number" => Box::new(|b: u8| b == b'-' || b.is_ascii_digit()),
-                    "boolean" => Box::new(|b: u8| b == b't' || b == b'f'),
-                    "null" => Box::new(|b: u8| b == b'n'),
-                    "object" => Box::new(|b: u8| b == b'{'),
-                    "array" => Box::new(|b: u8| b == b'['),
-                    _ => Box::new(|_: u8| false),
-                };
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    if !json_each_value_cb(raw, 0, |vs, ve| {
-                        let val = &raw[vs..ve];
-                        if !val.is_empty() && type_check(val[0]) {
-                            emit_raw_ln!(&mut compact_buf, val);
-                        }
-                    }) {
+                    let outcome = apply_each_type_filter_raw(raw, type_name, &mut compact_buf);
+                    if let RawApplyOutcome::Bail = outcome {
                         let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                         process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                     }

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -66,8 +66,8 @@ use crate::interpreter::{ArithExpr, MathUnary};
 use crate::ir::{BinOp, UnaryOp};
 use crate::runtime::jq_mod_f64;
 use crate::value::{
-    KeyStr, Value, ObjInner, json_object_assign_field_arith, json_object_assign_two_fields_arith,
-    json_object_del_field, json_object_del_fields,
+    KeyStr, Value, ObjInner, json_each_value_cb, json_object_assign_field_arith,
+    json_object_assign_two_fields_arith, json_object_del_field, json_object_del_fields,
     json_object_get_field_raw, json_object_get_fields_raw_buf, json_object_merge_literal,
     json_object_get_nested_field_raw, json_object_get_num, json_object_get_two_nums,
     json_object_has_all_keys, json_object_has_any_key, json_object_has_key,
@@ -935,6 +935,128 @@ pub fn apply_obj_merge_computed_raw(
     } else {
         RawApplyOutcome::Bail
     }
+}
+
+/// Test whether a JSON value's first byte indicates the given jq
+/// type name. Returns None for unrecognised type names so callers
+/// can Bail on detector regression.
+#[inline]
+fn type_byte_matches(type_name: &str, b: u8) -> Option<bool> {
+    Some(match type_name {
+        "string" => b == b'"',
+        "number" => b == b'-' || b.is_ascii_digit(),
+        "boolean" => b == b't' || b == b'f',
+        "null" => b == b'n',
+        "object" => b == b'{',
+        "array" => b == b'[',
+        _ => return None,
+    })
+}
+
+/// Apply the `.[] | <type>s` raw-byte fast path on a single JSON
+/// record (where `<type>s` is one of jq's type-filter built-ins —
+/// `strings`/`numbers`/`booleans`/`nulls`/`objects`/`arrays`).
+/// Iterates each element of the input array/object and emits the
+/// element bytes (with a trailing `\n`) for every element whose
+/// first byte indicates the given type.
+///
+/// Bail discipline:
+/// * Unrecognised type name (defensive) — Bail.
+/// * Non-iterable input (`json_each_value_cb` returns false) —
+///   Bail so jq's `Cannot iterate over <type>` error surfaces.
+///
+/// The helper writes element-bytes-plus-`\n` directly to `buf` for
+/// every match. On a passing iterable, returns `Emit` even if no
+/// element matched (no output is the correct `select` semantics for
+/// no-match).
+pub fn apply_each_type_filter_raw(
+    raw: &[u8],
+    type_name: &str,
+    buf: &mut Vec<u8>,
+) -> RawApplyOutcome {
+    if type_byte_matches(type_name, b'\0').is_none() {
+        return RawApplyOutcome::Bail;
+    }
+    let ok = json_each_value_cb(raw, 0, |vs, ve| {
+        let val = &raw[vs..ve];
+        if val.is_empty() { return; }
+        if matches!(type_byte_matches(type_name, val[0]), Some(true)) {
+            buf.extend_from_slice(val);
+            buf.push(b'\n');
+        }
+    });
+    if ok { RawApplyOutcome::Emit } else { RawApplyOutcome::Bail }
+}
+
+/// Apply the `[.[] | select(type == "<type>")]` raw-byte fast path
+/// on a single JSON record. Collects elements of the matching type
+/// into a single JSON array and emits the array with a trailing `\n`.
+///
+/// Bail discipline matches [`apply_each_type_filter_raw`]:
+/// unrecognised type → Bail; non-iterable input → Bail. The helper
+/// truncates `buf` back to its pre-call length on Bail so the caller
+/// doesn't need to manage the partial-write rollback itself.
+pub fn apply_collect_each_select_type_raw(
+    raw: &[u8],
+    type_name: &str,
+    buf: &mut Vec<u8>,
+) -> RawApplyOutcome {
+    if type_byte_matches(type_name, b'\0').is_none() {
+        return RawApplyOutcome::Bail;
+    }
+    let save_len = buf.len();
+    buf.push(b'[');
+    let mut first_elem = true;
+    let ok = json_each_value_cb(raw, 0, |vs, ve| {
+        let val = &raw[vs..ve];
+        if val.is_empty() { return; }
+        if matches!(type_byte_matches(type_name, val[0]), Some(true)) {
+            if !first_elem { buf.push(b','); }
+            first_elem = false;
+            buf.extend_from_slice(val);
+        }
+    });
+    if ok {
+        buf.extend_from_slice(b"]\n");
+        RawApplyOutcome::Emit
+    } else {
+        buf.truncate(save_len);
+        RawApplyOutcome::Bail
+    }
+}
+
+/// Apply the `first(.[] | select(type == "<type>"))` raw-byte fast
+/// path on a single JSON record. Emits the first element of the
+/// matching type with a trailing `\n`. If no element matches, emits
+/// nothing (returns `Emit` — that's jq's behaviour for `first` on an
+/// empty stream — no output, no error).
+///
+/// Bail discipline matches [`apply_each_type_filter_raw`].
+pub fn apply_first_each_select_type_raw(
+    raw: &[u8],
+    type_name: &str,
+    buf: &mut Vec<u8>,
+) -> RawApplyOutcome {
+    if type_byte_matches(type_name, b'\0').is_none() {
+        return RawApplyOutcome::Bail;
+    }
+    let mut found_range: Option<(usize, usize)> = None;
+    let ok = json_each_value_cb(raw, 0, |vs, ve| {
+        if found_range.is_some() { return; }
+        let val = &raw[vs..ve];
+        if val.is_empty() { return; }
+        if matches!(type_byte_matches(type_name, val[0]), Some(true)) {
+            found_range = Some((vs, ve));
+        }
+    });
+    if !ok {
+        return RawApplyOutcome::Bail;
+    }
+    if let Some((vs, ve)) = found_range {
+        buf.extend_from_slice(&raw[vs..ve]);
+        buf.push(b'\n');
+    }
+    RawApplyOutcome::Emit
 }
 
 /// Apply the `. + {k1: v1, k2: v2, ...}` raw-byte object-merge fast

--- a/tests/fast_path_contract.rs
+++ b/tests/fast_path_contract.rs
@@ -28,6 +28,8 @@ use jq_jit::fast_path::{
     apply_field_unary_arith_raw, apply_field_unary_num_raw,
     apply_field_update_trim_raw, apply_is_length_raw, apply_is_type_raw,
     apply_numeric_expr_raw, apply_obj_assign_field_arith_raw,
+    apply_collect_each_select_type_raw, apply_each_type_filter_raw,
+    apply_first_each_select_type_raw,
     apply_obj_assign_two_fields_arith_raw, apply_obj_merge_computed_raw,
     apply_obj_merge_lit_raw, apply_select_num_str_raw,
     apply_select_arith_cmp_raw, apply_select_cmp_raw,
@@ -2895,6 +2897,122 @@ fn raw_is_length_boolean_bails() {
         assert!(matches!(outcome, RawApplyOutcome::Bail), "raw={:?}", std::str::from_utf8(raw).unwrap());
         assert!(buf.is_empty());
     }
+}
+
+// ---------------------------------------------------------------------------
+// `.[] | <type>s` — each-element type filter. Bails on non-iterable input
+// or unrecognised type name.
+
+#[test]
+fn raw_each_type_filter_array_strings() {
+    let mut buf = Vec::new();
+    let outcome = apply_each_type_filter_raw(b"[1,\"a\",2,\"b\",null]", "string", &mut buf);
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(buf, b"\"a\"\n\"b\"\n");
+}
+
+#[test]
+fn raw_each_type_filter_object_numbers() {
+    let mut buf = Vec::new();
+    let outcome = apply_each_type_filter_raw(b"{\"a\":1,\"b\":\"hi\",\"c\":3}", "number", &mut buf);
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(buf, b"1\n3\n");
+}
+
+#[test]
+fn raw_each_type_filter_no_match_emits_nothing() {
+    let mut buf = Vec::new();
+    let outcome = apply_each_type_filter_raw(b"[1,2,3]", "string", &mut buf);
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert!(buf.is_empty());
+}
+
+#[test]
+fn raw_each_type_filter_non_iterable_bails() {
+    for raw in [&b"42"[..], &b"\"hi\""[..], &b"null"[..], &b"true"[..]] {
+        let mut buf = Vec::new();
+        let outcome = apply_each_type_filter_raw(raw, "string", &mut buf);
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "raw={:?}", std::str::from_utf8(raw).unwrap(),
+        );
+    }
+}
+
+#[test]
+fn raw_each_type_filter_unknown_type_bails() {
+    let mut buf = Vec::new();
+    let outcome = apply_each_type_filter_raw(b"[1,2]", "unknown", &mut buf);
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+}
+
+// ---------------------------------------------------------------------------
+// `[.[] | select(type == "T")]` — collect elements of given type into array.
+
+#[test]
+fn raw_collect_each_select_type_emits_array() {
+    let mut buf = Vec::new();
+    let outcome = apply_collect_each_select_type_raw(b"[1,\"a\",2,\"b\"]", "string", &mut buf);
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(buf, b"[\"a\",\"b\"]\n");
+}
+
+#[test]
+fn raw_collect_each_select_type_no_match_empty_array() {
+    let mut buf = Vec::new();
+    let outcome = apply_collect_each_select_type_raw(b"[1,2,3]", "string", &mut buf);
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(buf, b"[]\n");
+}
+
+#[test]
+fn raw_collect_each_select_type_truncates_buf_on_bail() {
+    // Caller's buffer should be restored to pre-call state on Bail.
+    let mut buf = Vec::from(&b"prefix"[..]);
+    let outcome = apply_collect_each_select_type_raw(b"42", "string", &mut buf);
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert_eq!(buf, b"prefix");
+}
+
+#[test]
+fn raw_collect_each_select_type_unknown_type_bails() {
+    let mut buf = Vec::new();
+    let outcome = apply_collect_each_select_type_raw(b"[1,2]", "unknown", &mut buf);
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+}
+
+// ---------------------------------------------------------------------------
+// `first(.[] | select(type == "T"))` — first element of given type.
+
+#[test]
+fn raw_first_each_select_type_emits_first_match() {
+    let mut buf = Vec::new();
+    let outcome = apply_first_each_select_type_raw(b"[1,\"a\",2,\"b\"]", "string", &mut buf);
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(buf, b"\"a\"\n");
+}
+
+#[test]
+fn raw_first_each_select_type_no_match_emits_nothing() {
+    // first(...) on empty stream: no output, no error.
+    let mut buf = Vec::new();
+    let outcome = apply_first_each_select_type_raw(b"[1,2,3]", "string", &mut buf);
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert!(buf.is_empty());
+}
+
+#[test]
+fn raw_first_each_select_type_non_iterable_bails() {
+    let mut buf = Vec::new();
+    let outcome = apply_first_each_select_type_raw(b"42", "string", &mut buf);
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+}
+
+#[test]
+fn raw_first_each_select_type_unknown_type_bails() {
+    let mut buf = Vec::new();
+    let outcome = apply_first_each_select_type_raw(b"[1,2]", "unknown", &mut buf);
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -4610,3 +4610,46 @@ select((.n > 0) and (.s | test("^h.l")))
 # behaviour directly; once select_mixed_compound is migrated under issue
 # #251, additional regression cases can verify the helper at the apply-site
 # entry too.
+
+# Issue #251: each_type_filter / collect_each_select_type / first_each_select_type
+# apply-sites use RawApplyOutcome (#83 Phase B). All three wrap json_each_value_cb
+# and Bail on non-iterable input or unrecognised type name.
+.[] | strings
+[1,"a",2,"b",null]
+"a"
+"b"
+
+.[] | numbers
+{"a":1,"b":"hi","c":3}
+1
+3
+
+[.[] | select(type == "string")]
+[1,"a",2,"b"]
+["a","b"]
+
+[.[] | select(type == "number")]
+[1,"a",2,"b"]
+[1,2]
+
+first(.[] | select(type == "string"))
+[1,"a",2,"b"]
+"a"
+
+# No match — first(...) emits nothing (empty stream).
+[ (first(.[] | select(type == "string")))? ]
+[1,2,3]
+[]
+
+# Non-iterable input — generic raises `Cannot iterate over <type>`, ? swallows.
+[ (.[] | strings)? ]
+42
+[]
+
+[ ([.[] | select(type == "string")])? ]
+42
+[]
+
+[ (first(.[] | select(type == "string")))? ]
+"plain"
+[]


### PR DESCRIPTION
## Summary
Adds three closely-related helpers to `src/fast_path.rs`, all wrapping `json_each_value_cb` with the same Bail discipline:

- `apply_each_type_filter_raw` — `.[] | strings/numbers/booleans/nulls/objects/arrays` (multi-output).
- `apply_collect_each_select_type_raw` — `[.[] | select(type == "T")]` (single-output array; restores `buf` on Bail).
- `apply_first_each_select_type_raw` — `first(.[] | select(type == "T"))` (single-output, no-match emits nothing).

Migrates the 6 corresponding apply-sites in `bin/jq-jit.rs` (stdin + file-mode for each variant) to the named `RawApplyOutcome::{Emit, Bail}` discipline.

Bail discipline: unrecognised type name (defensive), non-iterable input.

13 new contract cases pin the verdict surface (multi-output each_type, collect-into-array, first-no-match, every Bail branch including buf-truncate-on-bail for collect); 9 new regression cases cover the `?`-wrapped Bail matrix.

Closes the `each_type_filter`, `collect_each_select_type`, and `first_each_select_type` items in the "Length / type tests" section. Refs #251.

## Test plan
- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (952 regression cases pass, +9 over main; 359 contract cases, +13)
- [x] `./bench/comprehensive.sh --quick` (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)