### PR TITLE
refactor: select_regex_test apply-site uses RawApplyOutcome (#83 Phase B)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -7490,7 +7490,7 @@ fn real_main() {
                         Ok(())
                     })
                 } else if let Some((ref rt_field, ref rt_pattern, ref rt_flags)) = select_regex_test {
-                    // select(.field | test("regex")) — raw byte regex test, pass through matching lines
+                    // select(.field | test("regex")) — reuses apply_field_test_raw
                     let re_pattern = if let Some(flags) = rt_flags {
                         let mut prefix = String::from("(?");
                         for c in flags.chars() {
@@ -7505,16 +7505,14 @@ fn real_main() {
                     if let Ok(re) = regex::Regex::new(&re_pattern) {
                         json_stream_raw(&input_str, |start, end| {
                             let raw = &input_bytes[start..end];
-                            if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, rt_field) {
-                                let val = &raw[vs..ve];
-                                if val.len() >= 2 && val[0] == b'"' && val[val.len()-1] == b'"'
-                                    && !val[1..val.len()-1].contains(&b'\\')
-                                {
-                                    let content = unsafe { std::str::from_utf8_unchecked(&val[1..val.len()-1]) };
-                                    if re.is_match(content) {
-                                        emit_raw_ln!(&mut compact_buf, raw);
-                                    }
+                            let outcome = apply_field_test_raw(raw, rt_field, &re, |verdict| {
+                                if verdict == b"true" {
+                                    emit_raw_ln!(&mut compact_buf, raw);
                                 }
+                            });
+                            if let RawApplyOutcome::Bail = outcome {
+                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                             }
                             if compact_buf.len() >= 1 << 17 {
                                 let _ = out.write_all(&compact_buf);
@@ -15096,16 +15094,14 @@ fn real_main() {
                     let content_bytes = content.as_bytes();
                     json_stream_raw(content, |start, end| {
                         let raw = &content_bytes[start..end];
-                        if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, rt_field) {
-                            let val = &raw[vs..ve];
-                            if val.len() >= 2 && val[0] == b'"' && val[val.len()-1] == b'"'
-                                && !val[1..val.len()-1].contains(&b'\\')
-                            {
-                                let content_str = unsafe { std::str::from_utf8_unchecked(&val[1..val.len()-1]) };
-                                if re.is_match(content_str) {
-                                    emit_raw_ln!(&mut compact_buf, raw);
-                                }
+                        let outcome = apply_field_test_raw(raw, rt_field, &re, |verdict| {
+                            if verdict == b"true" {
+                                emit_raw_ln!(&mut compact_buf, raw);
                             }
+                        });
+                        if let RawApplyOutcome::Bail = outcome {
+                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }
                         if compact_buf.len() >= 1 << 17 {
                             let _ = out.write_all(&compact_buf);

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -4653,3 +4653,37 @@ first(.[] | select(type == "string"))
 [ (first(.[] | select(type == "string")))? ]
 "plain"
 []
+
+# Issue #251: select_regex_test apply-site uses RawApplyOutcome (#83 Phase B,
+# reuses apply_field_test_raw — same Bail discipline). Fixes pre-existing
+# divergences: silently emitted nothing on missing/non-string/non-object/
+# escape-bearing string instead of routing to generic for jq's correct
+# error/output.
+select(.x | test("^h"))
+{"x":"hello"}
+{"x":"hello"}
+
+select(.x | test("foo"))
+{"x":"barfoo"}
+{"x":"barfoo"}
+
+# `?`-wrapped: non-string field — generic raises type error, ? swallows.
+[ (select(.x | test("^h")))? ]
+{"x":42}
+[]
+
+# `?`-wrapped: missing field — generic null|test raises type error.
+[ (select(.x | test("^h")))? ]
+{"y":1}
+[]
+
+# `?`-wrapped: non-object input — generic raises indexing error.
+[ (select(.x | test("^h")))? ]
+"plain"
+[]
+
+# Escape-bearing string field: helper Bails, generic decodes the escape and
+# runs the regex against the decoded content.
+select(.x | test("^a"))
+{"x":"a\nb"}
+{"x":"a\nb"}


### PR DESCRIPTION
## Summary
- Migrate the `select_regex_test` apply-sites in `bin/jq-jit.rs` (stdin + file-mode) to the named `RawApplyOutcome::{Emit, Bail}` discipline.
- Reuses `apply_field_test_raw` with a different emit closure (write raw bytes on `b"true"` verdict) — same pattern as #254 / #276 / #284. No new helper.

**Bug fix:** Prior apply-site silently emitted nothing on missing/non-string/non-object/escape-bearing-string field, instead of jq's type / indexing errors. The structural Bail now routes those through the generic path.

6 new regression cases cover the happy path, `?`-wrapped Bail matrix on every divergence, and the escape-bearing string round-trip.

Closes the `select_field_regex_test` item in "Select family". `select_regex_then_value` left for a follow-up (uses pre-fetched `json_object_get_fields_raw_buf` for a remap).

Refs #251.

## Test plan
- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (958 regression cases pass, +6 over main)
- [x] `./bench/comprehensive.sh --quick` (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)