### PR TITLE
refactor: select_nested_cmp apply-site uses RawApplyOutcome (#83 Phase B)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -136,7 +136,7 @@ fn print_jq_error(msg: &str) {
     }
 }
 
-use jq_jit::value::{Value, json_to_value, json_stream, json_stream_offsets, json_stream_raw, json_stream_project, json_value_has_duplicate_keys, json_stream_has_duplicate_keys, json_object_get_num, json_object_get_two_nums, json_object_get_field_raw, json_object_get_fields_raw_buf, json_object_get_nested_field_raw, parse_json_num, json_value_length, json_object_keys_to_buf_reuse, json_object_extract_keys_only, json_object_keys_unsorted_to_buf, json_object_keys_join_to_buf, json_object_has_key, json_object_has_all_keys, json_object_has_any_key, json_object_del_field, json_object_del_fields, json_object_filter_by_key_str, json_object_merge_literal, json_object_sort_keys, json_object_filter_by_value_type, json_each_value_raw, json_each_value_cb, json_to_entries_raw, json_with_entries_select_value_cmp, json_object_set_field_raw, json_object_update_field_num, json_object_update_field_num_chain,json_object_select_then_update_num, json_object_select_then_update_str_concat, json_object_select_compound_then_update_num, json_object_select_str_then_update_num, json_object_values_tostring, is_json_compact, push_json_compact_raw, push_tojson_raw, push_json_pretty_raw, push_json_pretty_raw_at, value_to_json_precise, value_to_json_pretty_ext, push_compact_line, push_compact_line_color, push_pretty_line, push_pretty_line_color, push_jq_number_bytes, write_value_compact_ext, write_value_compact_line, write_value_pretty_line_color, value_to_json_pretty_color, walk_json_transform_nums, pool_value, skip_json_value};
+use jq_jit::value::{Value, json_to_value, json_stream, json_stream_offsets, json_stream_raw, json_stream_project, json_value_has_duplicate_keys, json_stream_has_duplicate_keys, json_object_get_num, json_object_get_two_nums, json_object_get_field_raw, json_object_get_fields_raw_buf, parse_json_num, json_value_length, json_object_keys_to_buf_reuse, json_object_extract_keys_only, json_object_keys_unsorted_to_buf, json_object_keys_join_to_buf, json_object_has_key, json_object_has_all_keys, json_object_has_any_key, json_object_del_field, json_object_del_fields, json_object_filter_by_key_str, json_object_merge_literal, json_object_sort_keys, json_object_filter_by_value_type, json_each_value_raw, json_each_value_cb, json_to_entries_raw, json_with_entries_select_value_cmp, json_object_set_field_raw, json_object_update_field_num, json_object_update_field_num_chain,json_object_select_then_update_num, json_object_select_then_update_str_concat, json_object_select_compound_then_update_num, json_object_select_str_then_update_num, json_object_values_tostring, is_json_compact, push_json_compact_raw, push_tojson_raw, push_json_pretty_raw, push_json_pretty_raw_at, value_to_json_precise, value_to_json_pretty_ext, push_compact_line, push_compact_line_color, push_pretty_line, push_pretty_line_color, push_jq_number_bytes, write_value_compact_ext, write_value_compact_line, write_value_pretty_line_color, value_to_json_pretty_color, walk_json_transform_nums, pool_value, skip_json_value};
 use jq_jit::interpreter::Filter;
 use jq_jit::fast_path::{
     apply_arith_chain_cmp_raw, apply_field_access_raw, apply_field_alternative_raw,
@@ -152,7 +152,8 @@ use jq_jit::fast_path::{
     apply_collect_each_select_type_raw, apply_each_type_filter_raw,
     apply_first_each_select_type_raw,
     apply_obj_assign_two_fields_arith_raw, apply_obj_merge_computed_raw,
-    apply_obj_merge_lit_raw, apply_select_num_str_raw, apply_two_field_binop_const_raw,
+    apply_obj_merge_lit_raw, apply_select_nested_cmp_raw, apply_select_num_str_raw,
+    apply_two_field_binop_const_raw,
     apply_has_field_raw, apply_has_multi_field_raw, apply_multi_field_access_raw,
     apply_nested_field_access_raw, apply_object_compute_raw, apply_select_arith_cmp_raw,
     apply_select_cmp_raw, apply_select_field_null_raw, apply_select_str_raw,
@@ -7584,25 +7585,16 @@ fn real_main() {
                         })
                     }
                 } else if let Some((ref fields, ref op, threshold)) = select_nested_cmp {
-                    use jq_jit::ir::BinOp;
                     let field_refs: Vec<&str> = fields.iter().map(|s| s.as_str()).collect();
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        if let Some((vs, ve)) = json_object_get_nested_field_raw(raw, 0, &field_refs) {
-                            if let Some(val) = parse_json_num(&raw[vs..ve]) {
-                                let pass = match op {
-                                    BinOp::Gt => val > threshold,
-                                    BinOp::Lt => val < threshold,
-                                    BinOp::Ge => val >= threshold,
-                                    BinOp::Le => val <= threshold,
-                                    BinOp::Eq => val == threshold,
-                                    BinOp::Ne => val != threshold,
-                                    _ => false,
-                                };
-                                if pass {
-                                    emit_raw_ln!(&mut compact_buf, raw);
-                                }
-                            }
+                        let outcome = apply_select_nested_cmp_raw(
+                            raw, &field_refs, *op, threshold,
+                            |bytes| { emit_raw_ln!(&mut compact_buf, bytes); },
+                        );
+                        if let RawApplyOutcome::Bail = outcome {
+                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }
                         if compact_buf.len() >= 1 << 17 {
                             let _ = out.write_all(&compact_buf);
@@ -15174,26 +15166,17 @@ fn real_main() {
                     })
                 }
             } else if let Some((ref fields, ref op, threshold)) = select_nested_cmp {
-                use jq_jit::ir::BinOp;
                 let content_bytes = content.as_bytes();
                 let field_refs: Vec<&str> = fields.iter().map(|s| s.as_str()).collect();
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    if let Some((vs, ve)) = json_object_get_nested_field_raw(raw, 0, &field_refs) {
-                        if let Some(val) = parse_json_num(&raw[vs..ve]) {
-                            let pass = match op {
-                                BinOp::Gt => val > threshold,
-                                BinOp::Lt => val < threshold,
-                                BinOp::Ge => val >= threshold,
-                                BinOp::Le => val <= threshold,
-                                BinOp::Eq => val == threshold,
-                                BinOp::Ne => val != threshold,
-                                _ => false,
-                            };
-                            if pass {
-                                emit_raw_ln!(&mut compact_buf, raw);
-                            }
-                        }
+                    let outcome = apply_select_nested_cmp_raw(
+                        raw, &field_refs, *op, threshold,
+                        |bytes| { emit_raw_ln!(&mut compact_buf, bytes); },
+                    );
+                    if let RawApplyOutcome::Bail = outcome {
+                        let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                        process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                     }
                     if compact_buf.len() >= 1 << 17 {
                         let _ = out.write_all(&compact_buf);

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -76,7 +76,8 @@ use crate::value::{
     json_object_update_field_split_first, json_object_update_field_split_last,
     json_object_update_field_str_concat, json_object_update_field_str_map,
     json_object_update_field_test, json_object_update_field_tostring,
-    json_object_update_field_trim, json_type_byte, json_value_length, push_jq_number_bytes,
+    json_object_update_field_trim, json_type_byte, json_value_length, parse_json_num,
+    push_jq_number_bytes,
 };
 
 /// A fast path whose type-dispatch obligations are encoded in its
@@ -1194,6 +1195,64 @@ pub fn apply_is_length_raw(raw: &[u8], buf: &mut Vec<u8>) -> RawApplyOutcome {
         }
         None => RawApplyOutcome::Bail,
     }
+}
+
+/// Apply the `select(.x.y.z <cmp> N)` raw-byte fast path on a single
+/// JSON record. Walks the nested field path, then runs a numeric
+/// comparison against a compile-time constant; emits the input
+/// bytes on a passing predicate (`select` semantics).
+///
+/// Bail discipline:
+/// * Non-object input or any nested step's intermediate value
+///   isn't an object — Bail (jq's `Cannot index <type> with "<key>"`
+///   surfaces via the generic path).
+/// * Leaf value absent or non-numeric — Bail (so jq's cross-type
+///   ordering / type-error on null applies via the generic path).
+/// * Non-comparison op (`Add`/`And`/etc.) — Bail (defensive).
+///
+/// On a passing predicate, calls `emit_match(raw)` so the apply-site
+/// emits the matching record. On a failing predicate, returns
+/// [`RawApplyOutcome::Emit`] without invoking the closure.
+pub fn apply_select_nested_cmp_raw<F>(
+    raw: &[u8],
+    fields: &[&str],
+    cmp_op: BinOp,
+    threshold: f64,
+    mut emit_match: F,
+) -> RawApplyOutcome
+where
+    F: FnMut(&[u8]),
+{
+    if raw.is_empty() || raw[0] != b'{' {
+        return RawApplyOutcome::Bail;
+    }
+    if !matches!(
+        cmp_op,
+        BinOp::Gt | BinOp::Lt | BinOp::Ge | BinOp::Le | BinOp::Eq | BinOp::Ne,
+    ) {
+        return RawApplyOutcome::Bail;
+    }
+    let (vs, ve) = match crate::value::json_object_get_nested_field_raw(raw, 0, fields) {
+        Some(r) => r,
+        None => return RawApplyOutcome::Bail,
+    };
+    let val = match parse_json_num(&raw[vs..ve]) {
+        Some(v) => v,
+        None => return RawApplyOutcome::Bail,
+    };
+    let pass = match cmp_op {
+        BinOp::Gt => val > threshold,
+        BinOp::Lt => val < threshold,
+        BinOp::Ge => val >= threshold,
+        BinOp::Le => val <= threshold,
+        BinOp::Eq => val == threshold,
+        BinOp::Ne => val != threshold,
+        _ => unreachable!(),
+    };
+    if pass {
+        emit_match(raw);
+    }
+    RawApplyOutcome::Emit
 }
 
 /// Apply the `select((.numfield <cmp> N) and (.strfield <op_str> arg))`

--- a/tests/fast_path_contract.rs
+++ b/tests/fast_path_contract.rs
@@ -31,7 +31,7 @@ use jq_jit::fast_path::{
     apply_collect_each_select_type_raw, apply_each_type_filter_raw,
     apply_first_each_select_type_raw,
     apply_obj_assign_two_fields_arith_raw, apply_obj_merge_computed_raw,
-    apply_obj_merge_lit_raw, apply_select_num_str_raw,
+    apply_obj_merge_lit_raw, apply_select_nested_cmp_raw, apply_select_num_str_raw,
     apply_select_arith_cmp_raw, apply_select_cmp_raw,
     apply_select_field_null_raw, apply_select_str_raw, apply_select_str_test_raw,
     apply_two_field_binop_const_raw,
@@ -3013,6 +3013,92 @@ fn raw_first_each_select_type_unknown_type_bails() {
     let mut buf = Vec::new();
     let outcome = apply_first_each_select_type_raw(b"[1,2]", "unknown", &mut buf);
     assert!(matches!(outcome, RawApplyOutcome::Bail));
+}
+
+// ---------------------------------------------------------------------------
+// `select(.x.y.z cmp N)` — nested-field numeric comparison. Bails on
+// non-object/missing-or-non-numeric/non-cmp-op.
+
+#[test]
+fn raw_select_nested_cmp_emits_match() {
+    let mut emitted: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_select_nested_cmp_raw(
+        b"{\"a\":{\"b\":{\"c\":5}}}", &["a", "b", "c"], BinOp::Gt, 3.0,
+        |raw| emitted.push(raw.to_vec()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec![b"{\"a\":{\"b\":{\"c\":5}}}".to_vec()]);
+}
+
+#[test]
+fn raw_select_nested_cmp_no_emit_on_predicate_fail() {
+    let mut emitted: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_select_nested_cmp_raw(
+        b"{\"a\":{\"b\":{\"c\":1}}}", &["a", "b", "c"], BinOp::Gt, 3.0,
+        |raw| emitted.push(raw.to_vec()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_select_nested_cmp_intermediate_non_object_bails() {
+    // .a.b.c on .a being a non-object: jq raises type error.
+    let mut emitted: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_select_nested_cmp_raw(
+        b"{\"a\":42}", &["a", "b", "c"], BinOp::Gt, 0.0,
+        |raw| emitted.push(raw.to_vec()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_select_nested_cmp_leaf_missing_bails() {
+    let mut emitted: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_select_nested_cmp_raw(
+        b"{\"a\":{\"b\":{}}}", &["a", "b", "c"], BinOp::Gt, 0.0,
+        |raw| emitted.push(raw.to_vec()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_select_nested_cmp_leaf_non_numeric_bails() {
+    let mut emitted: Vec<Vec<u8>> = Vec::new();
+    let outcome = apply_select_nested_cmp_raw(
+        b"{\"a\":{\"b\":{\"c\":\"hi\"}}}", &["a", "b", "c"], BinOp::Gt, 0.0,
+        |raw| emitted.push(raw.to_vec()),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_select_nested_cmp_non_cmp_op_bails() {
+    for op in [BinOp::Add, BinOp::Mul, BinOp::And] {
+        let mut emitted: Vec<Vec<u8>> = Vec::new();
+        let outcome = apply_select_nested_cmp_raw(
+            b"{\"a\":{\"b\":{\"c\":5}}}", &["a", "b", "c"], op, 0.0,
+            |raw| emitted.push(raw.to_vec()),
+        );
+        assert!(matches!(outcome, RawApplyOutcome::Bail), "op={:?}", op);
+    }
+}
+
+#[test]
+fn raw_select_nested_cmp_non_object_input_bails() {
+    for raw in [b"42".as_slice(), b"\"hi\"".as_slice(), b"null".as_slice(), b"[1,2]".as_slice()] {
+        let mut emitted: Vec<Vec<u8>> = Vec::new();
+        let outcome = apply_select_nested_cmp_raw(
+            raw, &["a", "b"], BinOp::Gt, 0.0, |raw| emitted.push(raw.to_vec()),
+        );
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "raw={:?}", std::str::from_utf8(raw).unwrap(),
+        );
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -4687,3 +4687,39 @@ select(.x | test("foo"))
 select(.x | test("^a"))
 {"x":"a\nb"}
 {"x":"a\nb"}
+
+# Issue #251: select_nested_cmp apply-site uses RawApplyOutcome (#83 Phase B).
+# Helper Bails on non-object input, intermediate non-object, missing/non-numeric
+# leaf, non-cmp op. Fixes pre-existing #83-class divergences.
+select(.a.b.c > 3)
+{"a":{"b":{"c":5}}}
+{"a":{"b":{"c":5}}}
+
+select(.a.b.c == 0)
+{"a":{"b":{"c":0}}}
+{"a":{"b":{"c":0}}}
+
+# Predicate fails — no output (select semantics).
+[ (select(.a.b.c > 3))? ]
+{"a":{"b":{"c":1}}}
+[]
+
+# Intermediate non-object — generic raises type error, ? swallows.
+[ (select(.a.b.c > 3))? ]
+{"a":42}
+[]
+
+# Missing leaf — generic resolves null > 3 = false (no error).
+[ (select(.a.b.c > 3))? ]
+{"a":{"b":{}}}
+[]
+
+# Non-numeric leaf — generic uses cross-type ordering ("hi" > 3 = true).
+select(.a.b.c > 3)
+{"a":{"b":{"c":"hi"}}}
+{"a":{"b":{"c":"hi"}}}
+
+# Non-object input — generic raises indexing error.
+[ (select(.a.b.c > 3))? ]
+"plain"
+[]


### PR DESCRIPTION
## Summary
- Add `apply_select_nested_cmp_raw` to `src/fast_path.rs` for `select(.x.y.z cmp N)`. Walks the nested field path, runs a numeric comparison, emits the input on a passing predicate.
- Migrate the `select_nested_cmp` apply-sites in `bin/jq-jit.rs` (stdin + file-mode) to the named `RawApplyOutcome::{Emit, Bail}` discipline.
- Bail discipline: non-object input, intermediate step's value isn't an object, leaf absent or non-numeric, non-cmp op (defensive).

**Bug fix:** Prior apply-site silently emitted nothing for non-object/non-numeric/intermediate-non-object instead of routing through the generic path so jq's correct error or cross-type ordering surfaces.

7 new contract cases pin the verdict surface (multi-level nesting, every Bail branch); 7 new regression cases cover the `?`-wrapped Bail matrix and cross-type ordering routing.

Closes the `select_nested_cmp` item in "Select family". Refs #251.

## Test plan
- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (965 regression cases pass, +7 over main; 366 contract cases, +7)
- [x] `./bench/comprehensive.sh --quick` (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)