### PR TITLE
refactor: select_compound apply-site uses RawApplyOutcome (#83 Phase B)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -8960,50 +8960,31 @@ fn real_main() {
                     })
                 } else if let Some((ref conj, ref cmps)) = select_compound {
                     use jq_jit::ir::BinOp;
-                    let is_and = matches!(conj, BinOp::And);
-                    // Specialized path for exactly 2 comparisons on different fields: use get_two_nums
-                    let two_field = if cmps.len() == 2 && cmps[0].0 != cmps[1].0 {
-                        Some((cmps[0].0.as_str(), cmps[1].0.as_str()))
-                    } else { None };
+                    // Pre-deduplicate field names + cmp_spec for the helper.
+                    let mut field_names: Vec<String> = Vec::new();
+                    let mut field_idx: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+                    for (f, _, _) in cmps {
+                        if !field_idx.contains_key(f) {
+                            field_idx.insert(f.clone(), field_names.len());
+                            field_names.push(f.clone());
+                        }
+                    }
+                    let field_refs: Vec<&str> = field_names.iter().map(|s| s.as_str()).collect();
+                    let cmp_spec: Vec<(usize, BinOp, f64)> = cmps.iter().map(|(f, op, n)| (field_idx[f], *op, *n)).collect();
+                    let mut vals_buf: Vec<f64> = vec![0.0; field_names.len()];
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        let pass = if let Some((f1, f2)) = two_field {
-                            if let Some((v1, v2)) = json_object_get_two_nums(raw, 0, f1, f2) {
-                                let c1 = match &cmps[0].1 {
-                                    BinOp::Gt => v1 > cmps[0].2, BinOp::Lt => v1 < cmps[0].2,
-                                    BinOp::Ge => v1 >= cmps[0].2, BinOp::Le => v1 <= cmps[0].2,
-                                    BinOp::Eq => v1 == cmps[0].2, BinOp::Ne => v1 != cmps[0].2,
-                                    _ => false,
-                                };
-                                let c2 = match &cmps[1].1 {
-                                    BinOp::Gt => v2 > cmps[1].2, BinOp::Lt => v2 < cmps[1].2,
-                                    BinOp::Ge => v2 >= cmps[1].2, BinOp::Le => v2 <= cmps[1].2,
-                                    BinOp::Eq => v2 == cmps[1].2, BinOp::Ne => v2 != cmps[1].2,
-                                    _ => false,
-                                };
-                                if is_and { c1 && c2 } else { c1 || c2 }
-                            } else { false }
-                        } else if is_and {
-                            cmps.iter().all(|(field, op, threshold)| {
-                                json_object_get_num(raw, 0, field).map_or(false, |val| match op {
-                                    BinOp::Gt => val > *threshold, BinOp::Lt => val < *threshold,
-                                    BinOp::Ge => val >= *threshold, BinOp::Le => val <= *threshold,
-                                    BinOp::Eq => val == *threshold, BinOp::Ne => val != *threshold,
-                                    _ => false,
-                                })
-                            })
-                        } else {
-                            cmps.iter().any(|(field, op, threshold)| {
-                                json_object_get_num(raw, 0, field).map_or(false, |val| match op {
-                                    BinOp::Gt => val > *threshold, BinOp::Lt => val < *threshold,
-                                    BinOp::Ge => val >= *threshold, BinOp::Le => val <= *threshold,
-                                    BinOp::Eq => val == *threshold, BinOp::Ne => val != *threshold,
-                                    _ => false,
-                                })
-                            })
-                        };
-                        if pass {
-                            emit_raw_ln!(&mut compact_buf, raw);
+                        let outcome = apply_compound_field_cmp_raw(
+                            raw, &field_refs, &cmp_spec, *conj, &mut vals_buf,
+                            |pass| {
+                                if pass {
+                                    emit_raw_ln!(&mut compact_buf, raw);
+                                }
+                            },
+                        );
+                        if let RawApplyOutcome::Bail = outcome {
+                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }
                         if compact_buf.len() >= 1 << 17 {
                             let _ = out.write_all(&compact_buf);
@@ -16491,49 +16472,30 @@ fn real_main() {
             } else if let Some((ref conj, ref cmps)) = select_compound {
                 use jq_jit::ir::BinOp;
                 let content_bytes = content.as_bytes();
-                let is_and = matches!(conj, BinOp::And);
-                let two_field = if cmps.len() == 2 && cmps[0].0 != cmps[1].0 {
-                    Some((cmps[0].0.as_str(), cmps[1].0.as_str()))
-                } else { None };
+                let mut field_names: Vec<String> = Vec::new();
+                let mut field_idx: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+                for (f, _, _) in cmps {
+                    if !field_idx.contains_key(f) {
+                        field_idx.insert(f.clone(), field_names.len());
+                        field_names.push(f.clone());
+                    }
+                }
+                let field_refs: Vec<&str> = field_names.iter().map(|s| s.as_str()).collect();
+                let cmp_spec: Vec<(usize, BinOp, f64)> = cmps.iter().map(|(f, op, n)| (field_idx[f], *op, *n)).collect();
+                let mut vals_buf: Vec<f64> = vec![0.0; field_names.len()];
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    let pass = if let Some((f1, f2)) = two_field {
-                        if let Some((v1, v2)) = json_object_get_two_nums(raw, 0, f1, f2) {
-                            let c1 = match &cmps[0].1 {
-                                BinOp::Gt => v1 > cmps[0].2, BinOp::Lt => v1 < cmps[0].2,
-                                BinOp::Ge => v1 >= cmps[0].2, BinOp::Le => v1 <= cmps[0].2,
-                                BinOp::Eq => v1 == cmps[0].2, BinOp::Ne => v1 != cmps[0].2,
-                                _ => false,
-                            };
-                            let c2 = match &cmps[1].1 {
-                                BinOp::Gt => v2 > cmps[1].2, BinOp::Lt => v2 < cmps[1].2,
-                                BinOp::Ge => v2 >= cmps[1].2, BinOp::Le => v2 <= cmps[1].2,
-                                BinOp::Eq => v2 == cmps[1].2, BinOp::Ne => v2 != cmps[1].2,
-                                _ => false,
-                            };
-                            if is_and { c1 && c2 } else { c1 || c2 }
-                        } else { false }
-                    } else if is_and {
-                        cmps.iter().all(|(field, op, threshold)| {
-                            json_object_get_num(raw, 0, field).map_or(false, |val| match op {
-                                BinOp::Gt => val > *threshold, BinOp::Lt => val < *threshold,
-                                BinOp::Ge => val >= *threshold, BinOp::Le => val <= *threshold,
-                                BinOp::Eq => val == *threshold, BinOp::Ne => val != *threshold,
-                                _ => false,
-                            })
-                        })
-                    } else {
-                        cmps.iter().any(|(field, op, threshold)| {
-                            json_object_get_num(raw, 0, field).map_or(false, |val| match op {
-                                BinOp::Gt => val > *threshold, BinOp::Lt => val < *threshold,
-                                BinOp::Ge => val >= *threshold, BinOp::Le => val <= *threshold,
-                                BinOp::Eq => val == *threshold, BinOp::Ne => val != *threshold,
-                                _ => false,
-                            })
-                        })
-                    };
-                    if pass {
-                        emit_raw_ln!(&mut compact_buf, raw);
+                    let outcome = apply_compound_field_cmp_raw(
+                        raw, &field_refs, &cmp_spec, *conj, &mut vals_buf,
+                        |pass| {
+                            if pass {
+                                emit_raw_ln!(&mut compact_buf, raw);
+                            }
+                        },
+                    );
+                    if let RawApplyOutcome::Bail = outcome {
+                        let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                        process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                     }
                     if compact_buf.len() >= 1 << 17 {
                         let _ = out.write_all(&compact_buf);

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -4723,3 +4723,30 @@ select(.a.b.c > 3)
 [ (select(.a.b.c > 3))? ]
 "plain"
 []
+
+# Issue #251: select_compound apply-site uses RawApplyOutcome (#83 Phase B,
+# reuses apply_compound_field_cmp_raw — same Bail discipline as #283).
+# Fixes pre-existing bug where non-numeric field silently dropped the input
+# instead of routing through generic for jq's cross-type ordering.
+select((.x > 0) and (.y > 0))
+{"x":5,"y":3}
+{"x":5,"y":3}
+
+select((.x > 0) or (.y > 100))
+{"x":5,"y":1}
+{"x":5,"y":1}
+
+# Non-numeric — helper Bails, generic uses cross-type ordering ("hi" > 0 = true).
+select((.x > 0) and (.y > 0))
+{"x":5,"y":"hi"}
+{"x":5,"y":"hi"}
+
+# Missing field — helper Bails, generic resolves null > 0 = false.
+[ (select((.x > 0) and (.y > 0)))? ]
+{"x":5}
+[]
+
+# `?`-wrapped: non-object input — generic raises indexing error.
+[ (select((.x > 0) and (.y > 0)))? ]
+"plain"
+[]


### PR DESCRIPTION
## Summary
- Migrate the `select_compound` apply-sites in `bin/jq-jit.rs` (stdin + file-mode) to the named `RawApplyOutcome::{Emit, Bail}` discipline.
- The shape is `select((.x cmp1 N1) and/or (.y cmp2 N2) ...)`. Same predicate logic as `apply_compound_field_cmp_raw` (#283), just a different emit closure (write raw bytes on `pass = true`) — so the apply-site reuses the existing helper. No new helper. (Same pattern as #284 / #290.)

**Bug fix:** Prior apply-sites silently dropped the input on a non-numeric field, masking jq's cross-type ordering (e.g. `select((.x > 0) and (.y > 0))` on `{"x":5,"y":"hi"}` should emit the input because `"hi" > 0 == true`).

5 new regression cases cover happy paths, the cross-type ordering fix, missing field (null comparison → false), and `?`-wrapped non-object input.

Closes the `select_compound` item. `select_compound_field`/`_remap`/`_computed`/`_cremap` left for follow-ups (each has additional output-side logic).

Refs #251.

## Test plan
- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (970 regression cases pass, +5 over main)
- [x] `./bench/comprehensive.sh --quick` (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)