### PR TITLE
refactor: cmp_branch_lit / null_branch_lit apply-sites use RawApplyOutcome (#83 Phase B)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -151,6 +151,7 @@ use jq_jit::fast_path::{
     apply_is_type_raw, apply_numeric_expr_raw, apply_obj_assign_field_arith_raw,
     apply_collect_each_select_type_raw, apply_each_type_filter_raw,
     apply_first_each_select_type_raw,
+    apply_null_branch_lit_raw,
     apply_obj_assign_two_fields_arith_raw, apply_obj_merge_computed_raw,
     apply_obj_merge_lit_raw, apply_select_nested_cmp_raw, apply_select_num_str_raw,
     apply_two_field_binop_const_raw,
@@ -8155,24 +8156,13 @@ fn real_main() {
                     })
                     } // end general path
                 } else if let Some((ref field, ref op, threshold, ref t_bytes, ref f_bytes)) = cmp_branch_lit {
-                    use jq_jit::ir::BinOp;
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        if let Some(val) = json_object_get_num(raw, 0, field) {
-                            let pass = match op {
-                                BinOp::Gt => val > threshold, BinOp::Lt => val < threshold,
-                                BinOp::Ge => val >= threshold, BinOp::Le => val <= threshold,
-                                BinOp::Eq => val == threshold, BinOp::Ne => val != threshold,
-                                _ => false,
-                            };
+                        let outcome = apply_field_const_cmp_raw(raw, field, *op, threshold, |pass| {
                             compact_buf.extend_from_slice(if pass { t_bytes } else { f_bytes });
                             compact_buf.push(b'\n');
-                        } else {
-                            // Field is missing or not numeric — defer to
-                            // generic eval so jq's total-order comparison
-                            // (null < number, string > number, etc.) applies
-                            // and the conditional resolves to a branch instead
-                            // of being silently dropped (#161).
+                        });
+                        if let RawApplyOutcome::Bail = outcome {
                             let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                             process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }
@@ -8392,13 +8382,13 @@ fn real_main() {
                 } else if let Some((ref field, is_eq_null, ref t_bytes, ref f_bytes)) = null_branch_lit {
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        let is_null = match json_object_get_field_raw(raw, 0, field) {
-                            Some((vs, ve)) => ve - vs == 4 && &raw[vs..ve] == b"null",
-                            None => true, // missing field is null
-                        };
-                        let pass = if is_eq_null { is_null } else { !is_null };
-                        compact_buf.extend_from_slice(if pass { t_bytes } else { f_bytes });
-                        compact_buf.push(b'\n');
+                        let outcome = apply_null_branch_lit_raw(
+                            raw, field, is_eq_null, t_bytes, f_bytes, &mut compact_buf,
+                        );
+                        if let RawApplyOutcome::Bail = outcome {
+                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                        }
                         if compact_buf.len() >= 1 << 17 {
                             let _ = out.write_all(&compact_buf);
                             compact_buf.clear();
@@ -15697,22 +15687,14 @@ fn real_main() {
                 })
                 } // end general path
             } else if let Some((ref field, ref op, threshold, ref t_bytes, ref f_bytes)) = cmp_branch_lit {
-                use jq_jit::ir::BinOp;
                 let content_bytes = content.as_bytes();
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    if let Some(val) = json_object_get_num(raw, 0, field) {
-                        let pass = match op {
-                            BinOp::Gt => val > threshold, BinOp::Lt => val < threshold,
-                            BinOp::Ge => val >= threshold, BinOp::Le => val <= threshold,
-                            BinOp::Eq => val == threshold, BinOp::Ne => val != threshold,
-                            _ => false,
-                        };
+                    let outcome = apply_field_const_cmp_raw(raw, field, *op, threshold, |pass| {
                         compact_buf.extend_from_slice(if pass { t_bytes } else { f_bytes });
                         compact_buf.push(b'\n');
-                    } else {
-                        // Field missing or non-numeric — bail to generic eval so
-                        // jq's total order picks the branch (#161).
+                    });
+                    if let RawApplyOutcome::Bail = outcome {
                         let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                         process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                     }
@@ -15906,13 +15888,13 @@ fn real_main() {
                 let content_bytes = content.as_bytes();
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    let is_null = match json_object_get_field_raw(raw, 0, field) {
-                        Some((vs, ve)) => ve - vs == 4 && &raw[vs..ve] == b"null",
-                        None => true,
-                    };
-                    let pass = if is_eq_null { is_null } else { !is_null };
-                    compact_buf.extend_from_slice(if pass { t_bytes } else { f_bytes });
-                    compact_buf.push(b'\n');
+                    let outcome = apply_null_branch_lit_raw(
+                        raw, field, is_eq_null, t_bytes, f_bytes, &mut compact_buf,
+                    );
+                    if let RawApplyOutcome::Bail = outcome {
+                        let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                        process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                    }
                     if compact_buf.len() >= 1 << 17 {
                         let _ = out.write_all(&compact_buf);
                         compact_buf.clear();

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -1197,6 +1197,43 @@ pub fn apply_is_length_raw(raw: &[u8], buf: &mut Vec<u8>) -> RawApplyOutcome {
     }
 }
 
+/// Apply the `if .field == null then T else F end` (or `!= null`)
+/// raw-byte fast path on a single JSON record. Both branches are
+/// pre-encoded byte literals.
+///
+/// `is_eq_null = true` selects `== null` (T when field is null or
+/// missing); `false` selects `!= null` (T when field is present and
+/// non-null).
+///
+/// Bail discipline:
+/// * Non-object input — Bail (jq's `Cannot index <type> with "<field>"`
+///   surfaces via the generic path; the prior fast path silently
+///   treated non-object input as "field missing → null", emitting the
+///   wrong branch — a #83-class divergence).
+///
+/// On Emit, writes `t_bytes` or `f_bytes` (whichever the predicate
+/// selects) followed by a trailing `\n` directly to `buf`.
+pub fn apply_null_branch_lit_raw(
+    raw: &[u8],
+    field: &str,
+    is_eq_null: bool,
+    t_bytes: &[u8],
+    f_bytes: &[u8],
+    buf: &mut Vec<u8>,
+) -> RawApplyOutcome {
+    if raw.is_empty() || raw[0] != b'{' {
+        return RawApplyOutcome::Bail;
+    }
+    let is_null = match json_object_get_field_raw(raw, 0, field) {
+        Some((vs, ve)) => ve - vs == 4 && &raw[vs..ve] == b"null",
+        None => true, // missing field is null in jq
+    };
+    let pass = if is_eq_null { is_null } else { !is_null };
+    buf.extend_from_slice(if pass { t_bytes } else { f_bytes });
+    buf.push(b'\n');
+    RawApplyOutcome::Emit
+}
+
 /// Apply the `select(.x.y.z <cmp> N)` raw-byte fast path on a single
 /// JSON record. Walks the nested field path, then runs a numeric
 /// comparison against a compile-time constant; emits the input

--- a/tests/fast_path_contract.rs
+++ b/tests/fast_path_contract.rs
@@ -30,6 +30,7 @@ use jq_jit::fast_path::{
     apply_numeric_expr_raw, apply_obj_assign_field_arith_raw,
     apply_collect_each_select_type_raw, apply_each_type_filter_raw,
     apply_first_each_select_type_raw,
+    apply_null_branch_lit_raw,
     apply_obj_assign_two_fields_arith_raw, apply_obj_merge_computed_raw,
     apply_obj_merge_lit_raw, apply_select_nested_cmp_raw, apply_select_num_str_raw,
     apply_select_arith_cmp_raw, apply_select_cmp_raw,
@@ -3013,6 +3014,74 @@ fn raw_first_each_select_type_unknown_type_bails() {
     let mut buf = Vec::new();
     let outcome = apply_first_each_select_type_raw(b"[1,2]", "unknown", &mut buf);
     assert!(matches!(outcome, RawApplyOutcome::Bail));
+}
+
+// ---------------------------------------------------------------------------
+// `if .field == null then T else F end` — null branch literal. Bails on
+// non-object input.
+
+#[test]
+fn raw_null_branch_lit_eq_null_present_field() {
+    let mut buf = Vec::new();
+    let outcome = apply_null_branch_lit_raw(
+        b"{\"x\":42}", "x", true, b"\"yes\"", b"\"no\"", &mut buf,
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(buf, b"\"no\"\n");
+}
+
+#[test]
+fn raw_null_branch_lit_eq_null_missing_field() {
+    // jq: missing field is null
+    let mut buf = Vec::new();
+    let outcome = apply_null_branch_lit_raw(
+        b"{\"y\":1}", "x", true, b"\"yes\"", b"\"no\"", &mut buf,
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(buf, b"\"yes\"\n");
+}
+
+#[test]
+fn raw_null_branch_lit_eq_null_explicit_null() {
+    let mut buf = Vec::new();
+    let outcome = apply_null_branch_lit_raw(
+        b"{\"x\":null}", "x", true, b"\"yes\"", b"\"no\"", &mut buf,
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(buf, b"\"yes\"\n");
+}
+
+#[test]
+fn raw_null_branch_lit_ne_null_inverted() {
+    let mut buf = Vec::new();
+    let outcome = apply_null_branch_lit_raw(
+        b"{\"x\":null}", "x", false, b"\"yes\"", b"\"no\"", &mut buf,
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(buf, b"\"no\"\n");
+    let mut buf2 = Vec::new();
+    let outcome2 = apply_null_branch_lit_raw(
+        b"{\"x\":42}", "x", false, b"\"yes\"", b"\"no\"", &mut buf2,
+    );
+    assert!(matches!(outcome2, RawApplyOutcome::Emit));
+    assert_eq!(buf2, b"\"yes\"\n");
+}
+
+#[test]
+fn raw_null_branch_lit_non_object_bails() {
+    // Pre-existing #83-class divergence: non-object root silently emitted T
+    // (treating as field-missing → null) instead of jq's `Cannot index <type>`.
+    for raw in [b"42".as_slice(), b"\"hi\"".as_slice(), b"null".as_slice(), b"[1,2]".as_slice()] {
+        let mut buf = Vec::new();
+        let outcome = apply_null_branch_lit_raw(
+            raw, "x", true, b"\"yes\"", b"\"no\"", &mut buf,
+        );
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "raw={:?}", std::str::from_utf8(raw).unwrap(),
+        );
+        assert!(buf.is_empty());
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -4750,3 +4750,46 @@ select((.x > 0) and (.y > 0))
 [ (select((.x > 0) and (.y > 0)))? ]
 "plain"
 []
+
+# Issue #251: cmp_branch_lit / null_branch_lit apply-sites use RawApplyOutcome
+# (#83 Phase B). cmp_branch_lit reuses apply_field_const_cmp_raw (#263);
+# null_branch_lit gets a new helper. Both fix non-object Bail divergences:
+# null_branch_lit silently emitted the null branch on non-object root instead
+# of jq's `Cannot index <type>` error.
+if .x > 10 then "big" else "small" end
+{"x":42}
+"big"
+
+if .x > 10 then "big" else "small" end
+{"x":5}
+"small"
+
+# Non-numeric — helper Bails, generic uses cross-type ordering ("hi" > 10 = true).
+if .x > 10 then "big" else "small" end
+{"x":"hi"}
+"big"
+
+if .x == null then "yes" else "no" end
+{"x":42}
+"no"
+
+if .x == null then "yes" else "no" end
+{"y":1}
+"yes"
+
+if .x == null then "yes" else "no" end
+{"x":null}
+"yes"
+
+if .x != null then "yes" else "no" end
+{"x":42}
+"yes"
+
+# Non-object input — helper Bails, generic raises indexing error, ? swallows.
+[ (if .x > 10 then "big" else "small" end)? ]
+"plain"
+[]
+
+[ (if .x == null then "yes" else "no" end)? ]
+42
+[]


### PR DESCRIPTION
## Summary
Two related conditional fast paths migrated to the named `RawApplyOutcome::{Emit, Bail}` discipline:

- `cmp_branch_lit` — `if .field cmp N then T else F end`. Reuses `apply_field_const_cmp_raw` (#263) with a different emit closure. No new helper. (Same pattern as #284 / #292.)
- `null_branch_lit` — `if .field == null then T else F end`. Adds `apply_null_branch_lit_raw` to `src/fast_path.rs`.

**Bug fix:** `null_branch_lit` silently treated non-object root as "field missing → null" and emitted the null branch instead of jq's `Cannot index <type>` error. The new helper Bails on non-object input.

5 new contract cases for `apply_null_branch_lit_raw`; 9 new regression cases covering both fast paths and the cross-type ordering routing.

Closes the `cmp_branch_lit` and `null_branch_lit` items. Refs #251.

## Test plan
- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (979 regression cases pass, +9 over main; 371 contract cases, +5)
- [x] `./bench/comprehensive.sh --quick` (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)