### PR TITLE
refactor: arith_cmp_branch_lit apply-site uses RawApplyOutcome (#83 Phase B)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -8173,27 +8173,16 @@ fn real_main() {
                         Ok(())
                     })
                 } else if let Some((ref field, ref arith_ops, ref cmp_op, threshold, ref t_bytes, ref f_bytes)) = arith_cmp_branch_lit {
-                    use jq_jit::ir::BinOp;
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        if let Some(mut val) = json_object_get_num(raw, 0, field) {
-                            for (aop, n) in arith_ops {
-                                val = match aop {
-                                    BinOp::Add => val + n, BinOp::Sub => val - n,
-                                    BinOp::Mul => val * n, BinOp::Div => val / n,
-                                    BinOp::Mod => jq_jit::runtime::jq_mod_f64(val, n).unwrap_or(f64::NAN), _ => val,
-                                };
-                            }
-                            let pass = match cmp_op {
-                                BinOp::Gt => val > threshold, BinOp::Lt => val < threshold,
-                                BinOp::Ge => val >= threshold, BinOp::Le => val <= threshold,
-                                BinOp::Eq => val == threshold, BinOp::Ne => val != threshold,
-                                _ => false,
-                            };
-                            compact_buf.extend_from_slice(if pass { t_bytes } else { f_bytes });
-                            compact_buf.push(b'\n');
-                        } else {
-                            // Non-numeric field — defer to generic eval (#161).
+                        let outcome = apply_arith_chain_cmp_raw(
+                            raw, field, arith_ops, *cmp_op, threshold,
+                            |pass| {
+                                compact_buf.extend_from_slice(if pass { t_bytes } else { f_bytes });
+                                compact_buf.push(b'\n');
+                            },
+                        );
+                        if let RawApplyOutcome::Bail = outcome {
                             let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                             process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }
@@ -15705,28 +15694,17 @@ fn real_main() {
                     Ok(())
                 })
             } else if let Some((ref field, ref arith_ops, ref cmp_op, threshold, ref t_bytes, ref f_bytes)) = arith_cmp_branch_lit {
-                use jq_jit::ir::BinOp;
                 let content_bytes = content.as_bytes();
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    if let Some(mut val) = json_object_get_num(raw, 0, field) {
-                        for (aop, n) in arith_ops {
-                            val = match aop {
-                                BinOp::Add => val + n, BinOp::Sub => val - n,
-                                BinOp::Mul => val * n, BinOp::Div => val / n,
-                                BinOp::Mod => jq_jit::runtime::jq_mod_f64(val, n).unwrap_or(f64::NAN), _ => val,
-                            };
-                        }
-                        let pass = match cmp_op {
-                            BinOp::Gt => val > threshold, BinOp::Lt => val < threshold,
-                            BinOp::Ge => val >= threshold, BinOp::Le => val <= threshold,
-                            BinOp::Eq => val == threshold, BinOp::Ne => val != threshold,
-                            _ => false,
-                        };
-                        compact_buf.extend_from_slice(if pass { t_bytes } else { f_bytes });
-                        compact_buf.push(b'\n');
-                    } else {
-                        // Non-numeric field — bail to generic eval (#161).
+                    let outcome = apply_arith_chain_cmp_raw(
+                        raw, field, arith_ops, *cmp_op, threshold,
+                        |pass| {
+                            compact_buf.extend_from_slice(if pass { t_bytes } else { f_bytes });
+                            compact_buf.push(b'\n');
+                        },
+                    );
+                    if let RawApplyOutcome::Bail = outcome {
                         let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                         process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                     }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -4793,3 +4793,28 @@ if .x != null then "yes" else "no" end
 [ (if .x == null then "yes" else "no" end)? ]
 42
 []
+
+# Issue #251: arith_cmp_branch_lit apply-site uses RawApplyOutcome (#83
+# Phase B, reuses apply_arith_chain_cmp_raw — same Bail discipline as #264).
+if (.x * 2 + 1) > 10 then "big" else "small" end
+{"x":5}
+"big"
+
+if (.x + 1) > 10 then "big" else "small" end
+{"x":3}
+"small"
+
+# Non-numeric — helper Bails, generic uses cross-type ordering ("hi" * 2 raises).
+[ (if (.x * 2) > 10 then "big" else "small" end)? ]
+{"x":"hi"}
+["big"]
+
+# Non-object input — helper Bails, generic raises indexing error, ? swallows.
+[ (if (.x * 2) > 10 then "big" else "small" end)? ]
+"plain"
+[]
+
+# Div-by-zero — helper Bails, generic raises, ? swallows.
+[ (if (.x / 0) > 10 then "big" else "small" end)? ]
+{"x":4}
+[]


### PR DESCRIPTION
## Summary
- Migrate the `arith_cmp_branch_lit` apply-sites in `bin/jq-jit.rs` (stdin + file-mode) to the named `RawApplyOutcome::{Emit, Bail}` discipline.
- Shape: `if (.field arith_chain) cmp N then T else F end`. Same predicate logic as `apply_arith_chain_cmp_raw` (#264), just a different emit closure (write t_bytes or f_bytes by the boolean) — so the apply-site reuses the existing helper. No new helper. (Same pattern as #284 / #292 / #293.)

Bail discipline (delegated to the parent helper): missing/non-numeric field, non-arith chain op, non-cmp op, non-finite arithmetic result, non-object input.

5 new regression cases covering happy paths, non-numeric routing through generic (jq's cross-type ordering), `?`-wrapped non-object input, and div-by-zero in the chain.

Closes the `arith_cmp_branch_lit` item. Refs #251.

## Test plan
- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (984 regression cases pass, +5 over main)
- [x] `./bench/comprehensive.sh --quick` (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)