### PR TITLE
refactor: cmp_branch_merge apply-site uses RawApplyOutcome (#83 Phase B)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -151,7 +151,7 @@ use jq_jit::fast_path::{
     apply_is_type_raw, apply_numeric_expr_raw, apply_obj_assign_field_arith_raw,
     apply_collect_each_select_type_raw, apply_each_type_filter_raw,
     apply_first_each_select_type_raw,
-    apply_null_branch_lit_raw,
+    apply_field_cmp_val_raw, apply_null_branch_lit_raw,
     apply_obj_assign_two_fields_arith_raw, apply_obj_merge_computed_raw,
     apply_obj_merge_lit_raw, apply_select_nested_cmp_raw, apply_select_num_str_raw,
     apply_two_field_binop_const_raw,
@@ -8307,10 +8307,8 @@ fn real_main() {
                         Ok(())
                     })
                 } else if let Some((ref field, ref op, ref cmp_val, ref merge_pairs, is_prepend)) = cmp_branch_merge {
-                    // if .field op val then {literal} +/. . else . end
-                    use jq_jit::ir::BinOp;
-                    use jq_jit::interpreter::CmpVal;
-                    // Build merge suffix/prefix: ,"key1":val1,"key2":val2}  or  {"key1":val1,"key2":val2,
+                    // if .field op val then {literal} +/. . else . end — predicate
+                    // resolved via apply_field_cmp_val_raw; merge body stays inline.
                     let mut merge_bytes = Vec::with_capacity(64);
                     if is_prepend {
                         merge_bytes.push(b'{');
@@ -8335,51 +8333,20 @@ fn real_main() {
                     }
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        // pass = None means the input also needs jq's total-order
-                        // semantics; bail to generic eval so we don't silently drop
-                        // the value or pick the wrong branch (#161).
-                        let pass: Option<bool> = match cmp_val {
-                            CmpVal::Num(threshold) => {
-                                json_object_get_num(raw, 0, field).map(|val| match op {
-                                    BinOp::Gt => val > *threshold, BinOp::Lt => val < *threshold,
-                                    BinOp::Ge => val >= *threshold, BinOp::Le => val <= *threshold,
-                                    BinOp::Eq => val == *threshold, BinOp::Ne => val != *threshold,
-                                    _ => false,
-                                })
+                        let mut verdict: Option<bool> = None;
+                        let outcome = apply_field_cmp_val_raw(raw, field, *op, cmp_val, |pass| {
+                            verdict = Some(pass);
+                        });
+                        if let RawApplyOutcome::Bail = outcome {
+                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                            if compact_buf.len() >= 1 << 17 {
+                                let _ = out.write_all(&compact_buf);
+                                compact_buf.clear();
                             }
-                            CmpVal::Str(ref s) => {
-                                match json_object_get_field_raw(raw, 0, field) {
-                                    Some((vs, ve)) => {
-                                        let vb = &raw[vs..ve];
-                                        if vb.len() >= 2 && vb[0] == b'"' && vb[vb.len()-1] == b'"' && !vb[1..vb.len()-1].contains(&b'\\') {
-                                            let inner = &vb[1..vb.len()-1];
-                                            Some(match op {
-                                                BinOp::Eq => inner == s.as_bytes(),
-                                                BinOp::Ne => inner != s.as_bytes(),
-                                                BinOp::Gt => inner > s.as_bytes(),
-                                                BinOp::Lt => inner < s.as_bytes(),
-                                                BinOp::Ge => inner >= s.as_bytes(),
-                                                BinOp::Le => inner <= s.as_bytes(),
-                                                _ => false,
-                                            })
-                                        } else { None }
-                                    }
-                                    None => None,
-                                }
-                            }
-                        };
-                        let pass = match pass {
-                            Some(p) => p,
-                            None => {
-                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                                if compact_buf.len() >= 1 << 17 {
-                                    let _ = out.write_all(&compact_buf);
-                                    compact_buf.clear();
-                                }
-                                return Ok(());
-                            }
-                        };
+                            return Ok(());
+                        }
+                        let pass = verdict.unwrap_or(false);
                         if pass {
                             let save = compact_buf.len();
                             if is_json_compact(raw) {
@@ -15745,8 +15712,6 @@ fn real_main() {
                     Ok(())
                 })
             } else if let Some((ref field, ref op, ref cmp_val, ref merge_pairs, is_prepend)) = cmp_branch_merge {
-                use jq_jit::ir::BinOp;
-                use jq_jit::interpreter::CmpVal;
                 let mut merge_bytes = Vec::with_capacity(64);
                 if is_prepend {
                     merge_bytes.push(b'{');
@@ -15772,50 +15737,20 @@ fn real_main() {
                 let content_bytes = content.as_bytes();
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    // pass = None means the input falls outside what the fast path
-                    // can decide; bail to generic eval (#161).
-                    let pass: Option<bool> = match cmp_val {
-                        CmpVal::Num(threshold) => {
-                            json_object_get_num(raw, 0, field).map(|val| match op {
-                                BinOp::Gt => val > *threshold, BinOp::Lt => val < *threshold,
-                                BinOp::Ge => val >= *threshold, BinOp::Le => val <= *threshold,
-                                BinOp::Eq => val == *threshold, BinOp::Ne => val != *threshold,
-                                _ => false,
-                            })
+                    let mut verdict: Option<bool> = None;
+                    let outcome = apply_field_cmp_val_raw(raw, field, *op, cmp_val, |pass| {
+                        verdict = Some(pass);
+                    });
+                    if let RawApplyOutcome::Bail = outcome {
+                        let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                        process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                        if compact_buf.len() >= 1 << 17 {
+                            let _ = out.write_all(&compact_buf);
+                            compact_buf.clear();
                         }
-                        CmpVal::Str(ref s) => {
-                            match json_object_get_field_raw(raw, 0, field) {
-                                Some((vs, ve)) => {
-                                    let vb = &raw[vs..ve];
-                                    if vb.len() >= 2 && vb[0] == b'"' && vb[vb.len()-1] == b'"' && !vb[1..vb.len()-1].contains(&b'\\') {
-                                        let inner = &vb[1..vb.len()-1];
-                                        Some(match op {
-                                            BinOp::Eq => inner == s.as_bytes(),
-                                            BinOp::Ne => inner != s.as_bytes(),
-                                            BinOp::Gt => inner > s.as_bytes(),
-                                            BinOp::Lt => inner < s.as_bytes(),
-                                            BinOp::Ge => inner >= s.as_bytes(),
-                                            BinOp::Le => inner <= s.as_bytes(),
-                                            _ => false,
-                                        })
-                                    } else { None }
-                                }
-                                None => None,
-                            }
-                        }
-                    };
-                    let pass = match pass {
-                        Some(p) => p,
-                        None => {
-                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                            if compact_buf.len() >= 1 << 17 {
-                                let _ = out.write_all(&compact_buf);
-                                compact_buf.clear();
-                            }
-                            return Ok(());
-                        }
-                    };
+                        return Ok(());
+                    }
+                    let pass = verdict.unwrap_or(false);
                     if pass {
                         let save = compact_buf.len();
                         if is_json_compact(raw) {

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -62,7 +62,7 @@
 
 use anyhow::Result;
 
-use crate::interpreter::{ArithExpr, MathUnary};
+use crate::interpreter::{ArithExpr, CmpVal, MathUnary};
 use crate::ir::{BinOp, UnaryOp};
 use crate::runtime::jq_mod_f64;
 use crate::value::{
@@ -1195,6 +1195,89 @@ pub fn apply_is_length_raw(raw: &[u8], buf: &mut Vec<u8>) -> RawApplyOutcome {
         }
         None => RawApplyOutcome::Bail,
     }
+}
+
+/// Apply a `.field <cmp> <val>` predicate (where `<val>` is either
+/// numeric or a quoted string) and report the boolean verdict via
+/// `emit`. Used by branch fast paths whose predicate shape is more
+/// general than `apply_field_const_cmp_raw` (which is numeric-only)
+/// or `apply_select_str_raw` (which is string-only).
+///
+/// Bail discipline:
+/// * Non-object input — Bail (jq's `Cannot index <type>` surfaces
+///   via the generic path).
+/// * Field absent — Bail (so jq's null comparison or cross-type
+///   ordering applies via the generic path).
+/// * For `CmpVal::Num`: field non-numeric — Bail.
+/// * For `CmpVal::Str`: field non-string or escape-bearing — Bail.
+/// * Non-comparison op (`Add`/`And`/etc.) — Bail (defensive).
+///
+/// On a passing type-guard, invokes `emit(verdict)` with the boolean
+/// result. The string comparison uses byte ordering (jq's lexicographic
+/// string comparison agrees with byte ordering for ASCII; non-ASCII
+/// strings without escapes also agree because UTF-8 byte-ordering
+/// preserves Unicode code-point ordering).
+pub fn apply_field_cmp_val_raw<F>(
+    raw: &[u8],
+    field: &str,
+    cmp_op: BinOp,
+    cmp_val: &CmpVal,
+    mut emit: F,
+) -> RawApplyOutcome
+where
+    F: FnMut(bool),
+{
+    if raw.is_empty() || raw[0] != b'{' {
+        return RawApplyOutcome::Bail;
+    }
+    if !matches!(
+        cmp_op,
+        BinOp::Gt | BinOp::Lt | BinOp::Ge | BinOp::Le | BinOp::Eq | BinOp::Ne,
+    ) {
+        return RawApplyOutcome::Bail;
+    }
+    let pass = match cmp_val {
+        CmpVal::Num(threshold) => {
+            let n = match json_object_get_num(raw, 0, field) {
+                Some(v) => v,
+                None => return RawApplyOutcome::Bail,
+            };
+            match cmp_op {
+                BinOp::Gt => n > *threshold,
+                BinOp::Lt => n < *threshold,
+                BinOp::Ge => n >= *threshold,
+                BinOp::Le => n <= *threshold,
+                BinOp::Eq => n == *threshold,
+                BinOp::Ne => n != *threshold,
+                _ => unreachable!(),
+            }
+        }
+        CmpVal::Str(s) => {
+            let (vs, ve) = match json_object_get_field_raw(raw, 0, field) {
+                Some(r) => r,
+                None => return RawApplyOutcome::Bail,
+            };
+            let val = &raw[vs..ve];
+            if val.len() < 2 || val[0] != b'"' || val[val.len() - 1] != b'"'
+                || val[1..val.len() - 1].contains(&b'\\')
+            {
+                return RawApplyOutcome::Bail;
+            }
+            let inner = &val[1..val.len() - 1];
+            let arg = s.as_bytes();
+            match cmp_op {
+                BinOp::Eq => inner == arg,
+                BinOp::Ne => inner != arg,
+                BinOp::Gt => inner > arg,
+                BinOp::Lt => inner < arg,
+                BinOp::Ge => inner >= arg,
+                BinOp::Le => inner <= arg,
+                _ => unreachable!(),
+            }
+        }
+    };
+    emit(pass);
+    RawApplyOutcome::Emit
 }
 
 /// Apply the `if .field == null then T else F end` (or `!= null`)

--- a/tests/fast_path_contract.rs
+++ b/tests/fast_path_contract.rs
@@ -30,14 +30,14 @@ use jq_jit::fast_path::{
     apply_numeric_expr_raw, apply_obj_assign_field_arith_raw,
     apply_collect_each_select_type_raw, apply_each_type_filter_raw,
     apply_first_each_select_type_raw,
-    apply_null_branch_lit_raw,
+    apply_field_cmp_val_raw, apply_null_branch_lit_raw,
     apply_obj_assign_two_fields_arith_raw, apply_obj_merge_computed_raw,
     apply_obj_merge_lit_raw, apply_select_nested_cmp_raw, apply_select_num_str_raw,
     apply_select_arith_cmp_raw, apply_select_cmp_raw,
     apply_select_field_null_raw, apply_select_str_raw, apply_select_str_test_raw,
     apply_two_field_binop_const_raw,
 };
-use jq_jit::interpreter::{ArithExpr, Filter, MathUnary};
+use jq_jit::interpreter::{ArithExpr, CmpVal, Filter, MathUnary};
 use jq_jit::ir::{BinOp, UnaryOp};
 use jq_jit::value::Value;
 
@@ -3014,6 +3014,101 @@ fn raw_first_each_select_type_unknown_type_bails() {
     let mut buf = Vec::new();
     let outcome = apply_first_each_select_type_raw(b"[1,2]", "unknown", &mut buf);
     assert!(matches!(outcome, RawApplyOutcome::Bail));
+}
+
+// ---------------------------------------------------------------------------
+// `apply_field_cmp_val_raw` — generic `.field cmp <num|str>` predicate
+// reporting bool via emit closure. Bails on non-object/missing/wrong-type/
+// escape-bearing-string/non-cmp-op.
+
+#[test]
+fn raw_field_cmp_val_numeric() {
+    let mut emitted: Vec<bool> = Vec::new();
+    let outcome = apply_field_cmp_val_raw(
+        b"{\"x\":5}", "x", BinOp::Gt, &CmpVal::Num(3.0), |b| emitted.push(b),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec![true]);
+}
+
+#[test]
+fn raw_field_cmp_val_string_eq() {
+    let mut emitted: Vec<bool> = Vec::new();
+    let outcome = apply_field_cmp_val_raw(
+        b"{\"x\":\"hi\"}", "x", BinOp::Eq, &CmpVal::Str("hi".to_string()), |b| emitted.push(b),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec![true]);
+}
+
+#[test]
+fn raw_field_cmp_val_string_lt() {
+    let mut emitted: Vec<bool> = Vec::new();
+    let outcome = apply_field_cmp_val_raw(
+        b"{\"x\":\"abc\"}", "x", BinOp::Lt, &CmpVal::Str("abd".to_string()), |b| emitted.push(b),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted, vec![true]);
+}
+
+#[test]
+fn raw_field_cmp_val_field_missing_bails() {
+    let mut emitted: Vec<bool> = Vec::new();
+    let outcome = apply_field_cmp_val_raw(
+        b"{\"y\":1}", "x", BinOp::Gt, &CmpVal::Num(3.0), |b| emitted.push(b),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_field_cmp_val_num_field_non_numeric_bails() {
+    let mut emitted: Vec<bool> = Vec::new();
+    let outcome = apply_field_cmp_val_raw(
+        b"{\"x\":\"hi\"}", "x", BinOp::Gt, &CmpVal::Num(3.0), |b| emitted.push(b),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+}
+
+#[test]
+fn raw_field_cmp_val_str_field_non_string_bails() {
+    let mut emitted: Vec<bool> = Vec::new();
+    let outcome = apply_field_cmp_val_raw(
+        b"{\"x\":42}", "x", BinOp::Eq, &CmpVal::Str("42".to_string()), |b| emitted.push(b),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+}
+
+#[test]
+fn raw_field_cmp_val_str_field_escape_bearing_bails() {
+    let mut emitted: Vec<bool> = Vec::new();
+    let outcome = apply_field_cmp_val_raw(
+        br#"{"x":"a\nb"}"#, "x", BinOp::Eq, &CmpVal::Str("a".to_string()), |b| emitted.push(b),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+}
+
+#[test]
+fn raw_field_cmp_val_non_cmp_op_bails() {
+    let mut emitted: Vec<bool> = Vec::new();
+    let outcome = apply_field_cmp_val_raw(
+        b"{\"x\":5}", "x", BinOp::Add, &CmpVal::Num(3.0), |b| emitted.push(b),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+}
+
+#[test]
+fn raw_field_cmp_val_non_object_input_bails() {
+    for raw in [b"42".as_slice(), b"\"hi\"".as_slice(), b"null".as_slice(), b"[1]".as_slice()] {
+        let mut emitted: Vec<bool> = Vec::new();
+        let outcome = apply_field_cmp_val_raw(
+            raw, "x", BinOp::Gt, &CmpVal::Num(3.0), |b| emitted.push(b),
+        );
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "raw={:?}", std::str::from_utf8(raw).unwrap(),
+        );
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -4882,3 +4882,27 @@ if (.x | startswith("xx")) then "match" else "no" end
 [ (if (.x | startswith("he")) then "match" else "no" end)? ]
 "plain"
 []
+
+# Issue #251: cmp_branch_merge apply-site uses RawApplyOutcome (#83 Phase B,
+# uses new apply_field_cmp_val_raw helper for the predicate). Shape:
+# `if .field op val then {literal}+. else . end` (or `.+{literal}`).
+if .x > 0 then {marked:true} + . else . end
+{"x":5,"y":1}
+{"marked":true,"x":5,"y":1}
+
+if .x > 0 then . + {marked:true} else . end
+{"x":5,"y":1}
+{"x":5,"y":1,"marked":true}
+
+if .x > 0 then {marked:true} + . else . end
+{"x":-1,"y":1}
+{"x":-1,"y":1}
+
+if .name == "alice" then {role:"admin"} + . else . end
+{"name":"alice","age":30}
+{"role":"admin","name":"alice","age":30}
+
+# Non-object input — generic raises indexing error.
+[ (if .x > 0 then {m:true} + . else . end)? ]
+"plain"
+[]


### PR DESCRIPTION
## Summary
- Add `apply_field_cmp_val_raw` to `src/fast_path.rs` for the generic `.field cmp <val>` predicate where `<val>` is numeric (`CmpVal::Num`) or a quoted string (`CmpVal::Str`). Predicate-only complement to the numeric-only `apply_field_const_cmp_raw` (#263) and the string-only `apply_select_str_raw` (#268).
- Migrate the `cmp_branch_merge` apply-sites in `bin/jq-jit.rs` (stdin + file-mode) to the named `RawApplyOutcome::{Emit, Bail}` discipline. The helper reports the boolean verdict; the apply-site keeps its merge logic.
- Bail discipline: non-object, field absent, wrong-type field, escape-bearing string, non-cmp op.

9 new contract cases pin the verdict surface across both `CmpVal` variants. 5 new regression cases cover prepend/append merge shapes, false-branch passthrough, string equality predicate, and `?`-wrapped non-object input.

Closes the `cmp_branch_merge` item. Refs #251.

## Test plan
- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (1002 regression cases pass, +5 over main; 380 contract cases, +9)
- [x] `./bench/comprehensive.sh --quick` (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)