### PR TITLE
refactor: select_compound_computed / select_compound_cremap apply-sites use RawApplyOutcome (#83 Phase B)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -8938,8 +8938,7 @@ fn real_main() {
                     })
                 } else if let Some((ref conj, ref cmps, ref rexpr)) = select_compound_computed {
                     use jq_jit::ir::BinOp;
-                    let is_and = matches!(conj, BinOp::And);
-                    // Collect all needed fields
+                    // Collect all needed fields (predicate + remap-referenced).
                     let mut all_fields: Vec<String> = Vec::new();
                     let mut field_idx = std::collections::HashMap::new();
                     let ensure_field = |f: &str, all: &mut Vec<String>, idx: &mut std::collections::HashMap<String, usize>| {
@@ -8949,32 +8948,41 @@ fn real_main() {
                     for f in remap_expr_fields(rexpr) { ensure_field(f, &mut all_fields, &mut field_idx); }
                     let resolved = resolve_one_remap(rexpr, &field_idx);
                     let field_refs: Vec<&str> = all_fields.iter().map(|s| s.as_str()).collect();
-                    let cmp_indices: Vec<(usize, BinOp, f64)> = cmps.iter().map(|(f, op, thr)| {
-                        (field_idx[f.as_str()], *op, *thr)
-                    }).collect();
                     let mut ranges_buf = vec![(0usize, 0usize); field_refs.len()];
+                    // Predicate side: pre-deduplicate into the helper's expected shape.
+                    let mut cmp_field_names: Vec<String> = Vec::new();
+                    let mut cmp_field_idx: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+                    for (f, _, _) in cmps {
+                        if !cmp_field_idx.contains_key(f) {
+                            cmp_field_idx.insert(f.clone(), cmp_field_names.len());
+                            cmp_field_names.push(f.clone());
+                        }
+                    }
+                    let cmp_field_refs: Vec<&str> = cmp_field_names.iter().map(|s| s.as_str()).collect();
+                    let cmp_spec: Vec<(usize, BinOp, f64)> = cmps.iter().map(|(f, op, n)| (cmp_field_idx[f], *op, *n)).collect();
+                    let mut vals_buf: Vec<f64> = vec![0.0; cmp_field_names.len()];
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        if !json_object_get_fields_raw_buf(raw, 0, &field_refs, &mut ranges_buf) {
+                        let mut verdict: Option<bool> = None;
+                        let outcome = apply_compound_field_cmp_raw(
+                            raw, &cmp_field_refs, &cmp_spec, *conj, &mut vals_buf,
+                            |pass| { verdict = Some(pass); },
+                        );
+                        if let RawApplyOutcome::Bail = outcome {
+                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                            if compact_buf.len() >= 1 << 17 { let _ = out.write_all(&compact_buf); compact_buf.clear(); }
                             return Ok(());
                         }
-                        let check = |idx: usize, op: &BinOp, thr: &f64| -> bool {
-                            let (vs, ve) = ranges_buf[idx];
-                            parse_json_num(&raw[vs..ve]).map_or(false, |val| match op {
-                                BinOp::Gt => val > *thr, BinOp::Lt => val < *thr,
-                                BinOp::Ge => val >= *thr, BinOp::Le => val <= *thr,
-                                BinOp::Eq => val == *thr, BinOp::Ne => val != *thr,
-                                _ => false,
-                            })
-                        };
-                        let pass = if is_and {
-                            cmp_indices.iter().all(|(idx, op, thr)| check(*idx, op, thr))
-                        } else {
-                            cmp_indices.iter().any(|(idx, op, thr)| check(*idx, op, thr))
-                        };
+                        let pass = verdict.unwrap_or(false);
                         if pass {
-                            emit_resolved_value(&mut compact_buf, &resolved, raw, &ranges_buf);
-                            compact_buf.push(b'\n');
+                            if !json_object_get_fields_raw_buf(raw, 0, &field_refs, &mut ranges_buf) {
+                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                            } else {
+                                emit_resolved_value(&mut compact_buf, &resolved, raw, &ranges_buf);
+                                compact_buf.push(b'\n');
+                            }
                         }
                         if compact_buf.len() >= 1 << 17 {
                             let _ = out.write_all(&compact_buf);
@@ -8984,7 +8992,6 @@ fn real_main() {
                     })
                 } else if let Some((ref conj, ref cmps, ref cremap)) = select_compound_cremap {
                     use jq_jit::ir::BinOp;
-                    let is_and = matches!(conj, BinOp::And);
                     let mut all_fields: Vec<String> = Vec::new();
                     let mut field_idx = std::collections::HashMap::new();
                     let ensure_field = |f: &str, all: &mut Vec<String>, idx: &mut std::collections::HashMap<String, usize>| {
@@ -9002,35 +9009,44 @@ fn real_main() {
                     };
                     let obj_close: &[u8] = if use_pretty_buf { b"\n}\n" } else { b"}\n" };
                     let field_refs: Vec<&str> = all_fields.iter().map(|s| s.as_str()).collect();
-                    let cmp_indices: Vec<(usize, BinOp, f64)> = cmps.iter().map(|(f, op, thr)| {
-                        (field_idx[f.as_str()], *op, *thr)
-                    }).collect();
                     let mut ranges_buf = vec![(0usize, 0usize); field_refs.len()];
+                    // Predicate side: pre-deduplicate into the helper's expected shape.
+                    let mut cmp_field_names: Vec<String> = Vec::new();
+                    let mut cmp_field_idx: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+                    for (f, _, _) in cmps {
+                        if !cmp_field_idx.contains_key(f) {
+                            cmp_field_idx.insert(f.clone(), cmp_field_names.len());
+                            cmp_field_names.push(f.clone());
+                        }
+                    }
+                    let cmp_field_refs: Vec<&str> = cmp_field_names.iter().map(|s| s.as_str()).collect();
+                    let cmp_spec: Vec<(usize, BinOp, f64)> = cmps.iter().map(|(f, op, n)| (cmp_field_idx[f], *op, *n)).collect();
+                    let mut vals_buf: Vec<f64> = vec![0.0; cmp_field_names.len()];
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        if !json_object_get_fields_raw_buf(raw, 0, &field_refs, &mut ranges_buf) {
+                        let mut verdict: Option<bool> = None;
+                        let outcome = apply_compound_field_cmp_raw(
+                            raw, &cmp_field_refs, &cmp_spec, *conj, &mut vals_buf,
+                            |pass| { verdict = Some(pass); },
+                        );
+                        if let RawApplyOutcome::Bail = outcome {
+                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                            if compact_buf.len() >= 1 << 17 { let _ = out.write_all(&compact_buf); compact_buf.clear(); }
                             return Ok(());
                         }
-                        let check = |idx: usize, op: &BinOp, thr: &f64| -> bool {
-                            let (vs, ve) = ranges_buf[idx];
-                            parse_json_num(&raw[vs..ve]).map_or(false, |val| match op {
-                                BinOp::Gt => val > *thr, BinOp::Lt => val < *thr,
-                                BinOp::Ge => val >= *thr, BinOp::Le => val <= *thr,
-                                BinOp::Eq => val == *thr, BinOp::Ne => val != *thr,
-                                _ => false,
-                            })
-                        };
-                        let pass = if is_and {
-                            cmp_indices.iter().all(|(idx, op, thr)| check(*idx, op, thr))
-                        } else {
-                            cmp_indices.iter().any(|(idx, op, thr)| check(*idx, op, thr))
-                        };
+                        let pass = verdict.unwrap_or(false);
                         if pass {
-                            for (i, res) in resolved.iter().enumerate() {
-                                compact_buf.extend_from_slice(&key_prefixes[i]);
-                                emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf);
+                            if !json_object_get_fields_raw_buf(raw, 0, &field_refs, &mut ranges_buf) {
+                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                            } else {
+                                for (i, res) in resolved.iter().enumerate() {
+                                    compact_buf.extend_from_slice(&key_prefixes[i]);
+                                    emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf);
+                                }
+                                compact_buf.extend_from_slice(obj_close);
                             }
-                            compact_buf.extend_from_slice(obj_close);
                         }
                         if compact_buf.len() >= 1 << 17 {
                             let _ = out.write_all(&compact_buf);
@@ -16231,7 +16247,6 @@ fn real_main() {
             } else if let Some((ref conj, ref cmps, ref rexpr)) = select_compound_computed {
                 use jq_jit::ir::BinOp;
                 let content_bytes = content.as_bytes();
-                let is_and = matches!(conj, BinOp::And);
                 let mut all_fields: Vec<String> = Vec::new();
                 let mut field_idx = std::collections::HashMap::new();
                 let ensure_field3 = |f: &str, all: &mut Vec<String>, idx: &mut std::collections::HashMap<String, usize>| {
@@ -16241,32 +16256,40 @@ fn real_main() {
                 for f in remap_expr_fields(rexpr) { ensure_field3(f, &mut all_fields, &mut field_idx); }
                 let resolved = resolve_one_remap(rexpr, &field_idx);
                 let field_refs: Vec<&str> = all_fields.iter().map(|s| s.as_str()).collect();
-                let cmp_indices: Vec<(usize, BinOp, f64)> = cmps.iter().map(|(f, op, thr)| {
-                    (field_idx[f.as_str()], *op, *thr)
-                }).collect();
                 let mut ranges_buf = vec![(0usize, 0usize); field_refs.len()];
+                let mut cmp_field_names: Vec<String> = Vec::new();
+                let mut cmp_field_idx: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+                for (f, _, _) in cmps {
+                    if !cmp_field_idx.contains_key(f) {
+                        cmp_field_idx.insert(f.clone(), cmp_field_names.len());
+                        cmp_field_names.push(f.clone());
+                    }
+                }
+                let cmp_field_refs: Vec<&str> = cmp_field_names.iter().map(|s| s.as_str()).collect();
+                let cmp_spec: Vec<(usize, BinOp, f64)> = cmps.iter().map(|(f, op, n)| (cmp_field_idx[f], *op, *n)).collect();
+                let mut vals_buf: Vec<f64> = vec![0.0; cmp_field_names.len()];
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    if !json_object_get_fields_raw_buf(raw, 0, &field_refs, &mut ranges_buf) {
+                    let mut verdict: Option<bool> = None;
+                    let outcome = apply_compound_field_cmp_raw(
+                        raw, &cmp_field_refs, &cmp_spec, *conj, &mut vals_buf,
+                        |pass| { verdict = Some(pass); },
+                    );
+                    if let RawApplyOutcome::Bail = outcome {
+                        let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                        process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                        if compact_buf.len() >= 1 << 17 { let _ = out.write_all(&compact_buf); compact_buf.clear(); }
                         return Ok(());
                     }
-                    let check = |idx: usize, op: &BinOp, thr: &f64| -> bool {
-                        let (vs, ve) = ranges_buf[idx];
-                        parse_json_num(&raw[vs..ve]).map_or(false, |val| match op {
-                            BinOp::Gt => val > *thr, BinOp::Lt => val < *thr,
-                            BinOp::Ge => val >= *thr, BinOp::Le => val <= *thr,
-                            BinOp::Eq => val == *thr, BinOp::Ne => val != *thr,
-                            _ => false,
-                        })
-                    };
-                    let pass = if is_and {
-                        cmp_indices.iter().all(|(idx, op, thr)| check(*idx, op, thr))
-                    } else {
-                        cmp_indices.iter().any(|(idx, op, thr)| check(*idx, op, thr))
-                    };
+                    let pass = verdict.unwrap_or(false);
                     if pass {
-                        emit_resolved_value(&mut compact_buf, &resolved, raw, &ranges_buf);
-                        compact_buf.push(b'\n');
+                        if !json_object_get_fields_raw_buf(raw, 0, &field_refs, &mut ranges_buf) {
+                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                        } else {
+                            emit_resolved_value(&mut compact_buf, &resolved, raw, &ranges_buf);
+                            compact_buf.push(b'\n');
+                        }
                     }
                     if compact_buf.len() >= 1 << 17 {
                         let _ = out.write_all(&compact_buf);
@@ -16277,7 +16300,6 @@ fn real_main() {
             } else if let Some((ref conj, ref cmps, ref cremap)) = select_compound_cremap {
                 use jq_jit::ir::BinOp;
                 let content_bytes = content.as_bytes();
-                let is_and = matches!(conj, BinOp::And);
                 let mut all_fields: Vec<String> = Vec::new();
                 let mut field_idx = std::collections::HashMap::new();
                 let ensure_field5 = |f: &str, all: &mut Vec<String>, idx: &mut std::collections::HashMap<String, usize>| {
@@ -16295,35 +16317,43 @@ fn real_main() {
                 };
                 let obj_close: &[u8] = if use_pretty_buf { b"\n}\n" } else { b"}\n" };
                 let field_refs: Vec<&str> = all_fields.iter().map(|s| s.as_str()).collect();
-                let cmp_indices: Vec<(usize, BinOp, f64)> = cmps.iter().map(|(f, op, thr)| {
-                    (field_idx[f.as_str()], *op, *thr)
-                }).collect();
                 let mut ranges_buf = vec![(0usize, 0usize); field_refs.len()];
+                let mut cmp_field_names: Vec<String> = Vec::new();
+                let mut cmp_field_idx: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+                for (f, _, _) in cmps {
+                    if !cmp_field_idx.contains_key(f) {
+                        cmp_field_idx.insert(f.clone(), cmp_field_names.len());
+                        cmp_field_names.push(f.clone());
+                    }
+                }
+                let cmp_field_refs: Vec<&str> = cmp_field_names.iter().map(|s| s.as_str()).collect();
+                let cmp_spec: Vec<(usize, BinOp, f64)> = cmps.iter().map(|(f, op, n)| (cmp_field_idx[f], *op, *n)).collect();
+                let mut vals_buf: Vec<f64> = vec![0.0; cmp_field_names.len()];
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    if !json_object_get_fields_raw_buf(raw, 0, &field_refs, &mut ranges_buf) {
+                    let mut verdict: Option<bool> = None;
+                    let outcome = apply_compound_field_cmp_raw(
+                        raw, &cmp_field_refs, &cmp_spec, *conj, &mut vals_buf,
+                        |pass| { verdict = Some(pass); },
+                    );
+                    if let RawApplyOutcome::Bail = outcome {
+                        let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                        process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                        if compact_buf.len() >= 1 << 17 { let _ = out.write_all(&compact_buf); compact_buf.clear(); }
                         return Ok(());
                     }
-                    let check = |idx: usize, op: &BinOp, thr: &f64| -> bool {
-                        let (vs, ve) = ranges_buf[idx];
-                        parse_json_num(&raw[vs..ve]).map_or(false, |val| match op {
-                            BinOp::Gt => val > *thr, BinOp::Lt => val < *thr,
-                            BinOp::Ge => val >= *thr, BinOp::Le => val <= *thr,
-                            BinOp::Eq => val == *thr, BinOp::Ne => val != *thr,
-                            _ => false,
-                        })
-                    };
-                    let pass = if is_and {
-                        cmp_indices.iter().all(|(idx, op, thr)| check(*idx, op, thr))
-                    } else {
-                        cmp_indices.iter().any(|(idx, op, thr)| check(*idx, op, thr))
-                    };
+                    let pass = verdict.unwrap_or(false);
                     if pass {
-                        for (i, res) in resolved.iter().enumerate() {
-                            compact_buf.extend_from_slice(&key_prefixes[i]);
-                            emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf);
+                        if !json_object_get_fields_raw_buf(raw, 0, &field_refs, &mut ranges_buf) {
+                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                        } else {
+                            for (i, res) in resolved.iter().enumerate() {
+                                compact_buf.extend_from_slice(&key_prefixes[i]);
+                                emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf);
+                            }
+                            compact_buf.extend_from_slice(obj_close);
                         }
-                        compact_buf.extend_from_slice(obj_close);
                     }
                     if compact_buf.len() >= 1 << 17 {
                         let _ = out.write_all(&compact_buf);

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -4988,3 +4988,25 @@ select((.x > 0) and (.y > 0)) | .z
 [ (select((.x > 0) and (.y > 0)) | .z)? ]
 "plain"
 []
+
+# Issue #251: select_compound_computed / select_compound_cremap apply-sites use
+# RawApplyOutcome (#83 Phase B, reuse apply_compound_field_cmp_raw from #283).
+select((.x > 0) and (.y > 0)) | (.x + .y)
+{"x":3,"y":4}
+7
+
+select((.x > 0) and (.y > 0)) | {sum: (.x + .y), prod: (.x * .y)}
+{"x":3,"y":4}
+{"sum":7,"prod":12}
+
+select((.x > 0) and (.y > 0)) | (.x + .y)
+{"x":-1,"y":4}
+
+# Non-object input — generic raises indexing error.
+[ (select((.x > 0) and (.y > 0)) | (.x + .y))? ]
+"plain"
+[]
+
+[ (select((.x > 0) and (.y > 0)) | {sum: (.x + .y)})? ]
+"plain"
+[]


### PR DESCRIPTION
## Summary
Two final `select_compound_*` fast paths migrated:

- `select_compound_computed` — `select((cmps...)) | <single ArithExpr>` (one computed value as output).
- `select_compound_cremap` — `select((cmps...)) | {k1: <expr>, k2: <expr>}` (multi-key remap object).

Both reuse `apply_compound_field_cmp_raw` (#283) for the predicate. Apply-sites keep inline body emission. Same pattern as #292 / #299 / #300.

**Bug fix:** Prior apply-sites silently dropped the input on a non-numeric field, masking jq's cross-type ordering.

5 new regression cases.

Closes the final two `select_compound_*` items, completing the entire family. Refs #251.

## Test plan
- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (1023 regression cases pass, +5 over main)
- [x] `./bench/comprehensive.sh --quick` (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)