### PR TITLE
refactor: remap_to_entries apply-site uses RawApplyOutcome (#83 Phase B)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -153,8 +153,8 @@ use jq_jit::fast_path::{
     apply_first_each_select_type_raw,
     apply_field_cmp_val_raw, apply_null_branch_lit_raw,
     apply_obj_assign_two_fields_arith_raw, apply_obj_merge_computed_raw,
-    apply_obj_merge_lit_raw, apply_select_nested_cmp_raw, apply_select_num_str_raw,
-    apply_two_field_binop_const_raw, apply_with_entries_del_raw,
+    apply_obj_merge_lit_raw, apply_remap_to_entries_raw, apply_select_nested_cmp_raw,
+    apply_select_num_str_raw, apply_two_field_binop_const_raw, apply_with_entries_del_raw,
     apply_with_entries_key_str_raw, apply_with_entries_select_raw,
     apply_with_entries_tostring_raw, apply_with_entries_type_raw,
     apply_has_field_raw, apply_has_multi_field_raw, apply_multi_field_access_raw,
@@ -11827,39 +11827,13 @@ fn real_main() {
                         Ok(())
                     })
                 } else if let Some(ref rte_pairs) = remap_to_entries {
-                    // {k1:.f1, k2:.f2} | to_entries → emit entries array from raw fields
-                    let rte_src: Vec<&str> = rte_pairs.iter().map(|(_, src)| src.as_str()).collect();
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        // Extract all source field values
-                        let mut vals: Vec<Option<(usize, usize)>> = Vec::with_capacity(rte_src.len());
-                        for src in &rte_src {
-                            vals.push(json_object_get_field_raw(raw, 0, src));
+                        let outcome = apply_remap_to_entries_raw(raw, rte_pairs, &mut compact_buf);
+                        if let RawApplyOutcome::Bail = outcome {
+                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }
-                        compact_buf.push(b'[');
-                        let mut first = true;
-                        for (i, (out_key, _)) in rte_pairs.iter().enumerate() {
-                            if !first { compact_buf.push(b','); }
-                            first = false;
-                            compact_buf.extend_from_slice(b"{\"key\":");
-                            // Write key as JSON string
-                            compact_buf.push(b'"');
-                            for &b in out_key.as_bytes() {
-                                match b {
-                                    b'"' => compact_buf.extend_from_slice(b"\\\""),
-                                    b'\\' => compact_buf.extend_from_slice(b"\\\\"),
-                                    _ => compact_buf.push(b),
-                                }
-                            }
-                            compact_buf.extend_from_slice(b"\",\"value\":");
-                            if let Some((vs, ve)) = vals[i] {
-                                compact_buf.extend_from_slice(&raw[vs..ve]);
-                            } else {
-                                compact_buf.extend_from_slice(b"null");
-                            }
-                            compact_buf.push(b'}');
-                        }
-                        compact_buf.extend_from_slice(b"]\n");
                         if compact_buf.len() >= 1 << 17 {
                             let _ = out.write_all(&compact_buf);
                             compact_buf.clear();
@@ -20493,36 +20467,13 @@ fn real_main() {
                 })
             } else if let Some(ref rte_pairs) = remap_to_entries {
                 let content_bytes = content.as_bytes();
-                let rte_src: Vec<&str> = rte_pairs.iter().map(|(_, src)| src.as_str()).collect();
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    let mut vals: Vec<Option<(usize, usize)>> = Vec::with_capacity(rte_src.len());
-                    for src in &rte_src {
-                        vals.push(json_object_get_field_raw(raw, 0, src));
+                    let outcome = apply_remap_to_entries_raw(raw, rte_pairs, &mut compact_buf);
+                    if let RawApplyOutcome::Bail = outcome {
+                        let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                        process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                     }
-                    compact_buf.push(b'[');
-                    let mut first = true;
-                    for (i, (out_key, _)) in rte_pairs.iter().enumerate() {
-                        if !first { compact_buf.push(b','); }
-                        first = false;
-                        compact_buf.extend_from_slice(b"{\"key\":");
-                        compact_buf.push(b'"');
-                        for &b in out_key.as_bytes() {
-                            match b {
-                                b'"' => compact_buf.extend_from_slice(b"\\\""),
-                                b'\\' => compact_buf.extend_from_slice(b"\\\\"),
-                                _ => compact_buf.push(b),
-                            }
-                        }
-                        compact_buf.extend_from_slice(b"\",\"value\":");
-                        if let Some((vs, ve)) = vals[i] {
-                            compact_buf.extend_from_slice(&raw[vs..ve]);
-                        } else {
-                            compact_buf.extend_from_slice(b"null");
-                        }
-                        compact_buf.push(b'}');
-                    }
-                    compact_buf.extend_from_slice(b"]\n");
                     if compact_buf.len() >= 1 << 17 {
                         let _ = out.write_all(&compact_buf);
                         compact_buf.clear();

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -1282,6 +1282,50 @@ where
     RawApplyOutcome::Emit
 }
 
+/// Apply the `{k1: .f1, k2: .f2, ...} | to_entries` raw-byte fast
+/// path on a single JSON record. Builds a JSON array of `{"key":
+/// k, "value": v}` entries from the named source fields. Missing
+/// source fields emit `"value": null` (matching jq's `to_entries`
+/// for `null` values).
+///
+/// Bail discipline:
+/// * Non-object input — Bail (jq raises `Cannot index <type> with
+///   "<field>"` for the underlying `.f1` access).
+///
+/// Writes the resulting JSON array bytes plus a trailing `\n` to
+/// `buf` on Emit.
+pub fn apply_remap_to_entries_raw(
+    raw: &[u8],
+    pairs: &[(String, String)],
+    buf: &mut Vec<u8>,
+) -> RawApplyOutcome {
+    if raw.is_empty() || raw[0] != b'{' {
+        return RawApplyOutcome::Bail;
+    }
+    buf.push(b'[');
+    let mut first = true;
+    for (out_key, src) in pairs {
+        if !first { buf.push(b','); }
+        first = false;
+        buf.extend_from_slice(b"{\"key\":\"");
+        for &b in out_key.as_bytes() {
+            match b {
+                b'"' => buf.extend_from_slice(b"\\\""),
+                b'\\' => buf.extend_from_slice(b"\\\\"),
+                _ => buf.push(b),
+            }
+        }
+        buf.extend_from_slice(b"\",\"value\":");
+        match json_object_get_field_raw(raw, 0, src) {
+            Some((vs, ve)) => buf.extend_from_slice(&raw[vs..ve]),
+            None => buf.extend_from_slice(b"null"),
+        }
+        buf.push(b'}');
+    }
+    buf.extend_from_slice(b"]\n");
+    RawApplyOutcome::Emit
+}
+
 /// Apply the `with_entries(select(.value cmp N))` raw-byte fast
 /// path on a single JSON record. Filters object entries by value
 /// against a numeric threshold.

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -5073,3 +5073,20 @@ with_entries(.value |= tostring)
 [ (with_entries(.value |= tostring))? ]
 42
 []
+
+# Issue #251: remap_to_entries apply-site uses RawApplyOutcome (#83 Phase B).
+# Helper Bails on non-object input. Fixes pre-existing bug where non-object
+# silently emitted entries with `null` values instead of jq's indexing error.
+{a:.x, b:.y} | to_entries
+{"x":1,"y":2}
+[{"key":"a","value":1},{"key":"b","value":2}]
+
+# Missing field — null value (matching jq behavior).
+{a:.x, b:.y} | to_entries
+{"x":1}
+[{"key":"a","value":1},{"key":"b","value":null}]
+
+# Non-object input — generic raises indexing error, ? swallows.
+[ ({a:.x, b:.y} | to_entries)? ]
+"plain"
+[]


### PR DESCRIPTION
## Summary
- Add `apply_remap_to_entries_raw` to `src/fast_path.rs` for `{k1: .f1, k2: .f2, ...} | to_entries`. Builds an array of `{"key": k, "value": v}` entries from named source fields.
- Migrate stdin + file-mode apply-sites to the named `RawApplyOutcome::{Emit, Bail}` discipline.

**Bug fix:** Prior apply-site silently emitted entries with `null` values for non-object input. New helper Bails on non-object input.

3 new regression cases.

Closes the `remap_to_entries` item. Refs #251.

## Test plan
- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (1038 regression cases pass, +3 over main)
- [x] `./bench/comprehensive.sh --quick` (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)