### PR TITLE
refactor: remap_tojson apply-site uses RawApplyOutcome (#83 Phase B)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -153,8 +153,9 @@ use jq_jit::fast_path::{
     apply_first_each_select_type_raw,
     apply_field_cmp_val_raw, apply_null_branch_lit_raw,
     apply_obj_assign_two_fields_arith_raw, apply_obj_merge_computed_raw,
-    apply_obj_merge_lit_raw, apply_remap_to_entries_raw, apply_select_nested_cmp_raw,
-    apply_select_num_str_raw, apply_two_field_binop_const_raw, apply_with_entries_del_raw,
+    apply_obj_merge_lit_raw, apply_remap_to_entries_raw, apply_remap_tojson_raw,
+    apply_select_nested_cmp_raw, apply_select_num_str_raw, apply_two_field_binop_const_raw,
+    apply_with_entries_del_raw,
     apply_with_entries_key_str_raw, apply_with_entries_select_raw,
     apply_with_entries_tostring_raw, apply_with_entries_type_raw,
     apply_has_field_raw, apply_has_multi_field_raw, apply_multi_field_access_raw,
@@ -12002,10 +12003,7 @@ fn real_main() {
                         Ok(())
                     })
                 } else if let Some(ref rt_pairs) = remap_tojson {
-                    // {a:.x,b:.y} | tojson — build inner object then tojson-escape
-                    let input_fields: Vec<&str> = rt_pairs.iter().map(|(_, f)| f.as_str()).collect();
-                    let mut ranges_buf = vec![(0usize, 0usize); input_fields.len()];
-                    // Pre-compute key prefixes for inner object: {"key1":val,"key2":val}
+                    let mut ranges_buf = vec![(0usize, 0usize); rt_pairs.len()];
                     let mut inner_key_prefixes: Vec<Vec<u8>> = Vec::with_capacity(rt_pairs.len());
                     for (i, (out_key, _)) in rt_pairs.iter().enumerate() {
                         let mut prefix = Vec::new();
@@ -12018,15 +12016,11 @@ fn real_main() {
                     let mut inner_buf: Vec<u8> = Vec::with_capacity(256);
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        if json_object_get_fields_raw_buf(raw, 0, &input_fields, &mut ranges_buf) {
-                            inner_buf.clear();
-                            for (i, (vs, ve)) in ranges_buf.iter().enumerate() {
-                                inner_buf.extend_from_slice(&inner_key_prefixes[i]);
-                                inner_buf.extend_from_slice(&raw[*vs..*ve]);
-                            }
-                            inner_buf.push(b'}');
-                            push_tojson_raw(&mut compact_buf, &inner_buf);
-                        } else {
+                        let outcome = apply_remap_tojson_raw(
+                            raw, rt_pairs, &inner_key_prefixes, &mut inner_buf,
+                            &mut ranges_buf, &mut compact_buf,
+                        );
+                        if let RawApplyOutcome::Bail = outcome {
                             let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                             process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }
@@ -20663,8 +20657,7 @@ fn real_main() {
                 })
             } else if let Some(ref rt_pairs) = remap_tojson {
                 let content_bytes = content.as_bytes();
-                let input_fields: Vec<&str> = rt_pairs.iter().map(|(_, f)| f.as_str()).collect();
-                let mut ranges_buf = vec![(0usize, 0usize); input_fields.len()];
+                let mut ranges_buf = vec![(0usize, 0usize); rt_pairs.len()];
                 let mut inner_key_prefixes: Vec<Vec<u8>> = Vec::with_capacity(rt_pairs.len());
                 for (i, (out_key, _)) in rt_pairs.iter().enumerate() {
                     let mut prefix = Vec::new();
@@ -20677,15 +20670,11 @@ fn real_main() {
                 let mut inner_buf: Vec<u8> = Vec::with_capacity(256);
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    if json_object_get_fields_raw_buf(raw, 0, &input_fields, &mut ranges_buf) {
-                        inner_buf.clear();
-                        for (i, (vs, ve)) in ranges_buf.iter().enumerate() {
-                            inner_buf.extend_from_slice(&inner_key_prefixes[i]);
-                            inner_buf.extend_from_slice(&raw[*vs..*ve]);
-                        }
-                        inner_buf.push(b'}');
-                        push_tojson_raw(&mut compact_buf, &inner_buf);
-                    } else {
+                    let outcome = apply_remap_tojson_raw(
+                        raw, rt_pairs, &inner_key_prefixes, &mut inner_buf,
+                        &mut ranges_buf, &mut compact_buf,
+                    );
+                    if let RawApplyOutcome::Bail = outcome {
                         let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                         process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                     }

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -70,7 +70,7 @@ use crate::value::{
     json_object_assign_two_fields_arith, json_object_del_field, json_object_del_fields,
     json_object_filter_by_key_str, json_object_filter_by_value_type,
     json_object_get_field_raw, json_object_get_fields_raw_buf, json_object_merge_literal,
-    json_object_values_tostring, json_with_entries_select_value_cmp,
+    json_object_values_tostring, json_with_entries_select_value_cmp, push_tojson_raw,
     json_object_get_nested_field_raw, json_object_get_num, json_object_get_two_nums,
     json_object_has_all_keys, json_object_has_any_key, json_object_has_key,
     json_object_update_field_case, json_object_update_field_gsub,
@@ -1279,6 +1279,52 @@ where
         }
     };
     emit(pass);
+    RawApplyOutcome::Emit
+}
+
+/// Apply the `{k1: .f1, k2: .f2, ...} | tojson` raw-byte fast path
+/// on a single JSON record. Builds the inner object from the named
+/// source fields, then emits the JSON-string-escaped representation.
+///
+/// Caller provides:
+/// * `pairs` — `(out_key, src_field)` mapping.
+/// * `inner_key_prefixes` — pre-encoded key prefixes for the inner
+///   object (e.g. `[b"{\"a\":", b",\"b\":"]`); passed in to avoid
+///   re-allocating per record.
+/// * `inner_buf` — scratch buffer for the inner object (cleared
+///   inside the helper).
+/// * `ranges_buf` — scratch sized to `pairs.len()` for the field
+///   range fetch.
+/// * `out_buf` — output buffer for the tojson result (no trailing
+///   `\n`; caller appends).
+///
+/// Bail discipline:
+/// * Non-object input — Bail (jq's `Cannot index <type>` for the
+///   underlying `.f1` access surfaces via the generic path).
+/// * Buffer length mismatch (defensive) — Bail.
+pub fn apply_remap_tojson_raw(
+    raw: &[u8],
+    pairs: &[(String, String)],
+    inner_key_prefixes: &[Vec<u8>],
+    inner_buf: &mut Vec<u8>,
+    ranges_buf: &mut [(usize, usize)],
+    out_buf: &mut Vec<u8>,
+) -> RawApplyOutcome {
+    let n = pairs.len();
+    if ranges_buf.len() < n || inner_key_prefixes.len() < n {
+        return RawApplyOutcome::Bail;
+    }
+    let input_fields: Vec<&str> = pairs.iter().map(|(_, f)| f.as_str()).collect();
+    if !json_object_get_fields_raw_buf(raw, 0, &input_fields, ranges_buf) {
+        return RawApplyOutcome::Bail;
+    }
+    inner_buf.clear();
+    for (i, (vs, ve)) in ranges_buf[..n].iter().enumerate() {
+        inner_buf.extend_from_slice(&inner_key_prefixes[i]);
+        inner_buf.extend_from_slice(&raw[*vs..*ve]);
+    }
+    inner_buf.push(b'}');
+    push_tojson_raw(out_buf, inner_buf);
     RawApplyOutcome::Emit
 }
 

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -5090,3 +5090,14 @@ with_entries(.value |= tostring)
 [ ({a:.x, b:.y} | to_entries)? ]
 "plain"
 []
+
+# Issue #251: remap_tojson apply-site uses RawApplyOutcome (#83 Phase B).
+# Helper Bails on non-object input.
+{a:.x, b:.y} | tojson
+{"x":1,"y":"hi"}
+"{\"a\":1,\"b\":\"hi\"}"
+
+# Non-object input — generic raises indexing error.
+[ ({a:.x, b:.y} | tojson)? ]
+"plain"
+[]


### PR DESCRIPTION
## Summary
- Add `apply_remap_tojson_raw` to `src/fast_path.rs` for `{a:.x, b:.y, ...} | tojson`.
- Migrate stdin + file-mode apply-sites to the named `RawApplyOutcome::{Emit, Bail}` discipline.
- Bail discipline: non-object input.

2 new regression cases.

Closes the `remap_tojson` item. Refs #251.

## Test plan
- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (1040 regression cases pass, +2 over main)
- [x] `./bench/comprehensive.sh --quick` (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)