### PR TITLE
refactor(fast_path): migrate to_entries_each_interp to RawApplyOutcome

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -154,6 +154,7 @@ use jq_jit::fast_path::{
     apply_field_cmp_val_raw, apply_null_branch_lit_raw,
     apply_obj_assign_two_fields_arith_raw, apply_obj_merge_computed_raw,
     apply_obj_merge_lit_raw, apply_remap_to_entries_raw, apply_remap_tojson_raw,
+    apply_to_entries_each_interp_raw,
     apply_select_nested_cmp_raw, apply_select_num_str_raw, apply_two_field_binop_const_raw,
     apply_with_entries_del_raw,
     apply_with_entries_key_str_raw, apply_with_entries_select_raw,
@@ -11733,93 +11734,12 @@ fn real_main() {
                         Ok(())
                     })
                 } else if let Some(ref te_interp_parts) = to_entries_each_interp {
-                    // to_entries[] | "\(.key)=\(.value)" — iterate kv pairs with string interpolation
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        if raw.is_empty() || raw[0] != b'{' {
+                        let outcome = apply_to_entries_each_interp_raw(raw, te_interp_parts, &mut compact_buf);
+                        if let RawApplyOutcome::Bail = outcome {
                             let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                             process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                            return Ok(());
-                        }
-                        let mut i = 1usize;
-                        while i < raw.len() && matches!(raw[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
-                        if i < raw.len() && raw[i] == b'}' {
-                            // Empty object — no entries to emit
-                            if compact_buf.len() >= 1 << 17 {
-                                let _ = out.write_all(&compact_buf);
-                                compact_buf.clear();
-                            }
-                            return Ok(());
-                        }
-                        loop {
-                            if i >= raw.len() || raw[i] != b'"' { break; }
-                            // Read key
-                            let ks = i + 1;
-                            i += 1;
-                            while i < raw.len() { match raw[i] { b'"' => break, b'\\' => { i += 2; continue }, _ => i += 1 } }
-                            if i >= raw.len() { break; }
-                            let ke = i;
-                            i += 1;
-                            while i < raw.len() && matches!(raw[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
-                            if i >= raw.len() || raw[i] != b':' { break; }
-                            i += 1;
-                            while i < raw.len() && matches!(raw[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
-                            let vs = i;
-                            i = match skip_json_value(raw, i) { Ok(e) => e, Err(_) => break };
-                            let ve = i;
-                            // Emit interpolated string for this entry
-                            compact_buf.push(b'"');
-                            for (is_lit, content) in te_interp_parts {
-                                if *is_lit {
-                                    for &b in content.as_bytes() {
-                                        match b {
-                                            b'"' => compact_buf.extend_from_slice(b"\\\""),
-                                            b'\\' => compact_buf.extend_from_slice(b"\\\\"),
-                                            _ => compact_buf.push(b),
-                                        }
-                                    }
-                                } else if content == "key" {
-                                    // Key: unescaped string content from JSON key
-                                    let key_bytes = &raw[ks..ke];
-                                    if !key_bytes.contains(&b'\\') {
-                                        // Simple key — re-escape for output string
-                                        for &b in key_bytes {
-                                            match b {
-                                                b'"' => compact_buf.extend_from_slice(b"\\\""),
-                                                b'\\' => compact_buf.extend_from_slice(b"\\\\"),
-                                                _ => compact_buf.push(b),
-                                            }
-                                        }
-                                    } else {
-                                        // Key has escapes — copy as-is (already JSON-escaped)
-                                        compact_buf.extend_from_slice(key_bytes);
-                                    }
-                                } else {
-                                    // "value": string repr of value
-                                    let val_bytes = &raw[vs..ve];
-                                    if val_bytes.len() >= 2 && val_bytes[0] == b'"' && val_bytes[val_bytes.len()-1] == b'"' {
-                                        // String value — output inner content (may have JSON escapes)
-                                        compact_buf.extend_from_slice(&val_bytes[1..val_bytes.len()-1]);
-                                    } else {
-                                        // Number/bool/null/array/object — output as JSON text
-                                        for &b in val_bytes {
-                                            match b {
-                                                b'"' => compact_buf.extend_from_slice(b"\\\""),
-                                                b'\\' => compact_buf.extend_from_slice(b"\\\\"),
-                                                _ => compact_buf.push(b),
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                            compact_buf.extend_from_slice(b"\"\n");
-                            // Skip to next entry
-                            while i < raw.len() && matches!(raw[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
-                            if i >= raw.len() { break; }
-                            if raw[i] == b'}' { break; }
-                            if raw[i] != b',' { break; }
-                            i += 1;
-                            while i < raw.len() && matches!(raw[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
                         }
                         if compact_buf.len() >= 1 << 17 {
                             let _ = out.write_all(&compact_buf);
@@ -20374,84 +20294,13 @@ fn real_main() {
                     Ok(())
                 })
             } else if let Some(ref te_interp_parts) = to_entries_each_interp {
-                // to_entries[] | "\(.key)=\(.value)" — iterate kv pairs (stdin)
                 let content_bytes = content.as_bytes();
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    if raw.is_empty() || raw[0] != b'{' {
+                    let outcome = apply_to_entries_each_interp_raw(raw, te_interp_parts, &mut compact_buf);
+                    if let RawApplyOutcome::Bail = outcome {
                         let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                         process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                        return Ok(());
-                    }
-                    let mut i = 1usize;
-                    while i < raw.len() && matches!(raw[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
-                    if i < raw.len() && raw[i] == b'}' {
-                        if compact_buf.len() >= 1 << 17 {
-                            let _ = out.write_all(&compact_buf);
-                            compact_buf.clear();
-                        }
-                        return Ok(());
-                    }
-                    loop {
-                        if i >= raw.len() || raw[i] != b'"' { break; }
-                        let ks = i + 1;
-                        i += 1;
-                        while i < raw.len() { match raw[i] { b'"' => break, b'\\' => { i += 2; continue }, _ => i += 1 } }
-                        if i >= raw.len() { break; }
-                        let ke = i;
-                        i += 1;
-                        while i < raw.len() && matches!(raw[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
-                        if i >= raw.len() || raw[i] != b':' { break; }
-                        i += 1;
-                        while i < raw.len() && matches!(raw[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
-                        let vs = i;
-                        i = match skip_json_value(raw, i) { Ok(e) => e, Err(_) => break };
-                        let ve = i;
-                        compact_buf.push(b'"');
-                        for (is_lit, ref_content) in te_interp_parts {
-                            if *is_lit {
-                                for &b in ref_content.as_bytes() {
-                                    match b {
-                                        b'"' => compact_buf.extend_from_slice(b"\\\""),
-                                        b'\\' => compact_buf.extend_from_slice(b"\\\\"),
-                                        _ => compact_buf.push(b),
-                                    }
-                                }
-                            } else if ref_content == "key" {
-                                let key_bytes = &raw[ks..ke];
-                                if !key_bytes.contains(&b'\\') {
-                                    for &b in key_bytes {
-                                        match b {
-                                            b'"' => compact_buf.extend_from_slice(b"\\\""),
-                                            b'\\' => compact_buf.extend_from_slice(b"\\\\"),
-                                            _ => compact_buf.push(b),
-                                        }
-                                    }
-                                } else {
-                                    compact_buf.extend_from_slice(key_bytes);
-                                }
-                            } else {
-                                let val_bytes = &raw[vs..ve];
-                                if val_bytes.len() >= 2 && val_bytes[0] == b'"' && val_bytes[val_bytes.len()-1] == b'"' {
-                                    compact_buf.extend_from_slice(&val_bytes[1..val_bytes.len()-1]);
-                                } else {
-                                    for &b in val_bytes {
-                                        match b {
-                                            b'"' => compact_buf.extend_from_slice(b"\\\""),
-                                            b'\\' => compact_buf.extend_from_slice(b"\\\\"),
-                                            _ => compact_buf.push(b),
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                        compact_buf.extend_from_slice(b"\"\n");
-                        while i < raw.len() && matches!(raw[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
-                        if i >= raw.len() { break; }
-                        if raw[i] == b'}' { break; }
-                        if raw[i] != b',' { break; }
-                        i += 1;
-                        while i < raw.len() && matches!(raw[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
                     }
                     if compact_buf.len() >= 1 << 17 {
                         let _ = out.write_all(&compact_buf);

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -79,7 +79,7 @@ use crate::value::{
     json_object_update_field_str_concat, json_object_update_field_str_map,
     json_object_update_field_test, json_object_update_field_tostring,
     json_object_update_field_trim, json_type_byte, json_value_length, parse_json_num,
-    push_jq_number_bytes,
+    push_jq_number_bytes, skip_json_value,
 };
 
 /// A fast path whose type-dispatch obligations are encoded in its
@@ -1369,6 +1369,178 @@ pub fn apply_remap_to_entries_raw(
         buf.push(b'}');
     }
     buf.extend_from_slice(b"]\n");
+    RawApplyOutcome::Emit
+}
+
+/// Apply the `to_entries[] | "\(.key)SEP\(.value)..."` raw-byte fast
+/// path. Iterates kv pairs of the input object and emits one
+/// interpolated string (with surrounding quotes and trailing `\n`)
+/// per entry.
+///
+/// `interp_parts` is the parsed interpolation: `(is_lit, content)`
+/// pairs where `is_lit=true` means literal text and `is_lit=false`
+/// means a reference to either `"key"` or `"value"`.
+///
+/// Bail discipline (truncates `buf` back to its entry-checkpoint on
+/// any per-entry violation, leaving caller state untouched):
+/// - Non-object input → Bail. jq accepts `to_entries` on arrays, so
+///   the slow path handles that.
+/// - Empty object → Emit (no output, matches jq).
+/// - Per entry, key bytes containing `\` → Bail. jq normalizes
+///   `\u00XX` etc. to the actual character; copying the JSON-quoted
+///   form would diverge.
+/// - Per entry, value (computed via `skip_json_value`):
+///   * Quoted string containing `\` → Bail (same escape-norm reason).
+///   * Number containing non-canonical bytes (`+`, `e`/`E` after
+///     digit/`.`) → Bail. jq normalizes `1e10`→`1E+10` and `+5`→`5`.
+///   * Array/object → Bail. jq compacts whitespace inside; raw bytes
+///     can preserve internal whitespace.
+///   * Bool/null/canonical-number/escape-free string → Emit.
+pub fn apply_to_entries_each_interp_raw(
+    raw: &[u8],
+    interp_parts: &[(bool, String)],
+    buf: &mut Vec<u8>,
+) -> RawApplyOutcome {
+    if raw.is_empty() || raw[0] != b'{' {
+        return RawApplyOutcome::Bail;
+    }
+    let entries_checkpoint = buf.len();
+    let mut i = 1usize;
+    while i < raw.len() && matches!(raw[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
+    if i < raw.len() && raw[i] == b'}' {
+        return RawApplyOutcome::Emit;
+    }
+    loop {
+        if i >= raw.len() || raw[i] != b'"' {
+            buf.truncate(entries_checkpoint);
+            return RawApplyOutcome::Bail;
+        }
+        let ks = i + 1;
+        i += 1;
+        while i < raw.len() {
+            match raw[i] {
+                b'"' => break,
+                b'\\' => { i = i.saturating_add(2); continue; }
+                _ => i += 1,
+            }
+        }
+        if i >= raw.len() {
+            buf.truncate(entries_checkpoint);
+            return RawApplyOutcome::Bail;
+        }
+        let ke = i;
+        i += 1;
+        while i < raw.len() && matches!(raw[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
+        if i >= raw.len() || raw[i] != b':' {
+            buf.truncate(entries_checkpoint);
+            return RawApplyOutcome::Bail;
+        }
+        i += 1;
+        while i < raw.len() && matches!(raw[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
+        let vs = i;
+        i = match skip_json_value(raw, i) {
+            Ok(e) => e,
+            Err(_) => {
+                buf.truncate(entries_checkpoint);
+                return RawApplyOutcome::Bail;
+            }
+        };
+        let ve = i;
+        let key_bytes = &raw[ks..ke];
+        let val_bytes = &raw[vs..ve];
+        if key_bytes.contains(&b'\\') {
+            buf.truncate(entries_checkpoint);
+            return RawApplyOutcome::Bail;
+        }
+        if val_bytes.is_empty() {
+            buf.truncate(entries_checkpoint);
+            return RawApplyOutcome::Bail;
+        }
+        let v0 = val_bytes[0];
+        match v0 {
+            b'"' => {
+                let inner_end = val_bytes.len().saturating_sub(1);
+                if val_bytes[1..inner_end].contains(&b'\\') {
+                    buf.truncate(entries_checkpoint);
+                    return RawApplyOutcome::Bail;
+                }
+            }
+            b'[' | b'{' => {
+                buf.truncate(entries_checkpoint);
+                return RawApplyOutcome::Bail;
+            }
+            b't' | b'f' | b'n' => {}
+            b'+' => {
+                buf.truncate(entries_checkpoint);
+                return RawApplyOutcome::Bail;
+            }
+            b'-' | b'0'..=b'9' => {
+                let mut idx = 0;
+                while idx < val_bytes.len() {
+                    let b = val_bytes[idx];
+                    if b == b'+' {
+                        buf.truncate(entries_checkpoint);
+                        return RawApplyOutcome::Bail;
+                    }
+                    if (b == b'e' || b == b'E') && idx > 0 {
+                        let prev = val_bytes[idx - 1];
+                        if prev.is_ascii_digit() || prev == b'.' {
+                            buf.truncate(entries_checkpoint);
+                            return RawApplyOutcome::Bail;
+                        }
+                    }
+                    idx += 1;
+                }
+            }
+            _ => {
+                buf.truncate(entries_checkpoint);
+                return RawApplyOutcome::Bail;
+            }
+        }
+        buf.push(b'"');
+        for (is_lit, content) in interp_parts {
+            if *is_lit {
+                for &b in content.as_bytes() {
+                    match b {
+                        b'"' => buf.extend_from_slice(b"\\\""),
+                        b'\\' => buf.extend_from_slice(b"\\\\"),
+                        _ => buf.push(b),
+                    }
+                }
+            } else if content == "key" {
+                for &b in key_bytes {
+                    match b {
+                        b'"' => buf.extend_from_slice(b"\\\""),
+                        b'\\' => buf.extend_from_slice(b"\\\\"),
+                        _ => buf.push(b),
+                    }
+                }
+            } else if v0 == b'"' {
+                buf.extend_from_slice(&val_bytes[1..val_bytes.len() - 1]);
+            } else {
+                for &b in val_bytes {
+                    match b {
+                        b'"' => buf.extend_from_slice(b"\\\""),
+                        b'\\' => buf.extend_from_slice(b"\\\\"),
+                        _ => buf.push(b),
+                    }
+                }
+            }
+        }
+        buf.extend_from_slice(b"\"\n");
+        while i < raw.len() && matches!(raw[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
+        if i >= raw.len() {
+            buf.truncate(entries_checkpoint);
+            return RawApplyOutcome::Bail;
+        }
+        if raw[i] == b'}' { break; }
+        if raw[i] != b',' {
+            buf.truncate(entries_checkpoint);
+            return RawApplyOutcome::Bail;
+        }
+        i += 1;
+        while i < raw.len() && matches!(raw[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
+    }
     RawApplyOutcome::Emit
 }
 

--- a/tests/fast_path_contract.rs
+++ b/tests/fast_path_contract.rs
@@ -35,7 +35,7 @@ use jq_jit::fast_path::{
     apply_obj_merge_lit_raw, apply_select_nested_cmp_raw, apply_select_num_str_raw,
     apply_select_arith_cmp_raw, apply_select_cmp_raw,
     apply_select_field_null_raw, apply_select_str_raw, apply_select_str_test_raw,
-    apply_two_field_binop_const_raw,
+    apply_to_entries_each_interp_raw, apply_two_field_binop_const_raw,
 };
 use jq_jit::interpreter::{ArithExpr, CmpVal, Filter, MathUnary};
 use jq_jit::ir::{BinOp, UnaryOp};
@@ -5657,4 +5657,122 @@ fn raw_del_fields_non_object_bails() {
             outcome,
         );
     }
+}
+
+fn te_interp_key_eq_value() -> Vec<(bool, String)> {
+    vec![
+        (false, "key".to_string()),
+        (true, "=".to_string()),
+        (false, "value".to_string()),
+    ]
+}
+
+#[test]
+fn raw_to_entries_each_interp_object_emits() {
+    let parts = te_interp_key_eq_value();
+    let mut buf = Vec::new();
+    let outcome = apply_to_entries_each_interp_raw(b"{\"a\":1,\"b\":\"x\"}", &parts, &mut buf);
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(buf.as_slice(), b"\"a=1\"\n\"b=x\"\n");
+}
+
+#[test]
+fn raw_to_entries_each_interp_empty_object_emits_nothing() {
+    let parts = te_interp_key_eq_value();
+    let mut buf = Vec::new();
+    let outcome = apply_to_entries_each_interp_raw(b"{}", &parts, &mut buf);
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert!(buf.is_empty());
+}
+
+#[test]
+fn raw_to_entries_each_interp_non_object_bails() {
+    let parts = te_interp_key_eq_value();
+    for raw in [b"[1,2]".as_slice(), b"42".as_slice(), b"null".as_slice(), b"\"s\"".as_slice()] {
+        let mut buf = Vec::new();
+        let outcome = apply_to_entries_each_interp_raw(raw, &parts, &mut buf);
+        assert!(
+            matches!(outcome, RawApplyOutcome::Bail),
+            "expected Bail for non-object input {:?}, got {:?}",
+            std::str::from_utf8(raw).unwrap(),
+            outcome,
+        );
+        assert!(buf.is_empty(), "buf should be untouched on Bail");
+    }
+}
+
+#[test]
+fn raw_to_entries_each_interp_non_canonical_number_bails() {
+    let parts = te_interp_key_eq_value();
+    let mut buf = Vec::new();
+    let outcome = apply_to_entries_each_interp_raw(b"{\"x\":1e10}", &parts, &mut buf);
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(buf.is_empty());
+}
+
+#[test]
+fn raw_to_entries_each_interp_leading_plus_number_bails() {
+    let parts = te_interp_key_eq_value();
+    let mut buf = Vec::new();
+    let outcome = apply_to_entries_each_interp_raw(b"{\"x\":+5}", &parts, &mut buf);
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(buf.is_empty());
+}
+
+#[test]
+fn raw_to_entries_each_interp_nested_array_value_bails() {
+    let parts = te_interp_key_eq_value();
+    let mut buf = Vec::new();
+    let outcome = apply_to_entries_each_interp_raw(b"{\"x\":[1,2]}", &parts, &mut buf);
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(buf.is_empty());
+}
+
+#[test]
+fn raw_to_entries_each_interp_nested_object_value_bails() {
+    let parts = te_interp_key_eq_value();
+    let mut buf = Vec::new();
+    let outcome = apply_to_entries_each_interp_raw(b"{\"x\":{\"y\":1}}", &parts, &mut buf);
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(buf.is_empty());
+}
+
+#[test]
+fn raw_to_entries_each_interp_escaped_value_string_bails() {
+    let parts = te_interp_key_eq_value();
+    let mut buf = Vec::new();
+    let outcome = apply_to_entries_each_interp_raw(b"{\"x\":\"a\\u00e9\"}", &parts, &mut buf);
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(buf.is_empty());
+}
+
+#[test]
+fn raw_to_entries_each_interp_escaped_key_bails() {
+    let parts = te_interp_key_eq_value();
+    let mut buf = Vec::new();
+    let outcome = apply_to_entries_each_interp_raw(b"{\"a\\nb\":1}", &parts, &mut buf);
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(buf.is_empty());
+}
+
+#[test]
+fn raw_to_entries_each_interp_bool_null_values_emit() {
+    let parts = te_interp_key_eq_value();
+    let mut buf = Vec::new();
+    let outcome = apply_to_entries_each_interp_raw(
+        b"{\"a\":true,\"b\":false,\"c\":null}",
+        &parts,
+        &mut buf,
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(buf.as_slice(), b"\"a=true\"\n\"b=false\"\n\"c=null\"\n");
+}
+
+#[test]
+fn raw_to_entries_each_interp_preserves_existing_buf_on_bail() {
+    let parts = te_interp_key_eq_value();
+    let mut buf = b"prefix-".to_vec();
+    let outcome = apply_to_entries_each_interp_raw(b"{\"x\":1e10}", &parts, &mut buf);
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert_eq!(buf.as_slice(), b"prefix-");
 }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -5101,3 +5101,40 @@ with_entries(.value |= tostring)
 [ ({a:.x, b:.y} | tojson)? ]
 "plain"
 []
+
+# Issue #251: to_entries_each_interp apply-site uses RawApplyOutcome (#83 Phase B).
+# Helper Bails on non-object input, on per-entry escape sequences in keys/strings,
+# on non-canonical numbers, and on nested array/object values, delegating to the
+# generic path which preserves jq's array-as-input semantics and number normalization.
+to_entries[] | "\(.key)=\(.value)"
+{"a":1,"b":"x"}
+"a=1"
+"b=x"
+
+# Empty object — no output.
+[ to_entries[] | "\(.key)=\(.value)" ]
+{}
+[]
+
+# Array input — generic supports `to_entries` over arrays (issue #44).
+to_entries[] | "\(.key)=\(.value)"
+[10,20]
+"0=10"
+"1=20"
+
+# Non-object/non-array — generic raises indexing error, ? swallows.
+[ (to_entries[] | "\(.key)=\(.value)")? ]
+"plain"
+[]
+
+# Bool/null/canonical-number values — fast path emits directly.
+to_entries[] | "\(.key)=\(.value)"
+{"a":true,"b":null,"c":-3.5}
+"a=true"
+"b=null"
+"c=-3.5"
+
+# Nested-object value — Bail to generic so jq's compact serialization wins.
+to_entries[] | "\(.key)=\(.value)"
+{"x":{ "y" : 1 }}
+"x={\"y\":1}"


### PR DESCRIPTION
## Summary

- Add `apply_to_entries_each_interp_raw` to `src/fast_path.rs` and migrate the two
  ~90-line stdin / file-mode apply-sites in `src/bin/jq-jit.rs` to use it.
- Bail discipline at the helper boundary covers non-object input, per-entry key
  escapes, escaped string values, non-canonical numbers (`+`, `e`/`E` after digit/`.`),
  and nested array/object values; the buffer is truncated to its entry-checkpoint
  on Bail so caller state is untouched.
- Fixes pre-existing divergences for inputs like `{\"x\":1e10}` and `{\"x\":+5}`
  where the in-place implementation copied raw bytes verbatim without
  canonicalization.

## Test plan

- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` — 1046 regression tests + 391 fast_path_contract pass
- [x] `./bench/comprehensive.sh --quick` — no perf regression vs `docs/benchmark-history.md`
- [x] 11 new fast_path_contract cases pin verdict surface (Emit happy path + every
      Bail branch + buffer-preservation on Bail).
- [x] 6 new regression groups, including `?`-wrapped non-object Bail matrix and
      array-input via generic.

Refs #251 (#83 Phase B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)