### PR TITLE
refactor: select_regex_value apply-site uses RawApplyOutcome

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -7543,7 +7543,10 @@ fn real_main() {
                         })
                     }
                 } else if let Some((ref rv_field, ref rv_pattern, ref rv_flags, ref rv_rexpr)) = select_regex_value {
-                    // select(.field | test("regex")) | value — regex test then emit value
+                    // Predicate via apply_field_test_raw (Bails on missing
+                    // field, non-string field, escaped string, non-object
+                    // input — all of which jq raises errors on); body fetches
+                    // remap fields and emits resolved value.
                     let re_pattern = if let Some(flags) = rv_flags {
                         let mut prefix = String::from("(?");
                         for c in flags.chars() {
@@ -7556,7 +7559,6 @@ fn real_main() {
                         rv_pattern.clone()
                     };
                     if let Ok(re) = regex::Regex::new(&re_pattern) {
-                        // Collect all needed fields
                         let mut all_fields: Vec<String> = Vec::new();
                         let mut field_idx = std::collections::HashMap::new();
                         let ensure_field = |f: &str, all: &mut Vec<String>, idx: &mut std::collections::HashMap<String, usize>| {
@@ -7565,24 +7567,41 @@ fn real_main() {
                         ensure_field(rv_field.as_str(), &mut all_fields, &mut field_idx);
                         for f in remap_expr_fields(rv_rexpr) { ensure_field(f, &mut all_fields, &mut field_idx); }
                         let resolved = resolve_one_remap(rv_rexpr, &field_idx);
-                        let cond_idx = field_idx[rv_field.as_str()];
                         let field_refs: Vec<&str> = all_fields.iter().map(|s| s.as_str()).collect();
                         let mut ranges_buf = vec![(0usize, 0usize); field_refs.len()];
                         json_stream_raw(&input_str, |start, end| {
                             let raw = &input_bytes[start..end];
-                            if json_object_get_fields_raw_buf(raw, 0, &field_refs, &mut ranges_buf) {
-                                let (vs, ve) = ranges_buf[cond_idx];
-                                let val = &raw[vs..ve];
-                                if val.len() >= 2 && val[0] == b'"' && val[val.len()-1] == b'"'
-                                    && !val[1..val.len()-1].contains(&b'\\')
-                                {
-                                    let content = unsafe { std::str::from_utf8_unchecked(&val[1..val.len()-1]) };
-                                    if re.is_match(content) {
-                                        emit_resolved_value(&mut compact_buf, &resolved, raw, &ranges_buf);
-                                        compact_buf.push(b'\n');
-                                    }
+                            let mut matched: Option<bool> = None;
+                            let outcome = apply_field_test_raw(raw, rv_field.as_str(), &re, |verdict| {
+                                matched = Some(verdict == b"true");
+                            });
+                            if let RawApplyOutcome::Bail = outcome {
+                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                                if compact_buf.len() >= 1 << 17 {
+                                    let _ = out.write_all(&compact_buf);
+                                    compact_buf.clear();
                                 }
+                                return Ok(());
                             }
+                            if matched != Some(true) {
+                                if compact_buf.len() >= 1 << 17 {
+                                    let _ = out.write_all(&compact_buf);
+                                    compact_buf.clear();
+                                }
+                                return Ok(());
+                            }
+                            if !json_object_get_fields_raw_buf(raw, 0, &field_refs, &mut ranges_buf) {
+                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                                if compact_buf.len() >= 1 << 17 {
+                                    let _ = out.write_all(&compact_buf);
+                                    compact_buf.clear();
+                                }
+                                return Ok(());
+                            }
+                            emit_resolved_value(&mut compact_buf, &resolved, raw, &ranges_buf);
+                            compact_buf.push(b'\n');
                             if compact_buf.len() >= 1 << 17 {
                                 let _ = out.write_all(&compact_buf);
                                 compact_buf.clear();
@@ -14805,24 +14824,41 @@ fn real_main() {
                     ensure_field4(rv_field.as_str(), &mut all_fields, &mut field_idx);
                     for f in remap_expr_fields(rv_rexpr) { ensure_field4(f, &mut all_fields, &mut field_idx); }
                     let resolved = resolve_one_remap(rv_rexpr, &field_idx);
-                    let cond_idx = field_idx[rv_field.as_str()];
                     let field_refs: Vec<&str> = all_fields.iter().map(|s| s.as_str()).collect();
                     let mut ranges_buf = vec![(0usize, 0usize); field_refs.len()];
                     json_stream_raw(content, |start, end| {
                         let raw = &content_bytes[start..end];
-                        if json_object_get_fields_raw_buf(raw, 0, &field_refs, &mut ranges_buf) {
-                            let (vs, ve) = ranges_buf[cond_idx];
-                            let val = &raw[vs..ve];
-                            if val.len() >= 2 && val[0] == b'"' && val[val.len()-1] == b'"'
-                                && !val[1..val.len()-1].contains(&b'\\')
-                            {
-                                let content_str = unsafe { std::str::from_utf8_unchecked(&val[1..val.len()-1]) };
-                                if re.is_match(content_str) {
-                                    emit_resolved_value(&mut compact_buf, &resolved, raw, &ranges_buf);
-                                    compact_buf.push(b'\n');
-                                }
+                        let mut matched: Option<bool> = None;
+                        let outcome = apply_field_test_raw(raw, rv_field.as_str(), &re, |verdict| {
+                            matched = Some(verdict == b"true");
+                        });
+                        if let RawApplyOutcome::Bail = outcome {
+                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                            if compact_buf.len() >= 1 << 17 {
+                                let _ = out.write_all(&compact_buf);
+                                compact_buf.clear();
                             }
+                            return Ok(());
                         }
+                        if matched != Some(true) {
+                            if compact_buf.len() >= 1 << 17 {
+                                let _ = out.write_all(&compact_buf);
+                                compact_buf.clear();
+                            }
+                            return Ok(());
+                        }
+                        if !json_object_get_fields_raw_buf(raw, 0, &field_refs, &mut ranges_buf) {
+                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                            if compact_buf.len() >= 1 << 17 {
+                                let _ = out.write_all(&compact_buf);
+                                compact_buf.clear();
+                            }
+                            return Ok(());
+                        }
+                        emit_resolved_value(&mut compact_buf, &resolved, raw, &ranges_buf);
+                        compact_buf.push(b'\n');
                         if compact_buf.len() >= 1 << 17 {
                             let _ = out.write_all(&compact_buf);
                             compact_buf.clear();

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -5180,3 +5180,40 @@ if .a < .b then .x else .y end
 [ (if .a > .b then .x else .y end)? ]
 "plain"
 []
+
+# Issue #251: select_regex_value (`select(.field | test("re")) | output`)
+# apply-site uses RawApplyOutcome (#83 Phase B). Predicate goes through
+# `apply_field_test_raw` which Bails on missing field, non-string field,
+# escaped string content, or non-object input — all of which jq raises
+# errors on. Fixes the pre-existing #83 silent-skip bug where these
+# inputs produced no output instead of the generic-path error.
+
+# Happy path — match emits computed output.
+select(.x | test("h")) | .y + 1
+{"x":"hello","y":42}
+43
+
+# No match — silent (select empty).
+[ select(.x | test("h")) | .y ]
+{"x":"world","y":42}
+[]
+
+# Non-object input — generic raises indexing error, ? swallows.
+[ (select(.x | test("h")) | .y)? ]
+"plain"
+[]
+
+# Missing predicate field — generic raises "null cannot be matched", ? swallows.
+[ (select(.x | test("h")) | .y)? ]
+{"y":42}
+[]
+
+# Non-string predicate field — generic raises "number cannot be matched", ? swallows.
+[ (select(.x | test("h")) | .y)? ]
+{"x":1,"y":42}
+[]
+
+# Match but missing body field — body fetch Bails to generic, which yields null.
+select(.x | test("h")) | .y
+{"x":"hello"}
+null


### PR DESCRIPTION
## Summary

- Migrate `detect_select_regex_then_value` apply-sites (stdin + file dispatch) to
  the named `RawApplyOutcome::{Emit, Bail}` discipline.
- Predicate reuses `apply_field_test_raw` via the verdict-pattern (same as
  #284 / #298): the helper drives the Bail boundary, the body fetches remap
  fields and emits via `emit_resolved_value`.
- Fixes #83-class silent-skip divergences for non-object inputs, missing
  predicate fields, and non-string predicate fields — all now route to the
  generic path which raises the jq-compatible error.

## Test plan

- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` — official 509 + regression all pass
- [x] `./bench/comprehensive.sh --quick` — no perf regression vs `docs/benchmark-history.md`
- [x] 6 new regression cases pin happy path + no-match silence + `?`-wrapped
      Bail matrix + match-with-missing-body fallback.

Refs #251 (#83 Phase B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)