### PR TITLE
refactor(fast_path): migrate select_compound_str_test to RawApplyOutcome

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -154,7 +154,8 @@ use jq_jit::fast_path::{
     apply_field_cmp_val_raw, apply_null_branch_lit_raw,
     apply_obj_assign_two_fields_arith_raw, apply_obj_merge_computed_raw,
     apply_obj_merge_lit_raw, apply_remap_to_entries_raw, apply_remap_tojson_raw,
-    apply_select_string_chain_raw, apply_to_entries_each_interp_raw,
+    apply_select_compound_str_test_raw, apply_select_string_chain_raw,
+    apply_to_entries_each_interp_raw,
     apply_select_nested_cmp_raw, apply_select_num_str_raw, apply_two_field_binop_const_raw,
     apply_with_entries_del_raw,
     apply_with_entries_key_str_raw, apply_with_entries_select_raw,
@@ -7320,32 +7321,16 @@ fn real_main() {
                     })
                 } else if let Some((ref logic_op, ref str_conds)) = select_compound_str_test {
                     use jq_jit::ir::BinOp;
+                    let is_and = matches!(logic_op, BinOp::And);
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        let is_and = matches!(logic_op, BinOp::And);
-                        let mut result = is_and; // true for AND (all must pass), false for OR (any must pass)
-                        for (field, test_name, test_arg) in str_conds {
-                            let pass = if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, field) {
-                                let val = &raw[vs..ve];
-                                if val.len() >= 2 && val[0] == b'"' && val[ve-vs-1] == b'"' && !val[1..ve-vs-1].contains(&b'\\') {
-                                    let inner = &val[1..ve-vs-1];
-                                    let arg_bytes = test_arg.as_bytes();
-                                    match test_name.as_str() {
-                                        "startswith" => inner.starts_with(arg_bytes),
-                                        "endswith" => inner.ends_with(arg_bytes),
-                                        "contains" => bytes_contains(inner, arg_bytes),
-                                        _ => false,
-                                    }
-                                } else { false }
-                            } else { false };
-                            if is_and {
-                                if !pass { result = false; break; }
-                            } else {
-                                if pass { result = true; break; }
-                            }
-                        }
-                        if result {
-                            emit_raw_ln!(&mut compact_buf, raw);
+                        let outcome = apply_select_compound_str_test_raw(
+                            raw, is_and, str_conds,
+                            |bytes| { emit_raw_ln!(&mut compact_buf, bytes); },
+                        );
+                        if let RawApplyOutcome::Bail = outcome {
+                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }
                         if compact_buf.len() >= 1 << 17 {
                             let _ = out.write_all(&compact_buf);
@@ -14552,32 +14537,16 @@ fn real_main() {
             } else if let Some((ref logic_op, ref str_conds)) = select_compound_str_test {
                 use jq_jit::ir::BinOp;
                 let content_bytes = content.as_bytes();
+                let is_and = matches!(logic_op, BinOp::And);
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    let is_and = matches!(logic_op, BinOp::And);
-                    let mut result = is_and;
-                    for (field, test_name, test_arg) in str_conds {
-                        let pass = if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, field) {
-                            let val = &raw[vs..ve];
-                            if val.len() >= 2 && val[0] == b'"' && val[ve-vs-1] == b'"' && !val[1..ve-vs-1].contains(&b'\\') {
-                                let inner = &val[1..ve-vs-1];
-                                let arg_bytes = test_arg.as_bytes();
-                                match test_name.as_str() {
-                                    "startswith" => inner.starts_with(arg_bytes),
-                                    "endswith" => inner.ends_with(arg_bytes),
-                                    "contains" => bytes_contains(inner, arg_bytes),
-                                    _ => false,
-                                }
-                            } else { false }
-                        } else { false };
-                        if is_and {
-                            if !pass { result = false; break; }
-                        } else {
-                            if pass { result = true; break; }
-                        }
-                    }
-                    if result {
-                        emit_raw_ln!(&mut compact_buf, raw);
+                    let outcome = apply_select_compound_str_test_raw(
+                        raw, is_and, str_conds,
+                        |bytes| { emit_raw_ln!(&mut compact_buf, bytes); },
+                    );
+                    if let RawApplyOutcome::Bail = outcome {
+                        let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                        process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                     }
                     if compact_buf.len() >= 1 << 17 {
                         let _ = out.write_all(&compact_buf);

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -1694,6 +1694,78 @@ where
     RawApplyOutcome::Emit
 }
 
+/// Apply the `select((.f1 | startswith/endswith/contains(arg)) AND/OR
+/// (.f2 | ...) AND/OR ...)` raw-byte fast path on a single JSON
+/// record. On a true verdict invokes `emit_pass(raw)` (select passes
+/// the input through unchanged); on a false verdict returns `Emit`
+/// silently with no buffer write.
+///
+/// `is_and = true` for AND-combination, `false` for OR. `str_conds`
+/// is a slice of `(field, test_name, test_arg)` triples where
+/// `test_name` is one of `"startswith"`, `"endswith"`, `"contains"`.
+///
+/// jq's `and`/`or` short-circuit: AND breaks on first false, OR
+/// breaks on first true. The helper reproduces that — once a verdict
+/// is determined by a successfully-evaluated condition, later
+/// conditions (which might error) are not evaluated, matching jq.
+///
+/// Bail discipline (only kicks in for conditions actually evaluated
+/// — short-circuited conditions never trigger Bail):
+/// - Non-object input → Bail. jq raises "Cannot index ..."; previously
+///   silent (#83-class bug).
+/// - Field absent → Bail. jq raises "startswith() requires string
+///   inputs" on `null`; previously silent.
+/// - Field is non-string or string with backslash escapes → Bail.
+/// - Unsupported test name (defensive) → Bail.
+pub fn apply_select_compound_str_test_raw<F>(
+    raw: &[u8],
+    is_and: bool,
+    str_conds: &[(String, String, String)],
+    mut emit_pass: F,
+) -> RawApplyOutcome
+where
+    F: FnMut(&[u8]),
+{
+    if raw.is_empty() || raw[0] != b'{' {
+        return RawApplyOutcome::Bail;
+    }
+    let mut result = is_and;
+    for (field, test_name, test_arg) in str_conds {
+        let (vs, ve) = match json_object_get_field_raw(raw, 0, field) {
+            Some(p) => p,
+            None => return RawApplyOutcome::Bail,
+        };
+        let val = &raw[vs..ve];
+        if val.len() < 2 || val[0] != b'"' || val[val.len() - 1] != b'"'
+            || val[1..val.len() - 1].contains(&b'\\')
+        {
+            return RawApplyOutcome::Bail;
+        }
+        let inner = &val[1..val.len() - 1];
+        let arg_bytes = test_arg.as_bytes();
+        let pass = match test_name.as_str() {
+            "startswith" => inner.starts_with(arg_bytes),
+            "endswith" => inner.ends_with(arg_bytes),
+            "contains" => arg_bytes.is_empty()
+                || memchr::memmem::find(inner, arg_bytes).is_some(),
+            _ => return RawApplyOutcome::Bail,
+        };
+        if is_and {
+            if !pass {
+                result = false;
+                break;
+            }
+        } else if pass {
+            result = true;
+            break;
+        }
+    }
+    if result {
+        emit_pass(raw);
+    }
+    RawApplyOutcome::Emit
+}
+
 /// Apply the `with_entries(select(.value cmp N))` raw-byte fast
 /// path on a single JSON record. Filters object entries by value
 /// against a numeric threshold.

--- a/tests/fast_path_contract.rs
+++ b/tests/fast_path_contract.rs
@@ -34,8 +34,8 @@ use jq_jit::fast_path::{
     apply_obj_assign_two_fields_arith_raw, apply_obj_merge_computed_raw,
     apply_obj_merge_lit_raw, apply_select_nested_cmp_raw, apply_select_num_str_raw,
     apply_select_arith_cmp_raw, apply_select_cmp_raw,
-    apply_select_field_null_raw, apply_select_str_raw,
-    apply_select_str_test_raw, apply_select_string_chain_raw,
+    apply_select_compound_str_test_raw, apply_select_field_null_raw,
+    apply_select_str_raw, apply_select_str_test_raw, apply_select_string_chain_raw,
     apply_to_entries_each_interp_raw, apply_two_field_binop_const_raw,
 };
 use jq_jit::interpreter::{StringChainOp, StringChainTerminal};
@@ -5895,4 +5895,137 @@ fn raw_select_string_chain_split_join_runs() {
     );
     assert!(matches!(outcome, RawApplyOutcome::Emit));
     assert_eq!(emitted.as_slice(), b"{\"x\":\"a-b-c\"}");
+}
+
+fn cs(field: &str, name: &str, arg: &str) -> (String, String, String) {
+    (field.to_string(), name.to_string(), arg.to_string())
+}
+
+#[test]
+fn raw_select_compound_str_test_and_match_emits() {
+    let conds = vec![
+        cs("x", "startswith", "hel"),
+        cs("y", "endswith", "ld"),
+    ];
+    let mut emitted: Vec<u8> = Vec::new();
+    let outcome = apply_select_compound_str_test_raw(
+        b"{\"x\":\"hello\",\"y\":\"world\"}", true, &conds,
+        |bytes| emitted.extend_from_slice(bytes),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted.as_slice(), b"{\"x\":\"hello\",\"y\":\"world\"}");
+}
+
+#[test]
+fn raw_select_compound_str_test_and_first_false_short_circuits() {
+    // First cond evaluates to false → break before second cond (which would
+    // otherwise Bail because field is missing). Verifies short-circuit.
+    let conds = vec![
+        cs("x", "startswith", "zzz"),
+        cs("y", "endswith", "ld"),
+    ];
+    let mut emitted: Vec<u8> = Vec::new();
+    let outcome = apply_select_compound_str_test_raw(
+        b"{\"x\":\"hello\"}", true, &conds,
+        |bytes| emitted.extend_from_slice(bytes),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_select_compound_str_test_or_first_true_short_circuits() {
+    let conds = vec![
+        cs("x", "startswith", "hel"),
+        cs("y", "endswith", "ld"),  // y missing — would Bail if reached
+    ];
+    let mut emitted: Vec<u8> = Vec::new();
+    let outcome = apply_select_compound_str_test_raw(
+        b"{\"x\":\"hello\"}", false, &conds,
+        |bytes| emitted.extend_from_slice(bytes),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(emitted.as_slice(), b"{\"x\":\"hello\"}");
+}
+
+#[test]
+fn raw_select_compound_str_test_non_object_bails() {
+    let conds = vec![cs("x", "startswith", "h")];
+    let mut emitted: Vec<u8> = Vec::new();
+    for raw in [b"42".as_slice(), b"\"s\"".as_slice(), b"null".as_slice(), b"[1]".as_slice()] {
+        let outcome = apply_select_compound_str_test_raw(
+            raw, true, &conds,
+            |bytes| emitted.extend_from_slice(bytes),
+        );
+        assert!(matches!(outcome, RawApplyOutcome::Bail));
+    }
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_select_compound_str_test_missing_field_bails() {
+    // AND case: field missing on first cond → Bail (no short-circuit yet).
+    let conds = vec![
+        cs("y", "startswith", "h"),
+        cs("z", "endswith", "z"),
+    ];
+    let mut emitted: Vec<u8> = Vec::new();
+    let outcome = apply_select_compound_str_test_raw(
+        b"{\"x\":1}", true, &conds,
+        |bytes| emitted.extend_from_slice(bytes),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_select_compound_str_test_or_no_short_circuit_then_error_bails() {
+    // OR with first cond false (no short-circuit), second cond errors → Bail.
+    let conds = vec![
+        cs("x", "startswith", "zzz"),  // false (no short-circuit on OR)
+        cs("y", "endswith", "z"),      // y missing → Bail
+    ];
+    let mut emitted: Vec<u8> = Vec::new();
+    let outcome = apply_select_compound_str_test_raw(
+        b"{\"x\":\"hello\"}", false, &conds,
+        |bytes| emitted.extend_from_slice(bytes),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_select_compound_str_test_non_string_bails() {
+    let conds = vec![cs("x", "startswith", "h")];
+    let mut emitted: Vec<u8> = Vec::new();
+    let outcome = apply_select_compound_str_test_raw(
+        b"{\"x\":1}", true, &conds,
+        |bytes| emitted.extend_from_slice(bytes),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_select_compound_str_test_escaped_string_bails() {
+    let conds = vec![cs("x", "contains", "h")];
+    let mut emitted: Vec<u8> = Vec::new();
+    let outcome = apply_select_compound_str_test_raw(
+        b"{\"x\":\"he\\nllo\"}", true, &conds,
+        |bytes| emitted.extend_from_slice(bytes),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
+}
+
+#[test]
+fn raw_select_compound_str_test_unsupported_test_bails() {
+    let conds = vec![cs("x", "ascii_downcase", "h")];
+    let mut emitted: Vec<u8> = Vec::new();
+    let outcome = apply_select_compound_str_test_raw(
+        b"{\"x\":\"hello\"}", true, &conds,
+        |bytes| emitted.extend_from_slice(bytes),
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert!(emitted.is_empty());
 }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -5258,3 +5258,44 @@ select(.x | ltrimstr("p-") | startswith("data"))
 select(.x | contains("oob"))
 {"x":"foobar"}
 {"x":"foobar"}
+
+# Issue #251: select_compound_str_test apply-site uses RawApplyOutcome
+# (#83 Phase B). Helper Bails on non-object, missing field, non-string
+# field, or escaped string content for *evaluated* conditions; matches
+# jq's `and`/`or` short-circuit so a true OR or false AND can break
+# before reaching an error. Fixes the #83-class silent-skip bugs.
+
+# Happy AND.
+select((.x | startswith("hel")) and (.y | startswith("wor")))
+{"x":"hello","y":"world"}
+{"x":"hello","y":"world"}
+
+# AND short-circuits on first false (jq behavior; no error from missing .y).
+[ select((.x | startswith("hel")) and (.y | startswith("wor"))) ]
+{"x":"world"}
+[]
+
+# OR short-circuits on first true; missing .y is never evaluated.
+select((.x | startswith("hel")) or (.y | startswith("wor")))
+{"x":"hello"}
+{"x":"hello"}
+
+# AND with missing second field — generic raises "startswith requires strings".
+[ (select((.x | startswith("hel")) and (.y | startswith("wor"))))? ]
+{"x":"hello"}
+[]
+
+# OR no short-circuit + second cond errors — generic propagates error.
+[ (select((.x | startswith("hel")) or (.y | startswith("wor"))))? ]
+{"x":"world"}
+[]
+
+# Non-object input — generic raises indexing error, ? swallows.
+[ (select((.x | startswith("hel")) and (.y | startswith("wor"))))? ]
+"plain"
+[]
+
+# Non-string field — generic raises, ? swallows.
+[ (select((.x | startswith("hel")) and (.y | startswith("wor"))))? ]
+{"x":1,"y":"world"}
+[]


### PR DESCRIPTION
## Summary

- Add `apply_select_compound_str_test_raw` to `src/fast_path.rs` and migrate the
  two `detect_select_compound_str_test` apply-sites in `src/bin/jq-jit.rs`
  (stdin + file dispatch) to use it. Pattern:
  `select((.f1 | startswith/endswith/contains(arg)) AND/OR (.f2 | ...) AND/OR ...)`.
- Helper preserves jq's short-circuit semantics (AND on first false, OR on first
  true) so later conditions that would otherwise error are never evaluated.
- Bails on non-object, missing field, non-string field, or escaped string for
  *evaluated* conditions — fixing #83-class silent-skip bugs while keeping
  short-circuit fast.

## Test plan

- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` — official 509 + regression all pass
- [x] `./bench/comprehensive.sh --quick` — no perf regression vs `docs/benchmark-history.md`
- [x] 9 new fast_path_contract cases pin AND/OR happy paths, short-circuit,
      and every Bail branch.
- [x] 7 new regression cases pin end-to-end semantics including `?`-wrapped Bail.

Refs #251 (#83 Phase B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)