### PR TITLE
docs(jq-jit): note projection_fields is intentionally outside #83 contract

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -2991,6 +2991,14 @@ fn real_main() {
         jqjit_trace_fast_path(fallback, &filter_text);
     }
 
+    // `projection_fields` is a parse-time optimization, not a raw-byte fast
+    // path: when no raw apply-site matched, we ask the filter which top-level
+    // object fields it actually reads, and steer parsing to skip the rest.
+    // The resulting `Value` still flows through `process_input` →
+    // `Filter::execute_cb`, so the generic interpreter is authoritative for
+    // every observable behaviour. There is no separate raw-emit branch that
+    // could disagree, so no `RawApplyOutcome::Bail` discipline is needed —
+    // this apply-site is intentionally outside the #83 contract (issue #251).
     let projection_fields: Option<Vec<String>> = if !has_raw_fast_path && !slurp && !raw_input {
         filter.needed_input_fields()
     } else { None };


### PR DESCRIPTION
## Summary

- `projection_fields` is a parse-time optimization that asks the filter which
  top-level object fields it reads and steers parsing to skip the rest. The
  resulting `Value` still flows through `process_input` → `Filter::execute_cb`,
  so the generic interpreter remains authoritative for every observable
  behaviour. There is no raw-emit branch that could disagree.
- Add a doc comment at the declaration site so future readers see the
  omission is intentional — matching the pattern established for
  `type_filter` in issue #251's \"No-Bail candidates\" section.
- Pure documentation change; no behaviour change.

## Test plan

- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` — all pass

Refs #251 (#83 Phase B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)