### PR TITLE
refactor(fast_path): migrate is_keys apply-site to RawApplyOutcome

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -136,7 +136,7 @@ fn print_jq_error(msg: &str) {
     }
 }
 
-use jq_jit::value::{Value, json_to_value, json_stream, json_stream_offsets, json_stream_raw, json_stream_project, json_value_has_duplicate_keys, json_stream_has_duplicate_keys, json_object_get_num, json_object_get_two_nums, json_object_get_field_raw, json_object_get_fields_raw_buf, parse_json_num, json_value_length, json_object_keys_to_buf_reuse, json_object_extract_keys_only, json_object_keys_unsorted_to_buf, json_object_keys_join_to_buf, json_object_has_key, json_object_has_all_keys, json_object_has_any_key, json_object_del_field, json_object_del_fields, json_object_merge_literal, json_object_sort_keys, json_each_value_raw, json_each_value_cb, json_to_entries_raw, json_object_set_field_raw, json_object_update_field_num, json_object_update_field_num_chain,json_object_select_then_update_num, json_object_select_then_update_str_concat, json_object_select_compound_then_update_num, json_object_select_str_then_update_num, is_json_compact, push_json_compact_raw, push_tojson_raw, push_json_pretty_raw, push_json_pretty_raw_at, value_to_json_precise, value_to_json_pretty_ext, push_compact_line, push_compact_line_color, push_pretty_line, push_pretty_line_color, push_jq_number_bytes, write_value_compact_ext, write_value_compact_line, write_value_pretty_line_color, value_to_json_pretty_color, walk_json_transform_nums, pool_value, skip_json_value};
+use jq_jit::value::{Value, json_to_value, json_stream, json_stream_offsets, json_stream_raw, json_stream_project, json_value_has_duplicate_keys, json_stream_has_duplicate_keys, json_object_get_num, json_object_get_two_nums, json_object_get_field_raw, json_object_get_fields_raw_buf, parse_json_num, json_value_length, json_object_keys_unsorted_to_buf,json_object_keys_join_to_buf, json_object_has_key, json_object_has_all_keys, json_object_has_any_key, json_object_del_field, json_object_del_fields, json_object_merge_literal, json_object_sort_keys, json_each_value_raw, json_each_value_cb, json_to_entries_raw, json_object_set_field_raw, json_object_update_field_num, json_object_update_field_num_chain,json_object_select_then_update_num, json_object_select_then_update_str_concat, json_object_select_compound_then_update_num, json_object_select_str_then_update_num, is_json_compact, push_json_compact_raw, push_tojson_raw, push_json_pretty_raw, push_json_pretty_raw_at, value_to_json_precise, value_to_json_pretty_ext, push_compact_line, push_compact_line_color, push_pretty_line, push_pretty_line_color, push_jq_number_bytes, write_value_compact_ext, write_value_compact_line, write_value_pretty_line_color, value_to_json_pretty_color, walk_json_transform_nums, pool_value, skip_json_value};
 use jq_jit::interpreter::Filter;
 use jq_jit::fast_path::{
     apply_arith_chain_cmp_raw, apply_field_access_raw, apply_field_alternative_raw,
@@ -153,9 +153,10 @@ use jq_jit::fast_path::{
     apply_first_each_select_type_raw,
     apply_field_cmp_val_raw, apply_null_branch_lit_raw,
     apply_obj_assign_two_fields_arith_raw, apply_obj_merge_computed_raw,
-    apply_obj_merge_lit_raw, apply_remap_to_entries_raw, apply_remap_tojson_raw,
-    apply_select_compound_str_test_raw, apply_select_mixed_compound_raw,
-    apply_select_string_chain_raw, apply_to_entries_each_interp_raw,
+    apply_is_keys_raw, apply_obj_merge_lit_raw, apply_remap_to_entries_raw,
+    apply_remap_tojson_raw, apply_select_compound_str_test_raw,
+    apply_select_mixed_compound_raw, apply_select_string_chain_raw,
+    apply_to_entries_each_interp_raw,
     apply_select_nested_cmp_raw, apply_select_num_str_raw, apply_two_field_binop_const_raw,
     apply_with_entries_del_raw,
     apply_with_entries_key_str_raw, apply_with_entries_select_raw,
@@ -10667,80 +10668,17 @@ fn real_main() {
                 } else if is_keys {
                     let mut tmp = Vec::new();
                     let mut keys_buf: Vec<(usize, usize)> = Vec::new();
-                    // Cache sorted output for identical key sets
                     let mut cached_output: Vec<u8> = Vec::new();
-                    let mut cached_keys: Vec<Vec<u8>> = Vec::new(); // unsorted key bytes
+                    let mut cached_keys: Vec<Vec<u8>> = Vec::new();
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        // Try cached permutation: extract unsorted keys, check if same set
-                        if !cached_keys.is_empty() {
-                            if let Some(extracted) = json_object_extract_keys_only(raw, 0, &mut keys_buf) {
-                                if extracted == cached_keys.len() {
-                                    // Check if all keys match
-                                    let mut same = true;
-                                    for (i, (ks, ke)) in keys_buf.iter().enumerate() {
-                                        if &raw[*ks..*ke] != cached_keys[i].as_slice() {
-                                            same = false;
-                                            break;
-                                        }
-                                    }
-                                    if same {
-                                        if use_pretty_buf {
-                                            // cached_output has no trailing \n
-                                            push_json_pretty_raw(&mut compact_buf, &cached_output, 2, false);
-                                            compact_buf.push(b'\n');
-                                        } else {
-                                            compact_buf.extend_from_slice(&cached_output);
-                                            compact_buf.push(b'\n');
-                                        }
-                                        if compact_buf.len() >= 1 << 17 {
-                                            let _ = out.write_all(&compact_buf);
-                                            compact_buf.clear();
-                                        }
-                                        return Ok(());
-                                    }
-                                }
-                            }
-                        }
-                        // Full path: extract, sort, output
-                        if use_pretty_buf {
-                            tmp.clear();
-                            if json_object_keys_to_buf_reuse(raw, 0, &mut tmp, &mut keys_buf) {
-                                let len = tmp.len();
-                                if len > 0 && tmp[len-1] == b'\n' { tmp.truncate(len-1); }
-                                // Cache for future objects
-                                if cached_keys.is_empty() {
-                                    cached_output = tmp.clone();
-                                    // We need to re-extract unsorted keys for caching
-                                    // keys_buf was sorted in-place, so re-extract
-                                    let mut unsorted: Vec<(usize, usize)> = Vec::new();
-                                    if let Some(_) = json_object_extract_keys_only(raw, 0, &mut unsorted) {
-                                        cached_keys = unsorted.iter().map(|(s, e)| raw[*s..*e].to_vec()).collect();
-                                    }
-                                }
-                                push_json_pretty_raw(&mut compact_buf, &tmp, 2, false);
-                                compact_buf.push(b'\n');
-                            } else {
-                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                            }
-                        } else {
-                            let before = compact_buf.len();
-                            if json_object_keys_to_buf_reuse(raw, 0, &mut compact_buf, &mut keys_buf) {
-                                // Cache the output (without trailing \n)
-                                if cached_keys.is_empty() {
-                                    let end_pos = compact_buf.len();
-                                    // Output is [...]\n, cache [...] (without \n)
-                                    cached_output = compact_buf[before..end_pos-1].to_vec();
-                                    let mut unsorted: Vec<(usize, usize)> = Vec::new();
-                                    if let Some(_) = json_object_extract_keys_only(raw, 0, &mut unsorted) {
-                                        cached_keys = unsorted.iter().map(|(s, e)| raw[*s..*e].to_vec()).collect();
-                                    }
-                                }
-                            } else {
-                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                            }
+                        let outcome = apply_is_keys_raw(
+                            raw, &mut cached_output, &mut cached_keys,
+                            &mut keys_buf, &mut tmp, use_pretty_buf, &mut compact_buf,
+                        );
+                        if let RawApplyOutcome::Bail = outcome {
+                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }
                         if compact_buf.len() >= 1 << 17 {
                             let _ = out.write_all(&compact_buf);
@@ -19192,66 +19130,13 @@ fn real_main() {
                 let mut cached_keys: Vec<Vec<u8>> = Vec::new();
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    if !cached_keys.is_empty() {
-                        if let Some(extracted) = json_object_extract_keys_only(raw, 0, &mut keys_buf) {
-                            if extracted == cached_keys.len() {
-                                let mut same = true;
-                                for (i, (ks, ke)) in keys_buf.iter().enumerate() {
-                                    if &raw[*ks..*ke] != cached_keys[i].as_slice() {
-                                        same = false;
-                                        break;
-                                    }
-                                }
-                                if same {
-                                    if use_pretty_buf {
-                                        push_json_pretty_raw(&mut compact_buf, &cached_output, 2, false);
-                                        compact_buf.push(b'\n');
-                                    } else {
-                                        compact_buf.extend_from_slice(&cached_output);
-                                        compact_buf.push(b'\n');
-                                    }
-                                    if compact_buf.len() >= 1 << 17 {
-                                        let _ = out.write_all(&compact_buf);
-                                        compact_buf.clear();
-                                    }
-                                    return Ok(());
-                                }
-                            }
-                        }
-                    }
-                    if use_pretty_buf {
-                        tmp.clear();
-                        if json_object_keys_to_buf_reuse(raw, 0, &mut tmp, &mut keys_buf) {
-                            let len = tmp.len();
-                            if len > 0 && tmp[len-1] == b'\n' { tmp.truncate(len-1); }
-                            if cached_keys.is_empty() {
-                                cached_output = tmp.clone();
-                                let mut unsorted: Vec<(usize, usize)> = Vec::new();
-                                if let Some(_) = json_object_extract_keys_only(raw, 0, &mut unsorted) {
-                                    cached_keys = unsorted.iter().map(|(s, e)| raw[*s..*e].to_vec()).collect();
-                                }
-                            }
-                            push_json_pretty_raw(&mut compact_buf, &tmp, 2, false);
-                            compact_buf.push(b'\n');
-                        } else {
-                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                        }
-                    } else {
-                        let before = compact_buf.len();
-                        if json_object_keys_to_buf_reuse(raw, 0, &mut compact_buf, &mut keys_buf) {
-                            if cached_keys.is_empty() {
-                                let end_pos = compact_buf.len();
-                                cached_output = compact_buf[before..end_pos-1].to_vec();
-                                let mut unsorted: Vec<(usize, usize)> = Vec::new();
-                                if let Some(_) = json_object_extract_keys_only(raw, 0, &mut unsorted) {
-                                    cached_keys = unsorted.iter().map(|(s, e)| raw[*s..*e].to_vec()).collect();
-                                }
-                            }
-                        } else {
-                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                        }
+                    let outcome = apply_is_keys_raw(
+                        raw, &mut cached_output, &mut cached_keys,
+                        &mut keys_buf, &mut tmp, use_pretty_buf, &mut compact_buf,
+                    );
+                    if let RawApplyOutcome::Bail = outcome {
+                        let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                        process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                     }
                     if compact_buf.len() >= 1 << 17 {
                         let _ = out.write_all(&compact_buf);

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -78,8 +78,9 @@ use crate::value::{
     json_object_update_field_split_first, json_object_update_field_split_last,
     json_object_update_field_str_concat, json_object_update_field_str_map,
     json_object_update_field_test, json_object_update_field_tostring,
-    json_object_update_field_trim, json_type_byte, json_value_length, parse_json_num,
-    push_jq_number_bytes, skip_json_value,
+    json_object_update_field_trim, json_type_byte, json_value_length,
+    json_object_extract_keys_only, json_object_keys_to_buf_reuse, parse_json_num,
+    push_jq_number_bytes, push_json_pretty_raw, skip_json_value,
 };
 
 /// A fast path whose type-dispatch obligations are encoded in its
@@ -1862,6 +1863,103 @@ where
     }
     if result {
         emit_pass(raw);
+    }
+    RawApplyOutcome::Emit
+}
+
+/// Apply the `keys` raw-byte fast path on a single JSON record. Emits
+/// a sorted JSON array literal of the input object's top-level keys.
+///
+/// The helper layers a per-stream key-set cache around the extraction:
+/// when consecutive records share the same (unsorted) key set, the
+/// cached sorted-output bytes are reused without re-sorting. The
+/// caller owns the cache state (`cached_output`, `cached_keys`,
+/// `keys_buf`) plus a scratch `tmp` buffer for pretty-printing.
+///
+/// `use_pretty` selects the formatting branch: when `true` the output
+/// is collected in `tmp` then re-emitted into `out_buf` via
+/// `push_json_pretty_raw` (with a trailing `\n`); when `false` the
+/// raw compact bytes are written directly to `out_buf` and the cache
+/// is captured from the same range. Both branches end with a single
+/// `\n` appended to `out_buf`.
+///
+/// Bail discipline (delegates to `json_object_keys_to_buf_reuse`):
+/// - Non-object input → Bail. jq's `keys` works on arrays too
+///   (returns indices), strings/numbers raise — the generic path
+///   handles both correctly.
+/// - Malformed input (escaped key boundary, unmatched braces, etc.)
+///   → Bail.
+pub fn apply_is_keys_raw(
+    raw: &[u8],
+    cached_output: &mut Vec<u8>,
+    cached_keys: &mut Vec<Vec<u8>>,
+    keys_buf: &mut Vec<(usize, usize)>,
+    tmp: &mut Vec<u8>,
+    use_pretty: bool,
+    out_buf: &mut Vec<u8>,
+) -> RawApplyOutcome {
+    // Try cached permutation: if the unsorted key set matches the cache,
+    // reuse the previously-sorted output bytes without re-sorting.
+    if !cached_keys.is_empty() {
+        if let Some(extracted) = json_object_extract_keys_only(raw, 0, keys_buf) {
+            if extracted == cached_keys.len() {
+                let mut same = true;
+                for (i, (ks, ke)) in keys_buf.iter().enumerate() {
+                    if &raw[*ks..*ke] != cached_keys[i].as_slice() {
+                        same = false;
+                        break;
+                    }
+                }
+                if same {
+                    if use_pretty {
+                        push_json_pretty_raw(out_buf, cached_output, 2, false);
+                    } else {
+                        out_buf.extend_from_slice(cached_output);
+                    }
+                    out_buf.push(b'\n');
+                    return RawApplyOutcome::Emit;
+                }
+            }
+        }
+    }
+    // Full path: extract + sort + emit. On non-object / malformed input,
+    // `json_object_keys_to_buf_reuse` returns false → Bail.
+    if use_pretty {
+        tmp.clear();
+        if !json_object_keys_to_buf_reuse(raw, 0, tmp, keys_buf) {
+            return RawApplyOutcome::Bail;
+        }
+        let len = tmp.len();
+        if len > 0 && tmp[len - 1] == b'\n' {
+            tmp.truncate(len - 1);
+        }
+        if cached_keys.is_empty() {
+            *cached_output = tmp.clone();
+            let mut unsorted: Vec<(usize, usize)> = Vec::new();
+            if json_object_extract_keys_only(raw, 0, &mut unsorted).is_some() {
+                *cached_keys = unsorted.iter().map(|(s, e)| raw[*s..*e].to_vec()).collect();
+            }
+        }
+        push_json_pretty_raw(out_buf, tmp, 2, false);
+        out_buf.push(b'\n');
+    } else {
+        let before = out_buf.len();
+        if !json_object_keys_to_buf_reuse(raw, 0, out_buf, keys_buf) {
+            // The helper truncates internal state on early failure, but
+            // it may have appended partial bytes before discovering a
+            // malformed structure — restore caller state.
+            out_buf.truncate(before);
+            return RawApplyOutcome::Bail;
+        }
+        if cached_keys.is_empty() {
+            let end_pos = out_buf.len();
+            // Output is "[...]\n"; cache the "[...]" portion (strip \n).
+            *cached_output = out_buf[before..end_pos - 1].to_vec();
+            let mut unsorted: Vec<(usize, usize)> = Vec::new();
+            if json_object_extract_keys_only(raw, 0, &mut unsorted).is_some() {
+                *cached_keys = unsorted.iter().map(|(s, e)| raw[*s..*e].to_vec()).collect();
+            }
+        }
     }
     RawApplyOutcome::Emit
 }

--- a/tests/fast_path_contract.rs
+++ b/tests/fast_path_contract.rs
@@ -33,7 +33,7 @@ use jq_jit::fast_path::{
     apply_field_cmp_val_raw, apply_null_branch_lit_raw,
     apply_obj_assign_two_fields_arith_raw, apply_obj_merge_computed_raw,
     apply_obj_merge_lit_raw, apply_select_nested_cmp_raw, apply_select_num_str_raw,
-    apply_select_arith_cmp_raw, apply_select_cmp_raw,
+    apply_is_keys_raw, apply_select_arith_cmp_raw, apply_select_cmp_raw,
     apply_select_compound_str_test_raw, apply_select_field_null_raw,
     apply_select_mixed_compound_raw, apply_select_str_raw,
     apply_select_str_test_raw, apply_select_string_chain_raw,
@@ -6157,4 +6157,100 @@ fn raw_select_mixed_compound_test_without_regex_bails() {
     );
     assert!(matches!(outcome, RawApplyOutcome::Bail));
     assert!(emitted.is_empty());
+}
+
+fn fresh_keys_state() -> (Vec<u8>, Vec<Vec<u8>>, Vec<(usize, usize)>, Vec<u8>) {
+    (Vec::new(), Vec::new(), Vec::new(), Vec::new())
+}
+
+#[test]
+fn raw_is_keys_object_emits_sorted_compact() {
+    let (mut co, mut ck, mut kb, mut tmp) = fresh_keys_state();
+    let mut buf = Vec::new();
+    let outcome = apply_is_keys_raw(
+        b"{\"b\":1,\"a\":2,\"c\":3}", &mut co, &mut ck, &mut kb, &mut tmp, false, &mut buf,
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(buf.as_slice(), b"[\"a\",\"b\",\"c\"]\n");
+}
+
+#[test]
+fn raw_is_keys_empty_object_emits_empty_array() {
+    let (mut co, mut ck, mut kb, mut tmp) = fresh_keys_state();
+    let mut buf = Vec::new();
+    let outcome = apply_is_keys_raw(
+        b"{}", &mut co, &mut ck, &mut kb, &mut tmp, false, &mut buf,
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(buf.as_slice(), b"[]\n");
+}
+
+#[test]
+fn raw_is_keys_non_object_bails() {
+    let (mut co, mut ck, mut kb, mut tmp) = fresh_keys_state();
+    let mut buf = Vec::new();
+    for raw in [b"42".as_slice(), b"\"s\"".as_slice(), b"null".as_slice(), b"[1,2]".as_slice()] {
+        let outcome = apply_is_keys_raw(
+            raw, &mut co, &mut ck, &mut kb, &mut tmp, false, &mut buf,
+        );
+        assert!(matches!(outcome, RawApplyOutcome::Bail));
+    }
+    assert!(buf.is_empty());
+}
+
+#[test]
+fn raw_is_keys_cache_hit_for_same_shape() {
+    let (mut co, mut ck, mut kb, mut tmp) = fresh_keys_state();
+    let mut buf = Vec::new();
+    // First record populates the cache.
+    let o1 = apply_is_keys_raw(
+        b"{\"a\":1,\"b\":2}", &mut co, &mut ck, &mut kb, &mut tmp, false, &mut buf,
+    );
+    assert!(matches!(o1, RawApplyOutcome::Emit));
+    assert_eq!(buf.as_slice(), b"[\"a\",\"b\"]\n");
+    assert!(!ck.is_empty(), "cache should be populated after first record");
+    // Second record with same shape — cache hit, no re-sort.
+    buf.clear();
+    let o2 = apply_is_keys_raw(
+        b"{\"a\":3,\"b\":4}", &mut co, &mut ck, &mut kb, &mut tmp, false, &mut buf,
+    );
+    assert!(matches!(o2, RawApplyOutcome::Emit));
+    assert_eq!(buf.as_slice(), b"[\"a\",\"b\"]\n");
+}
+
+#[test]
+fn raw_is_keys_cache_miss_on_different_shape() {
+    let (mut co, mut ck, mut kb, mut tmp) = fresh_keys_state();
+    let mut buf = Vec::new();
+    let _ = apply_is_keys_raw(
+        b"{\"a\":1,\"b\":2}", &mut co, &mut ck, &mut kb, &mut tmp, false, &mut buf,
+    );
+    buf.clear();
+    let outcome = apply_is_keys_raw(
+        b"{\"x\":1,\"y\":2}", &mut co, &mut ck, &mut kb, &mut tmp, false, &mut buf,
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(buf.as_slice(), b"[\"x\",\"y\"]\n");
+}
+
+#[test]
+fn raw_is_keys_pretty_branch_emits_indented() {
+    let (mut co, mut ck, mut kb, mut tmp) = fresh_keys_state();
+    let mut buf = Vec::new();
+    let outcome = apply_is_keys_raw(
+        b"{\"a\":1,\"b\":2}", &mut co, &mut ck, &mut kb, &mut tmp, true, &mut buf,
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Emit));
+    assert_eq!(buf.as_slice(), b"[\n  \"a\",\n  \"b\"\n]\n");
+}
+
+#[test]
+fn raw_is_keys_bail_does_not_pollute_buffer() {
+    let (mut co, mut ck, mut kb, mut tmp) = fresh_keys_state();
+    let mut buf = b"prefix-".to_vec();
+    let outcome = apply_is_keys_raw(
+        b"42", &mut co, &mut ck, &mut kb, &mut tmp, false, &mut buf,
+    );
+    assert!(matches!(outcome, RawApplyOutcome::Bail));
+    assert_eq!(buf.as_slice(), b"prefix-");
 }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -5336,3 +5336,32 @@ select((.x | test("^hel")) and (.n > 10))
 [ (select((.x | startswith("hel")) and (.n > 10)))? ]
 "plain"
 []
+
+# Issue #251: is_keys apply-site uses RawApplyOutcome (#83 Phase B).
+# Helper layers a per-stream cache around `keys`; Bails on non-object
+# / non-array (jq's `keys` works on arrays too — generic emits indices).
+
+# Happy object — sorted key list.
+keys
+{"b":1,"a":2,"c":3}
+["a","b","c"]
+
+# Empty object — empty array.
+keys
+{}
+[]
+
+# Array — generic supports `keys` on arrays (returns indices).
+keys
+[10,20,30]
+[0,1,2]
+
+# String — jq raises "string has no keys"; ? swallows.
+[ keys? ]
+"x"
+[]
+
+# Number — jq raises; ? swallows.
+[ keys? ]
+42
+[]


### PR DESCRIPTION
## Summary

- Add `apply_is_keys_raw` to `src/fast_path.rs` and migrate the two `is_keys`
  apply-sites in `src/bin/jq-jit.rs` (stdin + file dispatch, ~80 lines each
  with duplicated cache logic) to use it.
- Helper carries the per-stream key-set cache (`cached_output`, `cached_keys`,
  `keys_buf`) and scratch `tmp` through caller-owned references; same shape
  hits the cache without re-sorting.
- Bail discipline delegates to `json_object_keys_to_buf_reuse`: non-object
  input or malformed structure → Bail; the generic path then handles arrays
  (returns indices), strings/numbers (raises), etc.
- The previous in-place implementation already bailed via fallthrough; this
  PR formalises the boundary as `RawApplyOutcome::Bail` and unifies stdin/file
  apply-sites.

## Test plan

- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` — official 509 + regression all pass (424 fast_path_contract)
- [x] `./bench/comprehensive.sh --quick` — no perf regression vs `docs/benchmark-history.md`
- [x] 7 new fast_path_contract cases pin Emit / Bail / cache hit / cache miss /
      pretty-print / buffer-preservation.
- [x] 5 new regression cases pin happy object, empty object, array (generic),
      and `?`-wrapped string/number Bail.

Refs #251 (#83 Phase B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)