### PR TITLE
chore: bump to 1.4.3 for #83 Phase B completion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,7 +450,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jq-jit"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jq-jit"
-version = "1.4.2"
+version = "1.4.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A JIT-compiling implementation of jq using Cranelift"


### PR DESCRIPTION
## Summary
- Bump version to 1.4.3
- Ships the #83 Phase B completion tracked by #251 (40+ `detect_*` apply-sites migrated to the `RawApplyOutcome::{Emit, Bail}` discipline; every miss is now structurally routed through generic eval)
- Bundles the silent-skip and numeric-divergence fixes uncovered during the migration sweep (#275–#314)

## Test plan
- [x] \`cargo build --release\` (zero warnings)
- [x] \`cargo test --release\` (official 509 + regression)
- [ ] Tag \`v1.4.3\` after merge to trigger the release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)