### PR TITLE
refactor: drop unused JitOp variants (Alternative, F64Greater)

### DIFF
--- a/src/jit.rs
+++ b/src/jit.rs
@@ -324,7 +324,6 @@ type LabelId = u32;
 enum MutateFn { Reverse, Sort }
 
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 enum JitOp {
     // Value construction
     Clone { dst: SlotId, src: SlotId },
@@ -428,13 +427,9 @@ enum JitOp {
     IsNullOrFalse { dst_var: u32, src: SlotId },
     BranchOnVar { var: u32, nonzero_label: LabelId, zero_label: LabelId },
 
-    // Generic runtime alternative check
-    Alternative { dst: SlotId, primary: SlotId },
-
     // Range loop
     ToF64Var { dst_var: u32, src: SlotId },
     F64Less { dst_var: u32, a_var: u32, b_var: u32 },
-    F64Greater { dst_var: u32, a_var: u32, b_var: u32 },
     F64Add { dst_var: u32, a_var: u32, b_var: u32 },
     F64Sub { dst_var: u32, a_var: u32, b_var: u32 },
     F64Mul { dst_var: u32, a_var: u32, b_var: u32 },
@@ -7696,7 +7691,6 @@ fn optimize_clone_yield(mut ops: Vec<JitOp>) -> Vec<JitOp> {
             JitOp::IfTruthy { src, .. } => { *use_count.entry(*src).or_insert(0) += 1; }
             JitOp::FieldIsTruthy { base, .. } | JitOp::FieldCmpNum { base, .. } | JitOp::TypeCmpBranch { src: base, .. } => { *use_count.entry(*base).or_insert(0) += 1; }
             JitOp::IsNullOrFalse { src, .. } => { *use_count.entry(*src).or_insert(0) += 1; }
-            JitOp::Alternative { primary, .. } => { *use_count.entry(*primary).or_insert(0) += 1; }
             JitOp::SetVar { src, .. } | JitOp::MoveToVar { src, .. } => { *use_count.entry(*src).or_insert(0) += 1; }
             JitOp::PathExtract { container, key, .. } => {
                 *use_count.entry(*container).or_insert(0) += 1;
@@ -7783,7 +7777,6 @@ fn optimize_clone_yield(mut ops: Vec<JitOp>) -> Vec<JitOp> {
                 JitOp::IfTruthy { src, .. } => { *use_count.entry(*src).or_insert(0) += 1; }
                 JitOp::FieldIsTruthy { base, .. } | JitOp::FieldCmpNum { base, .. } | JitOp::TypeCmpBranch { src: base, .. } => { *use_count.entry(*base).or_insert(0) += 1; }
                 JitOp::IsNullOrFalse { src, .. } => { *use_count.entry(*src).or_insert(0) += 1; }
-                JitOp::Alternative { primary, .. } => { *use_count.entry(*primary).or_insert(0) += 1; }
                 JitOp::SetVar { src, .. } | JitOp::MoveToVar { src, .. } => { *use_count.entry(*src).or_insert(0) += 1; }
                 JitOp::PathExtract { container, key, .. } => {
                     *use_count.entry(*container).or_insert(0) += 1;
@@ -8960,10 +8953,6 @@ impl JitCompiler {
                         b.ins().brif(cmp, label_blocks[*nonzero_label as usize], &[], label_blocks[*zero_label as usize], &[]);
                         terminated = true;
                     }
-                    JitOp::Alternative { .. } => {
-                        // Not used directly in codegen (handled by IsNullOrFalse + BranchOnVar)
-                    }
-
                     // Float/Range ops
                     JitOp::ToF64Var { dst_var, src } => {
                         let s = slot_addr(&mut b, *src);
@@ -8979,15 +8968,6 @@ impl JitCompiler {
                         let a_f = b.ins().bitcast(types::F64, cranelift_codegen::ir::MemFlags::new(), a_bits);
                         let b_f = b.ins().bitcast(types::F64, cranelift_codegen::ir::MemFlags::new(), b_bits);
                         let cmp = b.ins().fcmp(cranelift_codegen::ir::condcodes::FloatCC::LessThan, a_f, b_f);
-                        let result = b.ins().uextend(ptr_ty, cmp);
-                        b.def_var(vars[*dst_var as usize], result);
-                    }
-                    JitOp::F64Greater { dst_var, a_var, b_var: bv } => {
-                        let a_bits = b.use_var(vars[*a_var as usize]);
-                        let b_bits = b.use_var(vars[*bv as usize]);
-                        let a_f = b.ins().bitcast(types::F64, cranelift_codegen::ir::MemFlags::new(), a_bits);
-                        let b_f = b.ins().bitcast(types::F64, cranelift_codegen::ir::MemFlags::new(), b_bits);
-                        let cmp = b.ins().fcmp(cranelift_codegen::ir::condcodes::FloatCC::GreaterThan, a_f, b_f);
                         let result = b.ins().uextend(ptr_ty, cmp);
                         b.def_var(vars[*dst_var as usize], result);
                     }


### PR DESCRIPTION
## Summary
- Remove two never-constructed variants from the \`JitOp\` enum and the \`match\` arms / use-count walks that referenced them.
- Drop the crate-level \`#[allow(dead_code)]\` attribute on \`JitOp\` — every remaining variant is now live (the lint confirms with zero warnings after removal).

## Detail
Both variants only survived as dispatch arms; no code path ever produced them.

- \`JitOp::Alternative { dst, primary }\` — the alternative (\`//\`) lowering is now driven by \`Expr::Alternative\` matching with \`IsNullOrFalse\` + \`BranchOnVar\`. The dispatcher arm even noted "Not used directly in codegen".
- \`JitOp::F64Greater { dst_var, a_var, b_var }\` — fused-numeric \`>\` goes through \`F64Cmp\` with a \`cc\` parameter (\`FloatCC::GreaterThan\`); no emitter constructs the dedicated variant anymore.

This is a pure cleanup: no behaviour change.

## Test plan
- [x] \`cargo build --release\` (zero warnings with \`#[allow(dead_code)]\` removed)
- [x] \`cargo test --release\` (official 509 + regression)
- [x] \`./bench/comprehensive.sh --quick\` — within ±5% of v1.4.3 baseline; no clean regression

Closes #317

🤖 Generated with [Claude Code](https://claude.com/claude-code)