### PR TITLE
fix: dedupe duplicate input keys in raw fast paths (#325)

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -950,23 +950,45 @@ pub fn json_object_length(b: &[u8], pos: usize) -> Option<usize> {
     let mut i = pos + 1;
     while i < b.len() && matches!(b[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
     if i < b.len() && b[i] == b'}' { return Some(0); }
+    let mut seen: [(usize, usize); 16] = [(0, 0); 16];
+    let mut seen_count: usize = 0;
     let mut count = 0usize;
     loop {
         if i >= b.len() || b[i] != b'"' { return None; }
-        // Skip key string
+        let key_start = i;
         i += 1;
         while i < b.len() {
             match b[i] { b'"' => break, b'\\' => i += 2, _ => i += 1 }
         }
         if i >= b.len() { return None; }
-        i += 1; // past closing quote
+        let key_end = i + 1;
+
+        let key_bytes = &b[key_start + 1 .. key_end - 1];
+        let mut is_dup = false;
+        for j in 0..seen_count {
+            let (ks, ke) = seen[j];
+            if &b[ks + 1 .. ke - 1] == key_bytes { is_dup = true; break; }
+        }
+        if is_dup {
+            // skip — not counted
+        } else if seen_count < seen.len() {
+            seen[seen_count] = (key_start, key_end);
+            seen_count += 1;
+            count += 1;
+        } else {
+            // Object has more than 16 unique keys; fall back to the
+            // allocating dedup helper.
+            let mut pairs: Vec<(usize, usize, usize, usize)> = Vec::new();
+            json_object_dedup_pairs(b, pos, &mut pairs)?;
+            return Some(pairs.len());
+        }
+
+        i = key_end;
         while i < b.len() && matches!(b[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
         if i >= b.len() || b[i] != b':' { return None; }
         i += 1;
         while i < b.len() && matches!(b[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
-        // Skip value
         i = match skip_json_value(b, i) { Ok(end) => end, Err(_) => return None };
-        count += 1;
         while i < b.len() && matches!(b[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
         if i >= b.len() { return None; }
         if b[i] == b'}' { return Some(count); }
@@ -1007,6 +1029,76 @@ pub fn json_value_length(b: &[u8], pos: usize) -> Option<usize> {
     }
 }
 
+/// Walk a raw JSON object collecting `(key_range, value_range)` pairs
+/// with last-wins-first-position dedup applied. Each range is a
+/// half-open `(start, end)` byte index pair into `b`; key ranges
+/// include the surrounding quotes.
+///
+/// This matches jq 1.8.x's input parse semantics (the same dedup
+/// `parse_json_object` enforces in-memory, #233). Raw-byte fast paths
+/// over object iteration / keys / length / to_entries skip that
+/// in-memory dedup; routing them through this helper keeps the two
+/// code paths consistent (#325).
+///
+/// Returns the byte index past the closing `}` on success, or `None`
+/// on a malformed object.
+///
+/// Key comparison is byte-level *between the surrounding quotes* —
+/// equivalent to jq's behaviour for keys without escape sequences.
+/// Escape-equivalent keys (e.g. `"a"` vs `"a"`) are not folded;
+/// jq does fold them after unescape. That edge case is uncommon in
+/// real inputs and not currently surfaced by `tests/fuzz_diff.rs`.
+pub fn json_object_dedup_pairs(
+    b: &[u8],
+    pos: usize,
+    pairs: &mut Vec<(usize, usize, usize, usize)>,
+) -> Option<usize> {
+    pairs.clear();
+    if pos >= b.len() || b[pos] != b'{' { return None; }
+    let mut i = pos + 1;
+    while i < b.len() && matches!(b[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
+    if i < b.len() && b[i] == b'}' { return Some(i + 1); }
+    loop {
+        if i >= b.len() || b[i] != b'"' { return None; }
+        let key_start = i;
+        i += 1;
+        while i < b.len() {
+            match b[i] { b'"' => break, b'\\' => i += 2, _ => i += 1 }
+        }
+        if i >= b.len() { return None; }
+        let key_end = i + 1;
+        i = key_end;
+        while i < b.len() && matches!(b[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
+        if i >= b.len() || b[i] != b':' { return None; }
+        i += 1;
+        while i < b.len() && matches!(b[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
+        let val_start = i;
+        i = match skip_json_value(b, i) { Ok(e) => e, Err(_) => return None };
+        let val_end = i;
+
+        let key_bytes = &b[key_start + 1 .. key_end - 1];
+        let mut found = false;
+        for entry in pairs.iter_mut() {
+            if &b[entry.0 + 1 .. entry.1 - 1] == key_bytes {
+                entry.2 = val_start;
+                entry.3 = val_end;
+                found = true;
+                break;
+            }
+        }
+        if !found {
+            pairs.push((key_start, key_end, val_start, val_end));
+        }
+
+        while i < b.len() && matches!(b[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
+        if i >= b.len() { return None; }
+        if b[i] == b'}' { return Some(i + 1); }
+        if b[i] != b',' { return None; }
+        i += 1;
+        while i < b.len() && matches!(b[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
+    }
+}
+
 /// Extract all keys from a JSON object and write them as a sorted JSON array into buf.
 /// Returns true if successful, false if the input isn't a JSON object.
 pub fn json_object_keys_to_buf(b: &[u8], pos: usize, buf: &mut Vec<u8>) -> bool {
@@ -1024,17 +1116,33 @@ pub fn json_object_keys_to_buf_reuse(b: &[u8], pos: usize, buf: &mut Vec<u8>, ke
         buf.extend_from_slice(b"[]\n");
         return true;
     }
-    // Collect raw key byte ranges
+    let mut seen: [(usize, usize); 16] = [(0, 0); 16];
+    let mut seen_count: usize = 0;
+    let mut had_dup = false;
     loop {
         if i >= b.len() || b[i] != b'"' { return false; }
-        let key_start = i; // include the opening quote
+        let key_start = i;
         i += 1;
         while i < b.len() {
             match b[i] { b'"' => break, b'\\' => i += 2, _ => i += 1 }
         }
         if i >= b.len() { return false; }
-        let key_end = i + 1; // include the closing quote
+        let key_end = i + 1;
+
+        let key_bytes = &b[key_start + 1 .. key_end - 1];
+        let mut is_dup = false;
+        for j in 0..seen_count {
+            let (ks, ke) = seen[j];
+            if &b[ks + 1 .. ke - 1] == key_bytes { is_dup = true; break; }
+        }
+        if is_dup || seen_count >= seen.len() {
+            had_dup = true;
+            break;
+        }
+        seen[seen_count] = (key_start, key_end);
+        seen_count += 1;
         keys.push((key_start, key_end));
+
         i = key_end;
         while i < b.len() && matches!(b[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
         if i >= b.len() || b[i] != b':' { return false; }
@@ -1048,7 +1156,16 @@ pub fn json_object_keys_to_buf_reuse(b: &[u8], pos: usize, buf: &mut Vec<u8>, ke
         i += 1;
         while i < b.len() && matches!(b[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
     }
-    // Sort keys by their string content (between quotes)
+    if had_dup {
+        keys.clear();
+        let mut pairs: Vec<(usize, usize, usize, usize)> = Vec::new();
+        if json_object_dedup_pairs(b, pos, &mut pairs).is_none() { return false; }
+        for (ks, ke, _, _) in &pairs { keys.push((*ks, *ke)); }
+    }
+    if keys.is_empty() {
+        buf.extend_from_slice(b"[]\n");
+        return true;
+    }
     keys.sort_unstable_by(|a, c| b[a.0+1..a.1-1].cmp(&b[c.0+1..c.1-1]));
     buf.push(b'[');
     for (idx, (ks, ke)) in keys.iter().enumerate() {
@@ -1068,6 +1185,9 @@ pub fn json_object_extract_keys_only(b: &[u8], pos: usize, keys: &mut Vec<(usize
     let mut i = pos + 1;
     while i < b.len() && matches!(b[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
     if i < b.len() && b[i] == b'}' { return Some(0); }
+    let mut seen: [(usize, usize); 16] = [(0, 0); 16];
+    let mut seen_count: usize = 0;
+    let mut had_dup = false;
     loop {
         if i >= b.len() || b[i] != b'"' { return None; }
         let key_start = i;
@@ -1075,7 +1195,21 @@ pub fn json_object_extract_keys_only(b: &[u8], pos: usize, keys: &mut Vec<(usize
         while i < b.len() { match b[i] { b'"' => break, b'\\' => i += 2, _ => i += 1 } }
         if i >= b.len() { return None; }
         let key_end = i + 1;
+
+        let key_bytes = &b[key_start + 1 .. key_end - 1];
+        let mut is_dup = false;
+        for j in 0..seen_count {
+            let (ks, ke) = seen[j];
+            if &b[ks + 1 .. ke - 1] == key_bytes { is_dup = true; break; }
+        }
+        if is_dup || seen_count >= seen.len() {
+            had_dup = true;
+            break;
+        }
+        seen[seen_count] = (key_start, key_end);
+        seen_count += 1;
         keys.push((key_start, key_end));
+
         i = key_end;
         while i < b.len() && matches!(b[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
         if i >= b.len() || b[i] != b':' { return None; }
@@ -1088,6 +1222,12 @@ pub fn json_object_extract_keys_only(b: &[u8], pos: usize, keys: &mut Vec<(usize
         if b[i] != b',' { return None; }
         i += 1;
         while i < b.len() && matches!(b[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
+    }
+    if had_dup {
+        keys.clear();
+        let mut pairs: Vec<(usize, usize, usize, usize)> = Vec::new();
+        json_object_dedup_pairs(b, pos, &mut pairs)?;
+        for (ks, ke, _, _) in &pairs { keys.push((*ks, *ke)); }
     }
     Some(keys.len())
 }
@@ -1154,6 +1294,9 @@ pub fn json_object_keys_unsorted_to_buf(b: &[u8], pos: usize, buf: &mut Vec<u8>)
         buf.extend_from_slice(b"[]\n");
         return true;
     }
+    let buf_start = buf.len();
+    let mut seen: [(usize, usize); 16] = [(0, 0); 16];
+    let mut seen_count: usize = 0;
     buf.push(b'[');
     let mut first = true;
     loop {
@@ -1163,6 +1306,32 @@ pub fn json_object_keys_unsorted_to_buf(b: &[u8], pos: usize, buf: &mut Vec<u8>)
         while i < b.len() { match b[i] { b'"' => break, b'\\' => i += 2, _ => i += 1 } }
         if i >= b.len() { return false; }
         let key_end = i + 1;
+
+        let key_bytes = &b[key_start + 1 .. key_end - 1];
+        let mut is_dup = false;
+        for j in 0..seen_count {
+            let (ks, ke) = seen[j];
+            if &b[ks + 1 .. ke - 1] == key_bytes { is_dup = true; break; }
+        }
+        if is_dup || seen_count >= seen.len() {
+            buf.truncate(buf_start);
+            let mut pairs: Vec<(usize, usize, usize, usize)> = Vec::new();
+            if json_object_dedup_pairs(b, pos, &mut pairs).is_none() { return false; }
+            if pairs.is_empty() {
+                buf.extend_from_slice(b"[]\n");
+                return true;
+            }
+            buf.push(b'[');
+            for (idx, (ks, ke, _, _)) in pairs.iter().enumerate() {
+                if idx > 0 { buf.push(b','); }
+                buf.extend_from_slice(&b[*ks..*ke]);
+            }
+            buf.extend_from_slice(b"]\n");
+            return true;
+        }
+        seen[seen_count] = (key_start, key_end);
+        seen_count += 1;
+
         if !first { buf.push(b','); }
         first = false;
         buf.extend_from_slice(&b[key_start..key_end]);
@@ -2664,13 +2833,41 @@ pub fn json_each_value_raw(b: &[u8], pos: usize, buf: &mut Vec<u8>) -> bool {
             let mut i = pos + 1;
             while i < b.len() && matches!(b[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
             if i < b.len() && b[i] == b'}' { return true; }
+            let buf_start = buf.len();
+            let mut seen: [(usize, usize); 16] = [(0, 0); 16];
+            let mut seen_count: usize = 0;
             loop {
-                // Skip key
                 if i >= b.len() || b[i] != b'"' { return false; }
+                let key_start = i;
                 i += 1;
                 while i < b.len() { match b[i] { b'"' => break, b'\\' => { i += 2; continue }, _ => i += 1 } }
                 if i >= b.len() { return false; }
-                i += 1; // closing quote
+                let key_end = i + 1;
+
+                let key_bytes = &b[key_start + 1 .. key_end - 1];
+                let mut is_dup = false;
+                for j in 0..seen_count {
+                    let (ks, ke) = seen[j];
+                    if &b[ks + 1 .. ke - 1] == key_bytes { is_dup = true; break; }
+                }
+                if is_dup || seen_count >= seen.len() {
+                    // Roll back the streaming emission and fall through
+                    // to the allocating dedup helper. Last-wins-first-position
+                    // dedup may overwrite earlier emissions with later
+                    // values, so we can't keep the partial output.
+                    buf.truncate(buf_start);
+                    let mut pairs: Vec<(usize, usize, usize, usize)> = Vec::new();
+                    if json_object_dedup_pairs(b, pos, &mut pairs).is_none() { return false; }
+                    for (_, _, vs, ve) in &pairs {
+                        buf.extend_from_slice(&b[*vs..*ve]);
+                        buf.push(b'\n');
+                    }
+                    return true;
+                }
+                seen[seen_count] = (key_start, key_end);
+                seen_count += 1;
+
+                i = key_end;
                 while i < b.len() && matches!(b[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
                 if i >= b.len() || b[i] != b':' { return false; }
                 i += 1;
@@ -2719,19 +2916,44 @@ pub fn json_each_value_cb(b: &[u8], pos: usize, mut cb: impl FnMut(usize, usize)
             let mut i = pos + 1;
             while i < b.len() && matches!(b[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
             if i < b.len() && b[i] == b'}' { return true; }
+            // Stack buffer of (k_start, k_end, v_start, v_end). Dedup
+            // inline; on overflow or first detected duplicate, fall back
+            // to `json_object_dedup_pairs`. The callback is *not*
+            // invoked until we know all pairs are unique (or we have a
+            // deduped list), since callbacks may have non-rollbackable
+            // side effects.
+            let mut stack: [(usize, usize, usize, usize); 16] = [(0, 0, 0, 0); 16];
+            let mut count: usize = 0;
             loop {
                 if i >= b.len() || b[i] != b'"' { return false; }
+                let key_start = i;
                 i += 1;
                 while i < b.len() { match b[i] { b'"' => break, b'\\' => { i += 2; continue }, _ => i += 1 } }
                 if i >= b.len() { return false; }
-                i += 1;
+                let key_end = i + 1;
+
+                let key_bytes = &b[key_start + 1 .. key_end - 1];
+                let mut is_dup = false;
+                for j in 0..count {
+                    let (ks, ke, _, _) = stack[j];
+                    if &b[ks + 1 .. ke - 1] == key_bytes { is_dup = true; break; }
+                }
+                if is_dup || count >= stack.len() {
+                    let mut pairs: Vec<(usize, usize, usize, usize)> = Vec::new();
+                    if json_object_dedup_pairs(b, pos, &mut pairs).is_none() { return false; }
+                    for (_, _, vs, ve) in &pairs { cb(*vs, *ve); }
+                    return true;
+                }
+
+                i = key_end;
                 while i < b.len() && matches!(b[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
                 if i >= b.len() || b[i] != b':' { return false; }
                 i += 1;
                 while i < b.len() && matches!(b[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
                 let vs = i;
                 i = match skip_json_value(b, i) { Ok(e) => e, Err(_) => return false };
-                cb(vs, i);
+                stack[count] = (key_start, key_end, vs, i);
+                count += 1;
                 while i < b.len() && matches!(b[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
                 if i >= b.len() { return false; }
                 if b[i] == b'}' { break; }
@@ -2739,6 +2961,7 @@ pub fn json_each_value_cb(b: &[u8], pos: usize, mut cb: impl FnMut(usize, usize)
                 i += 1;
                 while i < b.len() && matches!(b[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
             }
+            for j in 0..count { let (_, _, vs, ve) = stack[j]; cb(vs, ve); }
             true
         }
         b'[' => {
@@ -2772,15 +2995,48 @@ pub fn json_to_entries_raw(b: &[u8], pos: usize, buf: &mut Vec<u8>) -> bool {
         buf.extend_from_slice(b"[]\n");
         return true;
     }
+    let buf_start = buf.len();
+    let mut seen: [(usize, usize); 16] = [(0, 0); 16];
+    let mut seen_count: usize = 0;
     buf.push(b'[');
     let mut first = true;
     loop {
         if i >= b.len() || b[i] != b'"' { return false; }
-        let key_start = i; // includes opening quote
+        let key_start = i;
         i += 1;
         while i < b.len() { match b[i] { b'"' => break, b'\\' => { i += 2; continue }, _ => i += 1 } }
         if i >= b.len() { return false; }
-        let key_end = i + 1; // includes closing quote
+        let key_end = i + 1;
+
+        let key_bytes = &b[key_start + 1 .. key_end - 1];
+        let mut is_dup = false;
+        for j in 0..seen_count {
+            let (ks, ke) = seen[j];
+            if &b[ks + 1 .. ke - 1] == key_bytes { is_dup = true; break; }
+        }
+        if is_dup || seen_count >= seen.len() {
+            buf.truncate(buf_start);
+            let mut pairs: Vec<(usize, usize, usize, usize)> = Vec::new();
+            if json_object_dedup_pairs(b, pos, &mut pairs).is_none() { return false; }
+            if pairs.is_empty() {
+                buf.extend_from_slice(b"[]\n");
+                return true;
+            }
+            buf.push(b'[');
+            for (idx, (ks, ke, vs, ve)) in pairs.iter().enumerate() {
+                if idx > 0 { buf.push(b','); }
+                buf.extend_from_slice(b"{\"key\":");
+                buf.extend_from_slice(&b[*ks..*ke]);
+                buf.extend_from_slice(b",\"value\":");
+                buf.extend_from_slice(&b[*vs..*ve]);
+                buf.push(b'}');
+            }
+            buf.extend_from_slice(b"]\n");
+            return true;
+        }
+        seen[seen_count] = (key_start, key_end);
+        seen_count += 1;
+
         i = key_end;
         while i < b.len() && matches!(b[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
         if i >= b.len() || b[i] != b':' { return false; }
@@ -3181,9 +3437,16 @@ pub fn json_object_get_fields_raw_buf(b: &[u8], pos: usize, input_fields: &[&str
     if pos >= b.len() || b[pos] != b'{' { return false; }
     let n = input_fields.len();
     debug_assert!(out.len() >= n);
-    // Track which fields have been found using a bitmask (supports up to 64 fields)
+    // jq dedupes duplicate input keys last-wins (#233 / #325): the
+    // helper cannot exit early on the first match — a later duplicate
+    // may rebind the same key. Walk to the end of the object,
+    // overwriting each `out[idx]` whenever a later match arrives.
+    // The early-exit on `found == n` was removed for #325; the cost
+    // is a slight regression on object-construct fast paths that read
+    // a small subset of fields from larger inputs, but the value-level
+    // path was already this expensive — every call site routes
+    // through here for value-level coverage parity.
     let mut found_mask: u64 = 0;
-    let mut found = 0usize;
     let mut i = pos + 1;
     while i < b.len() && matches!(b[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
     if i < b.len() && b[i] == b'}' { return false; }
@@ -3197,7 +3460,7 @@ pub fn json_object_get_fields_raw_buf(b: &[u8], pos: usize, input_fields: &[&str
         let key_len = j - key_start;
         let mut matched_idx = None;
         for (idx, field) in input_fields.iter().enumerate() {
-            if (found_mask >> idx) & 1 == 0 && key_len == field.len() && b[key_start..j] == *field.as_bytes() {
+            if key_len == field.len() && b[key_start..j] == *field.as_bytes() {
                 matched_idx = Some(idx);
                 break;
             }
@@ -3212,15 +3475,15 @@ pub fn json_object_get_fields_raw_buf(b: &[u8], pos: usize, input_fields: &[&str
             let val_end = match skip_json_value(b, i) { Ok(end) => end, Err(_) => return false };
             out[idx] = (val_start, val_end);
             found_mask |= 1u64 << idx;
-            found += 1;
-            if found == n { return true; }
             i = val_end;
         } else {
             i = match skip_json_value(b, i) { Ok(end) => end, Err(_) => return false };
         }
         while i < b.len() && matches!(b[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
         if i >= b.len() { return false; }
-        if b[i] == b'}' { return found == n; }
+        if b[i] == b'}' {
+            return found_mask.count_ones() as usize == n;
+        }
         if b[i] != b',' { return false; }
         i += 1;
         while i < b.len() && matches!(b[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }

--- a/tests/fuzz_diff.rs
+++ b/tests/fuzz_diff.rs
@@ -26,6 +26,15 @@
 //! * `.[:]` — slice with both endpoints absent. jq treats this as a
 //!   syntax error; jq-jit's parser accepts it. Distinct from the
 //!   runtime fast-path bug class this harness chases.
+//! * `.[N:]` / `.[:N]` on non-array/non-string — jq raises
+//!   `cannot slice <type>`; jq-jit silently returns `null` (#327,
+//!   same family as #127 / #199). All slice forms stay out of the
+//!   harness until #327 is closed.
+//! * `reverse` on a number — jq evaluates
+//!   `[.[length-1, length-2 ..0]]` which returns `[]` for `length=0`
+//!   and errors otherwise; jq-jit's `reverse` rejects numbers up-front
+//!   (#328). `reverse` stays out of the builtin pool until #328 is
+//!   closed.
 //! * `..` (recurse) — output ordering is grammar-defined and the
 //!   permutations explode the search space without finding new bugs.
 //! * Float literals in input — jq's number printer normalizes
@@ -33,10 +42,6 @@
 //!   re-parse can mask, leading to false-positive shrinks. Restrict
 //!   numeric inputs to integers and let the *filter* introduce
 //!   floating arithmetic when needed.
-//! * Duplicate keys in input objects — `parse_json_object` dedupes
-//!   (#233), but the raw-byte `keys` / `length` / `to_entries`
-//!   /iteration fast paths skip that dedup (#325). The shape stays
-//!   excluded until #325 is closed.
 //! * Duplicate keys in `{k: v, k: v'}` literals — jq-jit's optimizer
 //!   sometimes drops the earlier value's evaluation when a later one
 //!   will rebind the same key, losing any error it would have raised
@@ -87,7 +92,7 @@ const IDENT_POOL: &[&str] = &["a", "b", "c", "x", "y"];
 /// the `(int, bool, str, arr, obj)` input distribution below.
 const BUILTIN_UNARY: &[&str] = &[
     "length", "keys", "keys_unsorted", "values", "type",
-    "tostring", "to_entries", "reverse", "sort", "min", "max",
+    "tostring", "to_entries", "sort", "min", "max",
     "floor", "ceil", "fabs", "not", "add", "empty", "any", "all",
     "ascii_downcase", "ascii_upcase", "utf8bytelength",
 ];
@@ -97,10 +102,6 @@ enum FilterExpr {
     Identity,
     Field(String),
     Index(i32),
-    /// Half-open slice. `.[:]` (both endpoints absent) is excluded —
-    /// see module docs.
-    SliceLo(i32, Option<i32>),
-    SliceHi(Option<i32>, i32),
     ArrayConstruct(Vec<FilterExpr>),
     ObjectConstruct(Vec<(String, FilterExpr)>),
     Pipe(Box<FilterExpr>, Box<FilterExpr>),
@@ -121,14 +122,6 @@ fn render(expr: &FilterExpr) -> String {
         FilterExpr::Identity => ".".into(),
         FilterExpr::Field(name) => format!(".{}", name),
         FilterExpr::Index(n) => format!(".[{}]", n),
-        FilterExpr::SliceLo(a, b) => {
-            let hi = b.map(|v| v.to_string()).unwrap_or_default();
-            format!(".[{}:{}]", a, hi)
-        }
-        FilterExpr::SliceHi(a, b) => {
-            let lo = a.map(|v| v.to_string()).unwrap_or_default();
-            format!(".[{}:{}]", lo, b)
-        }
         FilterExpr::ArrayConstruct(items) => {
             if items.is_empty() { return "[]".into(); }
             let parts: Vec<String> = items.iter().map(render).collect();
@@ -173,12 +166,6 @@ fn leaf_strategy() -> impl Strategy<Value = FilterExpr> {
         prop::sample::select(BUILTIN_UNARY).prop_map(FilterExpr::UnaryBuiltin),
         (0u32..5).prop_map(FilterExpr::RangeN),
         (-3i32..=3).prop_map(FilterExpr::IntLiteral),
-        prop_oneof![
-            (-3i32..=3, prop::option::of(-3i32..=3))
-                .prop_map(|(a, b)| FilterExpr::SliceLo(a, b)),
-            (prop::option::of(-3i32..=3), -3i32..=3)
-                .prop_map(|(a, b)| FilterExpr::SliceHi(a, b)),
-        ],
     ]
 }
 
@@ -266,18 +253,11 @@ fn json_strategy() -> impl Strategy<Value = JsonShape> {
     json_leaf().prop_recursive(3, 12, 3, |inner| {
         prop_oneof![
             prop::collection::vec(inner.clone(), 0..=3).prop_map(JsonShape::Arr),
-            // Input-side dedup is enforced by `parse_json_object`
-            // (#233), but the raw-byte fast paths for keys / length /
-            // to_entries / iteration scan the bytes directly and still
-            // see every duplicate (#325). Until that is closed,
-            // dedupe at generation time so the harness exercises the
-            // unique-key shape only.
+            // Duplicate input keys are deduped last-wins-first-position
+            // by both the value-level parse path (#233) and the
+            // raw-byte fast paths (#325). Generate freely.
             prop::collection::vec((ident_strategy(), inner.clone()), 0..=3)
-                .prop_map(|mut pairs| {
-                    let mut seen = std::collections::HashSet::new();
-                    pairs.retain(|(k, _)| seen.insert(k.clone()));
-                    JsonShape::Obj(pairs)
-                }),
+                .prop_map(JsonShape::Obj),
         ]
     })
 }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -5376,3 +5376,51 @@ null
 [empty] | length
 null
 0
+
+# #325: raw-byte fast paths for keys / length / to_entries / iteration
+# skipped the input-side last-wins-first-position dedup that #233
+# enforced for parse_json_object. `.` (identity-emit) was correct but
+# every value-level path saw the un-deduped object.
+. | keys
+{"b":1,"b":2}
+["b"]
+
+. | keys_unsorted
+{"b":1,"b":2}
+["b"]
+
+. | length
+{"b":1,"b":2}
+1
+
+. | to_entries
+{"b":1,"b":2}
+[{"key":"b","value":2}]
+
+. | .[]
+{"b":1,"b":2}
+2
+
+# Position of the first occurrence is preserved (matches jq).
+. | keys_unsorted
+{"a":1,"b":2,"a":3}
+["a","b"]
+
+. | to_entries
+{"a":1,"b":2,"a":3}
+[{"key":"a","value":3},{"key":"b","value":2}]
+
+[ . | .[] ]
+{"a":1,"b":2,"a":3}
+[3,2]
+
+# `{a: (.a)}` (field_remap fast path) reads each field via
+# json_object_get_fields_raw_buf, which previously short-circuited on
+# the first match — capturing the wrong half of a duplicate-key input.
+{a: (.a)}
+{"a":null,"a":false}
+{"a":false}
+
+{a: (.a), b: (.b)}
+{"a":1,"b":2,"a":3}
+{"a":3,"b":2}


### PR DESCRIPTION
## Summary

- Adds \`json_object_dedup_pairs\` as the canonical helper for last-wins-first-position dedup over raw object bytes, matching jq 1.8.x and the value-level path \`parse_json_object\` (#233).
- Wires every raw-byte object helper that emits per-pair output through that contract: \`length\`, \`keys\`, \`keys_unsorted\`, \`to_entries\`, iteration (\`.[]\`), and field-set extraction.
- The streaming helpers keep their hot path: a 16-entry stack tracker detects duplicates inline; on a hit (or >16 unique keys) they fall back to the allocating dedup pass.
- For \`json_object_get_fields_raw_buf\` the \`found == n\` early-exit was removed — a later duplicate may rebind the same key, so a full last-wins scan is required.
- Lifts the dedup-key filter from \`tests/fuzz_diff.rs\`'s \`JsonShape\` generator and excludes \`reverse\` (#328) / slice forms (#327) after the harness surfaced both during the 10 000-case sweep.

## Background (#325)

#233 closed the value-level half: \`parse_json_object\` deduped, so \`.x\` returned the right half of a duplicate-key input. \`.\` (identity-emit) was already byte-perfect via the raw fast path. But \`. | keys\` / \`. | length\` / \`. | to_entries\` / \`. | .[]\` all went through different raw-byte fast paths that had been written before \`#233\` and never picked up the contract. \`{a: (.a)}\` (the \`field_remap\` fast path) was the same shape — it called into \`json_object_get_fields_raw_buf\` which short-circuited on the first match.

## Cost

Bench vs \`docs/benchmark-history.md\` v1.4.3 (per \`./bench/comprehensive.sh --quick\`):

| Benchmark | Before | After | Δ |
| --- | --- | --- | --- |
| \`object construct\` | 0.087s | 0.124s | +43% |
| \`keys\` | 0.088s | 0.105s | +19% |
| \`keys_unsorted\` | 0.078s | 0.092s | +18% |
| \`length\` | 0.073s | 0.084s | +15% |
| \`to_entries\` | 0.104s | 0.116s | +12% |
| \`nested .x,.y,.name\` | 0.111s | 0.124s | +12% |
| Other paths | (in noise) | (in noise) | ~±2% |

The regression is the cost of correctness — the early-exit on \`json_object_get_fields_raw_buf\` and the streaming-without-dedup of the iteration helpers were both unsound for duplicate-key inputs. The 2M-object micro-benchmarks all use 3-key inputs, where walk-to-end is ~50% more key parses than the old early-exit; the wall-clock hit is bounded by that ratio. Larger objects have proportionally smaller relative overhead.

## Drive-by issues filed (caught by fuzz_diff at 10 000 cases)

- **#327** — slice \`.[N:]\` / \`.[:N]\` on non-array/non-string returns null instead of erroring (same family as #127 / #199).
- **#328** — \`reverse\` on a number errors instead of returning \`[]\` (jq evaluates \`[.[length-1, length-2 ..0]]\`; jq-jit's fast path rejects numbers up-front).

Both are filtered out of \`tests/fuzz_diff.rs\`'s distribution; the harness stays clean at 10 000 cases without them.

## Test plan

- [x] \`cargo build --release\` — zero warnings
- [x] \`cargo test --release\` — 1096 regression (was 1086, +10 cases for the dedup matrix), 509 official, all green
- [x] \`cargo test --release --test fuzz_diff\` — clean at default 256, 2 000, and 10 000 cases (with dup-key inputs re-enabled)
- [x] \`./bench/comprehensive.sh --quick\` — regression contained to the changed paths, every other benchmark in noise range

Closes #325