### PR TITLE
fix: reverse on zero-length number returns [] (#328)

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1056,6 +1056,10 @@ fn rt_reverse(v: &Value) -> Result<Value> {
         Value::Null => Ok(Value::Arr(Rc::new(vec![]))),
         Value::Str(s) if s.is_empty() => Ok(Value::Arr(Rc::new(vec![]))),
         Value::Obj(ObjInner(o)) if o.is_empty() => Ok(Value::Arr(Rc::new(vec![]))),
+        // n == 0.0 covers both +0 and -0; range(0; 0) is empty so the
+        // `[.[length-1, length-2 ..0]]` desugar yields []. Non-zero
+        // (including NaN) errors via the `.[idx]` step (#328).
+        Value::Num(n, _) if *n == 0.0 => Ok(Value::Arr(Rc::new(vec![]))),
         Value::Str(_) => bail!("Cannot index string with number"),
         Value::Obj(_) => bail!("Cannot index object with number"),
         Value::Num(_, _) => bail!("Cannot index number with number"),

--- a/tests/fuzz_diff.rs
+++ b/tests/fuzz_diff.rs
@@ -30,11 +30,6 @@
 //!   `cannot slice <type>`; jq-jit silently returns `null` (#327,
 //!   same family as #127 / #199). All slice forms stay out of the
 //!   harness until #327 is closed.
-//! * `reverse` on a number — jq evaluates
-//!   `[.[length-1, length-2 ..0]]` which returns `[]` for `length=0`
-//!   and errors otherwise; jq-jit's `reverse` rejects numbers up-front
-//!   (#328). `reverse` stays out of the builtin pool until #328 is
-//!   closed.
 //! * `..` (recurse) — output ordering is grammar-defined and the
 //!   permutations explode the search space without finding new bugs.
 //! * Float literals in input — jq's number printer normalizes
@@ -92,7 +87,7 @@ const IDENT_POOL: &[&str] = &["a", "b", "c", "x", "y"];
 /// the `(int, bool, str, arr, obj)` input distribution below.
 const BUILTIN_UNARY: &[&str] = &[
     "length", "keys", "keys_unsorted", "values", "type",
-    "tostring", "to_entries", "sort", "min", "max",
+    "tostring", "to_entries", "reverse", "sort", "min", "max",
     "floor", "ceil", "fabs", "not", "add", "empty", "any", "all",
     "ascii_downcase", "ascii_upcase", "utf8bytelength",
 ];

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -5424,3 +5424,26 @@ null
 {a: (.a), b: (.b)}
 {"a":1,"b":2,"a":3}
 {"a":3,"b":2}
+
+# #328: reverse on a number errored unconditionally instead of
+# matching jq's `[.[length-1, length-2 ..0]]` semantics: 0 → [],
+# non-zero (including NaN/fractions) → "Cannot index number with number".
+0 | reverse
+null
+[]
+
+0.0 | reverse
+null
+[]
+
+-0.0 | reverse
+null
+[]
+
+{} | reverse
+null
+[]
+
+"" | reverse
+null
+[]


### PR DESCRIPTION
## Summary

\`rt_reverse\` rejected every \`Value::Num\` with \"Cannot index number with number\". jq's actual semantics are \`[.[length-1, length-2 ..0]]\`, so:

- \`0 | reverse\` → \`[]\` (length 0, range empty)
- \`5 | reverse\` → error (range emits \`4,3,2,1,0\`; \`.[N]\` on a number errors)
- \`0.5 | reverse\`, \`nan | reverse\` → error
- \`null | reverse\`, \`{} | reverse\`, \`\"\" | reverse\` → \`[]\` (already correct)

Adds a \`Value::Num(n, _) if *n == 0.0\` guard to the existing match. \`+0.0\` and \`-0.0\` both compare equal under IEEE-754 so the single guard covers both.

## Test plan

- [x] \`cargo build --release\` — zero warnings
- [x] \`cargo test --release\` — 1101 regression (was 1096, +5 cases for the zero-number / -0.0 / empty-container matrix), 509 official, all green
- [x] \`tests/fuzz_diff.rs\` — re-enabled \`reverse\` in \`BUILTIN_UNARY\`, clean at 10 000 cases
- [x] \`./bench/comprehensive.sh --quick\` — no regression

Closes #328