### PR TITLE
fix: bail FieldSlice fast path on non-string non-null fields (#327)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -1196,12 +1196,28 @@ fn resolved_would_error(
             _ => true,
         }
     };
-    let _ = (is_arr, is_obj, is_null);
+    let _ = (is_arr, is_obj);
     match resolved {
         ResolvedRemap::FieldOpField(i1, op, i2) => !arith_fastpath_ok(bytes_of(*i1), bytes_of(*i2), op),
         ResolvedRemap::FieldOpConst(i, op, _) => !arith_op_with_const_ok(bytes_of(*i), op),
         ResolvedRemap::ConstOpField(_, op, i) => !arith_op_with_const_ok(bytes_of(*i), op),
         ResolvedRemap::FieldArray(items) => items.iter().any(|r| resolved_would_error(r, raw, ranges)),
+        // FieldSlice's inline emitter handles only ASCII-quoted strings;
+        // every other shape lands in its `else` branch and emits null
+        // silently — but jq slices arrays, returns null for null, and
+        // raises `cannot slice <type>` for booleans / numbers / objects
+        // (#327, same family as #127 / #199). Bail on anything that's
+        // not the emitter's narrow domain.
+        ResolvedRemap::FieldSlice(idx, _, _) => {
+            let val = bytes_of(*idx);
+            if is_null(val) { return false; }
+            if val.len() >= 2 && val[0] == b'"' && val[val.len()-1] == b'"'
+                && !val[1..val.len()-1].contains(&b'\\')
+            {
+                return false;
+            }
+            true
+        }
         _ => false,
     }
 }

--- a/tests/fuzz_diff.rs
+++ b/tests/fuzz_diff.rs
@@ -26,10 +26,6 @@
 //! * `.[:]` — slice with both endpoints absent. jq treats this as a
 //!   syntax error; jq-jit's parser accepts it. Distinct from the
 //!   runtime fast-path bug class this harness chases.
-//! * `.[N:]` / `.[:N]` on non-array/non-string — jq raises
-//!   `cannot slice <type>`; jq-jit silently returns `null` (#327,
-//!   same family as #127 / #199). All slice forms stay out of the
-//!   harness until #327 is closed.
 //! * `..` (recurse) — output ordering is grammar-defined and the
 //!   permutations explode the search space without finding new bugs.
 //! * Float literals in input — jq's number printer normalizes
@@ -97,6 +93,10 @@ enum FilterExpr {
     Identity,
     Field(String),
     Index(i32),
+    /// Half-open slice. `.[:]` (both endpoints absent) is excluded —
+    /// see module docs.
+    SliceLo(i32, Option<i32>),
+    SliceHi(Option<i32>, i32),
     ArrayConstruct(Vec<FilterExpr>),
     ObjectConstruct(Vec<(String, FilterExpr)>),
     Pipe(Box<FilterExpr>, Box<FilterExpr>),
@@ -117,6 +117,14 @@ fn render(expr: &FilterExpr) -> String {
         FilterExpr::Identity => ".".into(),
         FilterExpr::Field(name) => format!(".{}", name),
         FilterExpr::Index(n) => format!(".[{}]", n),
+        FilterExpr::SliceLo(a, b) => {
+            let hi = b.map(|v| v.to_string()).unwrap_or_default();
+            format!(".[{}:{}]", a, hi)
+        }
+        FilterExpr::SliceHi(a, b) => {
+            let lo = a.map(|v| v.to_string()).unwrap_or_default();
+            format!(".[{}:{}]", lo, b)
+        }
         FilterExpr::ArrayConstruct(items) => {
             if items.is_empty() { return "[]".into(); }
             let parts: Vec<String> = items.iter().map(render).collect();
@@ -161,6 +169,12 @@ fn leaf_strategy() -> impl Strategy<Value = FilterExpr> {
         prop::sample::select(BUILTIN_UNARY).prop_map(FilterExpr::UnaryBuiltin),
         (0u32..5).prop_map(FilterExpr::RangeN),
         (-3i32..=3).prop_map(FilterExpr::IntLiteral),
+        prop_oneof![
+            (-3i32..=3, prop::option::of(-3i32..=3))
+                .prop_map(|(a, b)| FilterExpr::SliceLo(a, b)),
+            (prop::option::of(-3i32..=3), -3i32..=3)
+                .prop_map(|(a, b)| FilterExpr::SliceHi(a, b)),
+        ],
     ]
 }
 

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -5447,3 +5447,30 @@ null
 "" | reverse
 null
 []
+
+# #327: standalone_array's FieldSlice fast path emitted null silently
+# when the field value wasn't an ASCII-quoted string. jq slices arrays,
+# returns null for null, and errors on bool/number/object.
+[0, .x[0:]]
+{"x":[1,2,3]}
+[0,[1,2,3]]
+
+[0, (.x[0:])?]
+{"x":false}
+[0]
+
+[0, (.x[0:])?]
+{"x":42}
+[0]
+
+[0, (.x[0:])?]
+{"x":{"a":1}}
+[0]
+
+[0, .x[0:]]
+{"x":null}
+[0,null]
+
+[0, .x[0:3]]
+{"x":"hello"}
+[0,"hel"]


### PR DESCRIPTION
## Summary

\`emit_resolved_value\`'s \`ResolvedRemap::FieldSlice\` arm only handles ASCII-quoted strings; every other field shape (arrays, numbers, booleans, objects) fell into its \`else\` branch and emitted \`null\` silently. jq slices arrays, returns \`null\` for null, and raises \`cannot slice <type>\` for booleans / numbers / objects.

Adds a \`FieldSlice\` arm to \`resolved_would_error\` that returns \`true\` whenever the field value is outside the inline emitter's domain — bailing the row to the generic path so it produces jq's verdict.

## Surface

Found by \`tests/fuzz_diff.rs\` (#319). Filter shrinks to:

```
(.x) | ([0,.[0:]])  on  {"x":false}
  jq:  errors (Cannot index boolean with object)
  jit: [0,null]
```

The simplifier beta-reduces this to \`[0, .x[0:]]\`, which \`detect_standalone_array\` classifies into a \`FieldSlice("x", 0, None)\` remap; the inline emitter then treats the boolean field as \"not a string → emit null.\"

Same bug class as the closed #127 / #199 — fast path silently coerces a type-incompatible value to \`null\` instead of erroring.

## Test plan

- [x] \`cargo build --release\` — zero warnings
- [x] \`cargo test --release\` — 1102 regression (was 1096, +6 cases for the slice-on-each-type matrix), 509 official, all green
- [x] \`tests/fuzz_diff.rs\` — re-enabled \`SliceLo\` / \`SliceHi\` in the AST distribution, clean at 10 000 cases
- [x] \`./bench/comprehensive.sh --quick\` — no regression from this change (numbers track the prior #325 baseline)

Closes #327