### PR TITLE
fix: ObjectConstruct literal fold checks every pair before dedup (#324)

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -2000,13 +2000,24 @@ fn push_const_json(expr: &crate::ir::Expr, buf: &mut Vec<u8>) -> bool {
         }
         Expr::ObjectConstruct { pairs } => {
             // All keys must be string literals. Duplicates collapse via
-            // `normalize_object_pairs` (last value wins, keeps first position).
+            // `normalize_object_pairs` (last value wins, keeps first
+            // position). Every value — including ones that will be
+            // overwritten by a later duplicate — must be `push_const_json`-
+            // emittable: jq evaluates each `(key: value)` pair in source
+            // order, so an earlier pair's runtime error must still surface
+            // even when a later pair would rebind the same key. If we
+            // dedup first and only check the survivors, the eliminated
+            // expression's error is silently dropped (#324).
             let mut extracted: Vec<(&str, &Expr)> = Vec::with_capacity(pairs.len());
             for (key, val) in pairs {
                 match key {
                     Expr::Literal(Literal::Str(k)) => extracted.push((k.as_str(), val)),
                     _ => return false,
                 }
+            }
+            for (_, val) in &extracted {
+                let mut probe = Vec::new();
+                if !push_const_json(val, &mut probe) { return false; }
             }
             let normalized = normalize_object_pairs(extracted);
             buf.push(b'{');

--- a/tests/fuzz_diff.rs
+++ b/tests/fuzz_diff.rs
@@ -33,10 +33,6 @@
 //!   re-parse can mask, leading to false-positive shrinks. Restrict
 //!   numeric inputs to integers and let the *filter* introduce
 //!   floating arithmetic when needed.
-//! * Duplicate keys in `{k: v, k: v'}` literals — jq-jit's optimizer
-//!   sometimes drops the earlier value's evaluation when a later one
-//!   will rebind the same key, losing any error it would have raised
-//!   (#324).
 //!
 //! ## Knobs
 //!
@@ -186,21 +182,10 @@ fn filter_strategy() -> impl Strategy<Value = FilterExpr> {
         |inner| {
             prop_oneof![
                 prop::collection::vec(inner.clone(), 0..=3).prop_map(FilterExpr::ArrayConstruct),
-                // Duplicate keys are deduped to last-wins by jq's parser
-                // before evaluation. jq-jit's optimizer occasionally
-                // skips earlier values' evaluation when a later one will
-                // rebind the same key, dropping any errors they would
-                // have raised (#324). To keep that bug class out of the
-                // default-on harness, generate unique keys only — the
-                // single-key case is just last-wins by tautology.
                 prop::collection::vec(
                     (ident_strategy(), inner.clone()),
                     0..=3,
-                ).prop_map(|mut pairs| {
-                    let mut seen = std::collections::HashSet::new();
-                    pairs.retain(|(k, _)| seen.insert(k.clone()));
-                    FilterExpr::ObjectConstruct(pairs)
-                }),
+                ).prop_map(FilterExpr::ObjectConstruct),
                 (inner.clone(), inner.clone())
                     .prop_map(|(a, b)| FilterExpr::Pipe(Box::new(a), Box::new(b))),
                 (inner.clone(), inner.clone())

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -5474,3 +5474,20 @@ null
 [0, .x[0:3]]
 {"x":"hello"}
 [0,"hel"]
+
+# #324: detect_literal_output's ObjectConstruct fold dedup'd duplicate
+# keys *before* checking that every value was input-free, so an earlier
+# pair like `b: (.[0])` was eliminated and its potential runtime error
+# never fired. Every pair's expression must be const before dedup
+# applies.
+{a: (.[0]), b: (0)}
+[42]
+{"a":42,"b":0}
+
+{a: 1, a: 2}
+null
+{"a":2}
+
+{b: 1, b: (1+1)}
+null
+{"b":2}


### PR DESCRIPTION
## Summary

\`push_const_json\`'s \`Expr::ObjectConstruct\` arm dedup'd duplicate keys via \`normalize_object_pairs\` *before* recursing on the surviving values. So for \`{b: (.[0]), b: (0)}\` over \`false\`, the dedup eliminated the first pair (the one with \`.[0]\`), the literal_output fast path then folded the result to \`{\"b\":0}\`, and \`.[0]\`'s runtime error against the boolean input never fired.

jq evaluates every key:value pair in source order and aborts on the first that raises. The fix runs \`push_const_json\` on every value as a pre-pass — if any value isn't const-foldable, the whole literal_output shortcut declines and the filter falls back to the generic interpreter (which already preserves source-order evaluation).

## Surface

```
$ echo 'false' | jq    -c '{b: (.[0]), b: (0)}'
jq: error (at <stdin>:1): Cannot index boolean with number
$ echo 'false' | jq-jit -c '{b: (.[0]), b: (0)}'
{\"b\":0}                                          # before this PR
```

After the fix, jq-jit also errors on the same input. The error wording differs slightly from jq's (\`number (0)\` vs bare \`number\`) — that's a separate cosmetic divergence in the #130 family; both implementations agree on \`is_error\`.

Same bug class as #220 (length rewrites eliding type-error checks). Found by \`tests/fuzz_diff.rs\` (#319).

## Test plan

- [x] \`cargo build --release\` — zero warnings
- [x] \`cargo test --release\` — 1110 regression (was 1107, +3 cases for the dup-key matrix and confirming literal-only dedup still folds), 509 official, all green
- [x] \`tests/fuzz_diff.rs\` — re-enabled freely-duplicated keys in \`ObjectConstruct\` generator, clean at 10 000 cases
- [x] \`./bench/comprehensive.sh --quick\` — no regression

Closes #324