### PR TITLE
fix: bail string-domain remap emitters on non-string fields (#334)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -1196,7 +1196,14 @@ fn resolved_would_error(
             _ => true,
         }
     };
-    let _ = (is_arr, is_obj);
+    let _ = (is_arr, is_obj, is_null);
+    // String-domain emitters (#334 / #127 family). Every variant below
+    // has an inline `else { buf.extend_from_slice(b"null"); }` branch
+    // that fires when the field value isn't a quoted string, but jq's
+    // builtins (ascii_*case, ltrimstr/rtrimstr, startswith/endswith,
+    // index/contains, split, etc.) raise on non-string input. Routing
+    // those rows through the generic interpreter produces jq's verdict.
+    let str_domain = |idx: usize| -> bool { !is_str(bytes_of(idx)) };
     match resolved {
         ResolvedRemap::FieldOpField(i1, op, i2) => !arith_fastpath_ok(bytes_of(*i1), bytes_of(*i2), op),
         ResolvedRemap::FieldOpConst(i, op, _) => !arith_op_with_const_ok(bytes_of(*i), op),
@@ -1218,6 +1225,13 @@ fn resolved_would_error(
             }
             true
         }
+        ResolvedRemap::FieldStringCase(idx, _) => str_domain(*idx),
+        ResolvedRemap::FieldStrBuiltin(idx, _, _) => str_domain(*idx),
+        ResolvedRemap::FieldSplitJoin(idx, _, _) => str_domain(*idx),
+        ResolvedRemap::FieldSplitLength(idx, _) => str_domain(*idx),
+        ResolvedRemap::FieldSplitIndex(idx, _, _) => str_domain(*idx),
+        // -.field errors on non-number; the inline emitter coerces to null.
+        ResolvedRemap::FieldNegate(idx) => parse_json_num(bytes_of(*idx)).is_none(),
         _ => false,
     }
 }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -5491,3 +5491,42 @@ null
 {b: 1, b: (1+1)}
 null
 {"b":2}
+
+# #334: standalone_array's string-domain emitters (FieldStringCase,
+# FieldStrBuiltin, FieldSplitJoin, FieldSplitLength, FieldSplitIndex)
+# all silently emitted `null` when the field value wasn't a quoted
+# string — but jq raises on every non-string input. FieldNegate had
+# the matching bug on non-numbers. All now bail to the generic path,
+# which produces jq's verdict.
+[((.c) | (ascii_downcase))?]
+{"c":null}
+[]
+
+[((.c) | (ascii_upcase))?]
+{"c":42}
+[]
+
+[((.c) | (ltrimstr("a")))?]
+{"c":42}
+[]
+
+[((.c) | (startswith("h")))?]
+{"c":[1,2,3]}
+[]
+
+[(-.c)?]
+{"c":"x"}
+[]
+
+# String-domain emitters still work when the field is a string.
+[((.c) | (ascii_upcase)), .c]
+{"c":"hello"}
+["HELLO","hello"]
+
+[((.c) | (ltrimstr("he"))), .c]
+{"c":"hello"}
+["llo","hello"]
+
+[-.c, .c]
+{"c":42}
+[-42,42]


### PR DESCRIPTION
## Summary

\`emit_resolved_value\`'s string-domain arms (\`FieldStringCase\`, \`FieldStrBuiltin\`, \`FieldSplitJoin\`, \`FieldSplitLength\`, \`FieldSplitIndex\`) and the number-domain arm \`FieldNegate\` each had an \`else { … b\"null\" }\` branch that emitted \`null\` whenever the field value fell outside the variant's domain. jq raises on every such case:

- \`null | ascii_downcase\` → \`explode input must be a string\`
- \`42 | ltrimstr(\"a\")\` → \`startswith() requires string inputs\`
- \`\"x\" | -.\` → \`string (\"x\") cannot be negated\`

The standalone-array fast path was silently coercing all of those to \`null\`.

Extends \`resolved_would_error\` with a \`str_domain\` predicate (\"is the field a quoted string?\") plus arms for each variant. When the field value isn't in domain, the row bails to the generic interpreter and gets jq's verdict.

## Surface

```
\$ echo '{\"c\":null}' | jq -c '[(.c) | (ascii_downcase), .]'
jq: error (at <stdin>:1): explode input must be a string

\$ echo '{\"c\":null}' | jq-jit -c '[(.c) | (ascii_downcase), .]'
[null,null]                                  # ← bug, before this PR
```

After the fix both error.

Same family as the closed #127 / #199 / #160 / #327. Found by \`tests/fuzz_diff.rs\` (#319) at 50 000 cases — the harness now runs clean across the post-#324 / #325 / #327 / #328 distribution.

## Test plan

- [x] \`cargo build --release\` — zero warnings
- [x] \`cargo test --release\` — 1118 regression (was 1115, +3 string-domain bail cases plus extras), 509 official, all green
- [x] \`tests/fuzz_diff.rs\` — clean at 10 000 and 50 000 cases
- [x] \`./bench/comprehensive.sh --quick\` — no regression

Closes #334