### PR TITLE
fix: const_expr_to_json ObjectConstruct fold checks every pair before dedup (#337)

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -385,6 +385,12 @@ fn const_expr_to_json(expr: &crate::ir::Expr) -> Option<Vec<u8>> {
         Expr::Literal(Literal::True) => Some(b"true".to_vec()),
         Expr::Literal(Literal::False) => Some(b"false".to_vec()),
         Expr::ObjectConstruct { pairs } => {
+            // Mirror of `push_const_json`'s ObjectConstruct arm (#324).
+            // Every value — including the ones that will be eliminated
+            // by `normalize_object_pairs` — must be const-foldable;
+            // otherwise an earlier `(key: input-touching)` pair's runtime
+            // error gets silently dropped when a later same-key pair
+            // rebinds the slot (#337).
             let mut extracted: Vec<(&str, &Expr)> = Vec::with_capacity(pairs.len());
             for (k, v) in pairs {
                 if let Expr::Literal(Literal::Str(key)) = k {
@@ -392,6 +398,9 @@ fn const_expr_to_json(expr: &crate::ir::Expr) -> Option<Vec<u8>> {
                 } else {
                     return None;
                 }
+            }
+            for (_, v) in &extracted {
+                const_expr_to_json(v)?;
             }
             let normalized = normalize_object_pairs(extracted);
             let mut buf = Vec::new();

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -5555,3 +5555,24 @@ null
 {a: 1, a: 2} | length
 null
 1
+
+# #337: const_expr_to_json's ObjectConstruct fold (sibling to #324)
+# dedup'd duplicate keys before checking that every value was
+# const-foldable, so an input-dependent expression in an earlier
+# pair was eliminated and its runtime error never fired.
+# `.[0]` on an object errors; jq-jit previously folded the inner
+# {a: (.[0]), a: (0)} to {a: 0} at parse time and never evaluated .[0].
+[({a: ({a: (.[0]), a: (0)})})?]
+{"a":null}
+[]
+
+# When .[0] is well-defined (array/null), the dedup still applies and
+# the inner pair collapses to the last value — matching jq.
+{a: ({a: (.[0]), a: (0)})}
+[42]
+{"a":{"a":0}}
+
+# Pure-literal nested object literals still fold to a constant.
+{a: {b: 1, b: 2}}
+null
+{"a":{"b":2}}


### PR DESCRIPTION
## Summary

Sibling fix to #324. \`const_expr_to_json\` (the helper that builds JSON literal bytes from constant expressions, used by \`classify_remap_value\` when folding nested literal objects in \`detect_computed_remap\`) had the same dedup-before-eval bug as \`push_const_json\`: duplicate keys were collapsed via \`normalize_object_pairs\` before recursing on the surviving values, so an input-dependent expression in an earlier pair could be silently eliminated by a later same-key pair.

## Surface

\`\`\`
\$ echo '{\"a\":null}' | jq    -c '{a: ({a: (.[0]), a: (0)})}'
jq: error (at <stdin>:1): Cannot index object with number

\$ echo '{\"a\":null}' | jq-jit -c '{a: ({a: (.[0]), a: (0)})}'
{\"a\":{\"a\":0}}                                # ← bug, before this PR
\`\`\`

The inner \`(.[0])\` would raise at runtime, but \`const_expr_to_json\` ran \`normalize_object_pairs\` first, kept only \`(a, 0)\`, emitted \`{\"a\":0}\` as a literal, and the outer construct folded to \`{\"a\":{\"a\":0}}\`. The runtime error never fired.

The fix mirrors #324: a pre-pass runs \`const_expr_to_json\` on every value before dedup; if any returns None, the whole expression isn't const-foldable.

Found by \`tests/fuzz_diff.rs\` (#319) at 100 000 cases on the post-#324 / #325 / #327 / #328 / #333 / #334 distribution.

## Test plan

- [x] \`cargo build --release\` — zero warnings
- [x] \`cargo test --release\` — 1126 regression (was 1123 in main, +3 cases for the dedup-eval matrix), 509 official, all green
- [x] \`./bench/comprehensive.sh --quick\` — no regression (next bench-history update bundles all today's perf deltas)

Closes #337