### PR TITLE
fix: bail compound-arith remap arms on non-numeric fields (#339)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -1232,6 +1232,19 @@ fn resolved_would_error(
         ResolvedRemap::FieldSplitIndex(idx, _, _) => str_domain(*idx),
         // -.field errors on non-number; the inline emitter coerces to null.
         ResolvedRemap::FieldNegate(idx) => parse_json_num(bytes_of(*idx)).is_none(),
+        // Compound arithmetic / unary math / arith comparisons. The
+        // inline emitter calls `eval_arith_raw` and emits null on None,
+        // but jq raises (and supports string × number repetition, etc.).
+        // Probe with the same evaluator and bail on None — same family
+        // as #334 / #339.
+        ResolvedRemap::Arith(arith) => eval_arith_raw(arith, raw, ranges).is_none(),
+        ResolvedRemap::ArithToString(arith) => eval_arith_raw(arith, raw, ranges).is_none(),
+        ResolvedRemap::ArithUnary(_, arith) => eval_arith_raw(arith, raw, ranges).is_none(),
+        ResolvedRemap::ArithCmp(arith, _, _) => eval_arith_raw(arith, raw, ranges).is_none(),
+        ResolvedRemap::FieldOpFieldToString(i1, _, i2) => {
+            parse_json_num(bytes_of(*i1)).is_none() || parse_json_num(bytes_of(*i2)).is_none()
+        }
+        ResolvedRemap::FieldOpConstToString(i, _, _) => parse_json_num(bytes_of(*i)).is_none(),
         _ => false,
     }
 }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -5576,3 +5576,24 @@ null
 {a: {b: 1, b: 2}}
 null
 {"a":{"b":2}}
+
+# #339: standalone_array's compound-arith / arith-tostring / unary-math
+# / arith-cmp arms emitted null on non-numeric fields. jq instead errors
+# (e.g. `string × number` is repetition, but the `+` after with a number
+# right operand raises). All now bail to the generic interpreter.
+[(.x * 2 + 1)?]
+{"x":"abc"}
+[]
+
+[((.x * 2) | tostring)?]
+{"x":null}
+[]
+
+[(.x | sqrt)?]
+{"x":"abc"}
+[]
+
+# Numeric inputs still fold normally.
+[.x * 2 + 1, .x]
+{"x":1}
+[3,1]


### PR DESCRIPTION
## Summary

\`emit_resolved_value\`'s compound-arith / arith-tostring / unary-math / arith-cmp arms (\`Arith\`, \`ArithToString\`, \`ArithUnary\`, \`ArithCmp\`, \`FieldOpFieldToString\`, \`FieldOpConstToString\`) had the same silent-coerce-to-null bug as the simpler \`FieldOpField\` / \`FieldOpConst\` family that \`resolved_would_error\` already covered: when a field value isn't a number, \`eval_arith_raw\` / \`parse_json_num\` returned None and the inline emitter wrote \`null\` — but jq raises (e.g. \`\"abc\" * 2 + 1\` becomes \`\"abcabc\" + 1\` → \"string and number cannot be added\").

Adds arms to \`resolved_would_error\` that probe the same evaluator the emitter uses; if it returns None, the row bails to the generic interpreter.

## Surface

\`\`\`
\$ echo '{\"x\":\"abc\"}' | jq -c '[.x * 2 + 1, .x]'
jq: error (at <stdin>:1): string (\"abcabc\") and number (1) cannot be added

\$ echo '{\"x\":\"abc\"}' | jq-jit -c '[.x * 2 + 1, .x]'
[null,\"abc\"]                                  # ← bug, before this PR
\`\`\`

After the fix, both error.

Same family as #127 / #199 / #160 / #327 / #334. Found by manual probe after the fuzz_diff sweep stayed clean at 50 000 cases — the standalone_array distribution didn't naturally generate the failing shape because the surrounding context needs at least two array elements.

## Test plan

- [x] \`cargo build --release\` — zero warnings
- [x] \`cargo test --release\` — 1130 regression (was 1126, +4 cases for the arith-domain matrix), 509 official, all green
- [x] \`tests/fuzz_diff.rs\` post-#339 50 000-case run in flight (monitored separately)
- [x] \`./bench/comprehensive.sh --quick\` — no regression

Closes #339