### PR TITLE
fix: bail BoolExpr / FieldCmpConst / CondChain on non-numeric fields (#341)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -1245,6 +1245,29 @@ fn resolved_would_error(
             parse_json_num(bytes_of(*i1)).is_none() || parse_json_num(bytes_of(*i2)).is_none()
         }
         ResolvedRemap::FieldOpConstToString(i, _, _) => parse_json_num(bytes_of(*i)).is_none(),
+        // `field cmp const` — the inline emitter handles only numeric
+        // fields. For non-numeric, jq still produces a verdict via its
+        // total ordering (`null < false < true < number < string <
+        // array < object`), e.g. `"abc" > 0` is true. Bail to generic
+        // (#341).
+        ResolvedRemap::FieldCmpConst(idx, _, _) => parse_json_num(bytes_of(*idx)).is_none(),
+        // BoolExpr (`cmp1 and/or cmp2`) emits null when any side's
+        // bool eval returns None — which happens whenever an inner
+        // FieldCmpConst hits a non-numeric field. Bail when any
+        // operand would bail.
+        ResolvedRemap::BoolExpr(l, _, r) => {
+            resolved_would_error(l, raw, ranges) || resolved_would_error(r, raw, ranges)
+        }
+        // `if .x cmp N then … else … end`: each branch's `Const` cond
+        // evaluator falls through to `false` when the field isn't a
+        // number, taking the wrong branch (#341). Bail any CondChain
+        // whose Const-branch fields aren't numeric.
+        ResolvedRemap::CondChain(branches, _) => {
+            branches.iter().any(|b| {
+                matches!(b.cond_rhs, ResolvedCondRhs::Const(_))
+                    && parse_json_num(bytes_of(b.cond_field_idx)).is_none()
+            })
+        }
         _ => false,
     }
 }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -5597,3 +5597,34 @@ null
 [.x * 2 + 1, .x]
 {"x":1}
 [3,1]
+
+# #341: standalone_array's BoolExpr / FieldCmpConst / CondChain (Const
+# branch) emitters used parse_json_num and either emitted null or took
+# the wrong branch when the field wasn't numeric. jq's total ordering
+# (null < false < true < number < string < array < object) makes
+# `"abc" > 0` true, `null > 0` false, etc. Now bail to the generic
+# interpreter on non-numeric fields.
+[(.x > 0) and (.y < 5), .x]
+{"x":"abc","y":1}
+[true,"abc"]
+
+[if .x > 0 then "pos" else "non-pos" end, .x]
+{"x":"abc"}
+["pos","abc"]
+
+[if .x > 0 then "pos" else "non-pos" end, .x]
+{"x":[1,2]}
+["pos",[1,2]]
+
+[if .x > 0 then "pos" else "non-pos" end, .x]
+{"x":null}
+["non-pos",null]
+
+# Numeric inputs still take the fast path correctly.
+[(.x > 0) and (.y < 5), .x]
+{"x":3,"y":1}
+[true,3]
+
+[if .x > 0 then "pos" else "non-pos" end, .x]
+{"x":1}
+["pos",1]


### PR DESCRIPTION
## Summary

jq's comparison operators use a total ordering across all types (null < false < true < number < string < array < object), so \`\"abc\" > 0\` is \`true\` and \`null > 0\` is \`false\`. The fast-path emitters for \`FieldCmpConst\`, \`BoolExpr\`, and \`CondChain\` (Const branches) all called \`parse_json_num\` on the field bytes and either emitted \`null\` or took the wrong branch when the field wasn't numeric.

Adds three arms to \`resolved_would_error\`:
- \`FieldCmpConst\`: bail when field bytes don't parse as a number.
- \`BoolExpr\`: bail when either operand bails (recursive).
- \`CondChain\`: bail when any Const-comparing branch's field is non-numeric.

The generic interpreter handles total ordering correctly, so bail produces jq's verdict.

## Surface

\`\`\`
\$ echo '{\"x\":\"abc\",\"y\":1}' | jq -c '[.x > 0 and .y < 5, .x]'
[true,\"abc\"]
\$ echo '{\"x\":\"abc\",\"y\":1}' | jq-jit -c '[.x > 0 and .y < 5, .x]'
[null,\"abc\"]                                  # ← bug, before this PR

\$ echo '{\"x\":\"abc\"}' | jq -c '[if .x > 0 then \"pos\" else \"non-pos\" end]'
[\"pos\"]
\$ echo '{\"x\":\"abc\"}' | jq-jit -c '[if .x > 0 then \"pos\" else \"non-pos\" end]'
[\"non-pos\"]                                   # ← wrong branch
\`\`\`

After the fix, both cases match jq.

Same family as #127 / #199 / #160 / #327 / #334 / #339.

## Test plan

- [x] \`cargo build --release\` — zero warnings
- [x] \`cargo test --release\` — 1136 regression (was 1130, +6 cross-type cmp cases plus non-regression numeric cases), 509 official, all green
- [x] \`tests/fuzz_diff.rs\` 50 000-case post-#341 run in flight (monitored separately)
- [x] \`./bench/comprehensive.sh --quick\` — no regression

Closes #341