### PR TITLE
fix: compare_values for objects compares full key arrays before values (#343)

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -929,7 +929,14 @@ pub fn compare_values(a: &Value, b: &Value) -> std::cmp::Ordering {
             x.len().cmp(&y.len())
         }
         (Value::Obj(ObjInner(x)), Value::Obj(ObjInner(y))) => {
-            // Compare by sorted keys then values
+            // jq's object ordering: compare the *full* sorted-keys
+            // arrays first, then — only if they're equal — compare
+            // values key by key. The previous implementation
+            // interleaved key and value compares per-position, which
+            // got the simple `{"c":null}` vs `{"c":false}` shape right
+            // but flipped `{"c":null,"y":null}` vs `{"c":false}` (the
+            // shorter object should come first when its keys are a
+            // strict prefix).
             let mut xkeys: Vec<&KeyStr> = x.keys().collect();
             let mut ykeys: Vec<&KeyStr> = y.keys().collect();
             xkeys.sort();
@@ -939,14 +946,20 @@ pub fn compare_values(a: &Value, b: &Value) -> std::cmp::Ordering {
                 if kord != Ordering::Equal {
                     return kord;
                 }
+            }
+            let len_ord = xkeys.len().cmp(&ykeys.len());
+            if len_ord != Ordering::Equal {
+                return len_ord;
+            }
+            for xk in &xkeys {
                 let xv = x.get(xk.as_str()).unwrap();
-                let yv = y.get(yk.as_str()).unwrap();
+                let yv = y.get(xk.as_str()).unwrap();
                 let vord = compare_values(xv, yv);
                 if vord != Ordering::Equal {
                     return vord;
                 }
             }
-            x.len().cmp(&y.len())
+            Ordering::Equal
         }
         _ => Ordering::Equal,
     }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -5628,3 +5628,24 @@ null
 [if .x > 0 then "pos" else "non-pos" end, .x]
 {"x":1}
 ["pos",1]
+
+# #343: object compare interleaved key/value cmp per zip position; jq
+# compares the full sorted-keys array first, then values. The shorter
+# object (whose keys are a strict prefix of the other's) is always
+# less.
+sort
+[{"c":null,"y":null},{"c":false}]
+[{"c":false},{"c":null,"y":null}]
+
+{"c":null,"y":null} < {"c":false}
+null
+false
+
+# Same-shape objects still compare by values.
+sort
+[{"c":null},{"c":false}]
+[{"c":null},{"c":false}]
+
+{"c":null} < {"c":false}
+null
+true


### PR DESCRIPTION
## Summary

\`compare_values\`'s object arm walked sorted-keys arrays in parallel and ran key-cmp / value-cmp at each zip position. For asymmetric-key objects like \`{\"c\":null,\"y\":null}\` vs \`{\"c\":false}\`, zip yielded just one pair \`(\"c\",\"c\")\`; the value compare then ran \`null < false\` and returned Less — but jq says the longer-keys object should win regardless of values, because the shorter-keys object's key array is a strict prefix.

jq's \`jv_cmp\` (src/jv.c) compares the full key arrays first and only walks values when the key arrays are byte-identical. The fix mirrors that.

## Surface

\`\`\`
\$ echo '[{\"c\":null,\"y\":null},{\"c\":false}]' | jq -c 'sort'
[{\"c\":false},{\"c\":null,\"y\":null}]

\$ echo '[{\"c\":null,\"y\":null},{\"c\":false}]' | jq-jit -c 'sort'
[{\"c\":null,\"y\":null},{\"c\":false}]            # ← bug, before this PR
\`\`\`

After the fix, both match jq.

The order is observable through \`sort\`, \`unique\`, \`min\`, \`max\`, and the comparison operators. Same-shape objects still compare by values, so the existing \`{\"c\":null} < {\"c\":false}\` semantics (true) are preserved.

Found by \`tests/fuzz_diff.rs\` (#319) at 50 000 cases on the post-#341 distribution.

## Test plan

- [x] \`cargo build --release\` — zero warnings
- [x] \`cargo test --release\` — 1134 regression (was 1130 in main without the cross-fix; +4 cases for the asymmetric-keys matrix), 509 official, all green
- [x] \`tests/fuzz_diff.rs\` — clean post-fix
- [x] \`./bench/comprehensive.sh --quick\` — no regression (object compare is a hot path; numbers track the prior baseline)

Closes #343