### PR TITLE
fix: bail StringChain remap on non-string Field / non-numeric FieldArithToString (#345)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -1268,6 +1268,18 @@ fn resolved_would_error(
                     && parse_json_num(bytes_of(b.cond_field_idx)).is_none()
             })
         }
+        // `.a + ":" + (.b | tostring)`: `Field` parts silently coerce
+        // non-string fields to raw bytes (jq raises
+        // `string + number cannot be added`); `FieldArithToString`
+        // parts silently drop the part on non-numeric fields, leaving
+        // a truncated string. Bail when any part is outside its
+        // emitter's domain (#345).
+        ResolvedRemap::StringChain(parts) => parts.iter().any(|p| match p {
+            ResolvedStringChainPart::Literal(_) => false,
+            ResolvedStringChainPart::Field(idx) => !is_str(bytes_of(*idx)),
+            ResolvedStringChainPart::FieldToString(_) => false,
+            ResolvedStringChainPart::FieldArithToString(idx, _) => parse_json_num(bytes_of(*idx)).is_none(),
+        }),
         _ => false,
     }
 }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -5649,3 +5649,21 @@ sort
 {"c":null} < {"c":false}
 null
 true
+
+# #345: StringChain's Field part silently coerced non-string fields to
+# raw bytes (`"hi" + 42` was concatenated as `"hi42"`); the
+# FieldArithToString part dropped non-numeric arith silently. Both
+# now bail to the generic interpreter, which raises jq's
+# `string + number` error.
+[(.a + ":" + .b)?]
+{"a":"hi","b":42}
+[]
+
+[(.a + ":" + (.b * 2 + 1 | tostring))?]
+{"a":"hi","b":"xyz"}
+[]
+
+# String-string concatenation still folds via the fast path.
+[.a + ":" + (.b | tostring), .a]
+{"a":"hi","b":42}
+["hi:42","hi"]


### PR DESCRIPTION
## Summary

\`StringChain\`'s inline emitter silently coerced types in two places:

1. \`Field(idx)\` parts copied raw bytes when the field wasn't a quoted string, producing \`\"hi\" + 42 → \"hi42\"\` instead of jq's \`string (\"hi\") and number (42) cannot be added\`.
2. \`FieldArithToString(idx, ops)\` parts dropped the part entirely when the field wasn't numeric (the inner \`if let Ok(...)\` has no \`else\`), leaving a truncated string in the chain.

Adds a \`StringChain\` arm to \`resolved_would_error\` that bails when any part falls outside its emitter's narrow domain.

## Surface

\`\`\`
\$ echo '{\"a\":\"hi\",\"b\":42}' | jq -c '[.a + \":\" + .b, .a]'
jq: error (at <stdin>:1): string (\"hi:\") and number (42) cannot be added

\$ echo '{\"a\":\"hi\",\"b\":42}' | jq-jit -c '[.a + \":\" + .b, .a]'
[\"hi:42\",\"hi\"]                             # ← bug, before this PR
\`\`\`

After the fix, both error.

Same family as #339 / #334 / #341. Found by manual probe after the post-#343 100 000-case fuzz_diff sweep stayed clean.

## Test plan

- [x] \`cargo build --release\` — zero warnings
- [x] \`cargo test --release\` — 1143 regression (was 1140 in main, +3 cases for the StringChain bail matrix), 509 official, all green
- [x] \`tests/fuzz_diff.rs\` — clean post-fix
- [x] \`./bench/comprehensive.sh --quick\` — no regression

Closes #345