### PR TITLE
fix: bail FieldCmpField on cross-type pairs outside num/str (#347)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -1251,6 +1251,18 @@ fn resolved_would_error(
         // array < object`), e.g. `"abc" > 0` is true. Bail to generic
         // (#341).
         ResolvedRemap::FieldCmpConst(idx, _, _) => parse_json_num(bytes_of(*idx)).is_none(),
+        // `field cmp field` — the inline emitter handles num/num,
+        // str/str, and (num/str)-mixed; everything else falls through
+        // to `null`. jq's total ordering produces a defined verdict for
+        // null/bool/array/object pairs too, so bail when neither side
+        // is numeric and at most one is a string (#347).
+        ResolvedRemap::FieldCmpField(i1, _, i2) => {
+            let a = bytes_of(*i1);
+            let b = bytes_of(*i2);
+            !((is_num(a) && is_num(b))
+                || (is_str(a) && is_str(b))
+                || (is_str(a) ^ is_str(b)))
+        }
         // BoolExpr (`cmp1 and/or cmp2`) emits null when any side's
         // bool eval returns None — which happens whenever an inner
         // FieldCmpConst hits a non-numeric field. Bail when any

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -5667,3 +5667,32 @@ true
 [.a + ":" + (.b | tostring), .a]
 {"a":"hi","b":42}
 ["hi:42","hi"]
+
+# #347: FieldCmpField inline emitter only covered num/num, str/str,
+# and num/str pairs; null/bool/array/object pairs fell through to
+# `null`. jq's total ordering produces a defined verdict for every
+# pair (`null < false < true < number < string < array < object`).
+[.x > .y, .x]
+{"x":[1],"y":2}
+[true,[1]]
+
+[.x > .y, .x]
+{"x":null,"y":false}
+[false,null]
+
+[.x > .y, .x]
+{"x":true,"y":false}
+[true,true]
+
+[.x > .y, .x]
+{"x":{"a":1},"y":[1]}
+[true,{"a":1}]
+
+# num/num and str/str still take the fast path.
+[.x > .y, .x]
+{"x":1,"y":2}
+[false,1]
+
+[.x > .y, .x]
+{"x":"b","y":"a"}
+[true,"b"]


### PR DESCRIPTION
## Summary

\`emit_resolved_value\`'s \`FieldCmpField\` arm covered three cases (num/num, str/str, num/str-mixed) and fell through to \`null\` for every other type pair (null/bool, bool/bool, array/array, object/object, etc.). jq's total ordering (\`null < false < true < number < string < array < object\`) produces a defined verdict for every pair.

Adds a \`FieldCmpField\` arm to \`resolved_would_error\` that bails when neither side is numeric and at most one is a string. The generic interpreter then runs the full total-ordering compare. The fast path keeps the high-volume cases without regression.

## Surface

\`\`\`
\$ echo '{\"x\":[1],\"y\":2}' | jq -c '[.x > .y, .x]'
[true,[1]]

\$ echo '{\"x\":[1],\"y\":2}' | jq-jit -c '[.x > .y, .x]'
[null,[1]]                                       # ← bug, before this PR
\`\`\`

After the fix, all type pairs match jq.

Same family as #341 / #339 / #334 / #327. Found by manual probe after the post-#345 100 000-case fuzz_diff run stayed clean — the proptest filter strategy currently emits \`.x op N\` (FieldCmpConst) but not \`.x op .y\` (FieldCmpField), so this shape wasn't exercised.

## Test plan

- [x] \`cargo build --release\` — zero warnings
- [x] \`cargo test --release\` — 1149 regression (was 1143 in main, +6 cases for the cross-type cmp matrix), 509 official, all green
- [x] \`tests/fuzz_diff.rs\` — clean post-fix
- [x] \`./bench/comprehensive.sh --quick\` — no regression

Closes #347