### PR TITLE
fix: select(.f1 cmp .f2) handles null + non-object inputs (#349)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -1143,17 +1143,83 @@ fn eval_arith_raw_unresolved(
 #[inline]
 fn compare_raw_fields(raw: &[u8], r1: (usize, usize), r2: (usize, usize), op: &jq_jit::ir::BinOp) -> bool {
     use jq_jit::ir::BinOp;
-    if let (Some(v1), Some(v2)) = (parse_json_num(&raw[r1.0..r1.1]), parse_json_num(&raw[r2.0..r2.1])) {
-        match op { BinOp::Gt => v1 > v2, BinOp::Lt => v1 < v2, BinOp::Ge => v1 >= v2, BinOp::Le => v1 <= v2, BinOp::Eq => v1 == v2, BinOp::Ne => v1 != v2, _ => false }
-    } else if raw[r1.0] == b'"' && raw[r2.0] == b'"' {
-        let s1 = &raw[r1.0+1..r1.1-1];
-        let s2 = &raw[r2.0+1..r2.1-1];
-        match op { BinOp::Gt => s1 > s2, BinOp::Lt => s1 < s2, BinOp::Ge => s1 >= s2, BinOp::Le => s1 <= s2, BinOp::Eq => s1 == s2, BinOp::Ne => s1 != s2, _ => false }
-    } else if raw[r1.0] == b'"' || raw[r2.0] == b'"' {
-        // Mixed type: number < string in jq ordering
-        let left_is_str = raw[r1.0] == b'"';
-        match op { BinOp::Gt => left_is_str, BinOp::Lt => !left_is_str, BinOp::Ge => left_is_str, BinOp::Le => !left_is_str, BinOp::Eq => false, BinOp::Ne => true, _ => false }
-    } else { false }
+    // jq's total ordering: null < false < true < number < string < array < object.
+    // Use the first byte of each span as a cheap type tag so we can resolve
+    // null/null, bool/*, and cross-type pairs without parsing.
+    fn type_rank(first: u8) -> u8 {
+        match first {
+            b'n' => 0,
+            b'f' => 1,
+            b't' => 2,
+            b'-' | b'0'..=b'9' => 3,
+            b'"' => 4,
+            b'[' => 5,
+            b'{' => 6,
+            _ => 7,
+        }
+    }
+    let s1 = &raw[r1.0..r1.1];
+    let s2 = &raw[r2.0..r2.1];
+    if s1.is_empty() || s2.is_empty() { return false; }
+    let t1 = type_rank(s1[0]);
+    let t2 = type_rank(s2[0]);
+    if t1 != t2 {
+        return match op {
+            BinOp::Gt => t1 > t2, BinOp::Lt => t1 < t2,
+            BinOp::Ge => t1 >= t2, BinOp::Le => t1 <= t2,
+            BinOp::Eq => false, BinOp::Ne => true,
+            _ => false,
+        };
+    }
+    // Same type: compare values.
+    match s1[0] {
+        b'n' => matches!(op, BinOp::Eq | BinOp::Ge | BinOp::Le),
+        b'f' | b't' => matches!(op, BinOp::Eq | BinOp::Ge | BinOp::Le),
+        b'-' | b'0'..=b'9' => match (parse_json_num(s1), parse_json_num(s2)) {
+            (Some(v1), Some(v2)) => match op {
+                BinOp::Gt => v1 > v2, BinOp::Lt => v1 < v2,
+                BinOp::Ge => v1 >= v2, BinOp::Le => v1 <= v2,
+                BinOp::Eq => v1 == v2, BinOp::Ne => v1 != v2,
+                _ => false,
+            },
+            _ => false,
+        },
+        b'"' => {
+            let i1 = &s1[1..s1.len()-1];
+            let i2 = &s2[1..s2.len()-1];
+            match op {
+                BinOp::Gt => i1 > i2, BinOp::Lt => i1 < i2,
+                BinOp::Ge => i1 >= i2, BinOp::Le => i1 <= i2,
+                BinOp::Eq => i1 == i2, BinOp::Ne => i1 != i2,
+                _ => false,
+            }
+        }
+        b'[' | b'{' => {
+            // Array/object: defer to compare_values via parse. The
+            // array-array and object-object cases are rare on select
+            // hot paths; correctness over speed.
+            match (
+                json_to_value(unsafe { std::str::from_utf8_unchecked(s1) }),
+                json_to_value(unsafe { std::str::from_utf8_unchecked(s2) }),
+            ) {
+                (Ok(v1), Ok(v2)) => {
+                    let ord = jq_jit::runtime::compare_values(&v1, &v2);
+                    use std::cmp::Ordering;
+                    match op {
+                        BinOp::Gt => ord == Ordering::Greater,
+                        BinOp::Lt => ord == Ordering::Less,
+                        BinOp::Ge => ord != Ordering::Less,
+                        BinOp::Le => ord != Ordering::Greater,
+                        BinOp::Eq => ord == Ordering::Equal,
+                        BinOp::Ne => ord != Ordering::Equal,
+                        _ => false,
+                    }
+                }
+                _ => false,
+            }
+        }
+        _ => false,
+    }
 }
 
 /// Return true if `resolved` would raise an error in jq for the given
@@ -10024,21 +10090,55 @@ fn real_main() {
                     use jq_jit::ir::BinOp;
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        let pass = if let Some((v1, v2)) = json_object_get_two_nums(raw, 0, sff_f1, sff_f2) {
+                        // Object input: existing fast path. Null input:
+                        // both fields resolve to null; run the standard
+                        // compare. Anything else (bool/number/string/
+                        // array): bail to the generic interpreter, which
+                        // raises jq's `Cannot index <type> with string`
+                        // (#349).
+                        let bytes_or_null: &[u8] = b"null";
+                        let null_range = (0usize, 4usize);
+                        let cmp_op_to_pass = |v1: f64, v2: f64| -> bool {
                             match sff_op {
                                 BinOp::Gt => v1 > v2, BinOp::Lt => v1 < v2,
                                 BinOp::Ge => v1 >= v2, BinOp::Le => v1 <= v2,
                                 BinOp::Eq => v1 == v2, BinOp::Ne => v1 != v2,
                                 _ => false,
                             }
-                        } else if let (Some(r1), Some(r2)) = (
-                            json_object_get_field_raw(raw, 0, sff_f1),
-                            json_object_get_field_raw(raw, 0, sff_f2),
-                        ) {
-                            compare_raw_fields(raw, r1, r2, &sff_op)
-                        } else { false };
-                        if pass {
-                            emit_raw_ln!(&mut compact_buf, raw);
+                        };
+                        let first = raw.first().copied();
+                        let pass_opt = match first {
+                            Some(b'{') => {
+                                if let Some((v1, v2)) = json_object_get_two_nums(raw, 0, sff_f1, sff_f2) {
+                                    Some(cmp_op_to_pass(v1, v2))
+                                } else if let (Some(r1), Some(r2)) = (
+                                    json_object_get_field_raw(raw, 0, sff_f1),
+                                    json_object_get_field_raw(raw, 0, sff_f2),
+                                ) {
+                                    Some(compare_raw_fields(raw, r1, r2, &sff_op))
+                                } else {
+                                    // Both fields missing. jq emits null
+                                    // for missing-key access, so .f1 and
+                                    // .f2 are both null. Run the cmp on
+                                    // two null spans of `raw`. Use a
+                                    // sentinel buffer instead of `raw`
+                                    // since there's no guaranteed `null`
+                                    // span inside the object bytes.
+                                    Some(compare_raw_fields(bytes_or_null, null_range, null_range, &sff_op))
+                                }
+                            }
+                            Some(b'n') if raw.starts_with(b"null") => {
+                                Some(compare_raw_fields(bytes_or_null, null_range, null_range, &sff_op))
+                            }
+                            _ => None,
+                        };
+                        match pass_opt {
+                            Some(true) => emit_raw_ln!(&mut compact_buf, raw),
+                            Some(false) => {}
+                            None => {
+                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                            }
                         }
                         if compact_buf.len() >= 1 << 17 {
                             let _ = out.write_all(&compact_buf);
@@ -17077,26 +17177,49 @@ fn real_main() {
                     Ok(())
                 })
             } else if let Some((ref sff_f1, sff_op, ref sff_f2)) = select_ff_cmp {
-                // select(.f1 cmp .f2) — file path, output whole object
+                // select(.f1 cmp .f2) — file path, output whole object.
+                // Mirrors the stdin apply-site discipline (#349): null
+                // input → both fields null; non-object/non-null → bail.
                 use jq_jit::ir::BinOp;
                 let content_bytes = content.as_bytes();
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    let pass = if let Some((v1, v2)) = json_object_get_two_nums(raw, 0, sff_f1, sff_f2) {
+                    let bytes_or_null: &[u8] = b"null";
+                    let null_range = (0usize, 4usize);
+                    let cmp_op_to_pass = |v1: f64, v2: f64| -> bool {
                         match sff_op {
                             BinOp::Gt => v1 > v2, BinOp::Lt => v1 < v2,
                             BinOp::Ge => v1 >= v2, BinOp::Le => v1 <= v2,
                             BinOp::Eq => v1 == v2, BinOp::Ne => v1 != v2,
                             _ => false,
                         }
-                    } else if let (Some(r1), Some(r2)) = (
-                        json_object_get_field_raw(raw, 0, sff_f1),
-                        json_object_get_field_raw(raw, 0, sff_f2),
-                    ) {
-                        compare_raw_fields(raw, r1, r2, &sff_op)
-                    } else { false };
-                    if pass {
-                        emit_raw_ln!(&mut compact_buf, raw);
+                    };
+                    let first = raw.first().copied();
+                    let pass_opt = match first {
+                        Some(b'{') => {
+                            if let Some((v1, v2)) = json_object_get_two_nums(raw, 0, sff_f1, sff_f2) {
+                                Some(cmp_op_to_pass(v1, v2))
+                            } else if let (Some(r1), Some(r2)) = (
+                                json_object_get_field_raw(raw, 0, sff_f1),
+                                json_object_get_field_raw(raw, 0, sff_f2),
+                            ) {
+                                Some(compare_raw_fields(raw, r1, r2, &sff_op))
+                            } else {
+                                Some(compare_raw_fields(bytes_or_null, null_range, null_range, &sff_op))
+                            }
+                        }
+                        Some(b'n') if raw.starts_with(b"null") => {
+                            Some(compare_raw_fields(bytes_or_null, null_range, null_range, &sff_op))
+                        }
+                        _ => None,
+                    };
+                    match pass_opt {
+                        Some(true) => emit_raw_ln!(&mut compact_buf, raw),
+                        Some(false) => {}
+                        None => {
+                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                        }
                     }
                     if compact_buf.len() >= 1 << 17 {
                         let _ = out.write_all(&compact_buf);

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -5696,3 +5696,16 @@ true
 [.x > .y, .x]
 {"x":"b","y":"a"}
 [true,"b"]
+
+# #349: select(.f1 cmp .f2) silently dropped null and non-object inputs.
+# null: both fields null, comparison is well-defined → emit input.
+# non-object/non-null: jq raises `Cannot index <type> with string`, the
+# fast path now bails to the generic interpreter.
+select(.a >= .a)
+null
+null
+
+# `false | .a` errors in jq; the wrapper `?` catches it to empty.
+[(select(.a > .a))?]
+false
+[]


### PR DESCRIPTION
## Summary

\`select_ff_cmp\` apply silently dropped non-object input records (\`pass = false\`); but jq's contract:

- null input: \`.f1\` and \`.f2\` both resolve to null; \`null cmp null\` is well-defined → emit.
- bool / number / string / array input: \`.f1\` errors → whole stream errors.

Adds discrimination on the input's first byte. \`{\` keeps the fast path, \`null\` uses the standard cross-type compare with two null spans, anything else bails to the generic interpreter (which raises jq's \`Cannot index <type> with string\`).

\`compare_raw_fields\` also got a full total-ordering rewrite — the previous version only handled num/num, str/str, and num/str-mixed pairs and fell through to \`false\` for everything else (null/null, bool/bool, array/array, etc.). Now uses a type-rank tag on the first byte and defers array/object pairs to \`compare_values\` via \`json_to_value\` for correctness.

## Surface

\`\`\`
\$ echo 'null' | jq -c 'select(.a >= .a)'
null

\$ echo 'null' | jq-jit -c 'select(.a >= .a)'
                                                 # ← bug, before this PR

\$ echo 'false' | jq -c 'select(.a > .a)'
jq: error (at <stdin>:1): Cannot index boolean with string \"a\"

\$ echo 'false' | jq-jit -c 'select(.a > .a)'
                                                 # exit 0, silent — bug
\`\`\`

After the fix, both error or emit correctly.

Found by extending \`tests/fuzz_diff.rs\` with \`FieldFieldBinop(.x op .y)\` shapes (separate harness PR upcoming) — surfaced immediately at ~70 cases.

## Test plan

- [x] \`cargo build --release\` — zero warnings
- [x] \`cargo test --release\` — 1151 regression (was 1149 in main, +2 cases for null/non-object input matrix), 509 official, all green
- [x] Manual probe: select on null/bool/number/array all match jq
- [x] \`./bench/comprehensive.sh --quick\` — no regression on \`compare_raw_fields\`-heavy paths

Closes #349