### PR TITLE
fix: detect_computed_remap rejects duplicate keys to preserve source-order eval (#351)

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -3685,16 +3685,31 @@ impl Filter {
             let _ = this; // silence unused
             None
         }
+        // Reject computed remaps with duplicate keys: `normalize_object_pairs`
+        // collapses to last-wins, but jq evaluates every pair in source
+        // order and aborts on the first error. If an earlier pair has a
+        // computed (input-touching) value, that value's runtime error
+        // would be silently elided when the later pair rebinds the same
+        // key. Same family as #324 / #337; here the fold lives in
+        // `detect_computed_remap` rather than `push_const_json` /
+        // `const_expr_to_json`.
+        let has_duplicate_keys = |pairs: &[(String, RemapExpr)]| -> bool {
+            let mut seen = std::collections::HashSet::new();
+            !pairs.iter().all(|(k, _)| seen.insert(k.clone()))
+        };
         // Direct ObjectConstruct
         if let Some((result, has_computed)) = extract_computed_pairs(self, expr) {
-            if has_computed { return Some(normalize_object_pairs(result)); }
-            return None;
+            if !has_computed { return None; }
+            if has_duplicate_keys(&result) { return None; }
+            return Some(normalize_object_pairs(result));
         }
         // {a:.x,b:(.y*2)} + {c:.z} — merged object constructs
         if let Expr::BinOp { op: BinOp::Add, lhs, rhs } = expr {
             if let (Some((mut left, lc)), Some((right, rc))) = (extract_computed_pairs(self, lhs), extract_computed_pairs(self, rhs)) {
                 left.extend(right);
-                if lc || rc { return Some(normalize_object_pairs(left)); }
+                if !(lc || rc) { return None; }
+                if has_duplicate_keys(&left) { return None; }
+                return Some(normalize_object_pairs(left));
             }
         }
         None

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -5709,3 +5709,20 @@ null
 [(select(.a > .a))?]
 false
 []
+
+# #351: detect_computed_remap also dedup'd duplicate keys before
+# evaluation, dropping earlier computed pairs' runtime errors. This
+# mirrors the #324 / #337 fixes for push_const_json / const_expr_to_json.
+[({x: (.a - .b), x: (0)})?]
+{"a":null}
+[]
+
+# Unique keys + computed values still classify and fast-path.
+{x: (.a + .b), y: (.a)}
+{"a":1,"b":2}
+{"x":3,"y":1}
+
+# Duplicate-key literals still fold (no computed value involved).
+{x: 1, x: 2}
+null
+{"x":2}


### PR DESCRIPTION
## Summary

Sibling fix to #324 (\`push_const_json\`) and #337 (\`const_expr_to_json\`): \`detect_computed_remap\` collected \`(key, RemapExpr)\` pairs and applied \`normalize_object_pairs(result)\` before the apply path ran. Same-key earlier pairs with computed (input-touching) values were eliminated, dropping their potential runtime errors.

Adds a duplicate-key check before \`normalize_object_pairs\`: when any value is computed AND there are duplicate keys, return None so the filter falls through to the generic interpreter, which evaluates every pair in source order.

Same-key literal-only pairs still safely fold via push_const_json's \`literal_output\` path (which got its own dup-key fix in #324).

## Surface

\`\`\`
\$ echo '{\"a\":null}' | jq -c '{x: (.a - .b), x: (0)}'
jq: error (at <stdin>:1): null (null) and null (null) cannot be subtracted

\$ echo '{\"a\":null}' | jq-jit -c '{x: (.a - .b), x: (0)}'
{\"x\":0}                                       # ← bug, before this PR
\`\`\`

After the fix both error.

Found by extending \`tests/fuzz_diff.rs\` with \`FieldFieldBinop\` shapes (\`.x op .y\`) at ~500 cases — surfaced because the new shapes finally hit the computed_remap apply path with non-numeric inputs.

## Test plan

- [x] \`cargo build --release\` — zero warnings
- [x] \`cargo test --release\` — 1154 regression (was 1151, +3 cases for the dedup-eval / unique-key non-regression matrix), 509 official, all green
- [x] \`tests/fuzz_diff.rs\` — clean post-fix
- [x] \`./bench/comprehensive.sh --quick\` — no regression (the fix is parse-time)

Closes #351