### PR TITLE
fix: select_ff_cmp_value bails to generic on non-object / missing fields (#358)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -10196,7 +10196,12 @@ fn real_main() {
                         Ok(())
                     })
                 } else if let Some((ref sff_f1, ref sff_op, ref sff_f2, ref out_rexpr)) = select_ff_cmp_value {
-                    // select(.f1 cmp .f2) | value — field-field select + computed value output
+                    // select(.f1 cmp .f2) | value — field-field select + computed value output.
+                    // Fast path requires object input, both select fields
+                    // present *and* numeric. Anything else (#358) bails
+                    // to the generic interpreter, which emits jq's
+                    // verdict (including type errors on non-object
+                    // input).
                     use jq_jit::ir::BinOp;
                     let mut all_fields: Vec<String> = Vec::new();
                     let mut field_idx = std::collections::HashMap::new();
@@ -10219,6 +10224,7 @@ fn real_main() {
                     let mut ranges_buf = vec![(0usize, 0usize); field_refs.len()];
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
+                        let mut handled = false;
                         if json_object_get_fields_raw_buf(raw, 0, &field_refs, &mut ranges_buf) {
                             let r1 = &ranges_buf[f1_idx];
                             let r2 = &ranges_buf[f2_idx];
@@ -10237,8 +10243,13 @@ fn real_main() {
                                         emit_resolved_value(&mut compact_buf, &resolved, raw, &ranges_buf);
                                         compact_buf.push(b'\n');
                                     }
+                                    handled = true;
                                 }
                             }
+                        }
+                        if !handled {
+                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }
                         if compact_buf.len() >= 1 << 17 {
                             let _ = out.write_all(&compact_buf);
@@ -17294,6 +17305,7 @@ fn real_main() {
                 let mut ranges_buf = vec![(0usize, 0usize); field_refs.len()];
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
+                    let mut handled = false;
                     if json_object_get_fields_raw_buf(raw, 0, &field_refs, &mut ranges_buf) {
                         let r1 = &ranges_buf[f1_idx];
                         let r2 = &ranges_buf[f2_idx];
@@ -17312,8 +17324,13 @@ fn real_main() {
                                     emit_resolved_value(&mut compact_buf, &resolved, raw, &ranges_buf);
                                     compact_buf.push(b'\n');
                                 }
+                                handled = true;
                             }
                         }
+                    }
+                    if !handled {
+                        let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                        process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                     }
                     if compact_buf.len() >= 1 << 17 {
                         let _ = out.write_all(&compact_buf);

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -5757,3 +5757,10 @@ null
 [select(.c >= .a)]
 {"c":false}
 [{"c":false}]
+
+# #358: select_ff_cmp_value silent-skipped on non-object input.
+# `select(.a > .a) | (.a + .a)` over `[]` errored in jq but jq-jit
+# emitted nothing. Now bails to generic so the type error reaches stdout.
+[((select(.a > .a)) | (.a + .a))?]
+[]
+[]


### PR DESCRIPTION
## Summary

Sibling fix to #349 / #356. The \`select_ff_cmp_value\` apply (stdin + file) silently skipped records whose input wasn't an object, fields were missing, or the select fields weren't both numeric:

\`\`\`
\$ echo '[]' | jq -c '(select(.a > .a)) | (.a + .a)'
jq: error (at <stdin>:1): Cannot index array with string \"a\"

\$ echo '[]' | jq-jit -c '(select(.a > .a)) | (.a + .a)'
                                                # exit 0, silent — bug
\`\`\`

Threads a \`handled\` flag through the inner gates; when the fast path can't fully complete, bails to the generic interpreter via \`process_input\`.

The other four \`select_ff_cmp_*\` siblings (\`_field\`, \`_cremap\`, \`_array\`) likely have the same gap; they'll get parallel fixes if they surface.

Found by \`tests/fuzz_diff.rs\` at ~3000 cases on the post-#356 main.

## Test plan

- [x] \`cargo build --release\` — zero warnings
- [x] \`cargo test --release\` — 1160 regression (was 1159, +1 case for the bail matrix), 509 official, all green
- [x] \`tests/fuzz_diff.rs\` — clean post-fix
- [x] \`./bench/comprehensive.sh --quick\` — no regression

Closes #358