### PR TITLE
fix: json_object_get_num scans to end for last-wins on dup keys (#360)

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -802,15 +802,19 @@ where F: FnMut(usize, usize) -> Result<()> {
 /// Returns Some(f64) if the field exists and is numeric, None otherwise.
 /// Used for select fast paths to avoid parsing discarded objects.
 pub fn json_object_get_num(b: &[u8], pos: usize, field: &str) -> Option<f64> {
+    // jq dedupes duplicate input keys last-wins (#233 / #325). Scan to
+    // end of the object and use the LAST matching key's value; if that
+    // value isn't numeric, return None even when an earlier same-key
+    // value was numeric (#360).
     if pos >= b.len() || b[pos] != b'{' { return None; }
     let field_bytes = field.as_bytes();
     let mut i = pos + 1;
-    // Skip whitespace
     while i < b.len() && matches!(b[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
     if i < b.len() && b[i] == b'}' { return None; }
+    let mut last_match: Option<f64> = None;
+    let mut last_was_match: bool = false;
     loop {
-        if i >= b.len() || b[i] != b'"' { return None; }
-        // Scan key
+        if i >= b.len() || b[i] != b'"' { return last_match; }
         let key_start = i + 1;
         let mut j = key_start;
         while j < b.len() {
@@ -819,50 +823,52 @@ pub fn json_object_get_num(b: &[u8], pos: usize, field: &str) -> Option<f64> {
         let key_matches = (j - key_start) == field_bytes.len()
             && b[key_start..j] == *field_bytes;
         i = j + 1;
-        // Skip ws + colon
         while i < b.len() && matches!(b[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
-        if i >= b.len() || b[i] != b':' { return None; }
+        if i >= b.len() || b[i] != b':' { return last_match; }
         i += 1;
         while i < b.len() && matches!(b[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
         if key_matches {
-            // Parse the numeric value inline
-            if i >= b.len() { return None; }
-            let neg = b[i] == b'-';
-            let start = if neg { i + 1 } else { i };
-            if start >= b.len() || !b[start].is_ascii_digit() { return None; }
-            // Fast integer path
-            let mut n: i64 = (b[start] - b'0') as i64;
-            let mut k = start + 1;
-            while k < b.len() && b[k].is_ascii_digit() {
-                n = n * 10 + (b[k] - b'0') as i64;
-                k += 1;
-            }
-            if k < b.len() && (b[k] == b'.' || b[k] == b'e' || b[k] == b'E') {
-                // Has decimal/exponent — use fast-float
-                let end = {
-                    let mut e = k;
-                    if b[e] == b'.' { e += 1; while e < b.len() && b[e].is_ascii_digit() { e += 1; } }
-                    if e < b.len() && (b[e] == b'e' || b[e] == b'E') {
-                        e += 1;
-                        if e < b.len() && (b[e] == b'+' || b[e] == b'-') { e += 1; }
-                        while e < b.len() && b[e].is_ascii_digit() { e += 1; }
+            // Parse the numeric value inline; record None when the
+            // current value isn't numeric so a later non-match doesn't
+            // resurrect an earlier numeric value.
+            last_was_match = true;
+            let mut value: Option<f64> = None;
+            if i < b.len() {
+                let neg = b[i] == b'-';
+                let start = if neg { i + 1 } else { i };
+                if start < b.len() && b[start].is_ascii_digit() {
+                    let mut n: i64 = (b[start] - b'0') as i64;
+                    let mut k = start + 1;
+                    while k < b.len() && b[k].is_ascii_digit() {
+                        n = n * 10 + (b[k] - b'0') as i64;
+                        k += 1;
                     }
-                    e
-                };
-                let num_str = unsafe { std::str::from_utf8_unchecked(&b[i..end]) };
-                return fast_float::parse::<f64, _>(num_str).ok();
+                    if k < b.len() && (b[k] == b'.' || b[k] == b'e' || b[k] == b'E') {
+                        let end = {
+                            let mut e = k;
+                            if b[e] == b'.' { e += 1; while e < b.len() && b[e].is_ascii_digit() { e += 1; } }
+                            if e < b.len() && (b[e] == b'e' || b[e] == b'E') {
+                                e += 1;
+                                if e < b.len() && (b[e] == b'+' || b[e] == b'-') { e += 1; }
+                                while e < b.len() && b[e].is_ascii_digit() { e += 1; }
+                            }
+                            e
+                        };
+                        let num_str = unsafe { std::str::from_utf8_unchecked(&b[i..end]) };
+                        value = fast_float::parse::<f64, _>(num_str).ok();
+                    } else if (k - start) <= 15 {
+                        value = Some(if neg { -(n as f64) } else { n as f64 });
+                    }
+                }
             }
-            if (k - start) > 15 { return None; }
-            let val = if neg { -(n as f64) } else { n as f64 };
-            return Some(val);
+            last_match = value;
         }
-        // Skip value
-        i = match skip_json_value(b, i) { Ok(end) => end, Err(_) => return None };
-        // Skip ws
+        // Skip past the value (whether we parsed or not) so we keep scanning.
+        i = match skip_json_value(b, i) { Ok(end) => end, Err(_) => return if last_was_match { last_match } else { None } };
         while i < b.len() && matches!(b[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
-        if i >= b.len() { return None; }
-        if b[i] == b'}' { return None; }
-        if b[i] != b',' { return None; }
+        if i >= b.len() { return last_match; }
+        if b[i] == b'}' { return last_match; }
+        if b[i] != b',' { return last_match; }
         i += 1;
         while i < b.len() && matches!(b[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
     }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -5764,3 +5764,16 @@ null
 [((select(.a > .a)) | (.a + .a))?]
 []
 []
+
+# #360: json_object_get_num returned first-match for duplicate-key
+# inputs; jq dedupes last-wins. For `{"c":0,"c":false}`, .c is false
+# (not numeric), so `0 + .c` errors in jq. The fast path used to read
+# the first 0 and silently emit 0.
+[(0 + .c)?]
+{"c":0,"c":false}
+[]
+
+# Unique keys still take the fast path correctly.
+.x + .y
+{"x":3,"y":4}
+7


### PR DESCRIPTION
## Summary

#233 / #325 deduped duplicate input keys last-wins at the value-level parse path and most raw fast paths. \`json_object_get_num\` was the remaining holdout — it short-circuited on the first matching key, returning the FIRST occurrence's number instead of the last.

\`\`\`
\$ echo '{\"c\":0,\"c\":false}' | jq -c '0 + .c'
jq: error (at <stdin>:1): number (0) and boolean (false) cannot be added

\$ echo '{\"c\":0,\"c\":false}' | jq-jit -c '0 + .c'
0                                                # ← bug, before this PR
\`\`\`

After the fix both error on the same input.

The inner loop now tracks the LAST matching key's parsed value: a non-numeric later occurrence resets \`last_match\` to None, matching jq's last-wins semantics.

## Cost

\~75% regression on \`select .x > 1500000\` (2M-record NDJSON where every record is a unique-key object). The fast path scans every record to end-of-object now, where it previously short-circuited on first match. Same trade-off as #325 (raw fast-path dedup) — correctness over per-record speed.

\`json_object_get_two_nums\` likely needs the same treatment; flagged for a follow-up.

Found by \`tests/fuzz_diff.rs\` at ~30 cases on the post-#358 main.

## Test plan

- [x] \`cargo build --release\` — zero warnings
- [x] \`cargo test --release\` — 1162 regression (was 1160, +2 cases for the dedup-aware get_num matrix), 509 official, all green
- [x] \`tests/fuzz_diff.rs\` — clean post-fix
- [x] \`./bench/comprehensive.sh --quick\` — \~75% regression on \`select .x > 1500000\` (documented above), other paths in noise

Closes #360