### PR TITLE
fix: select_cmp_then_field bails to generic on non-object / non-numeric / missing field

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -9281,25 +9281,53 @@ fn real_main() {
                         Ok(())
                     })
                 } else if let Some((ref sel_field, ref op, threshold, ref out_field)) = select_cmp_field {
+                    // select(.sel cmp N) | .out — single-field select + field output.
+                    // Fast path requires object input with sel_field present
+                    // *and* numeric, plus out_field present. Anything else
+                    // bails to the generic interpreter so jq's verdict
+                    // (including type errors on non-object input, #362)
+                    // is preserved.
                     use jq_jit::ir::BinOp;
+                    let mut all_fields: Vec<String> = Vec::new();
+                    let mut field_idx = std::collections::HashMap::new();
+                    for f in [sel_field, out_field] {
+                        if !field_idx.contains_key(f) {
+                            field_idx.insert(f.clone(), all_fields.len());
+                            all_fields.push(f.clone());
+                        }
+                    }
+                    let field_refs: Vec<&str> = all_fields.iter().map(|s| s.as_str()).collect();
+                    let sel_idx = field_idx[sel_field];
+                    let out_idx = field_idx[out_field];
+                    let mut ranges_buf = vec![(0usize, 0usize); field_refs.len()];
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        if let Some(val) = json_object_get_num(raw, 0, sel_field) {
-                            let pass = match op {
-                                BinOp::Gt => val > threshold,
-                                BinOp::Lt => val < threshold,
-                                BinOp::Ge => val >= threshold,
-                                BinOp::Le => val <= threshold,
-                                BinOp::Eq => val == threshold,
-                                BinOp::Ne => val != threshold,
-                                _ => false,
-                            };
-                            if pass {
-                                if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, out_field) {
-                                    compact_buf.extend_from_slice(&raw[vs..ve]);
-                                    compact_buf.push(b'\n');
+                        let mut handled = false;
+                        if json_object_get_fields_raw_buf(raw, 0, &field_refs, &mut ranges_buf) {
+                            let r_sel = &ranges_buf[sel_idx];
+                            if r_sel.0 < r_sel.1 {
+                                if let Some(val) = parse_json_num(&raw[r_sel.0..r_sel.1]) {
+                                    let pass = match op {
+                                        BinOp::Gt => val > threshold,
+                                        BinOp::Lt => val < threshold,
+                                        BinOp::Ge => val >= threshold,
+                                        BinOp::Le => val <= threshold,
+                                        BinOp::Eq => val == threshold,
+                                        BinOp::Ne => val != threshold,
+                                        _ => false,
+                                    };
+                                    if pass {
+                                        let r_out = &ranges_buf[out_idx];
+                                        compact_buf.extend_from_slice(&raw[r_out.0..r_out.1]);
+                                        compact_buf.push(b'\n');
+                                    }
+                                    handled = true;
                                 }
                             }
+                        }
+                        if !handled {
+                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }
                         if compact_buf.len() >= 1 << 17 {
                             let _ = out.write_all(&compact_buf);
@@ -16393,26 +16421,49 @@ fn real_main() {
                     Ok(())
                 })
             } else if let Some((ref sel_field, ref op, threshold, ref out_field)) = select_cmp_field {
+                // Sibling fix to the stdin apply-site above.
                 use jq_jit::ir::BinOp;
                 let content_bytes = content.as_bytes();
+                let mut all_fields: Vec<String> = Vec::new();
+                let mut field_idx = std::collections::HashMap::new();
+                for f in [sel_field, out_field] {
+                    if !field_idx.contains_key(f) {
+                        field_idx.insert(f.clone(), all_fields.len());
+                        all_fields.push(f.clone());
+                    }
+                }
+                let field_refs: Vec<&str> = all_fields.iter().map(|s| s.as_str()).collect();
+                let sel_idx = field_idx[sel_field];
+                let out_idx = field_idx[out_field];
+                let mut ranges_buf = vec![(0usize, 0usize); field_refs.len()];
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    if let Some(val) = json_object_get_num(raw, 0, sel_field) {
-                        let pass = match op {
-                            BinOp::Gt => val > threshold,
-                            BinOp::Lt => val < threshold,
-                            BinOp::Ge => val >= threshold,
-                            BinOp::Le => val <= threshold,
-                            BinOp::Eq => val == threshold,
-                            BinOp::Ne => val != threshold,
-                            _ => false,
-                        };
-                        if pass {
-                            if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, out_field) {
-                                compact_buf.extend_from_slice(&raw[vs..ve]);
-                                compact_buf.push(b'\n');
+                    let mut handled = false;
+                    if json_object_get_fields_raw_buf(raw, 0, &field_refs, &mut ranges_buf) {
+                        let r_sel = &ranges_buf[sel_idx];
+                        if r_sel.0 < r_sel.1 {
+                            if let Some(val) = parse_json_num(&raw[r_sel.0..r_sel.1]) {
+                                let pass = match op {
+                                    BinOp::Gt => val > threshold,
+                                    BinOp::Lt => val < threshold,
+                                    BinOp::Ge => val >= threshold,
+                                    BinOp::Le => val <= threshold,
+                                    BinOp::Eq => val == threshold,
+                                    BinOp::Ne => val != threshold,
+                                    _ => false,
+                                };
+                                if pass {
+                                    let r_out = &ranges_buf[out_idx];
+                                    compact_buf.extend_from_slice(&raw[r_out.0..r_out.1]);
+                                    compact_buf.push(b'\n');
+                                }
+                                handled = true;
                             }
                         }
+                    }
+                    if !handled {
+                        let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                        process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                     }
                     if compact_buf.len() >= 1 << 17 {
                         let _ = out.write_all(&compact_buf);

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -5777,3 +5777,37 @@ null
 .x + .y
 {"x":3,"y":4}
 7
+
+# #362: select_cmp_then_field silent-skipped on non-object input.
+# `(select(.a > 0)) | (.a)` over `[]` errored in jq but jq-jit
+# emitted nothing. Sibling of #358 for the single-field shape; now
+# bails to generic when input isn't an object, fields are missing,
+# or the select field isn't numeric.
+[((select(.a > 0)) | (.a))?]
+[]
+[]
+
+# String input also errors — generic interpreter handles it.
+[((select(.a > 0)) | (.b))?]
+"x"
+[]
+
+# Object with non-numeric select field: jq still runs `"x" > 0` (true)
+# and outputs `.a`. Fast path used to silently skip; now bails to
+# generic.
+(select(.a > 0)) | (.a)
+{"a":"x"}
+"x"
+
+# Object with select pass but missing out_field: jq emits null.
+# Fast path used to silently skip; now bails to generic.
+(select(.a > 0)) | (.b)
+{"a":5}
+null
+
+# Duplicate keys in select field: jq dedupes last-wins, so .a is -5
+# (select fails). Fast path now scans to end via the multi-field
+# helper and produces the same verdict.
+[((select(.a > 0)) | (.a))?]
+{"a":5,"a":-5}
+[]


### PR DESCRIPTION
## Summary

- Sibling fix to #358/#359 for the single-field `select_cmp_*` shape
- Adds the `handled` flag pattern: switch to `json_object_get_fields_raw_buf` + `parse_json_num`, run the fast path only when fully in-domain (object input, select field present and numeric, output field present on a passing record), bail to the generic interpreter otherwise
- For `(select(.a > 0)) | (.a)` over `[]`, jq raises `Cannot index array with string "a"` and jq-jit now matches; previously silent

Found by `tests/fuzz_diff.rs` on the post-#361 main.

Closes #362

## Test plan

- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (official 509 + regression 1166 cases — added 5)
- [x] `./bench/comprehensive.sh --quick` — `select .x > 1500000` 0.121s → 0.120s, all related paths within ±3% noise
- [x] Manual: `[]`, `null`, `"x"`, `5` (non-object inputs) now error like jq; `{"a":"x"}` (non-numeric) returns `"x"`; `{"a":5}` with `.b` returns `null`; duplicate-key inputs honor last-wins via the multi-field helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)