### PR TITLE
fix: select_cmp_then_value bails to generic on non-object / non-numeric input

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -9840,6 +9840,11 @@ fn real_main() {
                     let mut ranges_buf = vec![(0usize, 0usize); gen_field_refs.len()];
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
+                        // Sibling of #359 / #363 / #365: each fused mode
+                        // gates on a numeric select field; bail to generic
+                        // when the gate fails so jq's verdict is preserved
+                        // (#366).
+                        let mut handled = false;
                         match fused_mode {
                             1 => {
                                 // Fused: select field == FieldOpConst field
@@ -9857,6 +9862,7 @@ fn real_main() {
                                         }
                                         compact_buf.push(b'\n');
                                     }
+                                    handled = true;
                                 }
                             }
                             2 => {
@@ -9878,6 +9884,7 @@ fn real_main() {
                                         }
                                         compact_buf.push(b'\n');
                                     }
+                                    handled = true;
                                 }
                             }
                             3 => {
@@ -9896,6 +9903,7 @@ fn real_main() {
                                         }
                                         compact_buf.push(b'\n');
                                     }
+                                    handled = true;
                                 }
                             }
                             _ => {
@@ -9915,8 +9923,13 @@ fn real_main() {
                                         }
                                         compact_buf.push(b'\n');
                                     }
+                                    handled = true;
                                 }
                             }
+                        }
+                        if !handled {
+                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }
                         if compact_buf.len() >= 1 << 17 {
                             let _ = out.write_all(&compact_buf);
@@ -16973,6 +16986,8 @@ fn real_main() {
                 let mut ranges_buf = vec![(0usize, 0usize); gen_field_refs.len()];
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
+                    // Sibling fix to the stdin apply-site above (#366).
+                    let mut handled = false;
                     match fused_mode {
                         1 => {
                             if let Some(val) = json_object_get_num(raw, 0, sel_field) {
@@ -16989,6 +17004,7 @@ fn real_main() {
                                     }
                                     compact_buf.push(b'\n');
                                 }
+                                handled = true;
                             }
                         }
                         2 => {
@@ -17008,6 +17024,7 @@ fn real_main() {
                                     }
                                     compact_buf.push(b'\n');
                                 }
+                                handled = true;
                             }
                         }
                         3 => {
@@ -17025,6 +17042,7 @@ fn real_main() {
                                     }
                                     compact_buf.push(b'\n');
                                 }
+                                handled = true;
                             }
                         }
                         _ => {
@@ -17043,8 +17061,13 @@ fn real_main() {
                                     }
                                     compact_buf.push(b'\n');
                                 }
+                                handled = true;
                             }
                         }
+                    }
+                    if !handled {
+                        let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                        process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                     }
                     if compact_buf.len() >= 1 << 17 {
                         let _ = out.write_all(&compact_buf);

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -5839,3 +5839,35 @@ null
 (select(.a >= .b)) | ({z: (.a + .b)})
 {"a":1}
 {"z":1}
+
+# #366: select_cmp_then_value silent-skipped on non-object input.
+# `(select(.a < 0)) | (.a + .a)` over `null` → jq evaluates
+# `null < 0` (true), `null + null` (null) and emits `null`; jq-jit
+# emitted nothing. Sibling of #358 / #362 / #364 covering the
+# `select(.f cmp N) | value` shape (4 fused modes).
+(select(.a < 0)) | (.a + .a)
+null
+null
+
+# Mode 1 (FieldOpConst, sel == compute field): non-object now bails.
+[((select(.a < 0)) | (.a + 1))?]
+[]
+[]
+
+# Mode 3 (ConstOpField, sel == compute field): non-object now bails.
+[((select(.a < 0)) | (1 + .a))?]
+[]
+[]
+
+# General mode (compute field differs from sel field): non-object
+# still bails to generic.
+[((select(.a < 0)) | (.b + 1))?]
+[]
+[]
+
+# Object missing the select field: jq evaluates `null < 0` (true)
+# and the compute as `null + null = null`. Fast path bails since
+# the gate fails on missing sel_field; generic emits null.
+(select(.a < 0)) | (.a + .a)
+{}
+null


### PR DESCRIPTION
## Summary

- Sibling of #359/#363/#365 for the `select(.f cmp N) | value` shape (4 fused modes)
- Apply the `handled` flag pattern to all four modes (FieldOpConst-reuse, FieldOpField-two_nums, ConstOpField-reuse, general) in both stdin and file apply-sites: bail to the generic interpreter when the gate fails
- For `(select(.a < 0)) | (.a + .a)` over `null`, jq evaluates `null<0` (true), `null+null` (null) and emits `null`; jq-jit now matches (previously silent)

Found by `tests/fuzz_diff.rs` on the post-#365 main.

Closes #366

## Test plan

- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (official 509 + regression cases — added 5 new)
- [x] `./bench/comprehensive.sh --quick` — `select .x > 1500000` 0.119s, all paths within ±3% noise
- [x] Manual: all 4 fused modes verified on `null`, `[]`, `5`, `"x"`, `{}`, `{"a":-1}`, `{"a":-1,"b":2}`, `{"a":"x"}`, `{"a":-1,"a":2}` (last-wins) — non-object inputs error like jq, missing-field cases produce `null`, happy paths unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)