### PR TITLE
fix: json_object_get_two_nums scans to end for last-wins on dup keys

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -3309,6 +3309,11 @@ pub fn json_object_get_two_nums(b: &[u8], pos: usize, field1: &str, field2: &str
     }
     let f1 = field1.as_bytes();
     let f2 = field2.as_bytes();
+    // jq dedupes duplicate input keys last-wins (#233 / #325 / #360):
+    // walk the entire object and overwrite each `val*` slot whenever a
+    // later duplicate arrives. The pre-#371 version exited on the first
+    // match for each field, returning a first-wins read that disagreed
+    // with jq for inputs like `{"a":5,"a":1,"b":3}` (#371).
     let mut val1: Option<f64> = None;
     let mut val2: Option<f64> = None;
     let mut i = pos + 1;
@@ -3322,8 +3327,8 @@ pub fn json_object_get_two_nums(b: &[u8], pos: usize, field1: &str, field2: &str
             match b[j] { b'"' => break, b'\\' => { j += 2; continue }, _ => j += 1 }
         }
         let key_len = j - key_start;
-        let match1 = val1.is_none() && key_len == f1.len() && b[key_start..j] == *f1;
-        let match2 = !match1 && val2.is_none() && key_len == f2.len() && b[key_start..j] == *f2;
+        let match1 = key_len == f1.len() && b[key_start..j] == *f1;
+        let match2 = !match1 && key_len == f2.len() && b[key_start..j] == *f2;
         i = j + 1;
         while i < b.len() && matches!(b[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
         if i >= b.len() || b[i] != b':' { return None; }
@@ -3361,15 +3366,20 @@ pub fn json_object_get_two_nums(b: &[u8], pos: usize, field1: &str, field2: &str
                 if neg { -(n as f64) } else { n as f64 }
             };
             if match1 { val1 = Some(val); } else { val2 = Some(val); }
-            if val1.is_some() && val2.is_some() {
-                return Some((val1.unwrap(), val2.unwrap()));
-            }
         } else {
             i = match skip_json_value(b, i) { Ok(end) => end, Err(_) => return None };
         }
         while i < b.len() && matches!(b[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
         if i >= b.len() { return None; }
-        if b[i] == b'}' { return None; }
+        // End of object — `val1` / `val2` are now their last-wins
+        // values across the entire scan (#371). Return Some only when
+        // both fields appeared at least once.
+        if b[i] == b'}' {
+            return match (val1, val2) {
+                (Some(a), Some(b)) => Some((a, b)),
+                _ => None,
+            };
+        }
         if b[i] != b',' { return None; }
         i += 1;
         while i < b.len() && matches!(b[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -5901,3 +5901,30 @@ null
 {a: (.x + 0)}
 {"x":null}
 {"a":0}
+
+# #371: json_object_get_two_nums returned first-match for duplicate
+# input keys; jq dedupes last-wins. For `{"a":5,"a":1,"b":3}` with
+# `select(.a > .b)`, last-wins gives .a=1, 1>3 is false, no output.
+# The fast path used to read the first 5, judge 5>3 true, and emit.
+[(select(.a > .b))?]
+{"a":5,"a":1,"b":3}
+[]
+
+# Reverse ordering — first-wins would skip the record (1>3 false),
+# last-wins emits it (5>3 true).
+select(.a > .b)
+{"a":1,"a":5,"b":3}
+{"a":5,"b":3}
+
+# Same field on both sides routes through the same-field optimization
+# (fall through to json_object_get_num), which already scans to end
+# (#360). Keeps the existing behaviour.
+[(select(.a > .a))?]
+{"a":5,"a":1}
+[]
+
+# Duplicate hits on both fields — last-wins on each side. With
+# last-wins .a=1 and .b=7, `.b > .a` is true and the record passes.
+select(.b > .a)
+{"b":1,"a":5,"a":1,"b":7}
+{"a":1,"b":7}


### PR DESCRIPTION
## Summary

- Family C audit candidate (sibling of #233/#325/#360)
- The helper short-circuited on the first match for each field, returning a first-wins read where jq dedupes input keys last-wins
- Drops the per-field `is_none()` guards and the early return; the `}` terminator handler now returns `Some((val1, val2))` when both fields appeared at least once
- Call sites (`select_ff_cmp`, `select_cmp_value` mode 2) are unaffected by the signature

For `{"a":5,"a":1,"b":3}` with `select(.a > .b)`, jq emits nothing (last-wins .a=1, 1>3 false); jq-jit now matches (previously emitted the record).

Closes #371

## Test plan

- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (official 509 + regression 1188 cases — added 4 new dup-key cases)
- [x] `./bench/comprehensive.sh --quick` — within ±3% noise on relevant paths
- [x] Manual: dup-key inputs in both orderings (`{"a":5,"a":1,...}` and `{"a":1,"a":5,...}`), unique-key happy paths, missing-field, non-object — all match jq

🤖 Generated with [Claude Code](https://claude.com/claude-code)