### PR TITLE
fix: select_cmp_then_array bails on non-object / type-mismatch (#377)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -9773,6 +9773,11 @@ fn real_main() {
                     let mut ranges_buf = vec![(0usize, 0usize); field_refs.len()];
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
+                        // Sibling of #363 / #367 / #374: gate on a numeric
+                        // select field; bail to generic when the gate fails
+                        // so jq's verdict (error on non-object, value-level
+                        // type-ordered cmp on non-numeric) is preserved.
+                        let mut handled = false;
                         if let Some(val) = json_object_get_num(raw, 0, sel_field) {
                             let pass = match sel_op {
                                 BinOp::Gt => val > threshold,
@@ -9793,6 +9798,11 @@ fn real_main() {
                                     compact_buf.extend_from_slice(b"]\n");
                                 }
                             }
+                            handled = true;
+                        }
+                        if !handled {
+                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }
                         if compact_buf.len() >= 1 << 17 {
                             let _ = out.write_all(&compact_buf);
@@ -16966,6 +16976,8 @@ fn real_main() {
                 let mut ranges_buf = vec![(0usize, 0usize); field_refs.len()];
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
+                    // Sibling fix to the stdin apply-site above.
+                    let mut handled = false;
                     if let Some(val) = json_object_get_num(raw, 0, sel_field) {
                         let pass = match sel_op {
                             BinOp::Gt => val > threshold, BinOp::Lt => val < threshold,
@@ -16983,6 +16995,11 @@ fn real_main() {
                                 compact_buf.extend_from_slice(b"]\n");
                             }
                         }
+                        handled = true;
+                    }
+                    if !handled {
+                        let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                        process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                     }
                     if compact_buf.len() >= 1 << 17 {
                         let _ = out.write_all(&compact_buf);

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -5989,3 +5989,33 @@ null
 ({"a": true}) | (.a or false)
 null
 true
+
+# #377: select_cmp_then_array (`select(.f cmp N) | [remap, ...]`)
+# silently emitted nothing on non-object input. jq raises a type
+# error indexing a non-object with a string key. Wrapped with `?`
+# to convert error → empty list, matching the fix's bail-to-generic
+# routing through `process_input`.
+[((select(.a > 0)) | ([.a,.a]))?]
+false
+[]
+
+# Object with non-numeric `.a`: jq's value-level cmp uses
+# type-ordered comparison (`"x" > 0` is true because str > num),
+# so select passes and the array reads succeed. Pre-fix the fast
+# path skipped because `json_object_get_num` returned `None`.
+(select(.a > 0)) | ([.a,.a])
+{"a":"x"}
+["x","x"]
+
+# Object missing the select field: `.a` is null, `null > 0` is
+# false (null sorts smallest), select rejects and emits nothing.
+# Asserting the bail-to-generic doesn't introduce a spurious row.
+[((select(.a > 0)) | ([.a,.a]))?]
+{"b":1}
+[]
+
+# Baseline: numeric field passes the comparison and the array is
+# emitted unchanged.
+(select(.a > 0)) | ([.a,.a])
+{"a":5}
+[5,5]


### PR DESCRIPTION
## Summary

- `select(.field cmp N) | [remap, ...]` (the `detect_select_cmp_then_array` fast path) silently emitted nothing on non-object inputs and on objects whose select-field was non-numeric. jq raises a type error in the non-object case and uses value-level type-ordered comparison in the non-numeric case — both paths diverged.
- Same `handled` flag template as #363 / #365 / #367 / #374: only mark the iteration as handled when `json_object_get_num` returns `Some`, otherwise fall back to `process_input` so jq's verdict is preserved.
- Both apply sites (stdin path at `src/bin/jq-jit.rs:9754` and file path at `src/bin/jq-jit.rs:16947`) needed the same change.

Surfaced by the composition-biased `filter_strategy` work in #320.

Closes #377

## Test plan

- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (all suites green, including 4 new regression cases)
- [x] `./bench/comprehensive.sh --quick` (no regression on hot paths; the bail only fires when the fast-path can't faithfully match jq)
- [x] Manual repro: `echo 'false' | jq-jit -c '(select(.a > 0)) | ([.a,.a])'` now matches jq's `Cannot index boolean with string "a"` error
- [x] Manual repro: `echo '{"a":"x"}' | jq-jit -c '(select(.a > 0)) | ([.a,.a])'` now emits `["x","x"]` matching jq's type-ordered comparison

🤖 Generated with [Claude Code](https://claude.com/claude-code)