### PR TITLE
fix: select_cmp_then_value general path bails on missing remap fields (#383)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -9994,7 +9994,14 @@ fn real_main() {
                                 }
                             }
                             _ => {
-                                // General path: extract select field, then output fields
+                                // General path (#383): emitting literal `null`
+                                // when remap fields are missing was wrong for
+                                // arithmetic shapes — jq raises a type error
+                                // (`null - null cannot be subtracted` etc.)
+                                // while the fast path silently emitted `null`.
+                                // Bail to generic on missing fields so the
+                                // verdict matches across all out_rexpr shapes
+                                // (Field → null, FieldOpField → error, etc.).
                                 if let Some(val) = json_object_get_num(raw, 0, sel_field) {
                                     let pass = match sel_op {
                                         BinOp::Gt => val > threshold, BinOp::Lt => val < threshold,
@@ -10002,15 +10009,13 @@ fn real_main() {
                                         BinOp::Eq => val == threshold, BinOp::Ne => val != threshold,
                                         _ => false,
                                     };
-                                    if pass {
-                                        if json_object_get_fields_raw_buf(raw, 0, &gen_field_refs, &mut ranges_buf) {
-                                            emit_remap_value(&mut compact_buf, out_rexpr, raw, &ranges_buf, &gen_field_idx);
-                                        } else {
-                                            compact_buf.extend_from_slice(b"null");
-                                        }
+                                    if !pass {
+                                        handled = true;
+                                    } else if json_object_get_fields_raw_buf(raw, 0, &gen_field_refs, &mut ranges_buf) {
+                                        emit_remap_value(&mut compact_buf, out_rexpr, raw, &ranges_buf, &gen_field_idx);
                                         compact_buf.push(b'\n');
+                                        handled = true;
                                     }
-                                    handled = true;
                                 }
                             }
                         }
@@ -17195,6 +17200,7 @@ fn real_main() {
                             }
                         }
                         _ => {
+                            // Sibling fix to the stdin apply-site above (#383).
                             if let Some(val) = json_object_get_num(raw, 0, sel_field) {
                                 let pass = match sel_op {
                                     BinOp::Gt => val > threshold, BinOp::Lt => val < threshold,
@@ -17202,15 +17208,13 @@ fn real_main() {
                                     BinOp::Eq => val == threshold, BinOp::Ne => val != threshold,
                                     _ => false,
                                 };
-                                if pass {
-                                    if json_object_get_fields_raw_buf(raw, 0, &gen_field_refs, &mut ranges_buf) {
-                                        emit_remap_value(&mut compact_buf, out_rexpr, raw, &ranges_buf, &gen_field_idx);
-                                    } else {
-                                        compact_buf.extend_from_slice(b"null");
-                                    }
+                                if !pass {
+                                    handled = true;
+                                } else if json_object_get_fields_raw_buf(raw, 0, &gen_field_refs, &mut ranges_buf) {
+                                    emit_remap_value(&mut compact_buf, out_rexpr, raw, &ranges_buf, &gen_field_idx);
                                     compact_buf.push(b'\n');
+                                    handled = true;
                                 }
-                                handled = true;
                             }
                         }
                     }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -6051,3 +6051,31 @@ false
 (select(.a > 0)) | ({a: (.b)})
 {"a":1,"b":2}
 {"a":2}
+
+# #383: select_cmp_then_value general path emitted literal `null`
+# when remap fields were missing. Correct for bare `.b` reads but
+# wrong for arithmetic — jq raises a type error on null-null
+# arithmetic. Bail to generic.
+[((select(.a != 0)) | (.b - .b))?]
+{"a":1}
+[]
+
+# Baseline: arithmetic remap with both fields present stays on
+# the fast path.
+(select(.a != 0)) | (.b - .b)
+{"a":1,"b":7}
+0
+
+# Counter-case: bare-field read on missing field — jq emits null,
+# the post-fix bail routes through generic which also emits null.
+# Same observable behavior; just no longer takes the fast-path
+# null shortcut.
+(select(.a != 0)) | (.b)
+{"a":1}
+null
+
+# Counter-case: ConstOpField NOT against the select field — the
+# `n - .b` shape lands in fused_mode 0 but errors on missing `.b`.
+[((select(.a != 0)) | (5 - .b))?]
+{"a":1}
+[]


### PR DESCRIPTION
## Summary

- The `fused_mode == 0` arm of `select_cmp_then_value` emitted literal `null` when `json_object_get_fields_raw_buf` returned `false`. Correct for bare `.b` reads (jq's `null` for missing field reads) but wrong for arithmetic shapes — jq raises a type error on null-null arithmetic.
- Mirror the cremap pattern: drop the `else extend_from_slice(b\"null\")` branch and bail to `process_input` on missing fields. Generic produces the right answer for both bare-field reads (null) and arithmetic-on-missing (error).
- Two apply sites: stdin (`src/bin/jq-jit.rs:9996`) and file (`src/bin/jq-jit.rs:17197`).

Surfaced by the composition-biased `filter_strategy` (#320 follow-up).

Closes #383

## Test plan

- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (all suites green; 4 new regression cases — error case, arithmetic baseline, bare-field counter-case, ConstOpField counter-case)
- [x] Manual repro: `echo '{\"a\":1}' | jq-jit -c '(select(.a != 0)) | (.b - .b)'` now matches jq's error
- [x] Manual repro: `echo '{\"a\":1}' | jq-jit -c '(select(.a != 0)) | .b'` still emits `null` matching jq
- [x] Manual repro: `echo '{\"a\":1,\"b\":7}' | jq-jit -c '(select(.a != 0)) | (.b - .b)'` still emits `0` (hot path preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)