### PR TITLE
fix: select_cmp_then_value general path probes resolved_would_error before emit (#385)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -9924,6 +9924,15 @@ fn real_main() {
                         }
                     }
                     let gen_field_refs: Vec<&str> = gen_all_fields.iter().map(|s| s.as_str()).collect();
+                    // Pre-resolve `out_rexpr` once for the general path so
+                    // each iteration can probe `resolved_would_error` (#385).
+                    // The general arm previously called `emit_remap_value`
+                    // unconditionally and trusted its `b"null"` fallbacks —
+                    // wrong for arr/arr or str/str arithmetic where jq does
+                    // concat, and for any other out-of-domain shape.
+                    let gen_resolved = if fused_mode == 0 {
+                        Some(resolve_one_remap(out_rexpr, &gen_field_idx))
+                    } else { None };
                     let mut ranges_buf = vec![(0usize, 0usize); gen_field_refs.len()];
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
@@ -9994,14 +10003,14 @@ fn real_main() {
                                 }
                             }
                             _ => {
-                                // General path (#383): emitting literal `null`
-                                // when remap fields are missing was wrong for
-                                // arithmetic shapes — jq raises a type error
-                                // (`null - null cannot be subtracted` etc.)
-                                // while the fast path silently emitted `null`.
-                                // Bail to generic on missing fields so the
-                                // verdict matches across all out_rexpr shapes
-                                // (Field → null, FieldOpField → error, etc.).
+                                // General path (#383 / #385): only mark
+                                // handled when fields are present *and*
+                                // the resolved remap is in the inline
+                                // emitter's faithful domain. Out-of-domain
+                                // operands (arr/arr, str/str for non-Add,
+                                // type-mismatched arithmetic, etc.) bail
+                                // to `process_input` so jq's exact verdict
+                                // applies.
                                 if let Some(val) = json_object_get_num(raw, 0, sel_field) {
                                     let pass = match sel_op {
                                         BinOp::Gt => val > threshold, BinOp::Lt => val < threshold,
@@ -10012,9 +10021,12 @@ fn real_main() {
                                     if !pass {
                                         handled = true;
                                     } else if json_object_get_fields_raw_buf(raw, 0, &gen_field_refs, &mut ranges_buf) {
-                                        emit_remap_value(&mut compact_buf, out_rexpr, raw, &ranges_buf, &gen_field_idx);
-                                        compact_buf.push(b'\n');
-                                        handled = true;
+                                        let res = gen_resolved.as_ref().unwrap();
+                                        if !resolved_would_error(res, raw, &ranges_buf) {
+                                            emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf);
+                                            compact_buf.push(b'\n');
+                                            handled = true;
+                                        }
                                     }
                                 }
                             }
@@ -17137,6 +17149,10 @@ fn real_main() {
                     }
                 }
                 let gen_field_refs: Vec<&str> = gen_all_fields.iter().map(|s| s.as_str()).collect();
+                // Pre-resolve `out_rexpr` once for the general path (#385).
+                let gen_resolved = if fused_mode == 0 {
+                    Some(resolve_one_remap(out_rexpr, &gen_field_idx))
+                } else { None };
                 let mut ranges_buf = vec![(0usize, 0usize); gen_field_refs.len()];
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
@@ -17200,7 +17216,7 @@ fn real_main() {
                             }
                         }
                         _ => {
-                            // Sibling fix to the stdin apply-site above (#383).
+                            // Sibling fix to the stdin apply-site above (#383 / #385).
                             if let Some(val) = json_object_get_num(raw, 0, sel_field) {
                                 let pass = match sel_op {
                                     BinOp::Gt => val > threshold, BinOp::Lt => val < threshold,
@@ -17211,9 +17227,12 @@ fn real_main() {
                                 if !pass {
                                     handled = true;
                                 } else if json_object_get_fields_raw_buf(raw, 0, &gen_field_refs, &mut ranges_buf) {
-                                    emit_remap_value(&mut compact_buf, out_rexpr, raw, &ranges_buf, &gen_field_idx);
-                                    compact_buf.push(b'\n');
-                                    handled = true;
+                                    let res = gen_resolved.as_ref().unwrap();
+                                    if !resolved_would_error(res, raw, &ranges_buf) {
+                                        emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf);
+                                        compact_buf.push(b'\n');
+                                        handled = true;
+                                    }
                                 }
                             }
                         }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -6079,3 +6079,29 @@ null
 [((select(.a != 0)) | (5 - .b))?]
 {"a":1}
 []
+
+# #385: select_cmp_then_value general path called emit_remap_value
+# unconditionally, trusting its inline `b"null"` fallback. Wrong
+# for array operands (jq concatenates / set-differences) and for
+# any other out-of-domain shape. Pre-resolve the rexpr and probe
+# `resolved_would_error` per-iteration; on miss, bail to generic
+# so jq's exact verdict applies.
+(select(.y > -3)) | (.c + .c)
+{"y":0,"c":[]}
+[]
+
+# Array concat with non-empty arrays.
+(select(.y > -3)) | (.c + .c)
+{"y":0,"c":[1,2]}
+[1,2,1,2]
+
+# String concat: was already inside emit_remap_value's domain via
+# the str+str branch; counter-case to ensure we didn't regress it.
+(select(.y > -3)) | (.c + .c)
+{"y":1,"c":"a"}
+"aa"
+
+# Numeric baseline stays on the hot path.
+(select(.y > -3)) | (.c + .c)
+{"y":1,"c":3}
+6


### PR DESCRIPTION
## Summary

- The general-mode apply (`fused_mode == 0`) of `select_cmp_then_value` called `emit_remap_value` unconditionally, trusting its inline `b\"null\"` fallback. Wrong for array operands (jq concatenates / set-differences), mixed-type arithmetic, and other out-of-domain shapes.
- Pre-resolve `out_rexpr` to a `ResolvedRemap` once outside the hot loop. Per-iteration: probe `resolved_would_error`; on miss, bail to `process_input`. Same template as the cremap apply (`src/bin/jq-jit.rs:9614` family).
- Two apply sites updated (stdin and file).

Surfaced by the composition-biased `filter_strategy` (#320 follow-up). Stacks on top of #383 in scope but not in code.

Closes #385

## Test plan

- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (all suites green; 4 new regression cases — empty-array concat, non-empty-array concat, str/str counter-case, num/num baseline)
- [x] Manual repro: `echo '{\"y\":0,\"c\":[]}' | jq-jit -c '(select(.y > -3)) | (.c + .c)'` now emits `[]` matching jq
- [x] Manual repro: `echo '{\"y\":0,\"c\":[1,2]}' | jq-jit -c '(select(.y > -3)) | (.c + .c)'` now emits `[1,2,1,2]` matching jq

🤖 Generated with [Claude Code](https://claude.com/claude-code)