### PR TITLE
fix: select_ff_cmp_then_field bails on missing output field (#387)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -10177,7 +10177,10 @@ fn real_main() {
                                     _ => false,
                                 };
                                 if pass {
-                                    // Only now fetch the output field
+                                    // Only now fetch the output field. If
+                                    // missing, jq emits null — bail to
+                                    // generic instead of silently dropping
+                                    // the row (#387).
                                     if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, sff_out) {
                                         let out_val = &raw[vs..ve];
                                         if use_pretty_buf && (out_val[0] == b'{' || out_val[0] == b'[') {
@@ -10186,6 +10189,9 @@ fn real_main() {
                                             compact_buf.extend_from_slice(out_val);
                                         }
                                         compact_buf.push(b'\n');
+                                    } else {
+                                        let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                                        process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                                     }
                                 }
                             } else {
@@ -17378,6 +17384,7 @@ fn real_main() {
                                 _ => false,
                             };
                             if pass {
+                                // Sibling fix to the stdin apply-site above (#387).
                                 if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, sff_out) {
                                     let out_val = &raw[vs..ve];
                                     if use_pretty_buf && (out_val[0] == b'{' || out_val[0] == b'[') {
@@ -17386,6 +17393,9 @@ fn real_main() {
                                         compact_buf.extend_from_slice(out_val);
                                     }
                                     compact_buf.push(b'\n');
+                                } else {
+                                    let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                                    process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                                 }
                             }
                         } else {

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -6105,3 +6105,15 @@ null
 (select(.y > -3)) | (.c + .c)
 {"y":1,"c":3}
 6
+
+# #387: select(.f1 cmp .f2) | .out silently dropped rows when the
+# select gate passed but `.out` was missing on the input. jq emits
+# null. Bail to generic on missing output field.
+(select(.a >= .a)) | (.b)
+{"a":0}
+null
+
+# Counter-case: output field present — fast path stays hot.
+(select(.a >= .a)) | (.b)
+{"a":0,"b":7}
+7


### PR DESCRIPTION
## Summary

- `select(.f1 cmp .f2) | .out` silently dropped rows when the select gate passed but the output field `.out` was missing on the input. jq emits null.
- Same Family A bail template as #381 / #383 / #385: bail to `process_input` on `None`. Two apply sites; both `out_is_separate` branches updated.

Surfaced by the composition-biased `filter_strategy` (#320 follow-up).

Closes #387

## Test plan

- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (all suites green; 2 new regression cases — missing-output and present-output baseline)
- [x] Manual repro: `echo '{\"a\":0}' | jq-jit -c '(select(.a >= .a)) | (.b)'` now emits `null` matching jq

🤖 Generated with [Claude Code](https://claude.com/claude-code)