### PR TITLE
fix: select_ff_cmp_then_value probes resolved_would_error before emit (#389)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -10402,11 +10402,14 @@ fn real_main() {
                                         BinOp::Eq => v1 == v2, BinOp::Ne => v1 != v2,
                                         _ => false,
                                     };
-                                    if pass {
+                                    if !pass {
+                                        handled = true;
+                                    } else if !resolved_would_error(&resolved, raw, &ranges_buf) {
                                         emit_resolved_value(&mut compact_buf, &resolved, raw, &ranges_buf);
                                         compact_buf.push(b'\n');
+                                        handled = true;
                                     }
-                                    handled = true;
+                                    // else: out-of-domain (#389) → bail to generic
                                 }
                             }
                         }
@@ -17595,11 +17598,14 @@ fn real_main() {
                                     BinOp::Eq => v1 == v2, BinOp::Ne => v1 != v2,
                                     _ => false,
                                 };
-                                if pass {
+                                // Sibling fix to the stdin apply-site above (#389).
+                                if !pass {
+                                    handled = true;
+                                } else if !resolved_would_error(&resolved, raw, &ranges_buf) {
                                     emit_resolved_value(&mut compact_buf, &resolved, raw, &ranges_buf);
                                     compact_buf.push(b'\n');
+                                    handled = true;
                                 }
-                                handled = true;
                             }
                         }
                     }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -6117,3 +6117,23 @@ null
 (select(.a >= .a)) | (.b)
 {"a":0,"b":7}
 7
+
+# #389: select(.f1 cmp .f2) | <value-expr> called emit_resolved_value
+# unconditionally and trusted its inline `b"null"` fallback — wrong
+# for out-of-domain operands (array+number errors, mixed types,
+# etc.). Probe `resolved_would_error` first; on miss, bail.
+[((select(.c >= .c)) | (.x + .c))?]
+{"c":0,"x":[]}
+[]
+
+# Array concat — out-of-domain for the inline emitter's numeric
+# branch but in jq's domain. Bail routes through generic which
+# concatenates correctly.
+(select(.c >= .c)) | (.x + .x)
+{"c":0,"x":[1]}
+[1,1]
+
+# Numeric baseline stays on the hot path.
+(select(.c >= .c)) | (.x + .c)
+{"c":1,"x":2}
+3


### PR DESCRIPTION
## Summary

- `select(.f1 cmp .f2) | <value-expr>` called `emit_resolved_value` unconditionally; `emit_resolved_value` emits literal `null` for out-of-domain operands (array+number, mixed types). jq raises type errors or applies type-aware verdicts (array+array concat) for those shapes.
- Same template as #385: probe `resolved_would_error` on the pre-resolved `out_rexpr` before calling `emit_resolved_value`. Bail to `process_input` on miss.
- Two apply sites updated.

Surfaced by the composition-biased `filter_strategy` (#320 follow-up).

Closes #389

## Test plan

- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (all suites green; 3 new regression cases — array+number error, array+array concat, numeric baseline)
- [x] Manual repro: `echo '{\"c\":0,\"x\":[]}' | jq-jit -c '(select(.c >= .c)) | (.x + .c)'` now matches jq's error
- [x] Manual repro: `echo '{\"c\":0,\"x\":[1]}' | jq-jit -c '(select(.c >= .c)) | (.x + .x)'` now emits `[1,1]` matching jq

🤖 Generated with [Claude Code](https://claude.com/claude-code)