### PR TITLE
fix: resolved_would_error::FieldCmpField requires non-str side to be numeric (#392)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -1319,15 +1319,20 @@ fn resolved_would_error(
         ResolvedRemap::FieldCmpConst(idx, _, _) => parse_json_num(bytes_of(*idx)).is_none(),
         // `field cmp field` — the inline emitter handles num/num,
         // str/str, and (num/str)-mixed; everything else falls through
-        // to `null`. jq's total ordering produces a defined verdict for
-        // null/bool/array/object pairs too, so bail when neither side
-        // is numeric and at most one is a string (#347).
+        // to `null`. jq's total ordering is
+        // null < false < true < number < string < array < object,
+        // so bail when one side is a string and the other is anything
+        // *other than a number* — the emitter's str/non-str branch
+        // assumes the non-str is numeric and would otherwise return
+        // the wrong verdict (#392). Same intent as #347; the prior
+        // `is_str(a) ^ is_str(b)` was too permissive.
         ResolvedRemap::FieldCmpField(i1, _, i2) => {
             let a = bytes_of(*i1);
             let b = bytes_of(*i2);
+            let num_str_mixed = (is_str(a) && is_num(b)) || (is_num(a) && is_str(b));
             !((is_num(a) && is_num(b))
                 || (is_str(a) && is_str(b))
-                || (is_str(a) ^ is_str(b)))
+                || num_str_mixed)
         }
         // BoolExpr (`cmp1 and/or cmp2`) emits null when any side's
         // bool eval returns None — which happens whenever an inner

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -6137,3 +6137,28 @@ null
 (select(.c >= .c)) | (.x + .c)
 {"c":1,"x":2}
 3
+
+# #392: resolved_would_error::FieldCmpField allowed str/non-num
+# pairs through the inline emitter, which returns the wrong
+# verdict (jq's total order is null<false<true<num<str<arr<obj,
+# but the emitter's str/non-str branch assumed non-str = num).
+# Tighten the gate to require the non-str side be numeric; bail
+# otherwise.
+(select(.c >= .c)) | (.a > .x)
+{"x":[],"c":0,"a":""}
+false
+
+# Counter-case: str vs num still rides the fast path (jq: num<str).
+(select(.c >= .c)) | (.a > .x)
+{"x":0,"c":0,"a":""}
+true
+
+# str vs null — null<str, so str>null=true. Should bail to generic.
+(select(.c >= .c)) | (.a > .x)
+{"x":null,"c":0,"a":""}
+true
+
+# str vs object — str<obj, so str>obj=false.
+(select(.c >= .c)) | (.a > .x)
+{"x":{},"c":0,"a":""}
+false


### PR DESCRIPTION
## Summary

- The fast-path gate \`resolved_would_error::FieldCmpField\` allowed any \`is_str(a) ^ is_str(b)\` pair to fire the inline emitter, but the emitter's str/non-str branch assumes the non-str operand is *numeric*. For str vs arr / obj / null / bool the emitter returned the wrong verdict.
- Single-site fix: tighten the gate to require the non-str side be numeric. All callers (cremap, #385's general path, #389's ff_cmp_value) inherit it.

Surfaced by the composition-biased \`filter_strategy\` at 67k of 200k cases. Found a str / arr cross-product (\`\"\" > []\`) which under jq's total order is false but the fast path emitted true.

Closes #392

## Test plan

- [x] \`cargo build --release\` (zero warnings)
- [x] \`cargo test --release\` (all suites green; 4 new regression cases — the bug input plus str/num, str/null, str/obj counter-cases)
- [x] Manual repro: \`echo '{\"x\":[],\"c\":0,\"a\":\"\"}' | jq-jit -c '(select(.c >= .c)) | (.a > .x)'\` now emits \`false\` matching jq

🤖 Generated with [Claude Code](https://claude.com/claude-code)