### PR TITLE
fix: select_str_then_field bails on non-object input (#394)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -10560,6 +10560,21 @@ fn real_main() {
                     } else { None };
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
+                        // #394: non-object input must bail to generic so jq's
+                        // type-error verdict (`Cannot index <type> with
+                        // string`) is preserved instead of silently dropping
+                        // the row. Detect by peeking the first byte; the
+                        // record fed by `json_stream_raw` is already
+                        // whitespace-trimmed at the boundary.
+                        if raw.first() != Some(&b'{') {
+                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                            if compact_buf.len() >= 1 << 17 {
+                                let _ = out.write_all(&compact_buf);
+                                compact_buf.clear();
+                            }
+                            return Ok(());
+                        }
                         let pass = if let Some(ref expected) = expected_eq {
                             // eq/ne test
                             if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, sel_field) {
@@ -17757,6 +17772,16 @@ fn real_main() {
                 } else { None };
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
+                    // Sibling fix to the stdin apply-site above (#394).
+                    if raw.first() != Some(&b'{') {
+                        let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                        process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                        if compact_buf.len() >= 1 << 17 {
+                            let _ = out.write_all(&compact_buf);
+                            compact_buf.clear();
+                        }
+                        return Ok(());
+                    }
                     let pass = if let Some(ref expected) = expected_eq {
                         if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, sel_field) {
                             let val_bytes = &raw[vs..ve];

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -6162,3 +6162,20 @@ true
 (select(.c >= .c)) | (.a > .x)
 {"x":{},"c":0,"a":""}
 false
+
+# #394: select(.f == "lit") | .out silently dropped non-object
+# inputs. jq raises a type error indexing a non-object with a
+# string key. Bail to generic on raw[0] != '{'.
+[((select(.a == "")) | (.a))?]
+false
+[]
+
+# Counter-case: object with matching string. Fast path stays hot.
+(select(.a == "hello")) | (.a)
+{"a":"hello"}
+"hello"
+
+# Counter-case: object with non-matching string — select rejects.
+[((select(.a == "")) | (.a))]
+{"a":"x"}
+[]


### PR DESCRIPTION
## Summary

- \`select(.f == \"lit\") | .out\` silently emitted nothing on non-object inputs. jq raises a type error indexing a non-object with a string key.
- Same Family A bail template as #377 / #379 with a different gate: peek raw[0] for \`{\`. On non-object, route through \`process_input\`.
- Two apply sites updated (stdin and file).

Surfaced by extending the composition-biased \`filter_strategy\` to include str-literal binops and compound select gates (work-in-progress harness extension; will be its own PR after the dependent fixes land).

Closes #394

## Test plan

- [x] \`cargo build --release\` (zero warnings)
- [x] \`cargo test --release\` (all suites green; 3 new regression cases — error case plus baseline counter-cases for matching/non-matching string)
- [x] Manual repro: \`echo 'false' | jq-jit -c '(select(.a == \"\")) | (.a)'\` now matches jq's error
- [x] Manual repro: \`echo '{\"a\":\"hello\"}' | jq-jit -c '(select(.a == \"hello\")) | (.a)'\` still emits \`\"hello\"\` (hot path preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)