### PR TITLE
fix: select_str_then_array bails on non-object / missing-field / out-of-domain (#398)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -11011,35 +11011,48 @@ fn real_main() {
                     let mut ranges = vec![(0usize, 0usize); all_fields.len()];
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        let pass = if let Some(ref expected) = expected_eq {
+                        // #398: bail to generic for shapes the inline emitter
+                        // can't faithfully match. Same template as #396.
+                        let mut handled = false;
+                        if raw.first() == Some(&b'{') {
                             if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, sel_field) {
-                                let val_bytes = &raw[vs..ve];
-                                let m = val_bytes == expected.as_slice();
-                                if test_type == "eq" { m } else { !m }
-                            } else { false }
-                        } else {
-                            if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, sel_field) {
-                                let val = &raw[vs..ve];
-                                if val.len() >= 2 && val[0] == b'"' && val[ve-vs-1] == b'"' && !val[1..ve-vs-1].contains(&b'\\') {
-                                    let inner = &val[1..ve-vs-1];
-                                    match test_type.as_str() {
-                                        "startswith" => inner.starts_with(test_arg.as_bytes()),
-                                        "endswith" => inner.ends_with(test_arg.as_bytes()),
-                                        "contains" => bytes_contains(inner, test_arg.as_bytes()),
-                                        _ => false,
+                                let pass = if let Some(ref expected) = expected_eq {
+                                    let val_bytes = &raw[vs..ve];
+                                    let m = val_bytes == expected.as_slice();
+                                    Some(if test_type == "eq" { m } else { !m })
+                                } else {
+                                    let val = &raw[vs..ve];
+                                    if val.len() >= 2 && val[0] == b'"' && val[ve-vs-1] == b'"' && !val[1..ve-vs-1].contains(&b'\\') {
+                                        let inner = &val[1..ve-vs-1];
+                                        Some(match test_type.as_str() {
+                                            "startswith" => inner.starts_with(test_arg.as_bytes()),
+                                            "endswith" => inner.ends_with(test_arg.as_bytes()),
+                                            "contains" => bytes_contains(inner, test_arg.as_bytes()),
+                                            _ => false,
+                                        })
+                                    } else { None }  // non-string field with str-builtin: jq errors
+                                };
+                                if let Some(pass) = pass {
+                                    if !pass {
+                                        handled = true;
+                                    } else if json_object_get_fields_raw_buf(raw, 0, &field_strs, &mut ranges)
+                                        && !resolved.iter().any(|r| resolved_would_error(r, raw, &ranges))
+                                    {
+                                        compact_buf.push(b'[');
+                                        for (i, res) in resolved.iter().enumerate() {
+                                            if i > 0 { compact_buf.push(b','); }
+                                            emit_resolved_value(&mut compact_buf, res, raw, &ranges);
+                                        }
+                                        compact_buf.extend_from_slice(b"]\n");
+                                        handled = true;
                                     }
-                                } else { false }
-                            } else { false }
-                        };
-                        if pass {
-                            if json_object_get_fields_raw_buf(raw, 0, &field_strs, &mut ranges) {
-                                compact_buf.push(b'[');
-                                for (i, res) in resolved.iter().enumerate() {
-                                    if i > 0 { compact_buf.push(b','); }
-                                    emit_resolved_value(&mut compact_buf, res, raw, &ranges);
+                                    // else: fields_raw_buf failed or domain miss → bail
                                 }
-                                compact_buf.extend_from_slice(b"]\n");
                             }
+                        }
+                        if !handled {
+                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }
                         if compact_buf.len() >= 1 << 17 {
                             let _ = out.write_all(&compact_buf);
@@ -18207,35 +18220,46 @@ fn real_main() {
                 let mut ranges = vec![(0usize, 0usize); all_fields.len()];
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    let pass = if let Some(ref expected) = expected_eq {
+                    // Sibling fix to the stdin apply-site above (#398).
+                    let mut handled = false;
+                    if raw.first() == Some(&b'{') {
                         if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, sel_field) {
-                            let val_bytes = &raw[vs..ve];
-                            let m = val_bytes == expected.as_slice();
-                            if test_type == "eq" { m } else { !m }
-                        } else { false }
-                    } else {
-                        if let Some((vs, ve)) = json_object_get_field_raw(raw, 0, sel_field) {
-                            let val = &raw[vs..ve];
-                            if val.len() >= 2 && val[0] == b'"' && val[ve-vs-1] == b'"' && !val[1..ve-vs-1].contains(&b'\\') {
-                                let inner = &val[1..ve-vs-1];
-                                match test_type.as_str() {
-                                    "startswith" => inner.starts_with(test_arg.as_bytes()),
-                                    "endswith" => inner.ends_with(test_arg.as_bytes()),
-                                    "contains" => bytes_contains(inner, test_arg.as_bytes()),
-                                    _ => false,
+                            let pass = if let Some(ref expected) = expected_eq {
+                                let val_bytes = &raw[vs..ve];
+                                let m = val_bytes == expected.as_slice();
+                                Some(if test_type == "eq" { m } else { !m })
+                            } else {
+                                let val = &raw[vs..ve];
+                                if val.len() >= 2 && val[0] == b'"' && val[ve-vs-1] == b'"' && !val[1..ve-vs-1].contains(&b'\\') {
+                                    let inner = &val[1..ve-vs-1];
+                                    Some(match test_type.as_str() {
+                                        "startswith" => inner.starts_with(test_arg.as_bytes()),
+                                        "endswith" => inner.ends_with(test_arg.as_bytes()),
+                                        "contains" => bytes_contains(inner, test_arg.as_bytes()),
+                                        _ => false,
+                                    })
+                                } else { None }
+                            };
+                            if let Some(pass) = pass {
+                                if !pass {
+                                    handled = true;
+                                } else if json_object_get_fields_raw_buf(raw, 0, &field_strs, &mut ranges)
+                                    && !resolved.iter().any(|r| resolved_would_error(r, raw, &ranges))
+                                {
+                                    compact_buf.push(b'[');
+                                    for (i, res) in resolved.iter().enumerate() {
+                                        if i > 0 { compact_buf.push(b','); }
+                                        emit_resolved_value(&mut compact_buf, res, raw, &ranges);
+                                    }
+                                    compact_buf.extend_from_slice(b"]\n");
+                                    handled = true;
                                 }
-                            } else { false }
-                        } else { false }
-                    };
-                    if pass {
-                        if json_object_get_fields_raw_buf(raw, 0, &field_strs, &mut ranges) {
-                            compact_buf.push(b'[');
-                            for (i, res) in resolved.iter().enumerate() {
-                                if i > 0 { compact_buf.push(b','); }
-                                emit_resolved_value(&mut compact_buf, res, raw, &ranges);
                             }
-                            compact_buf.extend_from_slice(b"]\n");
                         }
+                    }
+                    if !handled {
+                        let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                        process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                     }
                     if compact_buf.len() >= 1 << 17 {
                         let _ = out.write_all(&compact_buf);

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -6206,3 +6206,19 @@ null
 (select(.a != "")) | (.b)
 {"a":"x"}
 null
+
+# #398: select_str_then_array shares the same gap class as
+# select_str_then_field — non-object input, missing select field,
+# non-string field with str-builtin, and missing remap fields all
+# silent-skipped. Bail in each case.
+[((select(.a == "")) | ([.a,.a]))?]
+false
+[]
+
+(select(.a != "")) | ([.a,.a])
+{}
+[null,null]
+
+(select(.a == "")) | ([.a,.a])
+{"a":""}
+["",""]


### PR DESCRIPTION
## Summary

Same gap class as #394 / #396 — \`select(.f == \"lit\") | [a, b]\` silently emitted nothing for non-object input, missing select field, non-string field with str-builtin, and missing remap fields. Restructure the apply with a single \`handled\` flag, distinguish str-builtin domain miss from boolean pass=false, and probe \`resolved_would_error\` on each array element. Two apply sites updated.

Surfaced by the str-literal-binop extension to the composition-biased \`filter_strategy\`.

Closes #398

## Test plan

- [x] \`cargo build --release\` (zero warnings)
- [x] \`cargo test --release\` (all green; 3 new regression cases — non-object, missing-field, baseline)
- [x] Manual repros confirm jq parity for non-object error, missing-field [null,null], baseline [\"\",\"\"]

🤖 Generated with [Claude Code](https://claude.com/claude-code)