### PR TITLE
fix: select_str_str_chain bails when a plain Field operand is non-string

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -10892,39 +10892,55 @@ fn real_main() {
                             } else { None };
                             if let Some(pass) = pass {
                                 if pass {
-                                    compact_buf.push(b'"');
-                                    for &(idx, typ, ai) in &actions {
-                                        match typ {
-                                            0 => { compact_buf.extend_from_slice(&lit_bufs[idx]); }
-                                            1 => {
-                                                let (vs, ve) = ranges_buf[idx];
-                                                let val_bytes = &raw[vs..ve];
-                                                if val_bytes[0] == b'"' && val_bytes.len() >= 2 {
-                                                    compact_buf.extend_from_slice(&val_bytes[1..val_bytes.len()-1]);
-                                                } else {
-                                                    compact_buf.extend_from_slice(val_bytes);
-                                                }
-                                            }
-                                            _ => {
-                                                let (vs, ve) = ranges_buf[idx];
-                                                let s = unsafe { std::str::from_utf8_unchecked(&raw[vs..ve]) };
-                                                if let Ok(mut v) = s.trim().parse::<f64>() {
-                                                    for &(ref op, n) in arith_ops_list[ai] {
-                                                        v = match op {
-                                                            jq_jit::ir::BinOp::Add => v + n, jq_jit::ir::BinOp::Sub => v - n,
-                                                            jq_jit::ir::BinOp::Mul => v * n, jq_jit::ir::BinOp::Div => v / n,
-                                                            jq_jit::ir::BinOp::Mod => jq_jit::runtime::jq_mod_f64(v, n).unwrap_or(f64::NAN),
-                                                            _ => v,
-                                                        };
-                                                    }
-                                                    push_jq_number_bytes(&mut compact_buf, v);
-                                                }
+                                    // Plain-Field action (type 1) requires a quoted-string
+                                    // operand for the inline emit to match jq — `s + s`
+                                    // errors on non-string and `null + null` is null
+                                    // (handled by generic). Pre-check before emitting
+                                    // anything; on miss, bail to generic.
+                                    let mut needs_generic = false;
+                                    for &(idx, typ, _) in &actions {
+                                        if typ == 1 {
+                                            let (vs, ve) = ranges_buf[idx];
+                                            if vs >= ve || raw[vs] != b'"' {
+                                                needs_generic = true;
+                                                break;
                                             }
                                         }
                                     }
-                                    compact_buf.extend_from_slice(b"\"\n");
+                                    if !needs_generic {
+                                        compact_buf.push(b'"');
+                                        for &(idx, typ, ai) in &actions {
+                                            match typ {
+                                                0 => { compact_buf.extend_from_slice(&lit_bufs[idx]); }
+                                                1 => {
+                                                    let (vs, ve) = ranges_buf[idx];
+                                                    let val = &raw[vs..ve];
+                                                    // val is guaranteed quoted-string here.
+                                                    compact_buf.extend_from_slice(&val[1..val.len()-1]);
+                                                }
+                                                _ => {
+                                                    let (vs, ve) = ranges_buf[idx];
+                                                    let s = unsafe { std::str::from_utf8_unchecked(&raw[vs..ve]) };
+                                                    if let Ok(mut v) = s.trim().parse::<f64>() {
+                                                        for &(ref op, n) in arith_ops_list[ai] {
+                                                            v = match op {
+                                                                jq_jit::ir::BinOp::Add => v + n, jq_jit::ir::BinOp::Sub => v - n,
+                                                                jq_jit::ir::BinOp::Mul => v * n, jq_jit::ir::BinOp::Div => v / n,
+                                                                jq_jit::ir::BinOp::Mod => jq_jit::runtime::jq_mod_f64(v, n).unwrap_or(f64::NAN),
+                                                                _ => v,
+                                                            };
+                                                        }
+                                                        push_jq_number_bytes(&mut compact_buf, v);
+                                                    }
+                                                }
+                                            }
+                                        }
+                                        compact_buf.extend_from_slice(b"\"\n");
+                                        handled = true;
+                                    }
+                                } else {
+                                    handled = true;
                                 }
-                                handled = true;
                             }
                         }
                         if !handled {
@@ -18125,39 +18141,54 @@ fn real_main() {
                         } else { None };
                         if let Some(pass) = pass {
                             if pass {
-                                compact_buf.push(b'"');
-                                for &(idx, typ, ai) in &actions {
-                                    match typ {
-                                        0 => { compact_buf.extend_from_slice(&lit_bufs[idx]); }
-                                        1 => {
-                                            let (vs, ve) = ranges_buf[idx];
-                                            let val_bytes = &raw[vs..ve];
-                                            if val_bytes[0] == b'"' && val_bytes.len() >= 2 {
-                                                compact_buf.extend_from_slice(&val_bytes[1..val_bytes.len()-1]);
-                                            } else {
-                                                compact_buf.extend_from_slice(val_bytes);
-                                            }
-                                        }
-                                        _ => {
-                                            let (vs, ve) = ranges_buf[idx];
-                                            let s = unsafe { std::str::from_utf8_unchecked(&raw[vs..ve]) };
-                                            if let Ok(mut v) = s.trim().parse::<f64>() {
-                                                for &(ref op, n) in arith_ops_list[ai] {
-                                                    v = match op {
-                                                        jq_jit::ir::BinOp::Add => v + n, jq_jit::ir::BinOp::Sub => v - n,
-                                                        jq_jit::ir::BinOp::Mul => v * n, jq_jit::ir::BinOp::Div => v / n,
-                                                        jq_jit::ir::BinOp::Mod => jq_jit::runtime::jq_mod_f64(v, n).unwrap_or(f64::NAN),
-                                                        _ => v,
-                                                    };
-                                                }
-                                                push_jq_number_bytes(&mut compact_buf, v);
-                                            }
+                                // Sibling pre-check to the in-memory apply above:
+                                // a plain `.f` (action type 1) requires a string
+                                // operand to match jq inline. Bail to generic for
+                                // any non-string operand.
+                                let mut needs_generic = false;
+                                for &(idx, typ, _) in &actions {
+                                    if typ == 1 {
+                                        let (vs, ve) = ranges_buf[idx];
+                                        if vs >= ve || raw[vs] != b'"' {
+                                            needs_generic = true;
+                                            break;
                                         }
                                     }
                                 }
-                                compact_buf.extend_from_slice(b"\"\n");
+                                if !needs_generic {
+                                    compact_buf.push(b'"');
+                                    for &(idx, typ, ai) in &actions {
+                                        match typ {
+                                            0 => { compact_buf.extend_from_slice(&lit_bufs[idx]); }
+                                            1 => {
+                                                let (vs, ve) = ranges_buf[idx];
+                                                let val = &raw[vs..ve];
+                                                // val is guaranteed quoted-string here.
+                                                compact_buf.extend_from_slice(&val[1..val.len()-1]);
+                                            }
+                                            _ => {
+                                                let (vs, ve) = ranges_buf[idx];
+                                                let s = unsafe { std::str::from_utf8_unchecked(&raw[vs..ve]) };
+                                                if let Ok(mut v) = s.trim().parse::<f64>() {
+                                                    for &(ref op, n) in arith_ops_list[ai] {
+                                                        v = match op {
+                                                            jq_jit::ir::BinOp::Add => v + n, jq_jit::ir::BinOp::Sub => v - n,
+                                                            jq_jit::ir::BinOp::Mul => v * n, jq_jit::ir::BinOp::Div => v / n,
+                                                            jq_jit::ir::BinOp::Mod => jq_jit::runtime::jq_mod_f64(v, n).unwrap_or(f64::NAN),
+                                                            _ => v,
+                                                        };
+                                                    }
+                                                    push_jq_number_bytes(&mut compact_buf, v);
+                                                }
+                                            }
+                                        }
+                                    }
+                                    compact_buf.extend_from_slice(b"\"\n");
+                                    handled = true;
+                                }
+                            } else {
+                                handled = true;
                             }
-                            handled = true;
                         }
                     }
                     if !handled {

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -6261,3 +6261,17 @@ select(.a == .a)
 select(.a <= .a)
 {"a":9007199254740993}
 {"a":9007199254740993}
+
+# #406 follow-up: select_str_str_chain with non-string Field operand
+# silently produced "nullnull" by extending raw bytes; jq's null+null=null.
+[((select(.c != "")) | (.c + .c))?]
+{"c":null}
+[null]
+
+(select(.c != "")) | (.c + .c)
+{"c":null}
+null
+
+(select(.c != "")) | (.c + .c)
+{"c":42}
+84


### PR DESCRIPTION
## Summary

- `(select(.cond)) | (.f1 + .f2 + ...)` produced `"nullnull"` for `{"c":null}` with `(select(.c != "")) | (.c + .c)`. jq returns `null` (from `null + null = null`).
- The fast path in `select_str_str_chain` collapsed `StringAddPart::Field` and `FieldToString` into action type 1 and emitted raw bytes for non-string operands — diverging from jq where `s + non-s` errors and `null + null = null`.
- Fix: port the strict pre-check already present in `string_add_chain` (`src/bin/jq-jit.rs:7325`) to both `select_str_str_chain` apply sites (in-memory and stdin paths). Before emitting, walk every type-1 action and bail to generic if any operand is non-string.

## Repro

```bash
$ echo '{"c":null}' | ./target/release/jq-jit -c '(select(.c != "")) | (.c + .c)'
"nullnull"           # bug

$ echo '{"c":null}' | jq -c '(select(.c != "")) | (.c + .c)'
null
```

After fix:
```bash
$ echo '{"c":null}' | ./target/release/jq-jit -c '(select(.c != "")) | (.c + .c)'
null
```

Surfaced by `fuzz_diff` post-#406 with `JQJIT_PROPTEST_CASES=100000`.

## Test plan

- [x] Three regression cases added to `tests/regression.test` covering null operand (with `?`-wrap, plain), and number operand (numeric add through bail).
- [x] `cargo build --release` — zero warnings
- [x] `cargo test --release --test official` — all suites pass (official 509 + regression incl. new cases)
- [x] `JQJIT_PROPTEST_CASES=100000 cargo test --release --test fuzz_diff` — clean (37811 compared, 62189 both_errored)
- [x] `./bench/comprehensive.sh --quick` — no notable regression (bail only fires when an operand is non-string, otherwise unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)