### PR TITLE
fix: select_compound_field emits null on missing output field

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -8995,6 +8995,11 @@ fn real_main() {
                                     compact_buf.extend_from_slice(val);
                                 }
                                 compact_buf.push(b'\n');
+                            } else {
+                                // Output field absent on a passing row — jq reads
+                                // missing as null. Without this branch the fast path
+                                // silently dropped the row.
+                                compact_buf.extend_from_slice(b"null\n");
                             }
                         }
                         if compact_buf.len() >= 1 << 17 {
@@ -16355,6 +16360,10 @@ fn real_main() {
                                 compact_buf.extend_from_slice(val);
                             }
                             compact_buf.push(b'\n');
+                        } else {
+                            // Sibling fix to the in-memory apply above —
+                            // emit `null` for missing-output-field rows.
+                            compact_buf.extend_from_slice(b"null\n");
                         }
                     }
                     if compact_buf.len() >= 1 << 17 {

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -6275,3 +6275,18 @@ null
 (select(.c != "")) | (.c + .c)
 {"c":42}
 84
+
+# select_compound_field silently dropped rows when the output field
+# was missing instead of emitting `null` (jq's behaviour for
+# missing-field reads).
+(select((.x > 0) or (.x < 0))) | (.a)
+{"x":-2147483648}
+null
+
+(select((.x > 0) and (.y > 0))) | (.a)
+{"x":1,"y":2}
+null
+
+(select((.x > 0) or (.x < 0))) | (.a)
+{"x":1,"a":"hi"}
+"hi"


### PR DESCRIPTION
## Summary

- `(select(<compound>)) | (.f)` silently dropped the row when `.f` was missing instead of emitting `null` (jq's behaviour for a missing-field read).
- The `select_compound_field` apply had no `else` arm on the output-field lookup; the row went unwritten and the fast path diverged from jq.
- Fix: add `else { compact_buf.extend_from_slice(b"null\n"); }` to both apply sites (in-memory and stdin paths). This is the missing-field bail class from the existing playbook.

## Repro

```bash
$ echo '{"x":1}' | ./target/release/jq-jit -c '(select((.x > 0) or (.x < 0))) | (.a)'
(empty — bug)

$ echo '{"x":1}' | jq -c '(select((.x > 0) or (.x < 0))) | (.a)'
null
```

After fix:
```bash
$ echo '{"x":1}' | ./target/release/jq-jit -c '(select((.x > 0) or (.x < 0))) | (.a)'
null
```

Surfaced by `fuzz_diff` during `JQJIT_PROPTEST_CASES=200000` post-#406/#407 validation.

## Test plan

- [x] Three regression cases added to `tests/regression.test` (or-compound missing, and-compound missing, hit-with-value control).
- [x] `cargo build --release` — zero warnings
- [x] `cargo test --release --test official` — official 509 + regression suite all pass
- [x] `./bench/comprehensive.sh --quick` — no notable regression (added one branch on a previously-silent code path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)