### PR TITLE
test: real-world jq script corpus differential test (#322)

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -77,6 +77,32 @@ heavier opt-in 版が `tests/differential_proptest.rs`（`#[ignore]`）。こち
 `try/catch` を含む全 grammar を回すので、error 書式の divergence を含めて
 当てに行きたい時に `--ignored` で起動する。
 
+### Real-world スクリプト corpus（`tests/corpus/` / #322）
+
+人が実際に書く idiomatic な filter — cookbook 級の `group_by` / `with_entries` /
+`walk` / `paths` レシピや k8s manifest の image 列挙、ログ抽出、`@csv` 投影など —
+を curated set として保持し、`cargo test --release --test corpus_diff` で
+jq 1.8.x と毎回突き合わせる。proptest が generator distribution の射程外で
+取りこぼす「実際の人間が書く形」の divergence を網にかける位置づけ。
+
+レイアウトはフラット pair: `tests/corpus/<name>.jq` と `tests/corpus/<name>.json`。
+ケース追加は **2 ファイル新規作成のみ、harness 側に手は入れない**。runner は
+`*.jq` を全件走査して同名 `.json` と組ませる。
+
+```bash
+cargo test --release --test corpus_diff
+```
+
+新しいケースを足す時は:
+
+1. `tests/corpus/<name>.jq` に script、`tests/corpus/<name>.json` に input を置く。
+2. ローカルで `JQ_BIN=/opt/homebrew/opt/jq/bin/jq cargo test --release --test corpus_diff` を流して parity を確認。
+3. **expected-divergence の取り扱い**: corpus は parity-clean のみを保持する方針。
+   jq と jq-jit が割れる shape を見つけたら corpus には入れず、
+   `tests/regression.test` に divergence を再現する最小ケースを起票して
+   バグを潰してから corpus に昇格させる。corpus に「skip」「expected fail」の
+   仕組みは置かない（数が増えると divergence が常態化するので）。
+
 ### テスト出力
 
 `cargo test --release` だけだと regression 通過数が非表示。必ず `--nocapture`:

--- a/tests/corpus/01-filter-project.jq
+++ b/tests/corpus/01-filter-project.jq
@@ -1,0 +1,3 @@
+.users
+| map(select(.active))
+| map({id, name, email})

--- a/tests/corpus/01-filter-project.json
+++ b/tests/corpus/01-filter-project.json
@@ -1,0 +1,8 @@
+{
+  "users": [
+    {"id": 1, "name": "Alice", "email": "a@example.com", "active": true},
+    {"id": 2, "name": "Bob", "email": "b@example.com", "active": false},
+    {"id": 3, "name": "Carol", "email": "c@example.com", "active": true},
+    {"id": 4, "name": "Dan", "email": "d@example.com", "active": true}
+  ]
+}

--- a/tests/corpus/02-group-by-aggregate.jq
+++ b/tests/corpus/02-group-by-aggregate.jq
@@ -1,0 +1,9 @@
+.orders
+| group_by(.customer)
+| map({
+    customer: .[0].customer,
+    total: map(.amount) | add,
+    count: length
+  })
+| sort_by(.total)
+| reverse

--- a/tests/corpus/02-group-by-aggregate.json
+++ b/tests/corpus/02-group-by-aggregate.json
@@ -1,0 +1,10 @@
+{
+  "orders": [
+    {"id": "o1", "customer": "alice", "amount": 100},
+    {"id": "o2", "customer": "bob", "amount": 50},
+    {"id": "o3", "customer": "alice", "amount": 200},
+    {"id": "o4", "customer": "carol", "amount": 75},
+    {"id": "o5", "customer": "bob", "amount": 125},
+    {"id": "o6", "customer": "alice", "amount": 30}
+  ]
+}

--- a/tests/corpus/03-flatten-paths.jq
+++ b/tests/corpus/03-flatten-paths.jq
@@ -1,0 +1,1 @@
+[paths(scalars) as $p | {path: $p, value: getpath($p)}]

--- a/tests/corpus/03-flatten-paths.json
+++ b/tests/corpus/03-flatten-paths.json
@@ -1,0 +1,6 @@
+{
+  "server": {"host": "example.com", "port": 8080},
+  "features": {"auth": true, "cache": false},
+  "tags": ["prod", "us-east"],
+  "version": 3
+}

--- a/tests/corpus/04-rename-keys.jq
+++ b/tests/corpus/04-rename-keys.jq
@@ -1,0 +1,1 @@
+with_entries(.key |= ("user_" + .))

--- a/tests/corpus/04-rename-keys.json
+++ b/tests/corpus/04-rename-keys.json
@@ -1,0 +1,1 @@
+{"id": 42, "name": "Alice", "role": "admin", "active": true}

--- a/tests/corpus/05-k8s-container-images.jq
+++ b/tests/corpus/05-k8s-container-images.jq
@@ -1,0 +1,1 @@
+[.items[].spec.containers[]?.image] | unique

--- a/tests/corpus/05-k8s-container-images.json
+++ b/tests/corpus/05-k8s-container-images.json
@@ -1,0 +1,32 @@
+{
+  "items": [
+    {
+      "kind": "Pod",
+      "metadata": {"name": "web-1"},
+      "spec": {
+        "containers": [
+          {"name": "nginx", "image": "nginx:1.25"},
+          {"name": "sidecar", "image": "envoy:1.30"}
+        ]
+      }
+    },
+    {
+      "kind": "Pod",
+      "metadata": {"name": "web-2"},
+      "spec": {
+        "containers": [
+          {"name": "nginx", "image": "nginx:1.25"}
+        ]
+      }
+    },
+    {
+      "kind": "Pod",
+      "metadata": {"name": "worker-1"},
+      "spec": {
+        "containers": [
+          {"name": "app", "image": "myapp:v3.2"}
+        ]
+      }
+    }
+  ]
+}

--- a/tests/corpus/06-log-error-extract.jq
+++ b/tests/corpus/06-log-error-extract.jq
@@ -1,0 +1,3 @@
+.events
+| map(select(.level == "error"))
+| map({time, service, message})

--- a/tests/corpus/06-log-error-extract.json
+++ b/tests/corpus/06-log-error-extract.json
@@ -1,0 +1,9 @@
+{
+  "events": [
+    {"time": "2026-04-30T08:00:00Z", "level": "info", "service": "api", "message": "started"},
+    {"time": "2026-04-30T08:01:12Z", "level": "error", "service": "db", "message": "connection refused"},
+    {"time": "2026-04-30T08:01:15Z", "level": "warn", "service": "api", "message": "slow query"},
+    {"time": "2026-04-30T08:02:03Z", "level": "error", "service": "api", "message": "500 from upstream"},
+    {"time": "2026-04-30T08:03:00Z", "level": "info", "service": "api", "message": "ok"}
+  ]
+}

--- a/tests/corpus/07-recursive-find.jq
+++ b/tests/corpus/07-recursive-find.jq
@@ -1,0 +1,2 @@
+[.. | strings | select(startswith("https://"))]
+| unique

--- a/tests/corpus/07-recursive-find.json
+++ b/tests/corpus/07-recursive-find.json
@@ -1,0 +1,11 @@
+{
+  "name": "myproject",
+  "homepage": "https://example.com/proj",
+  "repository": {"type": "git", "url": "https://github.com/example/proj"},
+  "links": [
+    "http://insecure.example.com",
+    "https://docs.example.com",
+    "https://example.com/proj"
+  ],
+  "internal": {"trace": "trace-id-1234"}
+}

--- a/tests/corpus/08-reduce-running-sum.jq
+++ b/tests/corpus/08-reduce-running-sum.jq
@@ -1,0 +1,7 @@
+reduce .[] as $row ([];
+  . + [{
+    label: $row.label,
+    delta: $row.value,
+    running: ((.[-1].running // 0) + $row.value)
+  }]
+)

--- a/tests/corpus/08-reduce-running-sum.json
+++ b/tests/corpus/08-reduce-running-sum.json
@@ -1,0 +1,7 @@
+[
+  {"label": "Mon", "value": 10},
+  {"label": "Tue", "value": 5},
+  {"label": "Wed", "value": -3},
+  {"label": "Thu", "value": 8},
+  {"label": "Fri", "value": 0}
+]

--- a/tests/corpus/09-conditional-merge.jq
+++ b/tests/corpus/09-conditional-merge.jq
@@ -1,0 +1,6 @@
+. + {
+  status: (if .errors == 0 then "ok"
+           elif .errors < 5 then "warn"
+           else "fail" end),
+  rate: (if .total > 0 then (.errors / .total) else 0 end)
+}

--- a/tests/corpus/09-conditional-merge.json
+++ b/tests/corpus/09-conditional-merge.json
@@ -1,0 +1,1 @@
+{"name": "stats", "errors": 3, "total": 100}

--- a/tests/corpus/10-csv-projection.jq
+++ b/tests/corpus/10-csv-projection.jq
@@ -1,0 +1,1 @@
+[.records[] | [.id, .name, .score]] | @csv

--- a/tests/corpus/10-csv-projection.json
+++ b/tests/corpus/10-csv-projection.json
@@ -1,0 +1,7 @@
+{
+  "records": [
+    {"id": 1, "name": "alpha", "score": 92},
+    {"id": 2, "name": "beta", "score": 87},
+    {"id": 3, "name": "gamma", "score": 71}
+  ]
+}

--- a/tests/corpus/11-walk-update.jq
+++ b/tests/corpus/11-walk-update.jq
@@ -1,0 +1,1 @@
+walk(if type == "string" then ascii_downcase else . end)

--- a/tests/corpus/11-walk-update.json
+++ b/tests/corpus/11-walk-update.json
@@ -1,0 +1,7 @@
+{
+  "Title": "Hello World",
+  "Sections": [
+    {"Heading": "Introduction", "Body": "Some TEXT here."},
+    {"Heading": "Conclusion", "Body": "WrApUp."}
+  ]
+}

--- a/tests/corpus/12-count-by-status.jq
+++ b/tests/corpus/12-count-by-status.jq
@@ -1,0 +1,4 @@
+.entries
+| group_by(.status)
+| map({status: .[0].status, count: length})
+| sort_by(-.count)

--- a/tests/corpus/12-count-by-status.json
+++ b/tests/corpus/12-count-by-status.json
@@ -1,0 +1,11 @@
+{
+  "entries": [
+    {"id": 1, "status": "open"},
+    {"id": 2, "status": "closed"},
+    {"id": 3, "status": "open"},
+    {"id": 4, "status": "closed"},
+    {"id": 5, "status": "merged"},
+    {"id": 6, "status": "open"},
+    {"id": 7, "status": "closed"}
+  ]
+}

--- a/tests/corpus_diff.rs
+++ b/tests/corpus_diff.rs
@@ -1,0 +1,283 @@
+//! Real-world script corpus differential test (#322).
+//!
+//! Each case in `tests/corpus/` is a pair of files:
+//!   - `<name>.jq`   — the filter script.
+//!   - `<name>.json` — the input fixture.
+//!
+//! Both files are passed (via `-f` and stdin) to jq-jit and to a reference
+//! `jq-1.8.x` binary; outputs are normalised and compared value-level.
+//!
+//! Adding a new case is "one file + one fixture, no harness changes".
+//!
+//! The reference `jq` binary is resolved via, in order:
+//!   1. `$JQ_BIN` — explicit override.
+//!   2. `/opt/homebrew/opt/jq/bin/jq` — Homebrew canonical path.
+//!   3. `jq` in `$PATH`.
+//!
+//! If no jq-1.8.x binary is found, the test is skipped (panics on CI to
+//! prevent silent gaps; `eprintln!` + return locally to keep
+//! `cargo test --release` usable without 1.8.1 installed). Same policy as
+//! `tests/differential.rs`.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::Duration;
+
+struct Case {
+    name: String,
+    script_path: PathBuf,
+    input_path: PathBuf,
+}
+
+fn collect_cases() -> Vec<Case> {
+    let corpus_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/corpus");
+    let entries = std::fs::read_dir(&corpus_dir)
+        .unwrap_or_else(|e| panic!("failed to read {}: {}", corpus_dir.display(), e));
+
+    let mut cases: Vec<Case> = Vec::new();
+    for entry in entries {
+        let entry = entry.expect("read_dir entry");
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("jq") {
+            continue;
+        }
+        let stem = path.file_stem().and_then(|s| s.to_str())
+            .unwrap_or_else(|| panic!("non-utf8 corpus filename: {}", path.display()));
+        let input_path = corpus_dir.join(format!("{}.json", stem));
+        assert!(
+            input_path.exists(),
+            "corpus case `{}` is missing its `.json` fixture at {}",
+            stem, input_path.display()
+        );
+        cases.push(Case {
+            name: stem.to_string(),
+            script_path: path,
+            input_path,
+        });
+    }
+    cases.sort_by(|a, b| a.name.cmp(&b.name));
+    cases
+}
+
+#[derive(Debug)]
+struct RunOutput {
+    stdout: String,
+    is_error: bool,
+}
+
+fn run_once(bin: &str, script_path: &std::path::Path, input: &str) -> Option<RunOutput> {
+    let mut cmd = Command::new(bin);
+    cmd.arg("-c").arg("-f").arg(script_path);
+    cmd.stdin(std::process::Stdio::piped());
+    cmd.stdout(std::process::Stdio::piped());
+    cmd.stderr(std::process::Stdio::piped());
+
+    let mut child = cmd.spawn().ok()?;
+    {
+        use std::io::Write;
+        let mut stdin = child.stdin.take()?;
+        let _ = stdin.write_all(input.as_bytes());
+    }
+
+    let timeout = Duration::from_secs(10);
+    let start = std::time::Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                let out = child.wait_with_output().ok()?;
+                let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+                let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+                #[cfg(unix)]
+                {
+                    use std::os::unix::process::ExitStatusExt;
+                    if let Some(sig) = status.signal() {
+                        return Some(RunOutput {
+                            stdout: format!("<killed by signal {}> stderr: {}", sig, stderr.trim()),
+                            is_error: true,
+                        });
+                    }
+                }
+                let is_error = !status.success();
+                return Some(RunOutput { stdout, is_error });
+            }
+            Ok(None) => {
+                if start.elapsed() > timeout {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return Some(RunOutput {
+                        stdout: "<timeout after 10s>".to_string(),
+                        is_error: true,
+                    });
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            Err(_) => return None,
+        }
+    }
+}
+
+/// Parse one JSON value per output line and re-serialise compactly with sorted
+/// keys, so output equality is value-level (not format-level). `@csv` and
+/// other string-producing filters yield bare lines that are not JSON-parsable
+/// on their own; in that case we fall back to byte-for-byte comparison.
+fn normalize(output: &str) -> Result<String, String> {
+    let mut normalized_lines = Vec::new();
+    for line in output.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let val: serde_json::Value = serde_json::from_str(trimmed)
+            .map_err(|e| format!("non-JSON line `{}`: {}", trimmed, e))?;
+        normalized_lines.push(serialize_sorted(&normalize_value(val)));
+    }
+    Ok(normalized_lines.join("\n"))
+}
+
+fn normalize_value(val: serde_json::Value) -> serde_json::Value {
+    use serde_json::Value;
+    match val {
+        Value::Number(n) => {
+            if let Some(f) = n.as_f64() {
+                if f.is_finite() && f == (f as i64) as f64 && f.abs() < (1i64 << 53) as f64 {
+                    return Value::Number(serde_json::Number::from(f as i64));
+                }
+            }
+            Value::Number(n)
+        }
+        Value::Array(arr) => Value::Array(arr.into_iter().map(normalize_value).collect()),
+        Value::Object(map) => Value::Object(
+            map.into_iter()
+                .map(|(k, v)| (k, normalize_value(v)))
+                .collect(),
+        ),
+        other => other,
+    }
+}
+
+fn serialize_sorted(val: &serde_json::Value) -> String {
+    use serde_json::Value;
+    match val {
+        Value::Null => "null".to_string(),
+        Value::Bool(b) => b.to_string(),
+        Value::Number(n) => n.to_string(),
+        Value::String(s) => serde_json::to_string(s).unwrap(),
+        Value::Array(arr) => {
+            let items: Vec<String> = arr.iter().map(serialize_sorted).collect();
+            format!("[{}]", items.join(","))
+        }
+        Value::Object(map) => {
+            let mut entries: Vec<(&String, &Value)> = map.iter().collect();
+            entries.sort_by_key(|(k, _)| *k);
+            let items: Vec<String> = entries
+                .iter()
+                .map(|(k, v)| format!("{}:{}", serde_json::to_string(k).unwrap(), serialize_sorted(v)))
+                .collect();
+            format!("{{{}}}", items.join(","))
+        }
+    }
+}
+
+fn resolve_jq() -> Option<String> {
+    let candidates: Vec<String> = std::env::var("JQ_BIN")
+        .ok()
+        .into_iter()
+        .chain(std::iter::once("/opt/homebrew/opt/jq/bin/jq".to_string()))
+        .chain(std::iter::once("jq".to_string()))
+        .collect();
+
+    for cand in &candidates {
+        let Ok(output) = Command::new(cand).arg("--version").output() else {
+            continue;
+        };
+        if !output.status.success() {
+            continue;
+        }
+        let ver = String::from_utf8_lossy(&output.stdout);
+        let ver = ver.trim();
+        if ver.starts_with("jq-1.8.") {
+            return Some(cand.clone());
+        }
+        eprintln!("SKIP corpus_diff: candidate `{}` is `{}`, need jq-1.8.x", cand, ver);
+    }
+    None
+}
+
+#[test]
+fn corpus_diff_against_jq_1_8() {
+    let Some(jq) = resolve_jq() else {
+        let msg = "no jq-1.8.x binary found. Set JQ_BIN to a jq-1.8.x binary.";
+        if std::env::var_os("CI").is_some() {
+            panic!("corpus_diff: {}", msg);
+        }
+        eprintln!("SKIP corpus_diff: {}", msg);
+        return;
+    };
+    let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
+
+    let cases = collect_cases();
+    assert!(!cases.is_empty(), "corpus is empty (tests/corpus/)");
+
+    let mut pass = 0usize;
+    let mut fail = 0usize;
+    let mut failures: Vec<String> = Vec::new();
+
+    for case in &cases {
+        let input = std::fs::read_to_string(&case.input_path)
+            .unwrap_or_else(|e| panic!("read {}: {}", case.input_path.display(), e));
+
+        let jq_out = run_once(&jq, &case.script_path, &input);
+        let jit_out = run_once(jq_jit, &case.script_path, &input);
+
+        let (Some(a), Some(b)) = (jq_out, jit_out) else {
+            fail += 1;
+            failures.push(format!("  case `{}`: spawn failure", case.name));
+            continue;
+        };
+
+        if a.is_error && b.is_error {
+            pass += 1;
+            continue;
+        }
+        if a.is_error != b.is_error {
+            fail += 1;
+            failures.push(format!(
+                "  case `{}`: error mismatch (jq error={}, jit error={})\n    jq:  {}\n    jit: {}",
+                case.name, a.is_error, b.is_error, a.stdout.trim(), b.stdout.trim()
+            ));
+            continue;
+        }
+
+        // Try value-level normalisation first; fall back to byte-for-byte for
+        // string-producing filters like `@csv` whose output isn't JSON.
+        let cmp = match (normalize(&a.stdout), normalize(&b.stdout)) {
+            (Ok(an), Ok(bn)) => an == bn,
+            _ => a.stdout == b.stdout,
+        };
+        if cmp {
+            pass += 1;
+        } else {
+            fail += 1;
+            failures.push(format!(
+                "  case `{}`: value mismatch\n    jq:  {}\n    jit: {}",
+                case.name, a.stdout.trim(), b.stdout.trim()
+            ));
+        }
+    }
+
+    eprintln!();
+    eprintln!("=== Corpus diff (vs {}) ===", jq);
+    eprintln!("PASS: {}", pass);
+    eprintln!("FAIL: {}", fail);
+    eprintln!("TOTAL: {}", cases.len());
+
+    if !failures.is_empty() {
+        eprintln!();
+        eprintln!("=== Divergences ===");
+        for f in &failures {
+            eprintln!("{}", f);
+        }
+    }
+
+    assert_eq!(fail, 0, "{} corpus divergences out of {}", fail, cases.len());
+}


### PR DESCRIPTION
## Summary

Add a curated corpus under `tests/corpus/` and a runner (`tests/corpus_diff.rs`) that diffs jq-jit against jq-1.8.x on each `(<name>.jq, <name>.json)` pair. Targets the "works in synthetic tests, breaks on actual usage" class that proptest's distribution undersamples — idiomatic human-written compositions like `group_by` aggregation, `with_entries` key rewrites, `paths(scalars)` flattening, `walk` update, k8s manifest container-image listing, log error extraction, `@csv` projection, and reduce-based running totals.

Layout is a flat pair (`<name>.jq` + `<name>.json`); adding a new case is two files, no harness changes — per the issue's acceptance criteria. The runner reuses the spawn / timeout / `JQ_BIN` resolution / value-level normalisation pattern from `tests/differential.rs`. `@csv` and other string-producing filters fall back to byte-for-byte comparison when the output is not JSON.

12 cases land green against jq-1.8.1 byte-for-byte. The corpus is parity-clean only — divergences should be filed as regressions in `tests/regression.test` and fixed at the source, not marked as expected-skip.

Closes #322

## Test plan

- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (all green; new `corpus_diff` test 1/1, all 12 cases pass)
- [x] Each `(script, input)` pair manually verified against jq-1.8.1 byte-for-byte before landing
- [x] Documented in `docs/maintenance.md` next to the existing differential / proptest sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)