### PR TITLE
test: JIT vs interpreter self-diff harness (#323)

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -103,6 +103,34 @@ cargo test --release --test corpus_diff
    バグを潰してから corpus に昇格させる。corpus に「skip」「expected fail」の
    仕組みは置かない（数が増えると divergence が常態化するので）。
 
+### JIT vs interpreter self-diff（`tests/jit_vs_interp.rs` / #323）
+
+JIT/raw-byte fast path と generic tree-walking interpreter が同じ filter で
+同じ結果を返すかを `tests/regression.test` 全件で突き合わせる internal
+consistency check。jq バイナリは要らない。
+
+binary 側の knob は環境変数 `JQJIT_FORCE_INTERPRETER=1`:
+
+- raw-byte fast path 群（`detect_*` / `is_*`）を全部黙らせる
+- `compile_jit()` 呼び出しをスキップ
+- `Filter::execute` / `Filter::execute_cb` を `set_force_interpreter(true)` で
+  generic eval パスに固定
+
+```bash
+# self-diff 全件（CI 内、~14s）
+cargo test --release --test jit_vs_interp
+
+# 開発中に件数を絞る
+JIT_INTERP_DIFF_LIMIT=200 cargo test --release --test jit_vs_interp -- --nocapture
+```
+
+新しい fast path を足した直後 / 既存の fast path を弄った直後はこれが落ちる
+ことがある。落ちたら基本的に「fast path 側が正しい」（差分テストで jq と
+照合済み）／「interpreter 側が drift してる」のどちらか。両側を直すか、
+どうしても今すぐ直せない invariant 違反は `KNOWN_DIVERGENCES` に line 番号と
+理由を書いて allowlist する。allowlist は audit trail なので、ケースを直したら
+必ずエントリも消す（ハーネスは「known なのに今 pass した」も検知して落ちる）。
+
 ### テスト出力
 
 `cargo test --release` だけだと regression 通過数が非表示。必ず `--nocapture`:

--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -54,6 +54,22 @@ fn jqjit_trace_enabled() -> bool {
     })
 }
 
+/// Self-diff knob (issue #323): when `JQJIT_FORCE_INTERPRETER` is set in the
+/// environment, the binary disables raw-byte fast paths, skips JIT
+/// compilation, and routes [`Filter::execute`] / [`Filter::execute_cb`]
+/// through the generic tree-walking interpreter (see
+/// [`jq_jit::interpreter::set_force_interpreter`]). The
+/// `tests/jit_vs_interp.rs` self-diff harness shells out twice with the same
+/// arguments and asserts identical stdout / exit-code class.
+fn force_interpreter_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var_os("JQJIT_FORCE_INTERPRETER")
+            .map(|v| !v.is_empty() && v != "0")
+            .unwrap_or(false)
+    })
+}
+
 fn jqjit_trace_fast_path(name: &str, filter_text: &str) {
     use std::sync::atomic::{AtomicBool, Ordering};
     static EMITTED: AtomicBool = AtomicBool::new(false);
@@ -2103,6 +2119,10 @@ fn main() {
 }
 
 fn real_main() {
+    let force_interp = force_interpreter_enabled();
+    if force_interp {
+        jq_jit::interpreter::set_force_interpreter(true);
+    }
     let args: Vec<String> = std::env::args().collect();
 
     let mut filter_str = None;
@@ -2478,7 +2498,10 @@ fn real_main() {
     // since their runtime dominates regardless of input size.
     // Must be done before process_input closure captures &filter.
     const JIT_THRESHOLD: usize = 4096;
-    if filter.has_loop_constructs() || null_input {
+    if force_interp {
+        // Self-diff mode (#323) — leave jit_fn empty and let
+        // execute / execute_cb take the eval path.
+    } else if filter.has_loop_constructs() || null_input {
         filter.compile_jit();
     } else if !null_input {
         if files.is_empty() {
@@ -2542,7 +2565,9 @@ fn real_main() {
     }
     // Raw byte fast paths bypass Value construction and cannot inject color codes.
     // Disable them when color output is requested.
-    let use_raw_fast_paths = (use_compact_buf || use_pretty_buf) && !color_output;
+    // Self-diff mode (#323) also disables them so every filter shape is
+    // serviced by Filter::execute_cb on the eval path.
+    let use_raw_fast_paths = (use_compact_buf || use_pretty_buf) && !color_output && !force_interp;
 
     // JQJIT_TRACE: emit a single [trace] line naming the first fast path that
     // fires. `trace_detect!` wraps `Option`-returning detectors; `trace_is!`

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -2382,7 +2382,17 @@ pub fn eval(
                 let old_val = crate::runtime::rt_getpath(&result, path).unwrap_or(Value::Null);
                 let mut has_output = false;
                 let mut new_val = old_val.clone();
-                eval(update_expr, old_val, env, &mut |v| { has_output = true; new_val = v; Ok(true) })?;
+                // jq `|=` takes the FIRST value the RHS emits and discards the
+                // rest (`{a:1} | .a |= (1,2)` is `{a:1}`, not `{a:2}`). Returning
+                // `Ok(false)` from the callback stops the generator after the
+                // first hit; without it the interpreter ended up with the last
+                // emitted value and diverged from JIT / fast-path on the same
+                // filter (#323 self-diff caught this).
+                eval(update_expr, old_val, env, &mut |v| {
+                    has_output = true;
+                    new_val = v;
+                    Ok(false)
+                })?;
                 if has_output {
                     result = crate::runtime::rt_setpath(&result, path, &new_val)?;
                 } else {

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -9,6 +9,23 @@ use anyhow::Result;
 use crate::ir::CompiledFunc;
 use crate::value::Value;
 
+/// Self-diff knob for issue #323: when set, [`Filter::execute`] and
+/// [`Filter::execute_cb`] skip the typed fast path and JIT and run the generic
+/// tree-walking interpreter, regardless of whether `compile_jit` was called.
+/// The binary sets this once at startup when `JQJIT_FORCE_INTERPRETER` is in
+/// the environment; tests/jit_vs_interp.rs shells out twice — once with it,
+/// once without — and asserts identical output.
+static FORCE_INTERPRETER: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+pub fn set_force_interpreter(on: bool) {
+    FORCE_INTERPRETER.store(on, std::sync::atomic::Ordering::Relaxed);
+}
+
+pub fn force_interpreter() -> bool {
+    FORCE_INTERPRETER.load(std::sync::atomic::Ordering::Relaxed)
+}
+
 /// Comparison value: either numeric or string.
 #[derive(Debug, Clone)]
 pub enum CmpVal {
@@ -11063,17 +11080,22 @@ impl Filter {
 
     /// Execute the filter against an input value, collecting all results.
     pub fn execute(&self, input: &Value) -> Result<Vec<Value>> {
+        let forced = force_interpreter();
         // Typed fast path (issue #83): probed ahead of JIT / eval. Only
         // migrated filter shapes return `Some`; every other shape or
         // unhandled input type returns `None` and falls through to the
         // authoritative generic path below.
-        if let Some(verdict) = self.try_typed_fast_path(input) {
-            return verdict.map(|v| vec![v]);
+        if !forced {
+            if let Some(verdict) = self.try_typed_fast_path(input) {
+                return verdict.map(|v| vec![v]);
+            }
         }
 
         // Try JIT execution first
-        if let Some(jit_fn) = self.jit_fn {
-            return crate::jit::execute_jit(jit_fn, input);
+        if !forced {
+            if let Some(jit_fn) = self.jit_fn {
+                return crate::jit::execute_jit(jit_fn, input);
+            }
         }
 
         let (ref expr, ref funcs) = self.parsed;
@@ -11083,17 +11105,22 @@ impl Filter {
     /// Execute the filter with a callback for each result (avoids Vec allocation).
     /// Returns Ok(true) if all values were processed, Ok(false) if stopped early.
     pub fn execute_cb(&self, input: &Value, cb: &mut dyn FnMut(&Value) -> Result<bool>) -> Result<bool> {
+        let forced = force_interpreter();
         // Typed fast path (issue #83) — see `execute` for rationale. The
         // current pilot emits a single value, so hitting it closes out the
         // generator: we invoke `cb` once with the verdict and return its
         // continue/stop decision to the caller.
-        if let Some(verdict) = self.try_typed_fast_path(input) {
-            let val = verdict?;
-            return cb(&val);
+        if !forced {
+            if let Some(verdict) = self.try_typed_fast_path(input) {
+                let val = verdict?;
+                return cb(&val);
+            }
         }
 
-        if let Some(jit_fn) = self.jit_fn {
-            return crate::jit::execute_jit_cb(jit_fn, input, cb);
+        if !forced {
+            if let Some(jit_fn) = self.jit_fn {
+                return crate::jit::execute_jit_cb(jit_fn, input, cb);
+            }
         }
 
         let (ref expr, ref funcs) = self.parsed;

--- a/tests/jit_vs_interp.rs
+++ b/tests/jit_vs_interp.rs
@@ -191,9 +191,8 @@ fn serialize_sorted(val: &serde_json::Value) -> String {
 ///   values to `±1.7976931348623157e+308`. Plumbing the original `repr`
 ///   through `value_to_json_tojson` is the obvious local fix, but doing so
 ///   without also flipping `have_decnum` to `true` breaks the upstream
-///   `tests/official/jq.test` decnum consistency check (#443). Resolving
-///   that needs a coordinated answer about whether jq-jit claims decnum
-///   semantics — out of scope for the self-diff infrastructure work.
+///   `tests/official/jq.test` decnum consistency check (#443). Tracked
+///   in #415.
 const KNOWN_DIVERGENCES: &[usize] = &[2197, 2202, 2207, 2333, 2338];
 
 #[test]

--- a/tests/jit_vs_interp.rs
+++ b/tests/jit_vs_interp.rs
@@ -1,0 +1,302 @@
+//! Self-diff harness (issue #323): run every regression case through the JIT
+//! / fast-path dispatch *and* through the generic tree-walking interpreter,
+//! and assert identical stdout + exit-code class.
+//!
+//! Differential testing against `jq-1.8.1` (`tests/differential.rs`) catches
+//! external divergences only. This harness catches the *internal* class —
+//! the JIT path and the interpreter path inside jq-jit drifting apart on the
+//! same filter — without depending on an external `jq` binary.
+//!
+//! The runtime knob is `JQJIT_FORCE_INTERPRETER=1`: the binary then disables
+//! all raw-byte fast paths, skips JIT compilation, and routes
+//! `Filter::execute` / `Filter::execute_cb` through the generic interpreter
+//! (see `jq_jit::interpreter::set_force_interpreter`).
+//!
+//! Set `JIT_INTERP_DIFF_LIMIT=N` to truncate the corpus during local
+//! development; the default runs every case in `tests/regression.test`.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::Duration;
+
+struct Case {
+    filter: String,
+    input: String,
+    line: usize,
+}
+
+fn parse_corpus(content: &str) -> Vec<Case> {
+    let mut cases = Vec::new();
+    let mut block: Vec<(String, usize)> = Vec::new();
+
+    let flush = |block: &mut Vec<(String, usize)>, cases: &mut Vec<Case>| {
+        if block.len() >= 3 {
+            let (filter, line) = block[0].clone();
+            let input = block[1].0.clone();
+            cases.push(Case { filter, input, line });
+        }
+        block.clear();
+    };
+
+    for (idx, line) in content.lines().enumerate() {
+        let line_no = idx + 1;
+        if line.trim_start().starts_with('#') {
+            continue;
+        }
+        if line.trim().is_empty() {
+            flush(&mut block, &mut cases);
+            continue;
+        }
+        block.push((line.to_string(), line_no));
+    }
+    flush(&mut block, &mut cases);
+    cases
+}
+
+#[derive(Debug)]
+struct RunOutput {
+    stdout: String,
+    is_error: bool,
+}
+
+fn run_once(bin: &str, filter: &str, input: &str, force_interp: bool) -> Option<RunOutput> {
+    let lib_dir = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/modules");
+    let mut cmd = Command::new(bin);
+    cmd.arg("-L").arg(lib_dir).arg("-c").arg(filter);
+    cmd.env_remove("JQJIT_FORCE_INTERPRETER");
+    if force_interp {
+        cmd.env("JQJIT_FORCE_INTERPRETER", "1");
+    }
+    cmd.stdin(std::process::Stdio::piped());
+    cmd.stdout(std::process::Stdio::piped());
+    cmd.stderr(std::process::Stdio::null());
+
+    let mut child = cmd.spawn().ok()?;
+    {
+        use std::io::Write;
+        let mut stdin = child.stdin.take()?;
+        let _ = stdin.write_all(input.as_bytes());
+        let _ = stdin.write_all(b"\n");
+    }
+
+    let timeout = Duration::from_secs(10);
+    let start = std::time::Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                let out = child.wait_with_output().ok()?;
+                let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+                #[cfg(unix)]
+                {
+                    use std::os::unix::process::ExitStatusExt;
+                    if let Some(sig) = status.signal() {
+                        return Some(RunOutput {
+                            stdout: format!("<killed by signal {}>", sig),
+                            is_error: true,
+                        });
+                    }
+                }
+                let is_error = !status.success();
+                return Some(RunOutput { stdout, is_error });
+            }
+            Ok(None) => {
+                if start.elapsed() > timeout {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return Some(RunOutput {
+                        stdout: "<timeout after 10s>".to_string(),
+                        is_error: true,
+                    });
+                }
+                std::thread::sleep(Duration::from_millis(5));
+            }
+            Err(_) => return None,
+        }
+    }
+}
+
+/// Compact JSON normalisation matching `tests/differential.rs`. Filters that
+/// emit non-JSON lines (raw error text via `error("…")`) fall through to the
+/// raw string branch so their output still compares directly.
+fn normalize(output: &str) -> String {
+    let mut lines = Vec::new();
+    for line in output.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<serde_json::Value>(trimmed) {
+            Ok(val) => lines.push(serialize_sorted(&normalize_value(val))),
+            Err(_) => lines.push(trimmed.to_string()),
+        }
+    }
+    lines.join("\n")
+}
+
+fn normalize_value(val: serde_json::Value) -> serde_json::Value {
+    use serde_json::Value;
+    match val {
+        Value::Number(n) => {
+            if let Some(f) = n.as_f64() {
+                if f.is_finite() && f == (f as i64) as f64 && f.abs() < (1i64 << 53) as f64 {
+                    return Value::Number(serde_json::Number::from(f as i64));
+                }
+            }
+            Value::Number(n)
+        }
+        Value::Array(arr) => Value::Array(arr.into_iter().map(normalize_value).collect()),
+        Value::Object(map) => Value::Object(
+            map.into_iter()
+                .map(|(k, v)| (k, normalize_value(v)))
+                .collect(),
+        ),
+        other => other,
+    }
+}
+
+fn serialize_sorted(val: &serde_json::Value) -> String {
+    use serde_json::Value;
+    match val {
+        Value::Null => "null".to_string(),
+        Value::Bool(b) => b.to_string(),
+        Value::Number(n) => n.to_string(),
+        Value::String(s) => serde_json::to_string(s).unwrap(),
+        Value::Array(arr) => {
+            let items: Vec<String> = arr.iter().map(serialize_sorted).collect();
+            format!("[{}]", items.join(","))
+        }
+        Value::Object(map) => {
+            let mut entries: Vec<(&String, &Value)> = map.iter().collect();
+            entries.sort_by_key(|(k, _)| *k);
+            let items: Vec<String> = entries
+                .iter()
+                .map(|(k, v)| format!("{}:{}", serde_json::to_string(k).unwrap(), serialize_sorted(v)))
+                .collect();
+            format!("{{{}}}", items.join(","))
+        }
+    }
+}
+
+/// Cases the harness flags but does not fail on. Each entry pins a specific
+/// regression-test line to the underlying-divergence note that explains it.
+/// New divergences are NOT silently allowed — they have to be added here with
+/// rationale, which is the point: the allowlist is the audit trail of "we
+/// know about this, here's why we haven't fixed it yet."
+///
+/// Current entries (#323):
+/// - `tojson` on numbers that overflow `f64` (`1e1000` → `±INFINITY`):
+///   the raw-byte fast path on stdin lexes the digits and emits the
+///   canonicalised literal (`"1E+1000"`); the interpreter routes through
+///   `Value::Num(f64, repr)` and `push_jq_number_str` saturates non-finite
+///   values to `±1.7976931348623157e+308`. Plumbing the original `repr`
+///   through `value_to_json_tojson` is the obvious local fix, but doing so
+///   without also flipping `have_decnum` to `true` breaks the upstream
+///   `tests/official/jq.test` decnum consistency check (#443). Resolving
+///   that needs a coordinated answer about whether jq-jit claims decnum
+///   semantics — out of scope for the self-diff infrastructure work.
+const KNOWN_DIVERGENCES: &[usize] = &[2197, 2202, 2207, 2333, 2338];
+
+#[test]
+fn jit_vs_interpreter_self_diff() {
+    let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
+
+    let corpus_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/regression.test");
+    let content = std::fs::read_to_string(&corpus_path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {}", corpus_path.display(), e));
+    let mut cases = parse_corpus(&content);
+    assert!(!cases.is_empty(), "regression corpus is empty");
+
+    if let Ok(limit) = std::env::var("JIT_INTERP_DIFF_LIMIT") {
+        if let Ok(n) = limit.parse::<usize>() {
+            cases.truncate(n);
+        }
+    }
+
+    let mut pass = 0usize;
+    let mut fail = 0usize;
+    let mut spawn_fail = 0usize;
+    let mut known_diverged = 0usize;
+    let mut unexpected_pass: Vec<usize> = Vec::new();
+    let mut failures: Vec<String> = Vec::new();
+
+    for case in &cases {
+        let known = KNOWN_DIVERGENCES.contains(&case.line);
+        let jit = run_once(jq_jit, &case.filter, &case.input, false);
+        let interp = run_once(jq_jit, &case.filter, &case.input, true);
+
+        let (Some(jit), Some(interp)) = (jit, interp) else {
+            spawn_fail += 1;
+            failures.push(format!(
+                "  line {}: spawn failure\n    filter: {}\n    input:  {}",
+                case.line, case.filter, case.input
+            ));
+            continue;
+        };
+
+        if jit.is_error && interp.is_error {
+            if known { unexpected_pass.push(case.line); }
+            pass += 1;
+            continue;
+        }
+        if jit.is_error != interp.is_error {
+            if known {
+                known_diverged += 1;
+                continue;
+            }
+            fail += 1;
+            failures.push(format!(
+                "  line {}: error-class mismatch (jit error={}, interp error={})\n    filter: {}\n    input:  {}\n    jit:    {}\n    interp: {}",
+                case.line, jit.is_error, interp.is_error, case.filter, case.input,
+                jit.stdout.trim(), interp.stdout.trim()
+            ));
+            continue;
+        }
+
+        let jit_norm = normalize(&jit.stdout);
+        let interp_norm = normalize(&interp.stdout);
+        if jit_norm == interp_norm {
+            if known { unexpected_pass.push(case.line); }
+            pass += 1;
+        } else if known {
+            known_diverged += 1;
+        } else {
+            fail += 1;
+            failures.push(format!(
+                "  line {}: value mismatch\n    filter: {}\n    input:  {}\n    jit:    {}\n    interp: {}",
+                case.line, case.filter, case.input, jit_norm, interp_norm
+            ));
+        }
+    }
+
+    eprintln!();
+    eprintln!("=== JIT vs interpreter self-diff ===");
+    eprintln!("PASS:        {}", pass);
+    eprintln!("FAIL:        {}", fail);
+    eprintln!("SPAWN:       {}", spawn_fail);
+    eprintln!("KNOWN-DIV:   {}", known_diverged);
+    eprintln!("TOTAL:       {}", cases.len());
+
+    if !failures.is_empty() {
+        eprintln!();
+        eprintln!("=== Divergences ===");
+        for f in &failures {
+            eprintln!("{}", f);
+        }
+    }
+
+    assert_eq!(
+        fail + spawn_fail,
+        0,
+        "{} self-diff divergences out of {}",
+        fail + spawn_fail,
+        cases.len()
+    );
+
+    // If a previously-known-divergent case now agrees, the allowlist entry is
+    // stale: shrinking the list is the goal, so flag it loudly.
+    assert!(
+        unexpected_pass.is_empty(),
+        "KNOWN_DIVERGENCES is stale — these line(s) now agree and should be removed: {:?}",
+        unexpected_pass
+    );
+}


### PR DESCRIPTION
## Summary

Adds an internal consistency check that runs every regression case through both the JIT / raw-byte fast-path dispatch and the generic tree-walking interpreter and asserts identical output. No dependency on an external `jq` binary — this catches the *internal* class of bugs where one path drifts from the other.

## How it works

The runtime knob is `JQJIT_FORCE_INTERPRETER=1`. When the binary sees it:

- raw-byte fast paths (`detect_*` / `is_*`) are gated off (`use_raw_fast_paths = false`)
- `compile_jit()` calls are skipped
- `Filter::execute` / `Filter::execute_cb` are routed through `eval` via `interpreter::set_force_interpreter`

`tests/jit_vs_interp.rs` then walks `tests/regression.test` (1074 cases), runs each case once with the knob off and once with it on, and asserts identical normalised stdout + identical exit-code class. `JIT_INTERP_DIFF_LIMIT=N` truncates the corpus during local development.

## Bugs surfaced and fixed in flight

The harness immediately found two interpreter divergences:

- **`.a |= (1, 2)` returned `{"a":2}` instead of `{"a":1}`.** jq's `|=` semantics take the *first* RHS emission; the eval branch was overwriting `new_val` on every callback invocation and ending up with the last. Fixed by short-circuiting (`Ok(false)`) after the first emit.
- **`tojson` on `1e1000` returned `"1.7976931348623157e+308"` instead of `"1E+1000"`** in the interpreter only. The obvious local fix (use `repr` when `n` is non-finite) breaks the upstream `tests/official/jq.test` decnum consistency check (#443: `[1E+1000,...|tojson] == if have_decnum then ... else ... end`), which assumes that `have_decnum=false` implies saturated `tojson`. Resolving that needs a coordinated answer about whether jq-jit claims decnum semantics, so the 5 cases are gated by `KNOWN_DIVERGENCES` with rationale and the test still passes.

The harness also detects "known divergence now agrees" (allowlist staleness) and fails with the line numbers to remove.

## Verification

- `cargo build --release` — zero warnings
- `cargo test --release` — all suites pass (official 508/509 + skip 1, regression 1182, self-diff 1069 PASS / 5 KNOWN-DIV, fuzz_diff, corpus_diff)
- `./bench/comprehensive.sh --quick` — within noise of v1.4.4

## Test plan

- [x] `cargo build --release` zero warnings
- [x] `cargo test --release` passes
- [x] new `tests/jit_vs_interp.rs` exercised end-to-end
- [x] `JQJIT_FORCE_INTERPRETER=1 jq-jit '.a + .b' <<< '{"a":1,"b":2}'` produces `3`
- [x] `./bench/comprehensive.sh --quick` no regression vs `docs/benchmark-history.md`

Closes #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)