### PR TITLE
test: extend fuzz_diff string pool with non-ASCII UTF-8 (#321 phase 3a)

### DIFF
--- a/tests/fuzz_diff.rs
+++ b/tests/fuzz_diff.rs
@@ -49,10 +49,14 @@
 //!   JSON. The integer adversarial pool deliberately caps at `±2^53`;
 //!   floats beyond that are left to a future phase that extends
 //!   `normalize` to recognise both spellings.
-//! * **Broken UTF-8** (lone surrogates, embedded NUL, BOM in the
-//!   middle of a string). jq-1.8 may reject these at input parse; the
-//!   reference run lands in `is_error` and the case is skipped. The
-//!   adversarial string pool stays inside well-formed UTF-8 for now.
+//! * **Broken UTF-8** (lone surrogates such as `"\uD83D"` without the
+//!   trailing low surrogate, embedded NUL bytes). jq-1.8 rejects these
+//!   at input parse while jq-jit's parser accepts them, producing an
+//!   error-vs-success mismatch the harness would flag as a bug. The
+//!   adversarial string pool stays inside well-formed UTF-8 — multi-
+//!   byte text, RTL, combining marks, supplementary-plane emoji, and
+//!   mid-string BOM all round-trip cleanly through both implementations
+//!   and are safe to include.
 //! * **Empty input** — both implementations agree to error, so the
 //!   `both_error` branch covers it.
 //!
@@ -422,10 +426,15 @@ const ADVERSARIAL_INTS: &[i64] = &[
 
 /// String pool with shapes that have surfaced bugs historically:
 /// empty string, single ASCII, runs that brush against the small
-/// SSO threshold, and a longer ASCII string that exercises
-/// allocation paths on both runtimes. Stays ASCII-only — non-ASCII
-/// adds an encoding-class divergence the next round can broaden
-/// into once the integer expansion settles.
+/// SSO threshold, a longer ASCII string that exercises allocation
+/// paths on both runtimes, and a multi-byte UTF-8 cross-section
+/// (#321 phase 3a) covering 2-byte / 3-byte / 4-byte sequences,
+/// RTL text, combining marks, BMP-supplementary emoji, and a BOM
+/// in mid-string position. All values are well-formed UTF-8 — lone
+/// surrogates and embedded NUL are deliberately excluded because
+/// jq-1.8 rejects them at input parse and the harness would surface
+/// an error-vs-success mismatch (see "Expected-divergence classes"
+/// in the module doc).
 const ADVERSARIAL_STRS: &[&str] = &[
     "",
     "0",
@@ -433,6 +442,22 @@ const ADVERSARIAL_STRS: &[&str] = &[
     "null",
     "          ",
     "abcdefghijklmnopqrstuvwxyz",
+    // 3-byte CJK
+    "日本語",
+    // RTL Hebrew
+    "שלום",
+    // Combining mark: e + U+0301
+    "e\u{0301}",
+    // 4-byte BMP-supplementary emoji
+    "😀",
+    // 4-byte musical symbol
+    "𝄞",
+    // BOM (U+FEFF) in mid-string — exercises the path where the
+    // byte-order mark is *not* at offset 0 and must be preserved.
+    "a\u{FEFF}b",
+    // Long multi-byte run — stresses allocation / SSO boundaries
+    // for codepoint vs byte indexing.
+    "日本語日本語日本語日本語日本語日本語日本語日本語",
 ];
 
 fn json_leaf() -> impl Strategy<Value = JsonShape> {


### PR DESCRIPTION
## Summary

Phase 3a of #321 — broadens the adversarial string pool from ASCII-only
into the multi-byte UTF-8 cross-section the conservative generator
never produces:

- 3-byte CJK (`日本語`)
- 4-byte BMP-supplementary emoji (`😀`) and musical symbol (`𝄞`)
- RTL Hebrew (`שלום`)
- Combining mark sequence (`e\u{0301}`)
- BOM (U+FEFF) in mid-string position
- Long multi-byte run (24 codepoints, 72 bytes) for SSO / allocation
  paths

All values are well-formed UTF-8 — a probe against jq-1.8.1 confirmed
each round-trips identically through both implementations across
`length`, `utf8bytelength`, `explode`, `ascii_downcase`, and identity.

Lone surrogates and embedded NUL stay excluded: jq-1.8 rejects them at
input parse while jq-jit's parser accepts them, so they would surface
as an error-vs-success mismatch the harness flags as a bug. The
"Expected-divergence classes" doc block is updated to spell that out
and to flip mid-string BOM out of the broken-UTF-8 bucket — it
round-trips cleanly and is now part of the safe pool.

NaN / ±Infinity / -0.0 / values past the f64 mantissa boundary still
need a `normalize` extension before they can join the pool; tracked
for a later phase under the same issue.

Refs #321

## Test plan

- [x] `cargo build --release --tests` (zero warnings)
- [x] `cargo test --release` — full suite green
- [x] `JQJIT_PROPTEST_CASES=2000 cargo test --release --test fuzz_diff` — clean (26s)
- [x] `JQJIT_PROPTEST_CASES=50000 cargo test --release --test fuzz_diff` — clean (646s)
- [x] `./bench/comprehensive.sh --quick` — runtime unaffected (test-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)