### PR TITLE
fix: lowercase `e+` for f64-resident numbers (#426)

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -426,11 +426,16 @@ impl Lexer {
         }
         let num_str: String = self.chars[start..self.pos].iter().collect();
         let n: f64 = num_str.parse().map_err(|e| anyhow::anyhow!("invalid number '{}': {}", num_str, e))?;
-        // Preserve original string for numbers that lose precision in f64.
-        // Drop preservation for source forms that aren't valid JSON (e.g. `.5`),
-        // so downstream emitters can rely on repr being JSON-safe.
+        // Preserve original string when the canonical literal form (jq's
+        // decnum-style uppercase `E+`, decimal-expanded when |te| is small)
+        // differs from the f64-default form. Without this, scientific
+        // literals like `1e-100` would lose their repr and re-render as
+        // lowercase `e-` from the no-repr path, dropping jq's literal
+        // preservation. Drop forms that aren't valid JSON (e.g. `.5`) so
+        // downstream emitters can rely on repr being JSON-safe.
+        let canonical = crate::value::normalize_jq_repr(&num_str).unwrap_or_else(|| num_str.clone());
         let f64_repr = crate::value::format_jq_number(n);
-        let repr = if f64_repr != num_str {
+        let repr = if canonical != f64_repr {
             let norm = normalize_num_repr(&num_str);
             if crate::value::is_valid_json_number(&norm) {
                 Some(Rc::from(norm))

--- a/src/value.rs
+++ b/src/value.rs
@@ -4603,8 +4603,14 @@ fn parse_json_number(b: &[u8], pos: usize) -> Result<(Value, usize)> {
             }
         }
     }
+    // Compare against the canonical decnum-style form (uppercase `E+`, decimal
+    // expansion when |te| is small) rather than the f64 default. Without this,
+    // scientific input like `1.5e-10` would lose its repr because the lowercase
+    // f64 default matches the lowercase source, and the no-repr path renders
+    // lowercase too — but jq's literal preservation expects uppercase. See #426.
+    let canonical = normalize_jq_repr(canonical_in).unwrap_or_else(|| canonical_in.to_string());
     let f64_repr = format_jq_number(n);
-    let repr = if f64_repr == canonical_in { None } else { Some(Rc::from(canonical_in)) };
+    let repr = if canonical == f64_repr { None } else { Some(Rc::from(canonical_in)) };
     Ok((Value::number_opt(n, repr), i))
 }
 
@@ -5264,13 +5270,13 @@ pub fn push_jq_number_str(buf: &mut String, n: f64) {
 
     // For very small numbers (abs < 1e-4), always use scientific notation (matching %g)
     if abs != 0.0 && abs < 1e-4 {
-        buf.push_str(&format_as_scientific(n));
+        buf.push_str(&format_as_scientific_lowercase(n));
         return;
     }
 
     // For large numbers: compare fixed vs scientific length, prefer shorter
     if abs >= 1e16 {
-        let sci = format_as_scientific(n);
+        let sci = format_as_scientific_lowercase(n);
         if sci.len() < s.len() {
             buf.push_str(&sci);
             return;
@@ -5404,34 +5410,29 @@ fn format_canonical_mantissa(sig: &str) -> String {
     }
 }
 
-/// Format a number in scientific notation matching jq's style.
-fn format_as_scientific(n: f64) -> String {
+/// Format a number in jq's f64 dtoa scientific style: lowercase `e`, explicit
+/// `+`/`-` sign, single-digit negative exponent zero-padded to two digits.
+///
+/// jq 1.8.1 uses two number renderers depending on whether the value is
+/// decnum-resident or f64-resident. Decnum literals print uppercase
+/// (`1E+10`) via `canonical_repr_bytes`; values without a preserved repr —
+/// arithmetic results, `tonumber`, etc — print lowercase here. See #426.
+fn format_as_scientific_lowercase(n: f64) -> String {
     let sci = format!("{:e}", n);
-    let sci = if sci.contains("e-") { sci } else { sci.replacen("e", "e+", 1) };
-    normalize_scientific(&sci)
-}
-
-/// Normalize scientific notation to match jq 1.8.1's format: uppercase `E`,
-/// explicit `+`/`-` sign, two-digit exponent for values below 100.
-fn normalize_scientific(s: &str) -> String {
-    if let Some(idx) = s.find(|c: char| c == 'e' || c == 'E') {
-        let mantissa = &s[..idx];
-        let exp_str = &s[idx+1..]; // includes sign
-        let (sign, digits) = if let Some(rest) = exp_str.strip_prefix('-') {
-            ("-", rest)
-        } else if let Some(rest) = exp_str.strip_prefix('+') {
-            ("+", rest)
-        } else {
-            ("+", exp_str)
-        };
-        let exp: i32 = digits.parse().unwrap_or(0);
-        if exp.abs() < 100 {
-            format!("{}E{}{:02}", mantissa, sign, exp.abs())
-        } else {
-            format!("{}E{}{}", mantissa, sign, exp.abs())
-        }
+    let (mantissa, exp_str) = match sci.find('e') {
+        Some(idx) => (&sci[..idx], &sci[idx + 1..]),
+        None => return sci,
+    };
+    let (sign, digits) = if let Some(rest) = exp_str.strip_prefix('-') {
+        ('-', rest)
     } else {
-        s.to_string()
+        ('+', exp_str)
+    };
+    let exp: i32 = digits.parse().unwrap_or(0);
+    if exp.abs() < 10 {
+        format!("{}e{}{:02}", mantissa, sign, exp.abs())
+    } else {
+        format!("{}e{}{}", mantissa, sign, exp.abs())
     }
 }
 

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -6392,3 +6392,37 @@ false
 [((select(.c >= .c)) | ([.x + .c, .c]))?]
 {"c":0,"x":[]}
 []
+
+# Issue #426: f64 arithmetic result formats with lowercase `e+` (jq's dtoa
+# style for non-decnum values). Decnum-resident literal preservation still
+# uses uppercase via canonical_repr_bytes; this only covers the no-repr path.
+1e100 * 1e100
+null
+1e+200
+
+# Issue #426: same for unary multiplication-by-1 dropping out of decnum
+1e308 * 1
+null
+1e+308
+
+# Issue #426: tonumber yields a no-repr Value::Num; arithmetic preserves that
+"1e200" | tonumber * 1
+null
+1e+200
+
+# Issue #426: literal preservation must keep uppercase `E-` even though the
+# new no-repr formatter would render lowercase. Lexer compares against the
+# canonical (decnum-style) form so repr is retained.
+1e-100
+null
+1E-100
+
+# Issue #426: same for fractional mantissa
+1.5e-10
+null
+1.5E-10
+
+# Issue #426: input JSON parser preserves repr too; tojson re-renders uppercase
+tojson
+1.5e-10
+"1.5E-10"


### PR DESCRIPTION
## Summary

- Switch the no-repr number formatter (`push_jq_number_str`) to jq's f64 dtoa style: lowercase `e+`/`e-`, explicit sign, 2-digit zero-padding for single-digit negative exponents.
- Update the lexer and the input JSON parser to compare the source against the canonical decnum-style form (uppercase `E+`) when deciding whether to preserve repr — without this, scientific literals like `1e-100` would lose their repr and re-render lowercase.
- Drop dead `format_as_scientific` / `normalize_scientific` helpers.

jq 1.8.1 uses two number renderers depending on whether a value is decnum-resident (uppercase `E+`) or f64-resident (lowercase `e+`). jq-jit already preserves literal repr through `Value::Num(_, NumRepr(Some))` → `canonical_repr_bytes` (uppercase, matches jq's decnum literals). The no-repr path — arithmetic results, `tonumber` output, etc. — was incorrectly normalised to uppercase too.

```
$ echo 1 | jq -c '1e100 * 1e100'
1e+200
$ echo 1 | jq-jit -c '1e100 * 1e100'   # before
1E+200
```

Closes #426

## Test plan

- [x] `cargo build --release` zero warnings
- [x] `cargo test --release` all green (jq off=509/509, regression=1264/1264, selfdiff=1079/1084 with 5 known-div, fuzz=ok)
- [x] Direct A/B microbench (pre-fix vs post-fix on /tmp/bench_2m.json, best of 5):
  - `tostring`: 0.078s → 0.077s
  - `.x*2|tostring`: 0.072s → 0.072s
  - `tonumber`: 0.125s → 0.125s
  - `.x + .y`: 0.100s → 0.098s
  - `.x | tojson`: 0.210s → 0.210s
- [x] 6 new regression tests covering arithmetic-result lowercase + literal-repr uppercase preservation