### PR TITLE
fix: preserve source repr in tonumber (#428)

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1371,7 +1371,20 @@ fn rt_tonumber(v: &Value) -> Result<Value> {
             // Strip leading '+' for compatibility with jq
             let parse_str = s_ref.strip_prefix('+').unwrap_or(s_ref);
             match fast_float::parse(parse_str) {
-                Ok(n) => Ok(Value::number(n)),
+                Ok(n) => {
+                    // Mirror parse_json_number: preserve repr when the canonical
+                    // decnum-style form differs from the f64 default. Without
+                    // this, `"1e10" | tonumber` collapses to `10000000000`
+                    // instead of jq's `1E+10`. See #428.
+                    let canonical = crate::value::normalize_jq_repr(parse_str)
+                        .unwrap_or_else(|| parse_str.to_string());
+                    let f64_repr = crate::value::format_jq_number(n);
+                    if canonical != f64_repr && crate::value::is_valid_json_number(parse_str) {
+                        Ok(Value::number_with_repr(n, Rc::from(parse_str)))
+                    } else {
+                        Ok(Value::number(n))
+                    }
+                }
                 Err(_) => bail!("Invalid numeric literal: {}", crate::value::value_to_json(v)),
             }
         }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -6426,3 +6426,44 @@ null
 tojson
 1.5e-10
 "1.5E-10"
+
+# Issue #428: tonumber preserves the source repr so scientific input round-trips
+# through jq's decnum-style canonical form (uppercase E+, decimal expansion when
+# |te| <= 6) instead of collapsing to f64-default rendering.
+"1e10" | tonumber
+null
+1E+10
+
+# Issue #428: fractional-mantissa scientific source preserves uppercase E+
+"1.5e10" | tonumber
+null
+1.5E+10
+
+# Issue #428: negative-mantissa scientific source preserves the sign
+"-1e10" | tonumber
+null
+-1E+10
+
+# Issue #428: leading `+` is stripped before the repr is stored, so output has
+# no leading `+` (matches jq).
+"+1e10" | tonumber
+null
+1E+10
+
+# Issue #428: small negative-exponent scientific input expands to decimal form
+# (matches jq's decimal-expansion threshold).
+"1e-5" | tonumber
+null
+0.00001
+
+# Issue #428: decimal source preserves its decimal form rather than reformatting
+# to scientific.
+"0.00001" | tonumber
+null
+0.00001
+
+# Issue #428: integer-valued scientific input above the f64 integer fast-path
+# threshold (>= 1e16) preserves uppercase E+, not the lowercase arithmetic form.
+"1.5e16" | tonumber
+null
+1.5E+16


### PR DESCRIPTION
## Summary

Mirror `parse_json_number`'s gating logic in `rt_tonumber`: when the canonical decnum-style form (uppercase `E+`, decimal expansion when `|te| <= 6`) differs from the f64-default form, store the parsed string as the repr.

Without this, `tonumber` collapsed scientific input to the no-repr path, so `"1e10" | tonumber` rendered as the f64 integer `10000000000` (jq: `1E+10`), and `"0.00001" | tonumber` rendered as `1e-05` (jq: `0.00001`).

```
$ echo null | jq -c '"1e10" | tonumber'
1E+10
$ echo null | jq-jit -c '"1e10" | tonumber'   # before
10000000000
```

This is the input-side companion to #426/#427 (which fixed the output-side decnum vs f64 distinction).

Closes #428

## Test plan

- [x] `cargo build --release` zero warnings
- [x] `cargo test --release` all green (jq off=509/509, regression=1271/1271 with 7 new, differential=1099/1099, corpus=12/12, fuzz=ok, selfdiff=ok)
- [x] Bench: tonumber 0.106s vs v1.4.5 baseline 0.117s (-9.4%); tostring/tojson/etc. flat within noise
- [x] All probed cases match jq 1.8.1: `"1e10"`, `"1.5e10"`, `"-1e10"`, `"+1e10"`, `"1e-5"`, `"0.00001"`, `"3.14e2"`, `"1e308"`, `"1.5e16"`, plus baseline integer/decimal cases