### PR TITLE
fix: treat null as the empty separator in join (#430)

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1849,13 +1849,20 @@ fn rt_regex_split(v: &Value, re: &Value, flags: &Value) -> Result<Value> {
 }
 
 fn rt_join(v: &Value, sep: &Value) -> Result<Value> {
-    match (v, sep) {
-        (Value::Arr(a), Value::Str(s)) => {
-            // Estimate capacity: average item ~8 bytes + separator
-            let cap = a.len() * (8 + s.len());
+    // jq treats `null` as the additive identity for strings (`"a" + null == "a"`),
+    // and `join` is internally a reduce over `acc + sep + item`, so a `null`
+    // separator collapses to the empty string. See #430.
+    let sep_bytes: &[u8] = match sep {
+        Value::Str(s) => s.as_bytes(),
+        Value::Null => b"",
+        _ => bail!("join requires array and string"),
+    };
+    match v {
+        Value::Arr(a) => {
+            let cap = a.len() * (8 + sep_bytes.len());
             let mut buf: Vec<u8> = Vec::with_capacity(cap);
             for (i, item) in a.iter().enumerate() {
-                if i > 0 { buf.extend_from_slice(s.as_bytes()); }
+                if i > 0 { buf.extend_from_slice(sep_bytes); }
                 match item {
                     Value::Str(sv) => buf.extend_from_slice(sv.as_bytes()),
                     Value::Null => {},

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -6467,3 +6467,24 @@ null
 "1.5e16" | tonumber
 null
 1.5E+16
+
+# Issue #430: join(null) treats null as the empty separator (jq's `+ null`
+# identity for strings; join is internally `reduce . as $i (null; . + sep + $i)`).
+[1,2,3] | join(null)
+null
+"123"
+
+# Issue #430: same for empty array (no items, no separator inserted)
+[] | join(null)
+null
+""
+
+# Issue #430: array of strings with null separator
+["a","b","c"] | join(null)
+null
+"abc"
+
+# Issue #430: mixed types with null separator (numbers/booleans render via tostring)
+[1,true,"x",false] | join(null)
+null
+"1truexfalse"


### PR DESCRIPTION
## Summary

`join` is internally a reduce over `acc + sep + item`, and jq treats `null` as the additive identity for strings (`"a" + null == "a"`), so `join(null)` collapses to using the empty string. `rt_join` only matched `Value::Str` and bailed on anything else, so the `null` case errored out.

```
$ echo '[1,2,3]' | jq -c 'join(null)'
"123"
$ echo '[1,2,3]' | jq-jit -c 'join(null)'   # before
jq: error (at <stdin>:1): join requires array and string
```

Hoist sep extraction so the loop body uses the same byte slice for both `Str` and `Null`.

Closes #430

## Test plan

- [x] `cargo build --release` zero warnings
- [x] `cargo test --release` all green (jq off=509/509, regression=1275/1275 with 4 new, differential=1099/1099, corpus=12/12, fuzz=ok, selfdiff=ok)
- [x] Bench: join 0.092s vs v1.4.5 baseline 0.104s (-11.5%); split/join 0.089 vs 0.098 (-9.2%); other ops flat within noise
- [x] Probed: `[1,2,3]|join(null)`, `[]|join(null)`, `["a","b","c"]|join(null)`, `[1,true,"x",false]|join(null)` all match jq 1.8.1
- [x] Non-null non-string separators (`0`, `[]`, `{}`, `true`) still error (message text differs from jq but that is an out-of-scope alignment)