### PR TITLE
fix: delpaths subsumes longer paths under their shorter prefix (#432)

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2301,11 +2301,38 @@ pub fn rt_setpath_mut(v: &mut Value, path: &[Value], val: Value) -> Result<()> {
 pub fn rt_delpaths(v: &Value, paths: &Value) -> Result<Value> {
     match paths {
         Value::Arr(ps) => {
-            let mut result = v.clone();
-            // Sort paths in reverse order so deletions don't affect indices
+            // Sort ascending so any path that is a strict prefix of another
+            // appears first; that lets us drop the longer path as subsumed.
+            // jq's `delpaths_sorted` (jv_aux.c) achieves the same by grouping
+            // paths sharing a first key and skipping descent when one path in
+            // the group is a "delete this whole key" path. Without this,
+            // `delpaths([["a"],["a","b"]]) on {"a":1,...}` errors on the
+            // second path (descending into `.a` = number); jq returns the
+            // object minus `.a`. See #432.
             let mut sorted_paths: Vec<&Value> = ps.iter().collect();
-            sorted_paths.sort_by(|a, b| compare_values(b, a));
+            sorted_paths.sort_by(|a, b| compare_values(a, b));
+            let mut filtered: Vec<&Value> = Vec::with_capacity(sorted_paths.len());
             for path in sorted_paths {
+                let p_arr = match path {
+                    Value::Arr(p) => p,
+                    _ => return Err(anyhow::anyhow!("Path must be specified as array")),
+                };
+                let subsumed = filtered.iter().any(|prev| {
+                    let prev_arr = match prev {
+                        Value::Arr(q) => q,
+                        _ => return false,
+                    };
+                    prev_arr.len() <= p_arr.len()
+                        && prev_arr.iter().zip(p_arr.iter()).all(|(a, b)| a == b)
+                });
+                if !subsumed {
+                    filtered.push(path);
+                }
+            }
+            // Iterate filtered paths in reverse to preserve array index
+            // stability when multiple sibling indices are deleted.
+            let mut result = v.clone();
+            for path in filtered.into_iter().rev() {
                 result = delete_path(&result, path)?;
             }
             Ok(result)

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -6532,3 +6532,42 @@ null
 [path(5)?]
 5
 []
+
+# Issue #432: delpaths subsumes longer paths under their shorter prefix when
+# the prefix is also being deleted. Without this, the longer path's intermediate
+# component would error on type mismatch (e.g. descending into .a where .a is
+# a number) even though .a is about to be deleted anyway.
+delpaths([["a"],["a","b"]])
+{"a":1,"b":2}
+{"b":2}
+
+# Issue #432: same regardless of input path order
+delpaths([["a","b"],["a"]])
+{"a":1,"b":2}
+{"b":2}
+
+# Issue #432: empty path subsumes everything; result is null
+delpaths([[],["a"]])
+[1,2,3]
+null
+
+# Issue #432: same on objects
+delpaths([[],["a"]])
+{"a":1,"b":2}
+null
+
+# Issue #432: array indices are still processed deepest-first for index stability
+delpaths([["a",0],["a",1]])
+{"a":[10,20,30]}
+{"a":[30]}
+
+# Issue #432: same with input order swapped
+delpaths([["a",1],["a",0]])
+{"a":[10,20,30]}
+{"a":[30]}
+
+# Issue #432: nested overlapping (.a and .a.b on a real subobject) still
+# subsumes .a.b under .a
+delpaths([["a"],["a","b"]])
+{"a":{"b":1,"c":2},"d":3}
+{"d":3}


### PR DESCRIPTION
## Summary

`rt_delpaths` processed every path independently in reverse-sorted order, so overlapping pairs like `delpaths([["a"],["a","b"]])` errored on the longer path's intermediate component even though the prefix was about to be deleted. jq returns `{"b":2}` because its `delpaths_sorted` groups paths sharing a first key and skips descent when one path in the group is a "delete this whole key" path.

Mirror the effect with a smaller change: sort paths ascending, drop any path whose strict prefix already appears earlier in the sorted list, then iterate survivors in reverse for array-index stability on sibling deletions like `[["a",0],["a",1]]`.

```
$ echo '{"a":1,"b":2}' | jq -c 'delpaths([["a"],["a","b"]])'
{"b":2}
$ echo '{"a":1,"b":2}' | jq-jit -c 'delpaths([["a"],["a","b"]])'   # before
jq: error (at <stdin>:1): Cannot delete fields from number
```

Closes #432

## Test plan

- [x] `cargo build --release` zero warnings
- [x] `cargo test --release` all green (jq off=509/509, regression=1275/1275 with 7 new, differential=1099/1099, corpus=12/12, fuzz=ok, selfdiff=ok)
- [x] Bench: del(.name) 0.100s vs v1.4.5 0.099s (within noise); join/tonumber/tostring/etc. flat
- [x] All probed combinations (object overlaps, root deletion, array index sibling, nested overlap on real subobject, plus regression of the previously-OK single-path cases) match jq 1.8.1
- [x] Error-message text divergences (`Cannot delete string "a" element of array` vs jq's `Cannot delete string element of array`) unchanged — explicitly out of scope per the issue