### PR TITLE
fix: accept null/true/false as identity path expressions (#434)

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -4206,11 +4206,27 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
             eval_path(fallback, input, env, cb)
         }
         _ => {
-            // Non-path-safe expression: evaluate and report error
+            // Non-path-safe expression: evaluate, then accept the value as
+            // the empty path `[]` if it is one of `null`/`true`/`false` and
+            // equals the input. jq treats those three literals as identity
+            // path expressions when their result matches the current input
+            // (so `path(.a // null)` and `path(if .x then .y else null end)`
+            // work on falsy branches that produce a literal value). All
+            // other shapes still report the original "Invalid path
+            // expression" error. See #434.
+            let input_for_check = input.clone();
             let mut result_val = Value::Null;
             let mut has_result = false;
-            eval(expr, input, env, &mut |val| { result_val = val; has_result = true; Ok(true) })?;
+            eval(expr, input, env, &mut |val| {
+                result_val = val;
+                has_result = true;
+                Ok(true)
+            })?;
             if has_result {
+                let is_id_value = matches!(&result_val, Value::Null | Value::True | Value::False);
+                if is_id_value && result_val == input_for_check {
+                    return cb(Value::Arr(Rc::new(vec![])));
+                }
                 bail!("__pathexpr_result__:{}", crate::value::value_to_json(&result_val));
             }
             Ok(true)

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -6488,3 +6488,47 @@ null
 [1,true,"x",false] | join(null)
 null
 "1truexfalse"
+
+# Issue #434: path(null) on null input yields [], not "Invalid path expression"
+[path(null)]
+null
+[[]]
+
+# Issue #434: same for true and false literals when they match input
+[path(true)]
+true
+[[]]
+
+[path(false)]
+false
+[[]]
+
+# Issue #434: composite expression yielding null works on null input (covers
+# the `path(.a // null)` idiom for marking the absence of a key as a path).
+[path(. // null)]
+null
+[[]]
+
+# Issue #434: if-then-else branch yielding null literal counts as an identity
+# path on null input.
+[path(if true then null else . end)]
+null
+[[]]
+
+# Issue #434: comma streams two null-paths through the same identity rule.
+[path(null, null)]
+null
+[[],[]]
+
+# Issue #434: error path still fires when the literal does not equal the
+# input — wrap with `?` so the harness pins the no-output behaviour without
+# inspecting stderr.
+[path(true)?]
+null
+[]
+
+# Issue #434: same — non-null/true/false literals never satisfy the rule even
+# when their value equals the input. `?` masks the error to empty.
+[path(5)?]
+5
+[]


### PR DESCRIPTION
## Summary

jq accepts a non-path expression as a valid path when its result is one of `null`/`true`/`false` AND equals the current input — the resulting path is `[]`. This makes idioms like `path(.a // null)` and `path(if .x then .y else null end)` work on falsy branches that produce a literal value. jq-jit's `eval_path` catch-all `_` arm bailed unconditionally.

```
$ echo true | jq -c '[path(true)]'
[[]]
$ echo true | jq-jit -c '[path(true)]'   # before
jq: error (at <stdin>:1): Invalid path expression with result true
```

Patch the catch-all to emit the empty path when the result is `Null`/`True`/`False` and equals the input. All other shapes — numbers, strings, arrays, objects, or null/true/false ≠ input — keep the original "Invalid path expression" error.

Closes #434

## Test plan

- [x] `cargo build --release` zero warnings
- [x] `cargo test --release` all green (regression=1283/1283 with 8 new, jq off=509/509, differential=1099/1099, corpus=12/12, fuzz=ok, selfdiff=ok)
- [x] Bench: del(.name) 0.101s vs v1.4.5 0.099s; everything else flat or faster (within noise)
- [x] All 12 probed cases (literal/composite, matching/mismatching, comma combinations, non-null-like literals) match jq 1.8.1