### PR TITLE
fix: preserve fractional seconds in gmtime/localtime (#436)

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2831,14 +2831,18 @@ pub fn sub_gsub_segments(input: &str, pattern: &str, flags: &Value, global: bool
 fn rt_gmtime(v: &Value) -> Result<Value> {
     match v {
         Value::Num(n, _) => {
-            let secs = *n as i64;
-            Ok(libc_gmtime(secs))
+            // jq preserves fractional seconds in tm_sec: trunc toward zero
+            // for the libc call, then add |n - trunc| (always non-negative)
+            // back. `(-1.5) | gmtime | .[5]` is `59.5`, not `58.5`. See #436.
+            let secs = n.trunc() as i64;
+            let frac = (n - n.trunc()).abs();
+            Ok(libc_gmtime(secs, frac))
         }
         _ => bail!("gmtime requires number"),
     }
 }
 
-fn libc_gmtime(secs: i64) -> Value {
+fn libc_gmtime(secs: i64, frac_sec: f64) -> Value {
     use libc::{gmtime_r, time_t, tm};
     let t = secs as time_t;
     let mut result: tm = unsafe { std::mem::zeroed() };
@@ -2853,7 +2857,7 @@ fn libc_gmtime(secs: i64) -> Value {
         Value::number(result.tm_mday as f64),
         Value::number(result.tm_hour as f64),
         Value::number(result.tm_min as f64),
-        Value::number(result.tm_sec as f64),
+        Value::number(result.tm_sec as f64 + frac_sec),
         Value::number(result.tm_wday as f64),
         Value::number(result.tm_yday as f64),
     ]))
@@ -2862,7 +2866,9 @@ fn libc_gmtime(secs: i64) -> Value {
 fn rt_localtime(v: &Value) -> Result<Value> {
     match v {
         Value::Num(n, _) => {
-            let secs = *n as i64;
+            // Same fractional-seconds preservation as gmtime (#436).
+            let secs = n.trunc() as i64;
+            let frac = (n - n.trunc()).abs();
             use libc::{localtime_r, time_t, tm};
             let t = secs as time_t;
             let mut result: tm = unsafe { std::mem::zeroed() };
@@ -2873,7 +2879,7 @@ fn rt_localtime(v: &Value) -> Result<Value> {
                 Value::number(result.tm_mday as f64),
                 Value::number(result.tm_hour as f64),
                 Value::number(result.tm_min as f64),
-                Value::number(result.tm_sec as f64),
+                Value::number(result.tm_sec as f64 + frac),
                 Value::number(result.tm_wday as f64),
                 Value::number(result.tm_yday as f64),
             ])))

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -6571,3 +6571,29 @@ delpaths([["a",1],["a",0]])
 delpaths([["a"],["a","b"]])
 {"a":{"b":1,"c":2},"d":3}
 {"d":3}
+
+# Issue #436: gmtime preserves fractional seconds in tm_sec (jq's behaviour)
+1700000000.5 | gmtime
+null
+[2023,10,14,22,13,20.5,2,317]
+
+# Issue #436: same for sub-second resolution at the start of an epoch second
+0.25 | gmtime | .[5]
+null
+0.25
+
+# Issue #436: integer epoch round-trips unchanged through the new code path
+1700000000 | gmtime
+null
+[2023,10,14,22,13,20,2,317]
+
+# Issue #436: negative-fractional epoch — jq truncates toward zero and adds
+# the absolute fractional offset, so `-1.5` yields sec=59.5 (not 58.5)
+-1.5 | gmtime | .[5]
+null
+59.5
+
+# Issue #436: mktime still drops fractional and round-trips as integer epoch
+1700000000.5 | gmtime | mktime
+null
+1700000000


### PR DESCRIPTION
## Summary

`rt_gmtime` and `rt_localtime` cast the f64 input directly to i64, dropping the fractional seconds before handing off to libc. jq instead preserves the fraction in the `tm_sec` field of the broken-down array.

```
$ echo 1700000000.5 | jq -c 'gmtime'
[2023,10,14,22,13,20.5,2,317]
$ echo 1700000000.5 | jq-jit -c 'gmtime'   # before
[2023,10,14,22,13,20,2,317]
```

Truncate toward zero for the libc call and add the absolute fractional offset back into `tm_sec`. The absolute value matters for negative epochs: `(-1.5) | gmtime | .[5]` is `59.5`, not `58.5` — jq adds `|n - trunc(n)| = 0.5` to the integer-epoch seconds rather than the signed difference.

`mktime` already discards fractional and round-trips as the integer epoch in both jq and jq-jit, so nothing changes there.

Closes #436

## Test plan

- [x] `cargo build --release` zero warnings
- [x] `cargo test --release` all green (regression+5, all suites pass)
- [x] Probed: positive fractional, integer, zero, sub-second epoch, negative-fractional, mktime round-trip — all match jq 1.8.1