### PR TITLE
fix: reject .[:] at parse time (#438)

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1994,6 +1994,12 @@ impl Parser {
                             } else {
                                 Some(self.parse_pipe()?)
                             };
+                            // jq rejects `.[:]` (both bounds absent) at parse
+                            // time; the explicit `.[null:null]` form is fine.
+                            // See #438.
+                            if first.is_none() && second.is_none() {
+                                anyhow::bail!("syntax error, unexpected ']'");
+                            }
                             self.expect(&Token::RBracket)?;
                             let _optional = self.eat(&Token::Question);
                             expr = Expr::Slice {
@@ -2094,6 +2100,9 @@ impl Parser {
                                 } else {
                                     Some(self.parse_pipe()?)
                                 };
+                                if first.is_none() && second.is_none() {
+                                    anyhow::bail!("syntax error, unexpected ']'");
+                                }
                                 self.expect(&Token::RBracket)?;
                                 Ok(Expr::Slice {
                                     expr: Box::new(Expr::Input),

--- a/tests/fuzz_restricted.rs
+++ b/tests/fuzz_restricted.rs
@@ -23,9 +23,6 @@
 //!   their own bug class. The opt-in `fuzz_full.rs` covers
 //!   that surface; this harness keeps errors on stderr so they remain
 //!   in the "both errored → skip" branch.
-//! * `.[:]` — slice with both endpoints absent. jq treats this as a
-//!   syntax error; jq-jit's parser accepts it. Distinct from the
-//!   runtime fast-path bug class this harness chases.
 //! * `..` (recurse) — output ordering is grammar-defined and the
 //!   permutations explode the search space without finding new bugs.
 //! * Float literals in input — jq's number printer normalizes
@@ -160,8 +157,9 @@ enum FilterExpr {
     Identity,
     Field(String),
     Index(i32),
-    /// Half-open slice. `.[:]` (both endpoints absent) is excluded —
-    /// see module docs.
+    /// Half-open slice. The both-bounds-absent form `.[:]` is now a
+    /// parse error in both jq and jq-jit (#438), so the type
+    /// signature still requires the lo bound to be present.
     SliceLo(i32, Option<i32>),
     SliceHi(Option<i32>, i32),
     ArrayConstruct(Vec<FilterExpr>),


### PR DESCRIPTION
## Summary

jq 1.8.1 rejects `.[:]` as a syntax error at parse time. jq-jit's parser accepted it and treated it as `.[null:null]`. Documented as a known carve-out in `tests/fuzz_restricted.rs` but never tracked in an issue. Surfaced by `cargo test --test fuzz_full --ignored`.

```
$ echo '[1,2,3]' | jq -c '.[:]'
jq: error: syntax error, unexpected ']' at <top-level>, line 1, column 4

$ echo '[1,2,3]' | jq-jit -c '.[:]'   # before
[1,2,3]
```

Add the same parse-time check at both `.[…]` parser sites (the top-level Index continuation and the `.[…]` primary). Explicit `.[null:null]` and one-side-omitted forms (`.[1:]`, `.[:2]`) are unaffected; jq accepts those.

Closes #438

## Test plan

- [x] `cargo build --release` zero warnings
- [x] `cargo test --release` all green (regression unchanged, jq off=509/509, fuzz_restricted ok)
- [x] Probed `.[:]`, `.[1:]`, `.[:1]`, `.[1:2]`, `.[null:null]`, `.[null:]`, `.[:null]` against jq 1.8.1 — all match (only `.[:]` errors, others succeed identically)