### PR TITLE
fix: align indexing-error wording with jq 1.8.1 (#440)

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3190,13 +3190,12 @@ pub fn eval_index(base: &Value, key: &Value, optional: bool) -> std::result::Res
             let i = if idx < 0 { (a.len() as i64 + idx) as usize } else { idx as usize };
             Ok(a.get(i).cloned().unwrap_or(Value::Null))
         }
-        (Value::Str(_), Value::Num(n, _)) => {
-            if n.fract() != 0.0 || n.is_nan() || n.is_infinite() {
-                Err(format!("Cannot index string with number ({})", crate::value::format_jq_number(*n)))
-            } else if optional {
+        (Value::Str(_), Value::Num(_, _)) => {
+            // jq's "Cannot index string with number" omits the value (#440).
+            if optional {
                 Err("type error".into())
             } else {
-                Err(format!("Cannot index string with number ({})", crate::value::format_jq_number(*n)))
+                Err("Cannot index string with number".to_string())
             }
         }
         // Null receiver: only string/number/object keys short-circuit to null;
@@ -3209,9 +3208,13 @@ pub fn eval_index(base: &Value, key: &Value, optional: bool) -> std::result::Res
         _ => {
             if optional { Err("type error".into()) }
             else {
+                // jq's "Cannot index X with Y" wording: string keys are
+                // quoted without parens (`with string "k"`), number keys
+                // omit the value entirely (`with number`). See #440 and
+                // `runtime::index_err_desc`.
                 let key_desc = match key {
-                    Value::Str(s) => format!("string (\"{}\")", s),
-                    Value::Num(n, _) => format!("number ({})", crate::value::format_jq_number(*n)),
+                    Value::Str(s) => format!("string \"{}\"", s),
+                    Value::Num(_, _) => "number".to_string(),
                     _ => key.type_name().to_string(),
                 };
                 Err(format!("Cannot index {} with {}", base.type_name(), key_desc))

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2169,11 +2169,13 @@ pub fn rt_setpath(v: &Value, path: &Value, val: &Value) -> Result<Value> {
                     arr[idx] = new_inner;
                     Ok(Value::Arr(Rc::new(arr)))
                 }
-                (Value::Obj(_), Value::Num(n, _)) => {
-                    bail!("Cannot index object with number ({})", crate::value::format_jq_number(*n));
+                (Value::Obj(_), Value::Num(_, _)) => {
+                    // jq: number keys omit the value (#440).
+                    bail!("Cannot index object with number");
                 }
                 (Value::Arr(_), Value::Str(k)) => {
-                    bail!("Cannot index array with string (\"{}\")", k);
+                    // jq: string keys are quoted without parens (#440).
+                    bail!("Cannot index array with string \"{}\"", k);
                 }
                 // Slice assignment: path element is {start: N, end: N}
                 (_, Value::Obj(ObjInner(slice_spec))) if slice_spec.contains_key("start") && slice_spec.contains_key("end") => {
@@ -2221,11 +2223,11 @@ pub fn rt_setpath(v: &Value, path: &Value, val: &Value) -> Result<Value> {
                 (_, Value::Arr(_)) => {
                     bail!("Cannot update field at array index of array");
                 }
-                (Value::Num(_, _), Value::Num(n, _)) => {
-                    bail!("Cannot index number with number ({})", crate::value::format_jq_number(*n));
+                (Value::Num(_, _), Value::Num(_, _)) => {
+                    bail!("Cannot index number with number");
                 }
                 (Value::Num(_, _), Value::Str(k)) => {
-                    bail!("Cannot index number with string (\"{}\")", k);
+                    bail!("Cannot index number with string \"{}\"", k);
                 }
                 _ => bail!("Cannot set path"),
             }
@@ -2298,7 +2300,9 @@ pub fn rt_setpath_mut(v: &mut Value, path: &[Value], val: Value) -> Result<()> {
                 }
                 Ok(())
             } else {
-                bail!("Cannot index {} with number ({})", v.type_name(), crate::value::format_jq_number(*n));
+                // jq: number keys omit the value (#440).
+                let _ = n;
+                bail!("Cannot index {} with number", v.type_name());
             }
         }
         Value::Arr(_) => {

--- a/tests/official/jq.test
+++ b/tests/official/jq.test
@@ -1242,10 +1242,10 @@ def inc(x): x |= .+1; inc(.[].a)
 [null,{"b":0},{"a":0},{"a":null},{"a":[0,1]},{"a":{"b":1}},{"a":[{}]},{"a":[{"c":3}]}]
 {"a":[{"b":5}]}
 {"b":0,"a":[{"b":5}]}
-"Cannot index number with number (0)"
+"Cannot index number with number"
 {"a":[{"b":5}]}
-"Cannot index number with string (\"b\")"
-"Cannot index object with number (0)"
+"Cannot index number with string \"b\""
+"Cannot index object with number"
 {"a":[{"b":5}]}
 {"a":[{"c":3,"b":5}]}
 
@@ -1430,7 +1430,7 @@ null
 # Try/catch and general `?` operator
 [.[]|try if . == 0 then error("foo") elif . == 1 then .a elif . == 2 then empty else . end catch .]
 [0,1,2,3]
-["foo","Cannot index number with string (\"a\")",3]
+["foo","Cannot index number with string \"a\"",3]
 
 [.[]|(.a, .a)?]
 [null,true,{"a":1}]
@@ -2380,7 +2380,7 @@ map(try implode catch .)
 
 try 0[implode] catch .
 []
-"Cannot index number with string (\"\")"
+"Cannot index number with string \"\""
 
 # walk
 walk(.)
@@ -2456,14 +2456,14 @@ null
 
 try ("foobar" | .[1.5]) catch .
 null
-"Cannot index string with number (1.5)"
+"Cannot index string with number"
 
 
 # setpath/2 does not leak the input after an invalid get #2970
 
 try ["ok", setpath([1]; 1)] catch ["ko", .]
 {"hi":"hello"}
-["ko","Cannot index object with number (1)"]
+["ko","Cannot index object with number"]
 
 try fromjson catch .
 "{'a': 123}"

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -6651,3 +6651,31 @@ null
 "a,b,c" | split(",")
 null
 ["a","b","c"]
+
+# Issue #440: indexing error wording — string keys quoted without parens,
+# number keys omit the value entirely. Matches jq 1.8.1's actual format
+# (which the older jq.test corpus was lagging behind).
+try .a catch .
+false
+"Cannot index boolean with string \"a\""
+
+# Issue #440: same for numeric input
+try .a catch .
+5
+"Cannot index number with string \"a\""
+
+# Issue #440: number keys never include the value, even on string targets
+try .[1] catch .
+"hello"
+"Cannot index string with number"
+
+# Issue #440: same on numeric/boolean targets
+try .[1] catch .
+true
+"Cannot index boolean with number"
+
+# Issue #440: setpath shares the same wording (covers the runtime.rs site
+# the field-access fix doesn't reach)
+try setpath([1]; 1) catch .
+{"hi":"hello"}
+"Cannot index object with number"


### PR DESCRIPTION
## Summary

jq's "Cannot index X with Y" wording for the Y side is type-specific:
- **string key** → `with string "k"` (quoted, no parens)
- **number key** → `with number` (no value)
- **other type** → `with <type>` (just the type name)

`runtime::index_err_desc` already follows these rules, but several direct call sites in `eval::eval_field_access`, `eval::eval_index`, and `runtime::rt_setpath` / `rt_setpath_mut` inlined a different formatter that wrapped strings in parens and tagged numbers with the value. After the fix, all three sites match jq.

```
$ echo false | jq -c 'try .a catch .'
"Cannot index boolean with string \"a\""
$ echo false | jq-jit -c 'try .a catch .'   # before
"Cannot index boolean with string (\"a\")"
```

`tests/official/jq.test` had six expected outputs in the older parens-tagged form — that copy of the corpus predates the wording change in upstream jq. Sync them to match jq 1.8.1's actual output.

Iteration errors (`Cannot iterate over X (val)`) are a separate format and unchanged.

Closes #440

## Test plan

- [x] `cargo build --release` zero warnings
- [x] `cargo test --release` all green (jq off=509/509, regression=1283/1283 with 5 new, differential, corpus, fuzz_restricted, selfdiff all pass)
- [x] Probed: `try .a catch .` and `try .[1] catch .` on all primitive types, plus setpath equivalents — all match jq 1.8.1