### PR TITLE
fix: align slice-error wording with jq (#442)

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3549,7 +3549,10 @@ pub fn eval_slice(base: &Value, from: &Value, to: &Value) -> Result<Value> {
             }
         }
         Value::Null => Ok(Value::Null),
-        _ => bail!("cannot slice {}", base.type_name()),
+        // jq treats slice as a path access whose key is the {start, end}
+        // object, so type errors share the "Cannot index X with object"
+        // wording rather than a slice-specific message. See #442.
+        _ => bail!("Cannot index {} with object", base.type_name()),
     }
 }
 

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -6597,3 +6597,25 @@ null
 1700000000.5 | gmtime | mktime
 null
 1700000000
+
+# Issue #442: slice on a non-iterable shares the indexing-error wording —
+# jq treats slice as path access whose key is the {start, end} object.
+try .[:0] catch .
+false
+"Cannot index boolean with object"
+
+# Issue #442: same on numeric input
+try .[1:2] catch .
+5
+"Cannot index number with object"
+
+# Issue #442: same on object input (objects aren't sliceable)
+try .[:0] catch .
+{"a":1}
+"Cannot index object with object"
+
+# Issue #442: arrays/strings/null still slice normally (regression of the
+# success path against the new wording landing on errors)
+.[:2]
+[1,2,3,4]
+[1,2]


### PR DESCRIPTION
## Summary

jq treats slice as a path access whose key is the `{start, end}` descriptor object, so type errors land in the same "Cannot index X with object" wording as `.field` / `.[N]`. jq-jit's `eval_slice` bailed with a custom `"cannot slice <type>"` message.

```
$ echo false | jq -c 'try (.[:0]) catch .'
"Cannot index boolean with object"
$ echo false | jq-jit -c 'try (.[:0]) catch .'   # before
"cannot slice boolean"
```

Same family as #440. Single line change to the `_` arm of `eval_slice`.

Closes #442

## Test plan

- [x] `cargo build --release` zero warnings
- [x] `cargo test --release` all green (regression+4)
- [x] Probed bool/number/object/array/string/null on `try .[:0] catch .` — all match jq 1.8.1