### PR TITLE
fix: split/gsub honour zero-width regex matches (#444)

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1838,9 +1838,19 @@ fn rt_regex_split(v: &Value, re: &Value, flags: &Value) -> Result<Value> {
         (Value::Str(s), Value::Str(r)) => {
             let (pat, _global) = apply_regex_flags(r.as_str(), flags)?;
             with_regex(&pat, |regex| {
-                let parts: Vec<Value> = regex.split(s.as_str())
-                    .map(Value::from_str)
-                    .collect();
+                // jq enumerates an empty match adjacent to a non-empty
+                // one; Rust's `Regex::split` skips it. Walk
+                // `jq_match_spans` instead so the slices line up with
+                // jq's output for zero-width regexes like `a*`. See #444.
+                let s_str = s.as_str();
+                let spans = jq_match_spans(regex, s_str);
+                let mut parts: Vec<Value> = Vec::with_capacity(spans.len() + 1);
+                let mut last = 0;
+                for (start, end) in spans {
+                    parts.push(Value::from_str(&s_str[last..start]));
+                    last = end;
+                }
+                parts.push(Value::from_str(&s_str[last..]));
                 Value::Arr(Rc::new(parts))
             })
         }
@@ -2796,14 +2806,28 @@ pub fn sub_gsub_segments(input: &str, pattern: &str, flags: &Value, global: bool
 
         let has_captures = regex.captures_len() > 1;
         if is_global {
+            // jq enumerates an empty match adjacent to a non-empty one for
+            // zero-width regexes (`a*`, etc.). `captures_iter` /
+            // `find_iter` skip those. Walk `jq_match_spans` so the
+            // segment list matches jq's output. See #444.
+            let spans = jq_match_spans(regex, input);
             if has_captures {
-                for caps in regex.captures_iter(input) {
-                    let m = caps.get(0).unwrap();
-                    process_match(m, Some(&caps));
+                for (start, _end) in spans {
+                    if let Some(caps) = regex.captures_at(input, start) {
+                        if let Some(m) = caps.get(0) {
+                            if m.start() == start {
+                                process_match(m, Some(&caps));
+                            }
+                        }
+                    }
                 }
             } else {
-                for m in regex.find_iter(input) {
-                    process_match(m, None);
+                for (start, _end) in spans {
+                    if let Some(m) = regex.find_at(input, start) {
+                        if m.start() == start {
+                            process_match(m, None);
+                        }
+                    }
                 }
             }
         } else if has_captures {

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -6619,3 +6619,35 @@ try .[:0] catch .
 .[:2]
 [1,2,3,4]
 [1,2]
+
+# Issue #444: split with a zero-width regex emits an empty match adjacent
+# to a non-empty one (jq's libonig behaviour). Without using
+# `jq_match_spans` here, Rust's `Regex::split` collapses them and the
+# array is one element short.
+"abc" | split("a*"; "")
+null
+["","","b","c",""]
+
+# Issue #444: same on `b*` (zero-width match falls between every pair of
+# consecutive characters)
+"abc" | split("b*"; "")
+null
+["","a","","c",""]
+
+# Issue #444: gsub with zero-width regex inserts the replacement at every
+# enumerated position, including the empty match right after a non-empty
+# match
+"abc" | gsub("a*"; "X")
+null
+"XXbXcX"
+
+# Issue #444: sub-only (non-global) keeps existing single-match behaviour
+"abc" | sub("a*"; "X")
+null
+"Xbc"
+
+# Issue #444: regression of the literal-separator path (zero-width fix
+# must not alter the simple split without flags)
+"a,b,c" | split(",")
+null
+["a","b","c"]


### PR DESCRIPTION
## Summary

jq enumerates an empty match adjacent to a non-empty one when the regex can match the empty string (`a*`, `b*`, etc.); Rust's `Regex::split` / `Regex::replace_all` skip that match (their iterators advance by `max(match_len, 1)` to avoid infinite loops). `scan` / `match("...g")` / `capture(...; "g")` already use `jq_match_spans` and get this right — `split` and `sub_gsub_segments` did not.

```
$ echo '"abc"' | jq -c 'split("a*"; "")'
["","","b","c",""]
$ echo '"abc"' | jq-jit -c 'split("a*"; "")'   # before
["","b","c",""]
```

Walk `jq_match_spans` in `rt_regex_split` and the global path of `sub_gsub_segments` so all four regex consumers share the same position enumeration.

Closes #444

## Test plan

- [x] `cargo build --release` zero warnings
- [x] `cargo test --release` all green (regression+5, all suites pass)
- [x] Bench: split/join 0.090s vs v1.4.5 0.098s (-8.2%, noise — literal `split(",")` goes through `rt_split`, not the path I changed)
- [x] Probed `split("a*"; "")`, `gsub("a*"; "X")`, capture-aware `gsub("(?<x>a)"; "[\(.x)]")`, plus the literal-separator fast path — all match jq 1.8.1