### PR TITLE
fix: escape 0x7F (DEL) in JSON string output (#446)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -8,6 +8,14 @@ use std::process;
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
+/// Returns true if `bytes` contains a 0x7F (DEL) byte. jq escapes DEL
+/// the same way it escapes U+0000..U+001F (`` instead of raw),
+/// so byte-copy passthrough paths must bail when this is present (#446).
+#[inline]
+fn raw_contains_del_byte(bytes: &[u8]) -> bool {
+    memchr::memchr(0x7F, bytes).is_some()
+}
+
 #[inline]
 /// Returns true if `bytes` contains a JSON number whose lexical form
 /// would normalise differently from jq's canonical output (e.g. `1e10`
@@ -5796,6 +5804,7 @@ fn real_main() {
                     // (#233); copying bytes through preserves them.
                     let stream_clean = whole_file_compact
                         && !raw_contains_non_canonical_number(content)
+                        && !raw_contains_del_byte(content)
                         && !json_stream_has_duplicate_keys(content);
                     if stream_clean {
                         let _ = out.write_all(content);
@@ -5806,10 +5815,10 @@ fn real_main() {
                             if json_value_has_duplicate_keys(raw) {
                                 let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                                 push_compact_line(&mut compact_buf, &v);
-                            } else if is_json_compact(raw) && !raw_contains_non_canonical_number(raw) {
+                            } else if is_json_compact(raw) && !raw_contains_non_canonical_number(raw) && !raw_contains_del_byte(raw) {
                                 compact_buf.extend_from_slice(raw);
                                 compact_buf.push(b'\n');
-                            } else if !raw_contains_non_canonical_number(raw) {
+                            } else if !raw_contains_non_canonical_number(raw) && !raw_contains_del_byte(raw) {
                                 push_json_compact_raw(&mut compact_buf, raw);
                                 compact_buf.push(b'\n');
                             } else {

--- a/src/value.rs
+++ b/src/value.rs
@@ -1345,7 +1345,8 @@ pub fn json_object_keys_join_to_buf(b: &[u8], pos: usize, sep: &[u8], sorted: bo
     }
     buf.push(b'"');
     // Check if separator needs JSON escaping
-    let sep_needs_escape = sep.iter().any(|&c| c == b'"' || c == b'\\' || c < 0x20);
+    // jq escapes 0x7F (DEL) too, in addition to U+0000..U+001F (#446).
+    let sep_needs_escape = sep.iter().any(|&c| c == b'"' || c == b'\\' || c < 0x20 || c == 0x7F);
     for (idx, &(ks, ke)) in keys_buf.iter().enumerate() {
         if idx > 0 {
             if sep_needs_escape {
@@ -1353,7 +1354,7 @@ pub fn json_object_keys_join_to_buf(b: &[u8], pos: usize, sep: &[u8], sorted: bo
                     match c {
                         b'"' => buf.extend_from_slice(b"\\\""),
                         b'\\' => buf.extend_from_slice(b"\\\\"),
-                        c if c < 0x20 => {
+                        c if c < 0x20 || c == 0x7F => {
                             buf.extend_from_slice(b"\\u00");
                             buf.push(b"0123456789abcdef"[(c >> 4) as usize]);
                             buf.push(b"0123456789abcdef"[(c & 0xf) as usize]);
@@ -1924,7 +1925,8 @@ pub fn json_object_update_field_gsub(
                 b'\n' => buf.extend_from_slice(b"\\n"),
                 b'\r' => buf.extend_from_slice(b"\\r"),
                 b'\t' => buf.extend_from_slice(b"\\t"),
-                c if c < 0x20 => {
+                // jq also escapes 0x7F (DEL) as `` (#446).
+                c if c < 0x20 || c == 0x7F => {
                     buf.extend_from_slice(format!("\\u{:04x}", c).as_bytes());
                 }
                 _ => buf.push(ch),
@@ -2105,7 +2107,8 @@ pub fn json_object_update_field_split_first(
                     b'\n' => buf.extend_from_slice(b"\\n"),
                     b'\r' => buf.extend_from_slice(b"\\r"),
                     b'\t' => buf.extend_from_slice(b"\\t"),
-                    c if c < 0x20 => {
+                    // jq also escapes 0x7F (DEL) (#446).
+                    c if c < 0x20 || c == 0x7F => {
                         buf.extend_from_slice(format!("\\u{:04x}", c).as_bytes());
                     }
                     _ => buf.push(ch),
@@ -2167,7 +2170,8 @@ pub fn json_object_update_field_split_last(
                     b'\n' => buf.extend_from_slice(b"\\n"),
                     b'\r' => buf.extend_from_slice(b"\\r"),
                     b'\t' => buf.extend_from_slice(b"\\t"),
-                    c if c < 0x20 => {
+                    // jq also escapes 0x7F (DEL) (#446).
+                    c if c < 0x20 || c == 0x7F => {
                         buf.extend_from_slice(format!("\\u{:04x}", c).as_bytes());
                     }
                     _ => buf.push(ch),
@@ -2232,7 +2236,8 @@ pub fn json_object_update_field_trim(
                     b'\n' => buf.extend_from_slice(b"\\n"),
                     b'\r' => buf.extend_from_slice(b"\\r"),
                     b'\t' => buf.extend_from_slice(b"\\t"),
-                    c if c < 0x20 => buf.extend_from_slice(format!("\\u{:04x}", c).as_bytes()),
+                    // jq also escapes 0x7F (DEL) (#446).
+                    c if c < 0x20 || c == 0x7F => buf.extend_from_slice(format!("\\u{:04x}", c).as_bytes()),
                     _ => buf.push(ch),
                 }
             }
@@ -2305,7 +2310,8 @@ pub fn json_object_update_field_slice(
                 b'\n' => buf.extend_from_slice(b"\\n"),
                 b'\r' => buf.extend_from_slice(b"\\r"),
                 b'\t' => buf.extend_from_slice(b"\\t"),
-                c if c < 0x20 => buf.extend_from_slice(format!("\\u{:04x}", c).as_bytes()),
+                // jq also escapes 0x7F (DEL) (#446).
+                c if c < 0x20 || c == 0x7F => buf.extend_from_slice(format!("\\u{:04x}", c).as_bytes()),
                 _ => buf.push(ch),
             }
         }
@@ -3807,16 +3813,25 @@ pub fn push_tojson_raw(buf: &mut Vec<u8>, b: &[u8]) {
             b'"' => {
                 buf.extend_from_slice(b"\\\"");
                 i += 1;
-                // Inside JSON string: scan chunks between special chars
+                // Inside JSON string: scan chunks between special chars.
+                // Also break at 0x7F so it can be escaped as `` —
+                // jq escapes DEL the same way it escapes U+0000..U+001F
+                // (#446). Raw 0x00..0x1F never reach this path because the
+                // input parser rejects unescaped control chars.
                 loop {
                     let chunk_start = i;
-                    while i < len && b[i] != b'"' && b[i] != b'\\' { i += 1; }
+                    while i < len && b[i] != b'"' && b[i] != b'\\' && b[i] != 0x7F { i += 1; }
                     if i > chunk_start { buf.extend_from_slice(&b[chunk_start..i]); }
                     if i >= len { break; }
                     if b[i] == b'"' {
                         buf.extend_from_slice(b"\\\"");
                         i += 1;
                         break;
+                    }
+                    if b[i] == 0x7F {
+                        buf.extend_from_slice(b"\\\\u007f");
+                        i += 1;
+                        continue;
                     }
                     // backslash escape sequence
                     buf.extend_from_slice(b"\\\\");

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -6740,3 +6740,16 @@ null
 0e0
 null
 0
+
+# Issue #446: tojson on a string containing 0x7F (DEL) escapes it as
+# ``, matching jq. Without this the byte was passed through raw,
+# producing valid JSON but a stream that didn't match jq byte-for-byte.
+"" | tojson
+null
+"\"\\u007f\""
+
+# Issue #446: identity output also escapes 0x7F (the whole-file
+# passthrough fast path now bails when the input contains DEL).
+. | length
+""
+1


### PR DESCRIPTION
## Summary

JSON RFC 8259 only mandates escaping U+0000..U+001F, but jq's encoder also escapes U+007F as ``. jq-jit's primary string encoders already handled it; two raw-byte fast paths did not:

- `push_tojson_raw` (`src/value.rs`): the per-string-content loop only broke on `"` and `\\`, so 0x7F passed through verbatim.
- whole-file identity passthrough (`src/bin/jq-jit.rs`): copies input bytes straight to stdout, skipping any per-byte transform.

```
$ printf '"\x7f"\n' | jq -c '.'
""
$ printf '"\x7f"\n' | jq-jit -c '.'    # before (raw 0x7F preserved)
```

Patch the tojson loop to break on 0x7F and emit `\\u007f`, and add a `raw_contains_del_byte` guard (memchr — SIMD, ~2 GB/s) on the whole-file and per-line passthrough sites so any input with DEL falls through to the proper encoder.

Closes #446

## Test plan

- [x] `cargo build --release` zero warnings
- [x] `cargo test --release` all green (regression+2)
- [x] Bench: identity -c 0.081s vs v1.4.5 0.081s (flat — typical NDJSON has no DEL bytes, memchr is just a SIMD prepass); split/@csv/etc. flat or faster
- [x] Probed `"\x7F"`, `"a\x7Fb"` on `.`, `tojson`, `tostring`, `. + ""` — all match jq 1.8.1 byte-for-byte