### PR TITLE
fix: to_entries error wording matches jq's keys (#448)

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1558,7 +1558,9 @@ fn rt_to_entries(v: &Value) -> Result<Value> {
             }).collect();
             Ok(Value::Arr(Rc::new(entries)))
         }
-        _ => bail!("{} has no entries", v.type_name()),
+        // jq implements `to_entries` on top of `keys`, so the error
+        // wording is shared: `<type> (<value>) has no keys`. See #448.
+        _ => bail!("{} has no keys", errdesc(v)),
     }
 }
 

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -6753,3 +6753,19 @@ null
 . | length
 ""
 1
+
+# Issue #448: to_entries error wording matches jq's `keys` (since jq
+# implements to_entries on top of keys, the error is shared).
+try to_entries catch .
+null
+"null (null) has no keys"
+
+# Issue #448: same on numeric input
+try to_entries catch .
+5
+"number (5) has no keys"
+
+# Issue #448: same on string input — value tag is JSON-quoted
+try to_entries catch .
+"x"
+"string (\"x\") has no keys"


### PR DESCRIPTION
## Summary

jq implements `to_entries` on top of `keys`, so type errors share the wording: `<type> (<value>) has no keys`. jq-jit bailed with `<type> has no entries` (missing value tag, wrong noun). `rt_to_entries` now uses `errdesc(v)` like the other `keys` family functions.

```
$ echo null | jq -c 'try to_entries catch .'
"null (null) has no keys"
$ echo null | jq-jit -c 'try to_entries catch .'   # before
"null has no entries"
```

Closes #448

## Test plan

- [x] `cargo build --release` zero warnings
- [x] `cargo test --release` all green (regression+3)
- [x] Probed null/true/5/"x" — all match jq; arrays + objects unchanged