### PR TITLE
fix: min/max/sort/unique wording matches jq (#450)

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1019,7 +1019,9 @@ fn rt_sort(v: &Value) -> Result<Value> {
             sort_values(&mut sorted);
             Ok(Value::Arr(Rc::new(sorted)))
         }
-        _ => bail!("{} is not an array", v.type_name()),
+        // jq's wording: `<type> (<value>) cannot be sorted, as it is not
+        // an array`. Same for unique. See #450.
+        _ => bail!("{} cannot be sorted, as it is not an array", errdesc(v)),
     }
 }
 
@@ -1121,7 +1123,8 @@ fn rt_unique(v: &Value) -> Result<Value> {
             sorted.dedup_by(|a, b| values_equal(a, b));
             Ok(Value::Arr(Rc::new(sorted)))
         }
-        _ => bail!("{} is not an array", v.type_name()),
+        // Shares wording with `sort` (#450).
+        _ => bail!("{} cannot be sorted, as it is not an array", errdesc(v)),
     }
 }
 
@@ -1137,7 +1140,9 @@ fn rt_min(v: &Value) -> Result<Value> {
             }
             Ok(min.clone())
         }
-        _ => bail!("{} is not an array", v.type_name()),
+        // jq's wording for min/max — implemented as a fold that compares
+        // pairs, so the value appears twice. See #450.
+        _ => bail!("{} and {} cannot be iterated over", errdesc(v), errdesc(v)),
     }
 }
 
@@ -1153,7 +1158,8 @@ fn rt_max(v: &Value) -> Result<Value> {
             }
             Ok(max.clone())
         }
-        _ => bail!("{} is not an array", v.type_name()),
+        // Shares wording with min (#450).
+        _ => bail!("{} and {} cannot be iterated over", errdesc(v), errdesc(v)),
     }
 }
 

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -6679,3 +6679,29 @@ true
 try setpath([1]; 1) catch .
 {"hi":"hello"}
 "Cannot index object with number"
+
+# Issue #450: min/max wording mirrors jq's fold-based implementation —
+# the value appears twice ("X and X cannot be iterated over").
+try min catch .
+{"a":1}
+"object ({\"a\":1}) and object ({\"a\":1}) cannot be iterated over"
+
+# Issue #450: same for max
+try max catch .
+5
+"number (5) and number (5) cannot be iterated over"
+
+# Issue #450: sort/unique use "cannot be sorted, as it is not an array"
+try sort catch .
+{"a":1}
+"object ({\"a\":1}) cannot be sorted, as it is not an array"
+
+# Issue #450: same for unique
+try unique catch .
+"hello"
+"string (\"hello\") cannot be sorted, as it is not an array"
+
+# Issue #450: array still works (regression of the success path)
+[3,1,2] | sort
+null
+[1,2,3]


### PR DESCRIPTION
## Summary

Two distinct phrasings to align:
- `min`/`max` → `<type> (<v>) and <type> (<v>) cannot be iterated over` (fold-style, value twice)
- `sort`/`unique` → `<type> (<v>) cannot be sorted, as it is not an array`

jq-jit emitted a generic `<type> is not an array` for both. The `*_by(f)` family uses a third wording that mentions the key array — out of scope here, follow-up if needed.

```
$ echo '{"a":1}' | jq -c 'try min catch .'
"object ({\"a\":1}) and object ({\"a\":1}) cannot be iterated over"
$ echo '{"a":1}' | jq-jit -c 'try min catch .'   # before
"object is not an array"
```

Closes #450

## Test plan

- [x] `cargo build --release` zero warnings
- [x] `cargo test --release` all green (regression+5)
- [x] Probed null/bool/number/string/object on min/max/sort/unique — all match jq; array success path unchanged