### PR TITLE
fix: preserve all-zero mantissa scientific literals (#452)

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -477,14 +477,21 @@ fn normalize_num_repr(s: &str) -> String {
         let first_sig = digits.iter().position(|c| *c != '0').unwrap_or(digits.len());
 
         if first_sig >= digits.len() {
-            // All-zero mantissa. Drop the exponent and the leading sign;
-            // preserve fractional shape so `0.0e0` stays `0.0`, not `0`.
-            if frac_part.is_empty() {
-                return "0".to_string();
+            // All-zero mantissa. jq's decnum keeps the explicit-exponent
+            // form: `0e1` → `0E+1`, `0e-1` → `0.0`, `0.0e-1` → `0.00`,
+            // `-0e10` → `-0E+10`. Hand the canonical normalisation off to
+            // `normalize_jq_repr`'s all-zero branch (#452).
+            if exp >= 1 {
+                return format!("{}0E+{}", sign, exp);
             }
-            let mut out = String::with_capacity(2 + frac_part.len());
+            let total_zeros = (frac_part.len() as i64) - exp;
+            if total_zeros <= 0 {
+                return format!("{}0", sign);
+            }
+            let mut out = String::with_capacity(2 + total_zeros as usize);
+            out.push_str(sign);
             out.push_str("0.");
-            for _ in 0..frac_part.len() {
+            for _ in 0..total_zeros {
                 out.push('0');
             }
             return out;

--- a/src/value.rs
+++ b/src/value.rs
@@ -5348,11 +5348,27 @@ pub fn normalize_jq_repr(repr: &str) -> Option<String> {
     }
     let leading_zeros = combined.bytes().take_while(|&b| b == b'0').count();
     if leading_zeros == combined.len() {
-        // Pure-zero value: jq keeps the explicit-exponent form when present
-        // (`0e10` → `0E+10`, `-0e10` → `-0E+10`) but folds plain `0.0` etc.
+        // Pure-zero value: jq keeps the explicit-exponent form when present.
+        // `0e10`  → `0E+10` (positive exp stays scientific)
+        // `0e-1`  → `0.0`   (negative exp expands to decimal — N+frac zeros)
+        // `0.0e-1` → `0.00` (frac digits add to the zero count)
+        // `0.0e0` → `0.0`   (no exp shift, drop the `e0`)
+        // See #452.
         if let Some(_) = e_pos {
-            let s = if exp >= 0 { '+' } else { '-' };
-            return Some(format!("{}0E{}{}", sign, s, exp.abs()));
+            if exp >= 1 {
+                return Some(format!("{}0E+{}", sign, exp));
+            }
+            // exp <= 0: expand to decimal `0.000...0` with `mant_frac.len() - exp` zeros.
+            // exp == 0 with no frac → "0"; exp == 0 with frac → keep frac zeros.
+            let total_zeros = (mant_frac.len() as i64) - exp as i64;
+            if total_zeros <= 0 {
+                return Some(format!("{}0", sign));
+            }
+            let mut s = String::with_capacity(2 + total_zeros as usize);
+            s.push_str(sign);
+            s.push_str("0.");
+            for _ in 0..total_zeros { s.push('0'); }
+            return Some(s);
         }
         return None;
     }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -6705,3 +6705,38 @@ try unique catch .
 [3,1,2] | sort
 null
 [1,2,3]
+
+# Issue #452: all-zero mantissa with positive exponent stays scientific
+0e1
+null
+0E+1
+
+# Issue #452: all-zero with negative exponent expands to decimal
+0e-1
+null
+0.0
+
+# Issue #452: more zeros for larger negative exponent
+0e-2
+null
+0.00
+
+# Issue #452: existing fractional zeros add to the expansion count
+0.0e-1
+null
+0.00
+
+# Issue #452: zero-mantissa preserves frac shape when exp == 0
+0.0e0
+null
+0.0
+
+# Issue #452: negative-zero preserves the form (sign already canonical)
+-0e10
+null
+0E+10
+
+# Issue #452: existing 0e0 still folds to plain `0`
+0e0
+null
+0


### PR DESCRIPTION
## Summary

jq's decnum keeps all-zero mantissa scientific literals through identity ops:
- `0e1` → `0E+1` (positive stays scientific)
- `0e-1` → `0.0`, `0e-2` → `0.00` (negative expands to decimal)
- `0.0e-1` → `0.00` (frac digits add to expansion)

jq-jit's `normalize_jq_repr` only emitted scientific (`0E-N`) for negative exp; `normalize_num_repr` dropped the exponent entirely on the all-zero branch. Both now expand to `0.<N+frac zeros>` when exp ≤ 0 and stay scientific when exp ≥ 1.

```
$ echo null | jq -c '0e-1'
0.0
$ echo null | jq-jit -c '0e-1'   # before
0
```

Closes #452

## Test plan

- [x] `cargo build --release` zero warnings
- [x] `cargo test --release` all green (regression+7)
- [x] Probed `0e-1`, `0e1`, `0e0`, `0e-2`, `0.0e-1`, `0.0e0`, `-0e10`, `-0e-1`, `-0.0e-2`, `0.00e0`, `0.00e-1`, `-0e1` — all match jq 1.8.1