### PR TITLE
fix: preserve number repr in division-by-zero error wording

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -531,14 +531,24 @@ pub fn call_builtin(name: &str, args: &[Value]) -> Result<Value> {
 pub fn errdesc_pub(v: &Value) -> String { errdesc(v) }
 
 fn errdesc(v: &Value) -> String {
-    // For numbers, use Rust's decimal Display (not scientific notation)
-    // so error messages show "12345678901234568000000000..." like jq does.
+    // For numbers, prefer the canonical form of the original repr (so
+    // `1.0` stays `"1.0"`, `1e30` becomes `"1E+30"` matching jq's decnum
+    // output) — but only when the repr round-trips exactly through f64.
+    // For repr that can't round-trip (e.g. 25+ digit literals) and for
+    // computed values without a repr, fall back to Rust's decimal Display
+    // so huge magnitudes show "12345678901234568000000000..." like jq's
+    // non-decnum form does.
     let json = match v {
-        Value::Num(n, _) => {
+        Value::Num(n, NumRepr(repr)) => {
             if n.is_nan() { "null".to_string() }
             else if n.is_infinite() {
                 if n.is_sign_positive() { "1.7976931348623157e+308".to_string() }
                 else { "-1.7976931348623157e+308".to_string() }
+            } else if let Some(canon) = repr.as_ref()
+                .filter(|r| crate::value::is_valid_json_number(r) && crate::value::repr_is_exact_for_f64(r, *n))
+                .map(|r| crate::value::canonical_repr_bytes(r).into_owned())
+            {
+                canon
             } else if *n == 0.0 {
                 if n.is_sign_negative() { "-0".to_string() } else { "0".to_string() }
             } else if *n == n.trunc() && n.abs() < 1e16 {

--- a/src/value.rs
+++ b/src/value.rs
@@ -5534,7 +5534,7 @@ fn push_value_tojson(v: &Value, out: &mut String, depth: usize) {
 /// True iff `repr` (a JSON-valid decimal literal) represents a value that f64
 /// can hold exactly. Rejects mantissas with more than 15 significant decimal
 /// digits and exponents outside f64's dynamic range.
-fn repr_is_exact_for_f64(repr: &str, n: f64) -> bool {
+pub(crate) fn repr_is_exact_for_f64(repr: &str, n: f64) -> bool {
     if !n.is_finite() { return false; }
     let bytes = repr.as_bytes();
     let mut i = 0;

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -6828,3 +6828,43 @@ null
 try pow(.; 2) catch .
 "x"
 "string (\"x\") number required"
+
+# Issue #460: division-by-zero error preserves the original number repr.
+# Was: jq-jit dropped trailing `.0`/`E+` and emitted `"number (1)"` even
+# when the literal was `1.0`. Now uses canonical_repr_bytes when the
+# literal round-trips exactly through f64 (so `1.0` stays `1.0`,
+# `1e30` becomes `1E+30`).
+try (1.0 / 0) catch .
+null
+"number (1.0) and number (0) cannot be divided because the divisor is zero"
+
+# Issue #460: divisor-side repr is also preserved
+try (1 / 0.0) catch .
+null
+"number (1) and number (0.0) cannot be divided because the divisor is zero"
+
+# Issue #460: scientific literal canonicalizes to uppercase E+
+try (1e30 / 0) catch .
+null
+"number (1E+30) and number (0) cannot be divided because the divisor is zero"
+
+# Issue #460: 0E+10 keeps its repr, not collapsed to 0
+try (0e10 / 0) catch .
+null
+"number (0E+10) and number (0) cannot be divided because the divisor is zero"
+
+# Issue #460: 0.0 (not -0.0) stays "0.0" — jq prints positive zero with
+# the original repr's decimal form.
+try (0.0 / 0) catch .
+null
+"number (0.0) and number (0) cannot be divided because the divisor is zero"
+
+# Issue #460: -0.0 strips the sign in jq's errdesc (matches its behavior)
+try (-0.0 / 0) catch .
+null
+"number (0.0) and number (0) cannot be divided because the divisor is zero"
+
+# Issue #460: same wording reuse path — modulo-by-zero
+try (1.5 % 0) catch .
+null
+"number (1.5) and number (0) cannot be divided (remainder) because the divisor is zero"


### PR DESCRIPTION
## Summary

- `errdesc` (the helper that formats `<type> (<v>)` in error messages) now keeps the user's original number repr when it round-trips exactly through f64. So `1.0 / 0` produces `"number (1.0) and number (0) ..."` instead of dropping the trailing `.0`. Same for `0.0`, `0E+10`, `1E+30`, etc.
- Long literals that can't round-trip (e.g. `12345678901234567890123456...`) still fall through to the existing f64 Display path so the official `tests/official/jq.test:1984` non-decnum branch keeps passing.
- 7 regression cases added under `# Issue #460`.

Spotted a related but separate divergence — jq truncates the value preview at 14 chars; jq-jit at 28. Filed as #465.

Closes #460

## Test plan

- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (all suites pass: official 509, regression, fuzz_restricted, selfdiff)
- [x] `./bench/comprehensive.sh` (no regression vs latest baseline)
- [x] Spot-checked `try (X / 0) catch .` for `1.0`, `1.5`, `0.0`, `-0.0`, `0e0`, `0e10`, `1e20`, `1e30` against jq 1.8.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)