### PR TITLE
fix: align tonumber error wording with jq

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1383,11 +1383,11 @@ fn rt_tonumber(v: &Value) -> Result<Value> {
         Value::Str(s) => {
             let s_ref: &str = s.as_ref();
             if s_ref.is_empty() {
-                bail!("Cannot convert empty string to number");
+                bail!("{} cannot be parsed as a number", errdesc(v));
             }
             // jq rejects leading/trailing whitespace
             if s_ref.as_bytes()[0].is_ascii_whitespace() || s_ref.as_bytes()[s_ref.len()-1].is_ascii_whitespace() {
-                bail!("Invalid numeric literal: {}", crate::value::value_to_json(v));
+                bail!("{} cannot be parsed as a number", errdesc(v));
             }
             // Strip leading '+' for compatibility with jq
             let parse_str = s_ref.strip_prefix('+').unwrap_or(s_ref);
@@ -1406,7 +1406,7 @@ fn rt_tonumber(v: &Value) -> Result<Value> {
                         Ok(Value::number(n))
                     }
                 }
-                Err(_) => bail!("Invalid numeric literal: {}", crate::value::value_to_json(v)),
+                Err(_) => bail!("{} cannot be parsed as a number", errdesc(v)),
             }
         }
         _ => bail!("{} cannot be parsed as a number", errdesc(v)),

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -6868,3 +6868,37 @@ null
 try (1.5 % 0) catch .
 null
 "number (1.5) and number (0) cannot be divided (remainder) because the divisor is zero"
+
+# Issue #464: tonumber error wording matches jq's uniform
+# `string ({}) cannot be parsed as a number` (was: jq-jit had three
+# different wordings — "Cannot convert empty string to number",
+# "Invalid numeric literal: ..." for whitespace, and the same for
+# parse failures).
+"" | try tonumber catch .
+null
+"string (\"\") cannot be parsed as a number"
+
+# Issue #464: leading whitespace is rejected with the same wording
+" " | try tonumber catch .
+null
+"string (\" \") cannot be parsed as a number"
+
+# Issue #464: trailing whitespace
+"1 " | try tonumber catch .
+null
+"string (\"1 \") cannot be parsed as a number"
+
+# Issue #464: parse failure on bare sign
+"+" | try tonumber catch .
+null
+"string (\"+\") cannot be parsed as a number"
+
+# Issue #464: parse failure on bare exponent prefix
+"1e" | try tonumber catch .
+null
+"string (\"1e\") cannot be parsed as a number"
+
+# Issue #464: alphabetic-only string
+"abc" | try tonumber catch .
+null
+"string (\"abc\") cannot be parsed as a number"


### PR DESCRIPTION
## Summary

- `tonumber` had three jq-jit-specific wordings ("Cannot convert empty string to number", and two variants of "Invalid numeric literal: ...") for empty / whitespace / parse-failure inputs. jq 1.8.1 uses a single uniform `string ({}) cannot be parsed as a number` for all three.
- All three paths now route through the existing `errdesc` helper.
- 6 regression cases added under `# Issue #464`.

Closes #464

## Test plan

- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (all suites pass)
- [x] `./bench/comprehensive.sh` (no regression)
- [x] Spot-checked `try (X | tonumber) catch .` against jq 1.8.1 for `""`, `" "`, `" 1"`, `"1 "`, `"abc"`, `"+"`, `"-"`, `"e"`, `"1e"`, `"e1"`, `"+1"`, `"01"`, `"1."`, `".1"`, `"1.5"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)