### PR TITLE
fix: dispatch .[{start,end}] as slice on array/string

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3198,6 +3198,30 @@ pub fn eval_index(base: &Value, key: &Value, optional: bool) -> std::result::Res
                 Err("Cannot index string with number".to_string())
             }
         }
+        // jq dispatches `.[obj]` on an array or string as a slice when the
+        // object has both `start` and `end` keys (each being a number or
+        // null). Otherwise it errors with the slice-indices wording — even
+        // when the base is null. See #463.
+        (Value::Arr(_), Value::Obj(ObjInner(spec)))
+        | (Value::Str(_), Value::Obj(ObjInner(spec))) => {
+            let start = spec.get("start");
+            let end = spec.get("end");
+            match (start, end) {
+                (Some(s), Some(e)) => {
+                    let valid = matches!(s, Value::Num(_, _) | Value::Null)
+                        && matches!(e, Value::Num(_, _) | Value::Null);
+                    if !valid {
+                        if optional { return Err("type error".into()); }
+                        return Err("Array/string slice indices must be integers".to_string());
+                    }
+                    eval_slice(base, s, e).map_err(|e| e.to_string())
+                }
+                _ => {
+                    if optional { Err("type error".into()) }
+                    else { Err("Array/string slice indices must be integers".to_string()) }
+                }
+            }
+        }
         // Null receiver: only string/number/object keys short-circuit to null;
         // null/bool/array keys still raise the same type error jq emits on a
         // non-null base (#193). The keys here mirror what jq's `.[$k]` accepts

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -6902,3 +6902,45 @@ null
 "abc" | try tonumber catch .
 null
 "string (\"abc\") cannot be parsed as a number"
+
+# Issue #463: `.[{start, end}]` on an array dispatches to a slice (was:
+# "Cannot index array with object" because the obj-key path errored
+# before checking for a slice spec).
+[1,2,3,4,5] | .[{start:1,end:3}]
+null
+[2,3]
+
+# Issue #463: same on a string
+"abcde" | .[{start:1,end:3}]
+null
+"bc"
+
+# Issue #463: null start = 0, null end = len (whole-array slice)
+[1,2,3] | .[{start:null,end:null}]
+null
+[1,2,3]
+
+# Issue #463: fractional start/end use floor / ceil like jq's slice
+[1,2,3,4,5] | .[{start:1.5,end:3.5}]
+null
+[2,3,4]
+
+# Issue #463: empty obj is not a slice spec — emit jq's wording
+try ([1,2,3] | .[{}]) catch .
+null
+"Array/string slice indices must be integers"
+
+# Issue #463: missing end → not a slice → wording
+try ([1,2,3] | .[{start:0}]) catch .
+null
+"Array/string slice indices must be integers"
+
+# Issue #463: non-numeric start → wording (the slice path validates types)
+try ([1,2,3] | .[{start:"x",end:2}]) catch .
+null
+"Array/string slice indices must be integers"
+
+# Issue #463: same wording for string receiver
+try ("abcde" | .[{a:1}]) catch .
+null
+"Array/string slice indices must be integers"


### PR DESCRIPTION
## Summary

- `eval_index` previously errored with `"Cannot index array with object"` whenever the key was an object on an array or string base. jq actually treats `.[{start, end}]` as a slice when the object has both keys (numeric or null), and emits `"Array/string slice indices must be integers"` for any other shape. So `[1,2,3,4,5] | .[{start:1,end:3}]` was erroring instead of returning `[2,3]`.
- Now the array/string + object branch:
  1. checks for both `start` and `end` keys with number/null values,
  2. invokes the existing `eval_slice` helper when the spec is well-formed,
  3. otherwise emits jq's `Array/string slice indices must be integers` wording.
- 8 regression cases added under `# Issue #463` covering both correct slices and invalid spec wordings.

Closes #463

## Test plan

- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (all suites pass)
- [x] `./bench/comprehensive.sh` (no regression)
- [x] Spot-checked `.[{start, end}]` shapes (well-formed, missing-key, non-numeric) and string receivers against jq 1.8.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)