### PR TITLE
fix: align sub/gsub and startswith/endswith error wording with jq

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -2909,8 +2909,14 @@ pub fn eval(
             eval(input_expr, input.clone(), env, &mut |s| {
                 eval(re, input.clone(), env, &mut |rv| {
                     eval(flags, input.clone(), env, &mut |fv| {
-                        let input_str = s.as_str().ok_or_else(|| anyhow::anyhow!("sub/gsub input must be string"))?;
-                        let re_str = rv.as_str().ok_or_else(|| anyhow::anyhow!("sub/gsub regex must be string"))?;
+                        let input_str = s.as_str().ok_or_else(|| anyhow::anyhow!(
+                            "{} cannot be matched, as it is not a string",
+                            crate::runtime::errdesc_pub(&s),
+                        ))?;
+                        let re_str = rv.as_str().ok_or_else(|| anyhow::anyhow!(
+                            "{} is not a string",
+                            crate::runtime::errdesc_pub(&rv),
+                        ))?;
                         let segments = crate::runtime::sub_gsub_segments(input_str, re_str, &fv, is_global)?;
                         let mut result = String::new();
                         for seg in &segments {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1728,14 +1728,14 @@ fn value_contains(a: &Value, b: &Value) -> bool {
 fn rt_startswith(v: &Value, prefix: &Value) -> Result<Value> {
     match (v, prefix) {
         (Value::Str(s), Value::Str(p)) => Ok(Value::from_bool(s.starts_with(p.as_str()))),
-        _ => bail!("startswith requires strings"),
+        _ => bail!("startswith() requires string inputs"),
     }
 }
 
 fn rt_endswith(v: &Value, suffix: &Value) -> Result<Value> {
     match (v, suffix) {
         (Value::Str(s), Value::Str(p)) => Ok(Value::from_bool(s.ends_with(p.as_str()))),
-        _ => bail!("endswith requires strings"),
+        _ => bail!("endswith() requires string inputs"),
     }
 }
 

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -6944,3 +6944,67 @@ null
 try ("abcde" | .[{a:1}]) catch .
 null
 "Array/string slice indices must be integers"
+
+# Issue #471: sub/gsub on non-string input emits jq's
+# `<errdesc> cannot be matched, as it is not a string` wording
+# (was: generic "sub/gsub input must be string").
+try (null | sub("a"; "b")) catch .
+null
+"null (null) cannot be matched, as it is not a string"
+
+# Issue #471: same wording for arrays
+try ([1] | sub("a"; "b")) catch .
+null
+"array ([1]) cannot be matched, as it is not a string"
+
+# Issue #471: same for objects
+try ({a:1} | sub("a"; "b")) catch .
+null
+"object ({\"a\":1}) cannot be matched, as it is not a string"
+
+# Issue #471: same for numbers
+try (5 | sub("a"; "b")) catch .
+null
+"number (5) cannot be matched, as it is not a string"
+
+# Issue #471: gsub follows the same path
+try (null | gsub("a"; "b")) catch .
+null
+"null (null) cannot be matched, as it is not a string"
+
+# Issue #471: regex arg uses jq's `<errdesc> is not a string` wording
+# (different from the input-side wording).
+try ("abc" | sub(123; "y")) catch .
+null
+"number (123) is not a string"
+
+# Issue #471: regex arg null
+try ("abc" | sub(null; "y")) catch .
+null
+"null (null) is not a string"
+
+# Issue #472: startswith error wording matches jq
+# (was: "startswith requires strings"; jq: "startswith() requires string inputs")
+try (1 | startswith("x")) catch .
+null
+"startswith() requires string inputs"
+
+# Issue #472: same on object input
+try ({a:1} | startswith("x")) catch .
+null
+"startswith() requires string inputs"
+
+# Issue #472: arg side also gets the same wording
+try ("abc" | startswith(123)) catch .
+null
+"startswith() requires string inputs"
+
+# Issue #472: endswith follows the same shape
+try (1 | endswith("x")) catch .
+null
+"endswith() requires string inputs"
+
+# Issue #472: endswith arg side
+try ("abc" | endswith(123)) catch .
+null
+"endswith() requires string inputs"


### PR DESCRIPTION
## Summary

Bundles two related wording fixes (both pure error-message changes, no semantic changes):

- **#471** — `sub`/`gsub` on non-string input now emits `<errdesc> cannot be matched, as it is not a string` (jq 1.8.1's wording) instead of the generic `sub/gsub input must be string`. Non-string regex argument uses jq's parallel `<errdesc> is not a string`.
- **#472** — `startswith`/`endswith` on non-string input now emit `startswith() requires string inputs` / `endswith() requires string inputs` (jq's parens + "inputs"). `ltrimstr` / `rtrimstr` already used the right wording, this just brings the underlying builtins in line.

12 regression cases added under the two issue numbers.

Closes #471
Closes #472

## Test plan

- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (all suites pass)
- [x] `./bench/comprehensive.sh` (no regression)
- [x] Spot-checked input-side and arg-side bad types against jq 1.8.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)