### PR TITLE
fix: align has/in error wording with jq

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1672,7 +1672,7 @@ fn rt_has(v: &Value, key: &Value) -> Result<Value> {
             Ok(Value::from_bool((idx as usize) < a.len()))
         }
         (Value::Null, _) => Ok(Value::False),
-        _ => bail!("{} ({}) and {} ({}) cannot be has-tested", v.type_name(), crate::value::value_to_json(v), key.type_name(), crate::value::value_to_json(key)),
+        _ => bail!("Cannot check whether {} has a {} key", v.type_name(), key.type_name()),
     }
 }
 

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -7008,3 +7008,46 @@ null
 try ("abc" | endswith(123)) catch .
 null
 "endswith() requires string inputs"
+
+# Issue #454: has/in error wording matches jq's
+# `Cannot check whether <type> has a <type> key` (was:
+# "X (v) and Y (v) cannot be has-tested" — different shape and including
+# values).
+try (1 | has(0)) catch .
+null
+"Cannot check whether number has a number key"
+
+# Issue #454: string receiver
+try ("x" | has(0)) catch .
+null
+"Cannot check whether string has a number key"
+
+# Issue #454: string key on number
+try (1 | has("k")) catch .
+null
+"Cannot check whether number has a string key"
+
+# Issue #454: array receiver with non-number key
+try ([1,2,3] | has("x")) catch .
+null
+"Cannot check whether array has a string key"
+
+# Issue #454: object receiver with non-string key
+try ({a:1} | has(0)) catch .
+null
+"Cannot check whether object has a number key"
+
+# Issue #454: in/2 reuses has internally → same wording
+try (0 | in(1)) catch .
+null
+"Cannot check whether number has a number key"
+
+# Issue #454: null receiver still short-circuits to false (no error)
+null | has(0)
+null
+false
+
+# Issue #454: null receiver with string key
+null | has("a")
+null
+false


### PR DESCRIPTION
## Summary

- Replace `<type> (<v>) and <type> (<v>) cannot be has-tested` with jq's `Cannot check whether <type> has a <type> key`. Just type names, no value previews.
- `in/2` is defined as `. as \$k | x | has(\$k)`, so it picks up the same wording automatically.
- Null-receiver short-circuit (`null | has(_)` → `false`) preserved — only error path changed.
- 8 regression cases added under `# Issue #454` covering all the type-pair shapes.

Closes #454

## Test plan

- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (all suites pass)
- [x] `./bench/comprehensive.sh` (no regression)
- [x] Spot-checked all type-pair combinations (number / string / array / object / boolean) against jq 1.8.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)