### PR TITLE
fix: align split error wording with jq

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1852,7 +1852,7 @@ fn rt_split(v: &Value, sep: &Value) -> Result<Value> {
                 Ok(Value::Arr(Rc::new(parts)))
             }
         }
-        _ => bail!("split requires strings"),
+        _ => bail!("split input and separator must be strings"),
     }
 }
 
@@ -1877,7 +1877,8 @@ fn rt_regex_split(v: &Value, re: &Value, flags: &Value) -> Result<Value> {
                 Value::Arr(Rc::new(parts))
             })
         }
-        _ => bail!("split requires strings"),
+        // Two-arg split shares the regex error wording with sub/gsub/scan/match.
+        _ => bail!("{} cannot be matched, as it is not a string", errdesc(v)),
     }
 }
 

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -7051,3 +7051,34 @@ false
 null | has("a")
 null
 false
+
+# Issue #455: split error wording matches jq
+# (single-arg form: "split input and separator must be strings")
+try (null | split(",")) catch .
+null
+"split input and separator must be strings"
+
+# Issue #455: same on number input
+try (5 | split(",")) catch .
+null
+"split input and separator must be strings"
+
+# Issue #455: separator-side bad type
+try ("abc" | split(123)) catch .
+null
+"split input and separator must be strings"
+
+# Issue #455: two-arg regex form uses sub/gsub-style wording
+try (null | split("a"; "")) catch .
+null
+"null (null) cannot be matched, as it is not a string"
+
+# Issue #455: same wording for number input on regex form
+try (5 | split("a"; "g")) catch .
+null
+"number (5) cannot be matched, as it is not a string"
+
+# Issue #455: object input on regex form
+try ({} | split("a"; "g")) catch .
+null
+"object ({}) cannot be matched, as it is not a string"


### PR DESCRIPTION
## Summary

- Single-arg `split(sep)` on non-string input/separator now emits `"split input and separator must be strings"` (jq 1.8.1's wording) instead of `"split requires strings"`.
- Two-arg `split(re; flags)` on non-string input shares the regex builtins' wording: `"<errdesc> cannot be matched, as it is not a string"` — matching what `sub`/`gsub`/`scan`/`match` use.
- 6 regression cases added under `# Issue #455`.

Closes #455

## Test plan

- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (all suites pass)
- [x] `./bench/comprehensive.sh` running — no regression so far
- [x] Spot-checked both forms across `null`/`number`/`array`/`object`/`bool` inputs and bad separators

🤖 Generated with [Claude Code](https://claude.com/claude-code)