### PR TITLE
fix: align halt_error/1 wording with jq's errdesc(input) prefix

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -4325,7 +4325,10 @@ fn eval_call_builtin(name: &str, args: &[Expr], input: Value, env: &EnvRef, cb: 
             return eval(&args[0], input.clone(), env, &mut |code_val| {
                 let code = match &code_val {
                     Value::Num(n, _) => *n as i32,
-                    _ => bail!("halt_error/1: exit code must be a number"),
+                    _ => bail!(
+                        "{} halt_error/1: number required",
+                        crate::runtime::errdesc_pub(&input)
+                    ),
                 };
                 halt_error_write(&input);
                 bail!("__halt__:{}", code);

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -7113,3 +7113,48 @@ null
 try (null | all) catch .
 null
 "Cannot iterate over null (null)"
+
+# Issue #470: halt_error/1 with non-number arg uses errdesc(input) prefix
+try halt_error("y") catch .
+null
+"null (null) halt_error/1: number required"
+
+# Issue #470: halt_error/1 with non-number arg, number input
+try halt_error("y") catch .
+0
+"number (0) halt_error/1: number required"
+
+# Issue #470: halt_error/1 with non-number arg, string input
+try halt_error("y") catch .
+"x"
+"string (\"x\") halt_error/1: number required"
+
+# Issue #470: halt_error/1 with non-number arg, array input
+try halt_error("y") catch .
+[1,2,3]
+"array ([1,2,3]) halt_error/1: number required"
+
+# Issue #470: halt_error/1 with non-number arg, object input
+try halt_error("y") catch .
+{"a":1}
+"object ({\"a\":1}) halt_error/1: number required"
+
+# Issue #470: halt_error/1 with array arg
+try halt_error([1,2,3]) catch .
+null
+"null (null) halt_error/1: number required"
+
+# Issue #470: halt_error/1 with object arg
+try halt_error({}) catch .
+null
+"null (null) halt_error/1: number required"
+
+# Issue #470: halt_error/1 with bool arg
+try halt_error(true) catch .
+null
+"null (null) halt_error/1: number required"
+
+# Issue #470: halt_error/1 with null arg
+try halt_error(null) catch .
+null
+"null (null) halt_error/1: number required"


### PR DESCRIPTION
## Summary

- jq prefixes the `halt_error/1: number required` message with the **input value's** errdesc (e.g. `number (5) halt_error/1: number required`), not the bad argument's. jq-jit was emitting a generic `halt_error/1: exit code must be a number`.
- Switched the bail to `<errdesc(input)> halt_error/1: number required` so the wording and the leading value match jq 1.8.1.
- Added 9 regression cases covering each input type (`null`, number, string, array, object) and each non-number arg type (string, array, object, bool, null).

## Test plan

- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (all suites pass)
- [x] `./bench/comprehensive.sh` (no FAIL/TIMEOUT — error-path wording change, no perf risk)

Closes #470

🤖 Generated with [Claude Code](https://claude.com/claude-code)