### PR TITLE
fix: align @csv/@tsv non-array wording with jq

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3380,7 +3380,7 @@ pub fn eval_format(name: &str, val: &Value) -> Result<String> {
     // For csv/tsv, the input must be an array
     match name {
         "csv" => {
-            let arr = match val { Value::Arr(a) => a, _ => bail!("@csv requires array input") };
+            let arr = match val { Value::Arr(a) => a, _ => bail!("{} cannot be csv-formatted, only array", crate::runtime::errdesc_pub(val)) };
             let mut buf = String::with_capacity(arr.len() * 16);
             for (i, v) in arr.iter().enumerate() {
                 if i > 0 { buf.push(','); }
@@ -3415,7 +3415,7 @@ pub fn eval_format(name: &str, val: &Value) -> Result<String> {
             return Ok(buf);
         }
         "tsv" => {
-            let arr = match val { Value::Arr(a) => a, _ => bail!("@tsv requires array input") };
+            let arr = match val { Value::Arr(a) => a, _ => bail!("{} cannot be tsv-formatted, only array", crate::runtime::errdesc_pub(val)) };
             let mut buf = String::with_capacity(arr.len() * 16);
             for (i, v) in arr.iter().enumerate() {
                 if i > 0 { buf.push('\t'); }

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -7205,7 +7205,10 @@ extern "C" fn jit_rt_call_builtin(dst: *mut Value, name_ptr: *const u8, name_len
                     std::ptr::write(dst, Value::from_string(String::from_utf8_unchecked(buf)));
                     return 0;
                 } else {
-                    set_jit_error("@csv requires array input".to_string());
+                    set_jit_error(format!(
+                        "{} cannot be csv-formatted, only array",
+                        crate::runtime::errdesc_pub(&args[0])
+                    ));
                     std::ptr::write(dst, Value::Null);
                     return GEN_ERROR;
                 }
@@ -7238,7 +7241,10 @@ extern "C" fn jit_rt_call_builtin(dst: *mut Value, name_ptr: *const u8, name_len
                     std::ptr::write(dst, Value::from_string(String::from_utf8_unchecked(buf)));
                     return 0;
                 } else {
-                    set_jit_error("@tsv requires array input".to_string());
+                    set_jit_error(format!(
+                        "{} cannot be tsv-formatted, only array",
+                        crate::runtime::errdesc_pub(&args[0])
+                    ));
                     std::ptr::write(dst, Value::Null);
                     return GEN_ERROR;
                 }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -7158,3 +7158,58 @@ null
 try halt_error(null) catch .
 null
 "null (null) halt_error/1: number required"
+
+# Issue #480: @csv on null input
+try @csv catch .
+null
+"null (null) cannot be csv-formatted, only array"
+
+# Issue #480: @csv on number input
+try @csv catch .
+5
+"number (5) cannot be csv-formatted, only array"
+
+# Issue #480: @csv on string input
+try @csv catch .
+"x"
+"string (\"x\") cannot be csv-formatted, only array"
+
+# Issue #480: @csv on object input
+try @csv catch .
+{"a":1}
+"object ({\"a\":1}) cannot be csv-formatted, only array"
+
+# Issue #480: @csv on boolean input
+try @csv catch .
+true
+"boolean (true) cannot be csv-formatted, only array"
+
+# Issue #480: @csv on array still works
+[1,2,3] | @csv
+null
+"1,2,3"
+
+# Issue #480: @tsv on null input
+try @tsv catch .
+null
+"null (null) cannot be tsv-formatted, only array"
+
+# Issue #480: @tsv on number input
+try @tsv catch .
+5
+"number (5) cannot be tsv-formatted, only array"
+
+# Issue #480: @tsv on string input
+try @tsv catch .
+"x"
+"string (\"x\") cannot be tsv-formatted, only array"
+
+# Issue #480: @tsv on object input
+try @tsv catch .
+{"a":1}
+"object ({\"a\":1}) cannot be tsv-formatted, only array"
+
+# Issue #480: @tsv on array still works
+[1,2,3] | @tsv
+null
+"1\t2\t3"


### PR DESCRIPTION
## Summary

- jq's wording for non-array input to `@csv`/`@tsv` is `<errdesc(input)> cannot be {csv,tsv}-formatted, only array` (e.g. `number (5) cannot be csv-formatted, only array`). jq-jit was emitting a generic `@csv requires array input`, dropping the value context.
- Replaced both the eval-path bail (`src/eval.rs`) and the JIT inline fast-path `set_jit_error` (`src/jit.rs`) with `errdesc_pub(input)` + the canonical suffix, for both `@csv` and `@tsv`.
- Added 11 regression cases covering all non-array inputs (`null`, number, string, object, boolean) for both formats plus happy-path arrays.

## Test plan

- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (all suites pass)
- [x] `./bench/comprehensive.sh` (no FAIL/TIMEOUT — error-path wording, no perf risk)

Closes #480

🤖 Generated with [Claude Code](https://claude.com/claude-code)