### PR TITLE
fix: align unknown @format wording with jq

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3536,7 +3536,7 @@ pub fn eval_format(name: &str, val: &Value) -> Result<String> {
             }
             Ok(String::from_utf8_lossy(&r).into_owned())
         }
-        _ => bail!("unknown format: @{}", name),
+        _ => bail!("{} is not a valid format", name),
     }
 }
 

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -7213,3 +7213,23 @@ try @tsv catch .
 [1,2,3] | @tsv
 null
 "1\t2\t3"
+
+# Issue #468: unknown @format wording uses '<name> is not a valid format'
+try @xyz catch .
+null
+"xyz is not a valid format"
+
+# Issue #468: unknown @format on string input
+try @hex catch .
+"x"
+"hex is not a valid format"
+
+# Issue #468: unknown @format on object input
+try @bogus catch .
+{"a":1}
+"bogus is not a valid format"
+
+# Issue #468: unknown @format with mixed-case name
+try @MyCustom catch .
+null
+"MyCustom is not a valid format"


### PR DESCRIPTION
## Summary

- jq emits `<name> is not a valid format` (no leading `@`) for unknown `@`-format filters; jq-jit was emitting `unknown format: @<name>`.
- Single-site bail change in `eval_format` (`src/eval.rs:3539`). The JIT inline @-format dispatcher (`src/jit.rs:7252`) delegates to `eval_format` on cache miss, so it picks the new wording up automatically — no separate JIT change needed.
- Added 4 regression cases (varied input types and a mixed-case format name).

## Test plan

- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (all suites pass)
- [x] `./bench/comprehensive.sh` (no FAIL/TIMEOUT — error-path wording, no perf risk)

Closes #468

🤖 Generated with [Claude Code](https://claude.com/claude-code)