### PR TITLE
fix: tighten fromdate/fromdateiso8601 to jq's strict %Y-%m-%dT%H:%M:%SZ

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -3150,52 +3150,22 @@ fn rt_strflocaltime_impl(input: &Value, fmt: &Value) -> Result<Value> {
 // -----------------------------------------------------------------------
 
 fn rt_fromisodate(v: &Value) -> Result<Value> {
-    use chrono::{DateTime, FixedOffset, NaiveDateTime, NaiveDate, Local};
+    use chrono::NaiveDateTime;
 
+    // jq's `fromdateiso8601` (and its alias `fromdate`) validates with
+    // strptime against the literal format `%Y-%m-%dT%H:%M:%SZ` — integer
+    // seconds, mandatory `T`, mandatory uppercase `Z`. Fractional seconds
+    // and timezone offsets are rejected. See #458.
     let s = match v {
-        Value::Str(s) => s.as_str().to_string(),
-        _ => bail!("fromisodate input must be a string"),
+        Value::Str(s) => s.as_str(),
+        _ => bail!("strptime/1 requires string inputs and arguments"),
     };
 
-    // Try RFC 3339 first (handles Z and +HH:MM offsets)
-    if let Ok(dt) = DateTime::<FixedOffset>::parse_from_rfc3339(&s) {
-        let epoch = dt.timestamp();
-        let nanos = dt.timestamp_subsec_nanos();
-        return Ok(epoch_with_frac(epoch, nanos));
+    if let Ok(ndt) = NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%SZ") {
+        return Ok(Value::number(ndt.and_utc().timestamp() as f64));
     }
 
-    // Try datetime without timezone (local timezone)
-    for fmt in &["%Y-%m-%dT%H:%M:%S%.f", "%Y-%m-%dT%H:%M:%S"] {
-        if let Ok(ndt) = NaiveDateTime::parse_from_str(&s, fmt) {
-            let local_dt = ndt.and_local_timezone(Local)
-                .single()
-                .ok_or_else(|| anyhow::anyhow!("ambiguous local time: {}", s))?;
-            let epoch = local_dt.timestamp();
-            let nanos = local_dt.timestamp_subsec_nanos();
-            return Ok(epoch_with_frac(epoch, nanos));
-        }
-    }
-
-    // Try date only (local timezone at midnight)
-    if let Ok(nd) = NaiveDate::parse_from_str(&s, "%Y-%m-%d") {
-        let ndt = nd.and_hms_opt(0, 0, 0).unwrap();
-        let local_dt = ndt.and_local_timezone(Local)
-            .single()
-            .ok_or_else(|| anyhow::anyhow!("ambiguous local time: {}", s))?;
-        let epoch = local_dt.timestamp();
-        return Ok(Value::number(epoch as f64));
-    }
-
-    bail!("fromisodate: invalid ISO 8601 date string: {}", s)
-}
-
-fn epoch_with_frac(epoch: i64, nanos: u32) -> Value {
-    if nanos == 0 {
-        Value::number(epoch as f64)
-    } else {
-        let frac = epoch as f64 + nanos as f64 / 1_000_000_000.0;
-        Value::number(frac)
-    }
+    bail!(r#"date "{}" does not match format "%Y-%m-%dT%H:%M:%SZ""#, s)
 }
 
 fn rt_toisodate(v: &Value) -> Result<Value> {

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -7353,3 +7353,63 @@ null
 "abc" | scan("a")
 null
 "a"
+
+# Issue #458: fromdate happy path (UTC, integer seconds, trailing Z)
+"2024-01-01T00:00:00Z" | fromdate
+null
+1704067200
+
+# Issue #458: fromdateiso8601 happy path
+"2024-01-01T00:00:00Z" | fromdateiso8601
+null
+1704067200
+
+# Issue #458: fromdate rejects non-string with strptime wording
+try (5 | fromdate) catch .
+null
+"strptime/1 requires string inputs and arguments"
+
+# Issue #458: fromdate rejects null with strptime wording
+try (null | fromdate) catch .
+null
+"strptime/1 requires string inputs and arguments"
+
+# Issue #458: fromdate rejects array with strptime wording
+try ([1] | fromdate) catch .
+null
+"strptime/1 requires string inputs and arguments"
+
+# Issue #458: fromdate rejects date-only string (no T, no time)
+try ("2024-01-01" | fromdate) catch .
+null
+"date \"2024-01-01\" does not match format \"%Y-%m-%dT%H:%M:%SZ\""
+
+# Issue #458: fromdate rejects datetime missing trailing Z
+try ("2024-01-01T00:00:00" | fromdate) catch .
+null
+"date \"2024-01-01T00:00:00\" does not match format \"%Y-%m-%dT%H:%M:%SZ\""
+
+# Issue #458: fromdate rejects offset timezone
+try ("2024-01-01T00:00:00+09:00" | fromdate) catch .
+null
+"date \"2024-01-01T00:00:00+09:00\" does not match format \"%Y-%m-%dT%H:%M:%SZ\""
+
+# Issue #458: fromdate rejects fractional seconds
+try ("2024-01-01T00:00:00.5Z" | fromdate) catch .
+null
+"date \"2024-01-01T00:00:00.5Z\" does not match format \"%Y-%m-%dT%H:%M:%SZ\""
+
+# Issue #458: fromdate rejects lowercase z
+try ("2024-01-01T00:00:00z" | fromdate) catch .
+null
+"date \"2024-01-01T00:00:00z\" does not match format \"%Y-%m-%dT%H:%M:%SZ\""
+
+# Issue #458: fromdate rejects empty string
+try ("" | fromdate) catch .
+null
+"date \"\" does not match format \"%Y-%m-%dT%H:%M:%SZ\""
+
+# Issue #458: fromdateiso8601 (alias) shares the same wording
+try ("not-a-date" | fromdateiso8601) catch .
+null
+"date \"not-a-date\" does not match format \"%Y-%m-%dT%H:%M:%SZ\""


### PR DESCRIPTION
## Summary

`fromdateiso8601` (and its alias `fromdate`) accepted strings jq rejects:

| input | jq | jq-jit (before) | jq-jit (this PR) |
|---|---|---|---|
| `"2024-01-01T00:00:00Z"` | `1704067200` | `1704067200` | `1704067200` |
| `"2024-01-01"` | error | `1704034800` | error |
| `"2024-01-01T00:00:00"` (no Z) | error | `1704034800` | error |
| `"...+09:00"` | error | accepted | error |
| `"...0.5Z"` | error | `1704067200.5` | error |

And the error wording diverged:

- non-string input: jq → `strptime/1 requires string inputs and arguments`; jq-jit → `fromisodate input must be a string`
- bad string: jq → `date "<input>" does not match format "%Y-%m-%dT%H:%M:%SZ"`; jq-jit → `fromisodate: invalid ISO 8601 date string: <input>`

Replaced the body with a single strict `NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%SZ")` and aligned both error wordings to jq's. Removed the now-unused `epoch_with_frac` helper. Verified end-to-end against jq for 12 cases.

## Test plan

- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (all suites pass)
- [x] `./bench/comprehensive.sh` (no FAIL/TIMEOUT — no date benchmarks exist; the simplified parser is strictly cheaper than the old fallback chain)

Closes #458

🤖 Generated with [Claude Code](https://claude.com/claude-code)