### PR TITLE
fix: preserve mantissa trailing zero in scientific-literal expansion

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -500,9 +500,11 @@ fn normalize_num_repr(s: &str) -> String {
         // Compute normalized exponent
         let new_exp = exp + (int_part.len() as i64) - 1 - (first_sig as i64);
 
-        // Build normalized mantissa from significant digits
+        // Build normalized mantissa from significant digits.
+        // jq's decnum keeps the literal mantissa's trailing zeros so
+        // `1.0e0` → `1.0`, `1.0e-5` → `0.000010`. Don't trim. See #457.
         let sig_digits: String = digits[first_sig..].iter().collect();
-        let sig_digits = sig_digits.trim_end_matches('0');
+        let sig_digits = sig_digits.as_str();
 
         let exp_sign = if new_exp >= 0 { "+" } else { "" };
         if sig_digits.len() <= 1 {

--- a/src/value.rs
+++ b/src/value.rs
@@ -5410,17 +5410,19 @@ pub fn normalize_jq_repr(repr: &str) -> Option<String> {
             for _ in 0..pad { s.push('0'); }
             return Some(format!("{}{}", sign, s));
         }
-        let frac = sig[int_len..].trim_end_matches('0');
+        // jq's decnum keeps the mantissa's trailing zeros through expansion
+        // (`1.0e0` → `1.0`, not `1`). Don't strip — preserve the original
+        // significand digit count. See #457.
+        let frac = &sig[int_len..];
         if frac.is_empty() {
             return Some(format!("{}{}", sign, &sig[..int_len]));
         }
         return Some(format!("{}{}.{}", sign, &sig[..int_len], frac));
     }
     let zeros = (-te - 1) as usize;
-    let frac = sig.trim_end_matches('0');
-    if frac.is_empty() {
-        return Some(format!("{}0", sign));
-    }
+    // Same trailing-zero preservation for negative-`te` expansion
+    // (`1.0e-5` → `0.000010`, not `0.00001`). See #457.
+    let frac = sig;
     let mut buf = String::with_capacity(zeros + frac.len() + 4);
     buf.push_str(sign);
     buf.push_str("0.");
@@ -5433,12 +5435,10 @@ fn format_canonical_mantissa(sig: &str) -> String {
     if sig.len() <= 1 {
         return sig.to_string();
     }
-    let frac = sig[1..].trim_end_matches('0');
-    if frac.is_empty() {
-        sig[..1].to_string()
-    } else {
-        format!("{}.{}", &sig[..1], frac)
-    }
+    // Preserve the mantissa's trailing zeros (`1.0e10` → `1.0E+10`,
+    // `1.00e10` → `1.00E+10`). See #457.
+    let frac = &sig[1..];
+    format!("{}.{}", &sig[..1], frac)
 }
 
 /// Format a number in jq's f64 dtoa scientific style: lowercase `e`, explicit

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -7478,3 +7478,93 @@ null
 [3,1,2] | sort_by(.)
 null
 [1,2,3]
+
+# Issue #457: 1.0e-5 keeps the mantissa trailing zero through expansion
+1.0e-5
+null
+0.000010
+
+# Issue #457: 1.00e-5 keeps both mantissa zeros
+1.00e-5
+null
+0.0000100
+
+# Issue #457: 1.0e0 expands to 1.0 not 1
+1.0e0
+null
+1.0
+
+# Issue #457: 1.0e-1 keeps trailing zero
+1.0e-1
+null
+0.10
+
+# Issue #457: 1.0e-2 keeps trailing zero
+1.0e-2
+null
+0.010
+
+# Issue #457: 1.0e-3 keeps trailing zero
+1.0e-3
+null
+0.0010
+
+# Issue #457: scientific output preserves mantissa trailing zero
+1.0e10
+null
+1.0E+10
+
+# Issue #457: 1.00e10 keeps both zeros
+1.00e10
+null
+1.00E+10
+
+# Issue #457: 12.0e2 normalizes mantissa to 1.20E+3
+12.0e2
+null
+1.20E+3
+
+# Issue #457: 12.30e-3 keeps trailing zero through expansion
+12.30e-3
+null
+0.01230
+
+# Issue #457: 5.0e-4 keeps trailing zero
+5.0e-4
+null
+0.00050
+
+# Issue #457: 1.5e-5 (no trailing zero in source) stays as 0.000015
+1.5e-5
+null
+0.000015
+
+# Issue #457: negative number preserves trailing zero
+-1.0e-5
+null
+-0.000010
+
+# Issue #457: 1e-5 (no fractional in source) stays minimal
+1e-5
+null
+0.00001
+
+# Issue #457: 1e0 stays as integer
+1e0
+null
+1
+
+# Issue #457: 12.0e1 normalizes to 120 (no fractional)
+12.0e1
+null
+120
+
+# Issue #457: 12.34e2 expands to 1234
+12.34e2
+null
+1234
+
+# Issue #457: tojson preserves trailing zero
+1.0e-5 | tojson
+null
+"0.000010"


### PR DESCRIPTION
## Summary

jq's decnum keeps the literal mantissa's trailing zeros through both scientific and expanded forms:

| literal | jq | jq-jit (before) | jq-jit (this PR) |
|---|---|---|---|
| `1.0e-5` | `0.000010` | `0.00001` | `0.000010` |
| `1.00e-5` | `0.0000100` | `0.00001` | `0.0000100` |
| `1.0e10` | `1.0E+10` | `1E+10` | `1.0E+10` |
| `1.0e0` | `1.0` | `1` | `1.0` |
| `12.0e2` | `1.20E+3` | `1.2E+3` | `1.20E+3` |
| `12.30e-3` | `0.01230` | `0.0123` | `0.01230` |

The trim happened at three sites:

1. `parser::normalize_num_repr` — when the lexer canonicalises the raw literal to scientific form for storage. `sig_digits.trim_end_matches('0')` dropped the `.0` before storing the repr.
2. `value::normalize_jq_repr` `te >= 0` decimal-expansion arm — `frac.trim_end_matches('0')` dropped trailing zeros from the post-decimal slice.
3. `value::normalize_jq_repr` `te < 0` decimal-expansion arm — same trim on the full significand before prepending `0.000…`.
4. `value::format_canonical_mantissa` — same trim in the scientific renderer.

Removed all four trims. Verified against jq for 30+ literals.

## Test plan

- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (all suites pass)
- [x] `./bench/comprehensive.sh` (no FAIL/TIMEOUT — output is one branch shorter, no perf risk)

Closes #457

🤖 Generated with [Claude Code](https://claude.com/claude-code)