### PR TITLE
fix: @csv/@tsv preserve number repr

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3407,8 +3407,8 @@ pub fn eval_format(name: &str, val: &Value) -> Result<String> {
                     Value::Null => {}
                     Value::True => buf.push_str("true"),
                     Value::False => buf.push_str("false"),
-                    Value::Num(n, _) => {
-                        crate::value::push_jq_number_str(&mut buf, *n);
+                    Value::Num(n, crate::value::NumRepr(repr)) => {
+                        crate::value::push_value_num_repr_str(&mut buf, *n, repr.as_ref());
                     }
                     // jq rejects arrays/objects as row elements (issue #79).
                     Value::Arr(_) | Value::Obj(_) => bail!(
@@ -3441,7 +3441,7 @@ pub fn eval_format(name: &str, val: &Value) -> Result<String> {
                     Value::Null => {}
                     Value::True => buf.push_str("true"),
                     Value::False => buf.push_str("false"),
-                    Value::Num(n, _) => crate::value::push_jq_number_str(&mut buf, *n),
+                    Value::Num(n, crate::value::NumRepr(repr)) => crate::value::push_value_num_repr_str(&mut buf, *n, repr.as_ref()),
                     // jq uses the same "csv row" wording for @tsv (issue #79).
                     Value::Arr(_) | Value::Obj(_) => bail!(
                         "{} ({}) is not valid in a csv row",

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -7198,7 +7198,7 @@ extern "C" fn jit_rt_call_builtin(dst: *mut Value, name_ptr: *const u8, name_len
                             Value::Null => {}
                             Value::True => buf.extend_from_slice(b"true"),
                             Value::False => buf.extend_from_slice(b"false"),
-                            Value::Num(n, _) => crate::value::push_jq_number_bytes(&mut buf, *n),
+                            Value::Num(n, crate::value::NumRepr(repr)) => crate::value::push_value_num_repr_bytes(&mut buf, *n, repr.as_ref()),
                             _ => buf.extend_from_slice(crate::value::value_to_json(v).as_bytes()),
                         }
                     }
@@ -7234,7 +7234,7 @@ extern "C" fn jit_rt_call_builtin(dst: *mut Value, name_ptr: *const u8, name_len
                             Value::Null => {}
                             Value::True => buf.extend_from_slice(b"true"),
                             Value::False => buf.extend_from_slice(b"false"),
-                            Value::Num(n, _) => crate::value::push_jq_number_bytes(&mut buf, *n),
+                            Value::Num(n, crate::value::NumRepr(repr)) => crate::value::push_value_num_repr_bytes(&mut buf, *n, repr.as_ref()),
                             _ => buf.extend_from_slice(crate::value::value_to_json(v).as_bytes()),
                         }
                     }

--- a/src/value.rs
+++ b/src/value.rs
@@ -5249,6 +5249,35 @@ pub fn format_jq_number(n: f64) -> String {
 
 /// Push a formatted jq number directly to a String buffer (avoids intermediate allocation).
 #[inline]
+/// Push a number's canonical jq representation, preferring the original
+/// repr (so `1.0` stays `1.0`, `0e10` stays `0E+10`) when it round-trips
+/// through f64. Falls back to f64 dtoa otherwise. Used by @csv / @tsv
+/// formatters where jq preserves the literal shape (#475).
+pub fn push_value_num_repr_str(buf: &mut String, n: f64, repr: Option<&Rc<str>>) {
+    if let Some(r) = repr.filter(|r| is_valid_json_number(r) && repr_is_exact_for_f64(r, n)) {
+        if let Some(canonical) = normalize_jq_repr(r) {
+            buf.push_str(&canonical);
+        } else {
+            buf.push_str(r);
+        }
+    } else {
+        push_jq_number_str(buf, n);
+    }
+}
+
+/// Same as [`push_value_num_repr_str`] but writes UTF-8 bytes to a `Vec<u8>`.
+pub fn push_value_num_repr_bytes(buf: &mut Vec<u8>, n: f64, repr: Option<&Rc<str>>) {
+    if let Some(r) = repr.filter(|r| is_valid_json_number(r) && repr_is_exact_for_f64(r, n)) {
+        if let Some(canonical) = normalize_jq_repr(r) {
+            buf.extend_from_slice(canonical.as_bytes());
+        } else {
+            buf.extend_from_slice(r.as_bytes());
+        }
+    } else {
+        push_jq_number_bytes(buf, n);
+    }
+}
+
 pub fn push_jq_number_str(buf: &mut String, n: f64) {
     if n.is_nan() {
         buf.push_str("null");

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -7568,3 +7568,58 @@ null
 1.0e-5 | tojson
 null
 "0.000010"
+
+# Issue #475: @csv preserves number repr
+[1.0] | @csv
+null
+"1.0"
+
+# Issue #475: @csv preserves multiple number reprs
+[1.0, 2.5, 0e10] | @csv
+null
+"1.0,2.5,0E+10"
+
+# Issue #475: @csv preserves 0E+10 form
+[0e10] | @csv
+null
+"0E+10"
+
+# Issue #475: @csv preserves 0.0 form
+[0.0] | @csv
+null
+"0.0"
+
+# Issue #475: @csv preserves 1.0e-5 expansion
+[1.0e-5] | @csv
+null
+"0.000010"
+
+# Issue #475: @csv preserves 1e30 → 1E+30 (uppercase scientific)
+[1e30] | @csv
+null
+"1E+30"
+
+# Issue #475: @csv mixed types still work
+[1.0, "a", null, true] | @csv
+null
+"1.0,\"a\",,true"
+
+# Issue #475: @csv on integer (no repr) stays as integer
+[1] | @csv
+null
+"1"
+
+# Issue #475: @tsv preserves number repr
+[1.0, 2.5] | @tsv
+null
+"1.0\t2.5"
+
+# Issue #475: @tsv preserves 0e10 form
+[0e10] | @tsv
+null
+"0E+10"
+
+# Issue #475: @tsv on integer (no repr)
+[1, 2, 3] | @tsv
+null
+"1\t2\t3"


### PR DESCRIPTION
## Summary

`@csv` and `@tsv` rendered numbers via the f64 default, so float-shaped literals lost their original form:

| input | jq | jq-jit (before) | jq-jit (this PR) |
|---|---|---|---|
| `[1.0]` | `1.0` | `1` | `1.0` |
| `[0.0]` | `0.0` | `0` | `0.0` |
| `[0e10]` | `0E+10` | `0` | `0E+10` |
| `[1e30]` | `1E+30` | `1e+30` | `1E+30` |
| `[1.0e-5]` | `0.000010` | `0.00001` | `0.000010` |

Added `push_value_num_repr_{str,bytes}` helpers in `value.rs` that mirror `tojson`'s repr-aware path: prefer `canonical_repr_bytes(repr)` when the repr round-trips through f64, fall back to the f64 dtoa otherwise. Wired both helpers into the @csv/@tsv eval paths and the JIT inline fast paths (4 sites total).

Note: integers (no repr) keep the f64 fast path, so `[1] | @csv` still renders as `1`.

## Test plan

- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (all suites pass)
- [x] `./bench/comprehensive.sh` — `@csv` (NDJSON 2M): 0.124s vs 0.137s baseline (8% faster); `@csv (array)`: 0.015s vs 0.018s; `@tsv (array)`: 0.015s vs 0.017s. No regression.

Closes #475

🤖 Generated with [Claude Code](https://claude.com/claude-code)