### PR TITLE
fix: dispatch INDEX/1 instead of advertising it as phantom

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3679,6 +3679,38 @@ impl Parser {
                     }),
                 })
             }
+            // INDEX/1: INDEX(idx_expr) = INDEX(.[]; idx_expr).
+            // jq advertised both /1 and /2 in `builtins`, but /1 had no
+            // dispatch path so callers got an "unknown function" error
+            // (#476). Desugar straight to the same Reduce shape as /2.
+            ("INDEX", 1) => {
+                let f = args.into_iter().next().unwrap();
+                let stream = Expr::Each { input_expr: Box::new(Expr::Input) };
+                let x_var = self.scope.alloc_var("__idx_x__");
+                let acc_var = self.scope.alloc_var("__idx_acc__");
+                Ok(Expr::Reduce {
+                    source: Box::new(stream),
+                    init: Box::new(Expr::ObjectConstruct { pairs: vec![] }),
+                    var_index: x_var,
+                    acc_index: acc_var,
+                    update: Box::new(Expr::BinOp {
+                        op: BinOp::Add,
+                        lhs: Box::new(Expr::Input),
+                        rhs: Box::new(Expr::ObjectConstruct {
+                            pairs: vec![(
+                                Expr::Pipe {
+                                    left: Box::new(Expr::LoadVar { var_index: x_var }),
+                                    right: Box::new(Expr::Pipe {
+                                        left: Box::new(f),
+                                        right: Box::new(Expr::UnaryOp { op: UnaryOp::ToString, operand: Box::new(Expr::Input) }),
+                                    }),
+                                },
+                                Expr::LoadVar { var_index: x_var },
+                            )],
+                        }),
+                    }),
+                })
+            }
             // INDEX/2: INDEX(stream; f) = reduce stream as $x ({}; . + {($x|f|tostring): $x})
             ("INDEX", 2) => {
                 let mut args = args.into_iter();

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -7623,3 +7623,28 @@ null
 [1, 2, 3] | @tsv
 null
 "1\t2\t3"
+
+# Issue #476: INDEX/1 desugars to INDEX(.[]; idx_expr)
+INDEX(.)
+[1,2,3]
+{"1":1,"2":2,"3":3}
+
+# Issue #476: INDEX/1 over array of objects keyed by .a
+INDEX(.a)
+[{"a":1,"b":2},{"a":3,"b":4}]
+{"1":{"a":1,"b":2},"3":{"a":3,"b":4}}
+
+# Issue #476: INDEX/1 last-write-wins on duplicate keys
+INDEX(.a)
+[{"a":1,"x":"first"},{"a":1,"x":"second"}]
+{"1":{"a":1,"x":"second"}}
+
+# Issue #476: INDEX/1 on empty input returns {}
+INDEX(.)
+[]
+{}
+
+# Issue #476: INDEX/1 advertised in builtins is now actually callable
+[builtins[]] | map(select(test("^INDEX"))) | sort
+null
+["INDEX/1","INDEX/2"]


### PR DESCRIPTION
## Summary

\`builtins\` advertised both \`INDEX/1\` and \`INDEX/2\`, but only the two-arg form had a parser desugar. \`INDEX(.)\` errored with \`unknown function 'INDEX' with 1 args\`.

jq's defs:
\`\`\`
def INDEX(stream; idx_expr): reduce stream as \$row ({}; .[\$row|idx_expr|tostring] = \$row);
def INDEX(idx_expr): INDEX(.[]; idx_expr);
\`\`\`

Added the same \`Reduce\` shape as \`INDEX/2\` with \`stream = Each(Input)\` for the unary form. The two-arg form is unchanged.

| input | filter | jq | jq-jit (before) | jq-jit (this PR) |
|---|---|---|---|---|
| \`[1,2,3]\` | \`INDEX(.)\` | \`{"1":1,"2":2,"3":3}\` | error | \`{"1":1,"2":2,"3":3}\` |
| \`[{"a":1},{"a":2}]\` | \`INDEX(.a)\` | \`{"1":...,"2":...}\` | error | \`{"1":...,"2":...}\` |

## Test plan

- [x] \`cargo build --release\` (zero warnings)
- [x] \`cargo test --release\` (all suites pass)
- [x] \`./bench/comprehensive.sh\` (no FAIL/TIMEOUT — parser-only addition, no perf risk)

Closes #476

🤖 Generated with [Claude Code](https://claude.com/claude-code)