### PR TITLE
fix: distinguish 0-arg recurse from recurse(.) in AST

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3261,8 +3261,12 @@ pub fn eval_index(base: &Value, key: &Value, optional: bool) -> std::result::Res
 }
 
 fn eval_recurse_expr(step: &Expr, val: &Value, env: &EnvRef, cb: &mut dyn FnMut(Value) -> GenResult) -> GenResult {
-    if matches!(step, Expr::Input) {
-        // Default recurse (.[]): recursive descent into arrays/objects
+    // The 0-arg `recurse` and `..` are desugared by the parser to
+    // `recurse(.[]?)` — i.e. `Expr::EachOpt { Expr::Input }`. Take the
+    // descent fast path only for that exact shape; user-written
+    // `recurse(.)` carries `Expr::Input` and should fall through to the
+    // generic loop (which never terminates, matching jq). See #497.
+    if matches!(step, Expr::EachOpt { input_expr } if matches!(**input_expr, Expr::Input)) {
         eval_recurse_default(val, cb)
     } else {
         // Custom step: use explicit stack to avoid stack overflow.

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -2930,14 +2930,21 @@ impl Flattener {
             }
 
             Expr::Recurse { input_expr } => {
-                if !is_scalar(input_expr) { return false; }
-                // Recurse: yield input, then recurse into each child
-                // Collect all recursive outputs via runtime, then iterate
-                let val = self.flatten_scalar(input_expr, input_slot);
+                // Only the descent-only 0-arg form (`recurse` / `..`) is
+                // safe for the recurse_collect fast path — the parser
+                // shapes that as `Recurse { EachOpt(Input) }`. Custom
+                // step expressions like `recurse(.)` (infinite) or
+                // `recurse(f)` need the eval-side generic loop. See #497.
+                let is_default_descent = matches!(
+                    input_expr.as_ref(),
+                    Expr::EachOpt { input_expr: inner } if matches!(**inner, Expr::Input)
+                );
+                if !is_default_descent { return false; }
+                // Seed is the pipeline input (jq's `def recurse: ., (.[]? | recurse);`).
+                let val = self.flatten_scalar(&Expr::Input, input_slot);
                 let arr = self.alloc_slot();
                 self.emit(JitOp::CallBuiltin { dst: arr, name: "recurse_collect".to_string(), args: vec![val] });
                 self.emit(JitOp::Drop { slot: val });
-                // Iterate the collected array, yielding each element
                 self.flatten_each_with_action(arr, false, &|s, elem| {
                     s.emit_yield(elem);
                 });
@@ -3015,9 +3022,15 @@ impl Flattener {
                     if !l_ok { return false; }
                     return self.flatten_gen(&Expr::PathExpr { expr: right.clone() }, input_slot);
                 }
-                // Native path(recurse) — bypass eval engine, generate paths directly
+                // Native path(recurse) — bypass eval engine, generate paths
+                // directly. Only the descent-only 0-arg form qualifies; the
+                // parser shapes that as `Recurse { EachOpt(Input) }`. See #497.
                 if let Expr::Recurse { input_expr } = path_expr.as_ref() {
-                    if matches!(input_expr.as_ref(), Expr::Input) {
+                    let is_default_descent = matches!(
+                        input_expr.as_ref(),
+                        Expr::EachOpt { input_expr: inner } if matches!(**inner, Expr::Input)
+                    );
+                    if is_default_descent {
                         let inp = self.alloc_slot();
                         self.emit(JitOp::Clone { dst: inp, src: input_slot });
                         let arr = self.alloc_slot();
@@ -3031,10 +3044,14 @@ impl Flattener {
                     }
                 }
                 // Native paths(f) — path(recurse | if f then . else empty end)
-                // DFS with filter applied at each node
+                // DFS with filter applied at each node. The descent shape
+                // is `Recurse { EachOpt(Input) }` after #497.
                 if let Expr::Pipe { left, right } = path_expr.as_ref() {
                     if let Expr::Recurse { input_expr } = left.as_ref() {
-                        if matches!(input_expr.as_ref(), Expr::Input) {
+                        if matches!(
+                            input_expr.as_ref(),
+                            Expr::EachOpt { input_expr: inner } if matches!(**inner, Expr::Input)
+                        ) {
                             if let Expr::IfThenElse { cond, then_branch, else_branch } = right.as_ref() {
                                 if matches!(then_branch.as_ref(), Expr::Input) && matches!(else_branch.as_ref(), Expr::Empty) {
                                     // This is paths(f) where f = cond

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2141,9 +2141,13 @@ impl Parser {
 
             Token::Recurse => {
                 self.advance();
-                // .. is recurse(. ; .[]?)
-                // Can optionally be followed by .field
-                Ok(Expr::Recurse { input_expr: Box::new(Expr::Input) })
+                // `..` is `recurse`, which jq defines as `recurse(.[]?)`.
+                // Use `EachOpt(Input)` as the AST step so eval/JIT can
+                // distinguish the descent-only 0-arg form from the
+                // user-written `recurse(.)` (which loops forever). See #497.
+                Ok(Expr::Recurse {
+                    input_expr: Box::new(Expr::EachOpt { input_expr: Box::new(Expr::Input) }),
+                })
             }
 
             Token::LParen => {
@@ -2795,11 +2799,14 @@ impl Parser {
                 key: Box::new(Expr::Literal(Literal::Num(-1.0, None))),
             }),
             "paths" => {
-                // paths = [path(..[])] but without the empty root path
-                // Use Recurse with .[] step and then get paths via Each
+                // paths = [path(..[])] but without the empty root path.
+                // Use the `EachOpt(Input)` sentinel so the `Recurse` shape
+                // matches the descent semantics, not `recurse(.)`. See #497.
                 Ok(Expr::Pipe {
                     left: Box::new(Expr::PathExpr {
-                        expr: Box::new(Expr::Recurse { input_expr: Box::new(Expr::Input) }),
+                        expr: Box::new(Expr::Recurse {
+                            input_expr: Box::new(Expr::EachOpt { input_expr: Box::new(Expr::Input) }),
+                        }),
                     }),
                     right: Box::new(Expr::IfThenElse {
                         cond: Box::new(Expr::BinOp {
@@ -2813,7 +2820,13 @@ impl Parser {
                 })
             }
             "recurse" | "recurse_down" => {
-                Ok(Expr::Recurse { input_expr: Box::new(Expr::Input) })
+                // jq: `def recurse: recurse(.[]?);`
+                // `EachOpt(Input)` represents `.[]?` and lets eval/JIT take
+                // the descent fast path; `recurse(.)` (which is infinite)
+                // takes the slow custom-step path instead. See #497.
+                Ok(Expr::Recurse {
+                    input_expr: Box::new(Expr::EachOpt { input_expr: Box::new(Expr::Input) }),
+                })
             }
             "gamma" | "tgamma" | "lgamma" | "lgamma_r" | "frexp"
             | "expm1" | "log1p" | "erf" | "erfc" | "y0" | "y1"
@@ -3246,7 +3259,11 @@ impl Parser {
                 Ok(Expr::Pipe {
                     left: Box::new(Expr::PathExpr {
                         expr: Box::new(Expr::Pipe {
-                            left: Box::new(Expr::Recurse { input_expr: Box::new(Expr::Input) }),
+                            // Use the EachOpt(Input) sentinel for descent
+                            // semantics (#497).
+                            left: Box::new(Expr::Recurse {
+                                input_expr: Box::new(Expr::EachOpt { input_expr: Box::new(Expr::Input) }),
+                            }),
                             right: Box::new(Expr::IfThenElse {
                                 cond: Box::new(f),
                                 then_branch: Box::new(Expr::Input),

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -7823,3 +7823,33 @@ null
 0 | y1
 null
 -1.7976931348623157e+308
+
+# Issue #497: recurse(.) is infinite (gated by limit)
+[limit(5; recurse(.))]
+null
+[null,null,null,null,null]
+
+# Issue #497: recurse with custom non-identity step still terminates only via limit
+[limit(3; recurse(. + 1))]
+null
+[null,1,2]
+
+# Issue #497: recurse(. + 1) on number (infinite, capped by limit)
+[limit(5; 5 | recurse(. + 1))]
+null
+[5,6,7,8,9]
+
+# Issue #497: 0-arg recurse still does descent (stops at scalars)
+[recurse]
+[1,[2,3]]
+[[1,[2,3]],1,[2,3],2,3]
+
+# Issue #497: .. (alias for recurse) does descent
+[..]
+[1,[2,3]]
+[[1,[2,3]],1,[2,3],2,3]
+
+# Issue #497: paths still works (uses descent under the hood)
+[paths]
+{"a":1,"b":[2,3]}
+[["a"],["b"],["b",0],["b",1]]


### PR DESCRIPTION
## Summary

The parser desugared both \`recurse\` (0-arg) and \`recurse(.)\` to \`Expr::Recurse { input_expr: Expr::Input }\`. Eval / JIT then used \`matches!(input_expr, Expr::Input)\` as a sentinel for the descent fast path, so user-written \`recurse(.)\` ended up doing descent-into-arrays-and-stop-on-scalars instead of looping forever (jq's actual semantics: \`def recurse(f): def r: ., (f | r); r\`).

| filter | jq | jq-jit (before) | jq-jit (this PR) |
|---|---|---|---|
| \`[limit(5; recurse(.))]\` on \`null\` | \`[null,null,null,null,null]\` | \`[null]\` | \`[null,null,null,null,null]\` |
| \`recurse(.)\` on \`[1,2,3]\` | infinite stream of \`[1,2,3]\` | \`[1,2,3], 1, 2, 3\` then stops | infinite (matches jq) |
| \`[limit(3; recurse(. + 1))]\` on \`null\` | \`[null,1,2]\` | (only emitted seed) | \`[null,1,2]\` |

Routed the parser desugar of \`recurse\` and \`..\` through \`Expr::Recurse { input_expr: Expr::EachOpt { input_expr: Expr::Input } }\` so the AST literally encodes \`recurse(.[]?)\`. Updated:

- **parser.rs**: \`..\`, \`recurse\` / \`recurse_down\`, and the \`paths(f)\` desugar all use the new sentinel.
- **eval.rs**: \`eval_recurse_expr\` matches the new sentinel for the descent fast path; everything else falls through to the generic loop.
- **jit.rs**: JIT-side fast paths for \`recurse\`, \`path(recurse)\`, and \`paths(f)\` all gate on the new sentinel.

## Bench note

\`jaq: tree-update\` (\`(.. | scalars) |= .+1\`) goes from **12ms to 230ms** at the bench's tree depth of 17.

Investigation showed that **on main this filter silently produces NO output** when the input shape is \`nth(.; 0 | recurse([., .]))\` — the "fast" timing was measuring an early-exit, not real work. With this fix the filter produces the correct value (verified against jq 1.8.1) and the bench number reflects the actual update cost. jq itself takes ~420ms on the same filter, so jq-jit is still 2x faster.

Reproduces:
\`\`\`sh
$ printf '3\\n' | <main> -c 'nth(.; 0 | recurse([., .])) | (.. | scalars) |= .+1'
(empty)

$ printf '3\\n' | <this PR> -c 'nth(.; 0 | recurse([., .])) | (.. | scalars) |= .+1'
[[[1,1],[1,1]],[[1,1],[1,1]]]
\`\`\`

## Test plan

- [x] \`cargo build --release\` (zero warnings)
- [x] \`cargo test --release\` (all suites pass)
- [x] \`./bench/comprehensive.sh\` (no FAIL/TIMEOUT; \`tree-update\` regression explained above is a correctness fix)

Closes #497

🤖 Generated with [Claude Code](https://claude.com/claude-code)