### PR TITLE
fix: path() index-error wording omits non-string key value

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -4067,10 +4067,14 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
                         (Value::Arr(_), Value::Arr(_)) => {}
                         (Value::Null, _) => {}
                         _ => {
+                            // jq's wording: string keys keep the quoted
+                            // value (`string "x"`), other key types use
+                            // the bare type name (`number`, `boolean`,
+                            // `null`). Aligns with the read-side fix from
+                            // #440. See #500.
                             let key_desc = match &key {
                                 Value::Str(s) => format!("string \"{}\"", s),
-                                Value::Num(n, _) => format!("number ({})", crate::value::format_jq_number(*n)),
-                                other => format!("{} ({})", other.type_name(), crate::value::value_to_json(other)),
+                                other => other.type_name().to_string(),
                             };
                             bail!("Cannot index {} with {}", base_val.type_name(), key_desc);
                         }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -7853,3 +7853,28 @@ null
 [paths]
 {"a":1,"b":[2,3]}
 [["a"],["b"],["b",0],["b",1]]
+
+# Issue #500: path(.[0]) on a number errors without value tag
+try path(.[0]) catch .
+5
+"Cannot index number with number"
+
+# Issue #500: path(.[0] // .[1]) preserves the same wording
+try path(.[0] // .[1]) catch .
+5
+"Cannot index number with number"
+
+# Issue #500: path(.x) on a number keeps the string-key value
+try path(.x) catch .
+5
+"Cannot index number with string \"x\""
+
+# Issue #500: path(.[true]) — boolean key, no value
+try path(.[true]) catch .
+5
+"Cannot index number with boolean"
+
+# Issue #500: path(.[null]) — null key
+try path(.[null]) catch .
+5
+"Cannot index number with null"


### PR DESCRIPTION
## Summary

The path-side eval of a failing index appended \`(value)\` for number / boolean / null keys, while jq emits the bare type name. The read-side wording was already correct (#440); the path side had its own formatter that still included the value tag.

| input | filter | jq | jq-jit (before) | jq-jit (this PR) |
|---|---|---|---|---|
| \`5\` | \`try path(.[0]) catch .\` | \`Cannot index number with number\` | \`Cannot index number with number (0)\` | \`Cannot index number with number\` |
| \`5\` | \`try path(.x) catch .\` | \`Cannot index number with string \"x\"\` | \`Cannot index number with string \"x\"\` | \`Cannot index number with string \"x\"\` |
| \`5\` | \`try path(.[true]) catch .\` | \`Cannot index number with boolean\` | \`Cannot index number with boolean (true)\` | \`Cannot index number with boolean\` |

jq's pattern: string keys keep the quoted value (\`string \"x\"\`), all other key types use the bare type name. Aligned the path-side bail in \`eval_path\` Index arm to match.

## Test plan

- [x] \`cargo build --release\` (zero warnings)
- [x] \`cargo test --release\` (all suites pass)
- [x] \`./bench/comprehensive.sh\` (no FAIL/TIMEOUT — error path, no perf risk)

Closes #500

🤖 Generated with [Claude Code](https://claude.com/claude-code)