### PR TITLE
fix: parser truncates scope on as/reduce/foreach binding exit

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1175,11 +1175,16 @@ impl Parser {
         }
 
         if alt_patterns.len() == 1 {
-            // No ?// alternatives - simple binding
+            // No ?// alternatives - simple binding. Snapshot the scope
+            // before allocating the pattern's vars so a same-name shadow
+            // (`5 as $x | (10 as $x | …), $x`) doesn't leak into outer
+            // lookups after the body is parsed. See #499.
             let pattern = alt_patterns.into_iter().next().unwrap();
+            let saved_vars = self.scope.vars.len();
             let allocs = self.alloc_pattern_vars(&pattern);
             self.expect(&Token::Pipe)?;
             let body = self.parse_pipe()?;
+            self.scope.vars.truncate(saved_vars);
             return self.build_binding(value_expr, pattern, allocs, body);
         }
 
@@ -1195,6 +1200,9 @@ impl Parser {
             .filter(|n| seen.insert(n.clone()))
             .collect();
 
+        // Snapshot scope before allocating the alt-destructure vars so
+        // they don't leak into outer lookups (#499).
+        let saved_vars = self.scope.vars.len();
         // Allocate once for shared variables
         let mut var_map: std::collections::HashMap<String, u16> = std::collections::HashMap::new();
         for name in &unique_vars {
@@ -1204,6 +1212,7 @@ impl Parser {
 
         self.expect(&Token::Pipe)?;
         let body = self.parse_pipe()?;
+        self.scope.vars.truncate(saved_vars);
 
         // Build: try (bind pattern1 | body) catch try (bind pattern2 | body) catch ... bind patternN | body
         // The last alternative runs WITHOUT a try-catch so its error propagates —
@@ -2573,10 +2582,14 @@ impl Parser {
             self.expect(&Token::LParen)?;
             let init = self.parse_pipe()?;
             self.expect(&Token::Semicolon)?;
+            // Snapshot scope so a same-name `$x` shadow doesn't leak after
+            // this reduce expression closes (#499).
+            let saved_vars = self.scope.vars.len();
             let var_idx = self.scope.alloc_var(&var_name);
             let acc_idx = self.scope.alloc_var("__acc__");
             let update = self.parse_pipe()?;
             self.expect(&Token::RParen)?;
+            self.scope.vars.truncate(saved_vars);
 
             Ok(Expr::Reduce {
                 source: Box::new(source),
@@ -2595,11 +2608,13 @@ impl Parser {
             self.expect(&Token::LParen)?;
             let init = self.parse_pipe()?;
             self.expect(&Token::Semicolon)?;
+            let saved_vars = self.scope.vars.len();
             let allocs = self.alloc_pattern_vars(&pattern);
             let tmp_var = self.scope.alloc_var("__reduce_item__");
             let acc_idx = self.scope.alloc_var("__acc__");
             let update_raw = self.parse_pipe()?;
             self.expect(&Token::RParen)?;
+            self.scope.vars.truncate(saved_vars);
 
             let update = self.build_binding(
                 Expr::LoadVar { var_index: tmp_var },
@@ -2635,6 +2650,9 @@ impl Parser {
             self.expect(&Token::LParen)?;
             let init = self.parse_pipe()?;
             self.expect(&Token::Semicolon)?;
+            // Snapshot scope so a same-name `$x` shadow doesn't leak after
+            // this foreach expression closes (#499).
+            let saved_vars = self.scope.vars.len();
             let var_idx = self.scope.alloc_var(&var_name);
             let acc_idx = self.scope.alloc_var("__acc__");
             let update = self.parse_pipe()?;
@@ -2644,6 +2662,7 @@ impl Parser {
                 None
             };
             self.expect(&Token::RParen)?;
+            self.scope.vars.truncate(saved_vars);
 
             Ok(Expr::Foreach {
                 source: Box::new(source),
@@ -2660,6 +2679,7 @@ impl Parser {
             self.expect(&Token::LParen)?;
             let init = self.parse_pipe()?;
             self.expect(&Token::Semicolon)?;
+            let saved_vars = self.scope.vars.len();
             let allocs = self.alloc_pattern_vars(&pattern);
             let tmp_var = self.scope.alloc_var("__foreach_item__");
             let acc_idx = self.scope.alloc_var("__acc__");
@@ -2670,6 +2690,7 @@ impl Parser {
                 None
             };
             self.expect(&Token::RParen)?;
+            self.scope.vars.truncate(saved_vars);
 
             // Wrap update in pattern binding
             let update = self.build_binding(

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -7878,3 +7878,53 @@ try path(.[true]) catch .
 try path(.[null]) catch .
 5
 "Cannot index number with null"
+
+# Issue #499: nested same-name `as $x` doesn't leak into outer scope
+5 as $x | (10 as $x | $x), $x
+null
+10
+5
+
+# Issue #499: array-context binding doesn't leak
+5 as $x | [10 as $x | $x], $x
+null
+[10]
+5
+
+# Issue #499: pipe-then-comma binding doesn't leak
+5 as $x | (10 as $x | $x | . + 1), $x
+null
+11
+5
+
+# Issue #499: reduce binding doesn't leak the iterator var name
+5 as $x | (reduce range(3) as $x (0; .+$x)), $x
+null
+3
+5
+
+# Issue #499: foreach binding doesn't leak
+5 as $x | (foreach range(3) as $x (0; .+$x; .)), $x
+null
+0
+1
+3
+5
+
+# Issue #499: array-context reduce doesn't leak
+5 as $x | [reduce range(3) as $x (0; .+$x)], $x
+null
+[3]
+5
+
+# Issue #499: destructuring binding doesn't leak
+. as [$a, $b] | (. as [$a, $b] | $a + $b), $a
+[1, 2]
+3
+1
+
+# Issue #499: deep nesting still respects scopes
+1 as $x | 2 as $y | (3 as $x | 4 as $y | $x + $y), $x + $y
+null
+7
+3


### PR DESCRIPTION
## Summary

The parser's \`Scope::vars\` is a flat list with reverse-iteration lookup. When an \`as\`/\`reduce\`/\`foreach\` body finished parsing the allocated pattern vars stayed in the list, so the inner same-name binding shadowed the outer one for the rest of the enclosing pipe:

\`\`\`sh
$ echo null | jq-jit -c '5 as \$x | (10 as \$x | \$x), \$x'
10
null    # <- expected 5
\`\`\`

| filter | jq | jq-jit (before) | jq-jit (this PR) |
|---|---|---|---|
| \`5 as \$x | (10 as \$x | \$x), \$x\` | \`10, 5\` | \`10, null\` | \`10, 5\` |
| \`5 as \$x | (reduce range(3) as \$x (0; .+\$x)), \$x\` | \`3, 5\` | \`3, null\` | \`3, 5\` |
| \`5 as \$x | (foreach range(3) as \$x (0; .+\$x; .)), \$x\` | \`0, 1, 3, 5\` | \`0, 1, 3, null\` | \`0, 1, 3, 5\` |
| \`5 as \$x | (10 as \$y | \$y), \$x\` (different name) | \`10, 5\` | \`10, 5\` ✓ | \`10, 5\` |

\`def\` already snapshotted \`vars.len()\` and truncated after parsing the body (line 824). Applied the same pattern to:

- \`parse_as_binding\` — simple binding and \`?//\` alt-destructure forms
- \`parse_reduce\` — simple binding and destructure form
- \`parse_foreach\` — simple binding and destructure form

Different-name shadowing was already correct because lookup picked the right index. The fix only affects same-name shadowing where lookup needed to fall back past the inner binding once its scope ended.

## Test plan

- [x] \`cargo build --release\` (zero warnings)
- [x] \`cargo test --release\` (all suites pass; 8 new regression cases)
- [x] \`./bench/comprehensive.sh\` (no FAIL/TIMEOUT — parser-only change, no runtime perf impact)

Closes #499

🤖 Generated with [Claude Code](https://claude.com/claude-code)