### PR TITLE
fix: range preserves repr of float-literal start on first yield

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3306,8 +3306,22 @@ fn eval_range(from: &Value, to: &Value, step: Option<&Value>, cb: &mut dyn FnMut
     let s = match step { Some(Value::Num(n, _)) => *n, Some(_) => bail!("range: step must be number"), None => 1.0 };
     if s == 0.0 { return Ok(true); }
     let mut c = f;
-    if s > 0.0 { while c < t { if !cb(Value::number(c))? { return Ok(false); } c += s; } }
-    else { while c > t { if !cb(Value::number(c))? { return Ok(false); } c += s; } }
+    let mut first = true;
+    if s > 0.0 {
+        while c < t {
+            let v = if first { from.clone() } else { Value::number(c) };
+            first = false;
+            if !cb(v)? { return Ok(false); }
+            c += s;
+        }
+    } else {
+        while c > t {
+            let v = if first { from.clone() } else { Value::number(c) };
+            first = false;
+            if !cb(v)? { return Ok(false); }
+            c += s;
+        }
+    }
     Ok(true)
 }
 

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -7928,3 +7928,33 @@ null
 null
 7
 3
+
+# Issue #503: range with float-literal start preserves repr on first yield
+[range(0.0; 3)]
+null
+[0.0,1,2]
+
+# Issue #503: explicit step preserves first-only repr
+[range(0.0; 1.0; 0.25)]
+null
+[0.0,0.25,0.5,0.75]
+
+# Issue #503: negative step preserves first-only repr
+[range(3.0; 0; -1)]
+null
+[3.0,2,1]
+
+# Issue #503: from a variable that holds a float-repr value
+1.0 as $x | [range($x; 4)]
+null
+[1.0,2,3]
+
+# Issue #503: empty range yields nothing (no spurious 0.0 emission)
+[range(5.0; 1)]
+null
+[]
+
+# Issue #503: integer literal still renders as integer
+[range(0; 3)]
+null
+[0,1,2]


### PR DESCRIPTION
## Summary

- jq emits `range(0.0; 3)` as `0.0, 1, 2` — the first yielded value carries the literal `from`'s `NumRepr`, while subsequent values come from `from + step` arithmetic and use the integer-style repr.
- jq-jit's `eval_range` was constructing every emission via `Value::number(c)` from the running f64 counter, dropping the repr even on the first iteration. Output became `0, 1, 2`.
- Fix: hand the original `from` value to the callback on the first iteration; only then start computing subsequent values from the f64 counter.

## Test plan

- [x] Six new regression cases in `tests/regression.test` cover positive step, custom step, negative step, repr-bearing variable input, empty range, and integer baseline (no regression).
- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (all green: 509 official + 1557 regression + diff_corpus + selfdiff + fuzz)
- [x] `bench/comprehensive.sh` (no FAIL/TIMEOUT, within noise vs v1.4.5 baseline)

Closes #503