### PR TITLE
fix: flatten error wording matches jq's 'Cannot iterate over' form

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1217,7 +1217,7 @@ fn rt_flatten(v: &Value, depth: Option<usize>) -> Result<Value> {
             flatten_inner(&values, depth.unwrap_or(usize::MAX), &mut result);
             Ok(Value::Arr(Rc::new(result)))
         }
-        _ => bail!("{} is not an array", v.type_name()),
+        _ => bail!("Cannot iterate over {}", errdesc(v)),
     }
 }
 

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -7958,3 +7958,38 @@ null
 [range(0; 3)]
 null
 [0,1,2]
+
+# Issue #505: flatten/0 on number says "Cannot iterate over <type> (<value>)"
+try flatten catch .
+1
+"Cannot iterate over number (1)"
+
+# Issue #505: flatten/0 on string keeps the value tag
+try flatten catch .
+"abc"
+"Cannot iterate over string (\"abc\")"
+
+# Issue #505: flatten/0 on null
+try flatten catch .
+null
+"Cannot iterate over null (null)"
+
+# Issue #505: flatten/0 on boolean
+try flatten catch .
+true
+"Cannot iterate over boolean (true)"
+
+# Issue #505: flatten/1 (with depth) shares the same wording
+try (flatten(2)) catch .
+1
+"Cannot iterate over number (1)"
+
+# Issue #505: array input still flattens normally
+flatten
+[1,[2,[3]]]
+[1,2,3]
+
+# Issue #505: object input still flattens its values
+flatten
+{"a":[1,2],"b":3}
+[1,2,3]


### PR DESCRIPTION
## Summary

- jq's \`flatten\`/\`flatten(N)\` on a non-iterable input emits \`\"Cannot iterate over <type> (<value>)\"\` — the same wording #481 standardized across the rest of the iteration sites.
- jq-jit's \`rt_flatten\` scalar fallback was still bailing with \`\"<type> is not an array\"\` (no value tag, different lead-in).
- Fix: route the error through \`errdesc(v)\` and switch the wording to match.

## Test plan

- [x] Seven new regression cases in \`tests/regression.test\` cover \`flatten\` on number / string / null / boolean / object input plus \`flatten(2)\` on a number, and confirm array/object inputs still flatten normally.
- [x] \`cargo build --release\` (zero warnings)
- [x] \`cargo test --release\` (1564 regression now, was 1557; all green: 509 official + diff_corpus + selfdiff + fuzz)
- [x] \`bench/comprehensive.sh\` (no FAIL/TIMEOUT). Two flagged regressions vs v1.4.5 baseline are non-issues:
  - \`jaq: tree-update\` x33.86 — known #498 baseline shift; the v1.4.5 row in \`docs/benchmark-history.tsv\` was captured against the buggy fast-path early-exit. Post-#498 the correct timing (~0.22s) is still 2x faster than jq itself.
  - \`if .x|flr>N b s\` x1.31 — single-run noise on a 45ms benchmark.

Closes #505