### PR TITLE
fix: tojson preserves trailing-zero floats above 1e14

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -5571,13 +5571,17 @@ pub(crate) fn repr_is_exact_for_f64(repr: &str, n: f64) -> bool {
     let mut i = 0;
     if matches!(bytes.first(), Some(b'-') | Some(b'+')) { i += 1; }
     let mut sig_digits = 0u32;
+    let mut trailing_zeros = 0u32;
     let mut started = false;
     while i < bytes.len() && bytes[i] != b'e' && bytes[i] != b'E' {
         let c = bytes[i];
         if c == b'.' { i += 1; continue; }
         if !c.is_ascii_digit() { return false; }
-        if c != b'0' { started = true; }
-        if started { sig_digits += 1; }
+        if c != b'0' { started = true; trailing_zeros = 0; }
+        if started {
+            sig_digits += 1;
+            if c == b'0' { trailing_zeros += 1; }
+        }
         i += 1;
     }
     let mut exp_val: i32 = 0;
@@ -5593,7 +5597,11 @@ pub(crate) fn repr_is_exact_for_f64(repr: &str, n: f64) -> bool {
         if exp_neg { exp_val = -exp_val; }
     }
     if exp_val > 308 || exp_val < -323 { return false; }
-    sig_digits <= 15
+    // Trailing zeros (after the last non-zero digit, integer or fractional)
+    // do not contribute precision: `100000000000000.0` has effective sig=1
+    // even though the digit count is 16. Subtract them so the cap matches
+    // the actual precision the literal claims.
+    sig_digits.saturating_sub(trailing_zeros) <= 15
 }
 
 fn value_to_json_depth(v: &Value, depth: usize, precise: bool) -> String {

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -7993,3 +7993,28 @@ flatten
 flatten
 {"a":[1,2],"b":3}
 [1,2,3]
+
+# Issue #507: tojson preserves trailing-zero floats up to f64-exact magnitudes
+100000000000000.0 | tojson
+null
+"100000000000000.0"
+
+# Issue #507: 1e15 with .0 stays a decimal-form float
+1000000000000000.0 | tojson
+null
+"1000000000000000.0"
+
+# Issue #507: 1e16 with .0 — exactly representable, repr preserved
+10000000000000000.0 | tojson
+null
+"10000000000000000.0"
+
+# Issue #507: trailing zero on a non-integer float still preserved
+100.50 | tojson
+null
+"100.50"
+
+# Issue #507: literal with significant non-zero digits beyond 15 still drops repr
+13911860366432393.0 | tojson | length
+null
+17


### PR DESCRIPTION
## Summary

- jq emits \`100000000000000.0 | tojson\` as \`\"100000000000000.0\"\` (decnum keeps the literal verbatim). jq-jit was emitting \`\"100000000000000\"\` — same divergence for any float-literal whose total digit count crosses 16, including \`1000000000000000.0\` (1e15) and \`10000000000000000.0\` (1e16, which collapsed to scientific \`\"1e+16\"\`).
- Cause: \`repr_is_exact_for_f64\` counted every digit (including trailing zeros) toward its \`sig_digits <= 15\` cap, so \`100000000000000.0\` was rejected as 16 sig digits even though only 1 digit (the leading \`1\`) carries precision.
- Fix: track the run of trailing zeros after the last non-zero digit (whether in the integer or fractional part) and subtract from \`sig_digits\` before the cap check. Literals with non-zero precision past the 15-digit cap (\`13911860366432393\`) still fall back to dtoa.

## Test plan

- [x] Five new regression cases in \`tests/regression.test\` cover 1e14, 1e15, 1e16 with \`.0\`, plus \`100.50\` (mid-magnitude with trailing zero on a non-integer) and the precision-bound floor.
- [x] \`cargo build --release\` (zero warnings)
- [x] \`cargo test --release\` (1569 regression now, was 1564; all green: 509 official + diff_corpus + selfdiff + fuzz)
- [x] \`bench/comprehensive.sh\` (no FAIL/TIMEOUT). Only \`jaq: tree-update\` flagged vs v1.4.5 — known #498 baseline shift, unrelated.

Closes #507