### PR TITLE
fix: align getpath/setpath/delpaths error wording with jq

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2228,7 +2228,7 @@ pub fn rt_getpath(v: &Value, path: &Value) -> Result<Value> {
             }
             Ok(current)
         }
-        _ => bail!("getpath requires array path"),
+        _ => bail!("Path must be specified as an array"),
     }
 }
 
@@ -2347,19 +2347,21 @@ pub fn rt_setpath(v: &Value, path: &Value, val: &Value) -> Result<Value> {
                         _ => bail!("Cannot set path"),
                     }
                 }
-                (_, Value::Arr(_)) => {
+                // jq emits a special message when both the container and the
+                // key are arrays: `Cannot update field at array index of array`.
+                // All other type-mismatch combinations use the same wording as
+                // the read side (`rt_getpath`, `.[k]`).
+                (Value::Arr(_), Value::Arr(_)) => {
                     bail!("Cannot update field at array index of array");
                 }
-                (Value::Num(_, _), Value::Num(_, _)) => {
-                    bail!("Cannot index number with number");
-                }
-                (Value::Num(_, _), Value::Str(k)) => {
-                    bail!("Cannot index number with string \"{}\"", k);
-                }
-                _ => bail!("Cannot set path"),
+                (_, _) => bail!(
+                    "Cannot index {} with {}",
+                    v.type_name(),
+                    index_err_desc(key),
+                ),
             }
         }
-        _ => bail!("setpath requires array path"),
+        _ => bail!("Path must be specified as an array"),
     }
 }
 
@@ -2394,7 +2396,7 @@ pub fn rt_setpath_mut(v: &mut Value, path: &[Value], val: Value) -> Result<()> {
                 }
                 Ok(())
             } else {
-                bail!("Cannot index {} with string", v.type_name());
+                bail!("Cannot index {} with string \"{}\"", v.type_name(), k);
             }
         }
         Value::Num(n, _) => {
@@ -2432,10 +2434,17 @@ pub fn rt_setpath_mut(v: &mut Value, path: &[Value], val: Value) -> Result<()> {
                 bail!("Cannot index {} with number", v.type_name());
             }
         }
-        Value::Arr(_) => {
+        // jq's special-case wording for array-key on array-container; the
+        // other combinations share the read-side `Cannot index <container>
+        // with <key_type>` form.
+        Value::Arr(_) if matches!(v, Value::Arr(_)) => {
             bail!("Cannot update field at array index of array");
         }
-        _ => bail!("Cannot set path with {} key", key.type_name()),
+        _ => bail!(
+            "Cannot index {} with {}",
+            v.type_name(),
+            index_err_desc(key),
+        ),
     }
 }
 
@@ -2456,7 +2465,10 @@ pub fn rt_delpaths(v: &Value, paths: &Value) -> Result<Value> {
             for path in sorted_paths {
                 let p_arr = match path {
                     Value::Arr(p) => p,
-                    _ => return Err(anyhow::anyhow!("Path must be specified as array")),
+                    _ => return Err(anyhow::anyhow!(
+                        "Path must be specified as array, not {}",
+                        path.type_name()
+                    )),
                 };
                 let subsumed = filtered.iter().any(|prev| {
                     let prev_arr = match prev {

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -8018,3 +8018,68 @@ null
 13911860366432393.0 | tojson | length
 null
 17
+
+# Issue #509: getpath with non-array path uses jq's "Path must be specified as an array"
+try getpath("x") catch .
+null
+"Path must be specified as an array"
+
+# Issue #509: getpath with number path
+try getpath(99) catch .
+null
+"Path must be specified as an array"
+
+# Issue #509: setpath with non-array path (same wording as getpath)
+try setpath("x"; 1) catch .
+null
+"Path must be specified as an array"
+
+# Issue #509: setpath with null path
+try setpath(null; 1) catch .
+null
+"Path must be specified as an array"
+
+# Issue #509: delpaths with non-array inner element appends type tag
+try delpaths([null]) catch .
+null
+"Path must be specified as array, not null"
+
+# Issue #509: delpaths inner element type tag for string
+try delpaths(["x"]) catch .
+null
+"Path must be specified as array, not string"
+
+# Issue #509: delpaths inner element type tag for number
+try delpaths([1]) catch .
+null
+"Path must be specified as array, not number"
+
+# Issue #509: setpath bad key on object — uses "Cannot index" wording
+try setpath([null]; 1) catch .
+{"a":1}
+"Cannot index object with null"
+
+# Issue #509: setpath bad key (boolean) on object
+try setpath([true]; 1) catch .
+{"a":1}
+"Cannot index object with boolean"
+
+# Issue #509: setpath bad key (array) on object
+try setpath([[1]]; 1) catch .
+{"a":1}
+"Cannot index object with array"
+
+# Issue #509: array key on array container keeps the special wording
+try setpath([[1]]; 1) catch .
+[1,2,3]
+"Cannot update field at array index of array"
+
+# Issue #509: setpath_mut path with string key on number includes value tag
+try (reduce range(1) as $_ (.; setpath(["a"]; 99))) catch .
+5
+"Cannot index number with string \"a\""
+
+# Issue #509: setpath_mut path with null key matches read-side wording
+try (reduce range(1) as $_ (.; setpath([null]; 99))) catch .
+5
+"Cannot index number with null"


### PR DESCRIPTION
## Summary

Several path-family error messages diverged from jq:

| Filter | jq | jq-jit (before) |
|---|---|---|
| \`getpath(\"x\")\` / \`getpath(99)\` / etc. | \`\"Path must be specified as an array\"\` | \`\"getpath requires array path\"\` |
| \`setpath(\"x\"; 1)\` / \`setpath(99; 1)\` / etc. | \`\"Path must be specified as an array\"\` | \`\"setpath requires array path\"\` |
| \`delpaths([null])\` / \`delpaths([\"x\"])\` / etc. | \`\"Path must be specified as array, not <type>\"\` | \`\"Path must be specified as array\"\` (no type tag) |
| \`{a:1} \| setpath([null]; 1)\` | \`\"Cannot index object with null\"\` | \`\"Cannot set path with null key\"\` |
| \`{a:1} \| setpath([true]; 1)\` | \`\"Cannot index object with boolean\"\` | \`\"Cannot set path with boolean key\"\` |
| \`{a:1} \| setpath([{}]; 1)\` | \`\"Cannot index object with object\"\` | \`\"Cannot set path with object key\"\` |
| \`{a:1} \| setpath([[1]]; 1)\` | \`\"Cannot index object with array\"\` | \`\"Cannot update field at array index of array\"\` (wrong wording for object container) |
| \`5 \| setpath([\"a\"]; 1)\` (via reduce) | \`\"Cannot index number with string \"a\"\"\` | \`\"Cannot index number with string\"\` (no value tag) |

## Fix

Reuse \`index_err_desc\` (the helper \`rt_getpath\` already uses) so setpath/getpath agree on the \`Cannot index <container> with <key_type>\` form. Carve out the historical \`Cannot update field at array index of array\` only when both the container AND the key are arrays — that's jq's actual special case (other containers with array key use \`Cannot index <container> with array\`). Apply the same fixes in \`rt_setpath_mut\` (the in-place variant used by reduce contexts) so it picks up both the value-tag-on-string-key and the bad-key-type wording.

## Test plan

- [x] Thirteen new regression cases in \`tests/regression.test\` cover getpath/setpath path-arg validation, delpaths inner-element type tag, setpath bad-key on object, setpath_mut bad-key with value tag, and the array-key-on-array carve-out.
- [x] \`cargo build --release\` (zero warnings)
- [x] \`cargo test --release\` (1582 regression now, was 1569; all green: 509 official + diff_corpus + selfdiff + fuzz). The official suite also exercises the array-key-on-array case (test #504); it now passes after the carve-out.
- [x] \`bench/comprehensive.sh\` (no FAIL/TIMEOUT). Two flagged regressions are noise (\`min, max(2M)\` and \`jaq: min-max\` are <25ms benchmarks; the change is in error-path strings only). \`jaq: tree-update\` is the known #498 baseline shift.

Closes #509