### PR TITLE
fix: parser handles invalid \uXXXX surrogate escapes like jq

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -596,25 +596,40 @@ impl Lexer {
 
                             // Handle surrogate pairs
                             if (0xD800..=0xDBFF).contains(&cp) {
-                                // High surrogate, look for \uXXXX low surrogate
-                                if self.pos + 5 < self.chars.len()
-                                    && self.chars[self.pos] == '\\'
-                                    && self.chars[self.pos + 1] == 'u'
+                                // High surrogate. jq requires the next escape
+                                // to be a valid low surrogate `\uDC00..=\uDFFF`;
+                                // anything else (EOF, plain char, another high
+                                // surrogate, low-surrogate-with-junk) is a parse
+                                // error. Silently dropping it would diverge from
+                                // jq, which rejects the literal at parse time.
+                                let invalid_pair = || anyhow::anyhow!(
+                                    "Invalid \\uXXXX\\uXXXX surrogate pair escape"
+                                );
+                                if self.pos + 5 >= self.chars.len()
+                                    || self.chars[self.pos] != '\\'
+                                    || self.chars[self.pos + 1] != 'u'
                                 {
-                                    self.pos += 2;
-                                    let hex2: String = self.chars[self.pos..self.pos+4].iter().collect();
-                                    self.pos += 4;
-                                    let cp2 = u32::from_str_radix(&hex2, 16)
-                                        .map_err(|_| anyhow::anyhow!("invalid unicode escape"))?;
-                                    if (0xDC00..=0xDFFF).contains(&cp2) {
-                                        let combined = ((cp - 0xD800) << 10) + (cp2 - 0xDC00) + 0x10000;
-                                        if let Some(c) = char::from_u32(combined) {
-                                            current.push(c);
-                                        }
-                                    }
+                                    return Err(invalid_pair());
+                                }
+                                self.pos += 2;
+                                let hex2: String = self.chars[self.pos..self.pos+4].iter().collect();
+                                self.pos += 4;
+                                let cp2 = u32::from_str_radix(&hex2, 16)
+                                    .map_err(|_| anyhow::anyhow!("invalid unicode escape"))?;
+                                if !(0xDC00..=0xDFFF).contains(&cp2) {
+                                    return Err(invalid_pair());
+                                }
+                                let combined = ((cp - 0xD800) << 10) + (cp2 - 0xDC00) + 0x10000;
+                                if let Some(c) = char::from_u32(combined) {
+                                    current.push(c);
                                 }
                             } else if let Some(c) = char::from_u32(cp) {
                                 current.push(c);
+                            } else {
+                                // Standalone low surrogate (DC00-DFFF) — jq
+                                // emits U+FFFD (replacement character) for these
+                                // rather than dropping or erroring.
+                                current.push('\u{FFFD}');
                             }
                         }
                         _ => {

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -8083,3 +8083,28 @@ try (reduce range(1) as $_ (.; setpath(["a"]; 99))) catch .
 try (reduce range(1) as $_ (.; setpath([null]; 99))) catch .
 5
 "Cannot index number with null"
+
+# Issue #511: standalone low surrogate (\udcXX) renders as U+FFFD (length 1)
+"\udc00" | length
+null
+1
+
+# Issue #511: low surrogate in a string keeps neighbours
+"a\udc00b" | length
+null
+3
+
+# Issue #511: two low surrogates each become U+FFFD
+"\udc00\udc00" | length
+null
+2
+
+# Issue #511: max low surrogate also becomes U+FFFD
+"\udfff" | length
+null
+1
+
+# Issue #511: low surrogate produces explicit replacement character
+"\udc00" | explode
+null
+[65533]


### PR DESCRIPTION
## Summary

Two adjacent bugs in `src/parser.rs`'s `\uXXXX` handler silently mishandled malformed surrogate sequences:

1. **High surrogate not followed by a valid low surrogate** (e.g. `"\ud83d"`, `"\ud83dA"`, `"\ud83d\ud83d"`, `"\udb00"` at EOF) was silently dropped. jq raises `Invalid \uXXXX\uXXXX surrogate pair escape` at parse time.
2. **Standalone low surrogate** (e.g. `"\udc00"`, `"\udfff"`, `"a\udc00b"`) returned `None` from `char::from_u32` and silently produced no character. jq emits U+FFFD (REPLACEMENT CHARACTER) for these.

| Filter | jq | jq-jit (before) |
|---|---|---|
| `"\ud83d" \| length` | parse error | `0` (silent) |
| `"\ud83dA" \| length` | parse error | `1` (drops high surrogate) |
| `"\udc00" \| length` | `1` (U+FFFD) | `0` (silent) |
| `"a\udc00b" \| length` | `3` | `2` |
| `"\udc00\udc00" \| length` | `2` (two U+FFFD) | `0` |

## Test plan

- [x] Five new regression cases in `tests/regression.test` cover the three low-surrogate forms (alone, in middle of string, two adjacent), max low surrogate, and explode confirming U+FFFD codepoint (65533).
- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (all green: 509 official + 1587 regression + diff_corpus + selfdiff + fuzz)
- [x] `bench/comprehensive.sh` (no FAIL/TIMEOUT). `has("x")` flagged at +33% but it's a 30ms benchmark — single-run noise; the change is in parser surrogate handling only. `jaq: tree-update` is the known #498 baseline shift.

Closes #511