### PR TITLE
fix: identity passthrough rejects NaN/Infinity input bytes

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -21,6 +21,11 @@ fn raw_contains_del_byte(bytes: &[u8]) -> bool {
 /// would normalise differently from jq's canonical output (e.g. `1e10`
 /// → `1E+10`, `+1` → `1`, `1e-5` → `0.00001`). Used to disable raw-byte
 /// passthrough so the canonical form lands on stdout (issues #110, #143).
+///
+/// Also catches the special-float literals `nan`, `NaN`, `Infinity` (and
+/// their `-`-prefixed variants) that jq's input parser accepts but
+/// re-renders as `null` / `±1.7976931348623157e+308` (issue #513).
+/// Without this check, identity passthrough would emit invalid JSON.
 fn raw_contains_non_canonical_number(bytes: &[u8]) -> bool {
     let mut i = 0;
     while i < bytes.len() {
@@ -36,6 +41,13 @@ fn raw_contains_non_canonical_number(bytes: &[u8]) -> bool {
                 }
             }
             b'+' => return true,
+            // Special-float literals accepted by parse_json_value: `nan`,
+            // `NaN`, `Infinity`, `-NaN`, `-Infinity`. jq normalises these to
+            // `null` (NaN) or `±1.7976931348623157e+308` (Infinity) — the
+            // raw input bytes would otherwise leak through as invalid JSON.
+            b'n' if bytes.get(i..i+3) == Some(b"nan") => return true,
+            b'N' if bytes.get(i..i+3) == Some(b"NaN") => return true,
+            b'I' if bytes.get(i..i+8) == Some(b"Infinity") => return true,
             b'e' | b'E' => {
                 // Only flag when this `e`/`E` is part of a number — the
                 // immediately preceding byte is a digit or `.`.

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -8108,3 +8108,38 @@ null
 "\udc00" | explode
 null
 [65533]
+
+# Issue #513: identity passthrough on NaN input emits canonical null
+.
+nan
+null
+
+# Issue #513: identity passthrough on NaN (capitalised) input emits null
+.
+NaN
+null
+
+# Issue #513: identity passthrough on Infinity input emits canonical max-f64
+.
+Infinity
+1.7976931348623157e+308
+
+# Issue #513: identity passthrough on -Infinity input emits canonical min-f64
+.
+-Infinity
+-1.7976931348623157e+308
+
+# Issue #513: identity passthrough on -NaN input emits null
+.
+-NaN
+null
+
+# Issue #513: a string literal containing "NaN" still passes through verbatim
+.
+"NaN"
+"NaN"
+
+# Issue #513: an object key "Infinity" still passes through unchanged
+.
+{"Infinity":1}
+{"Infinity":1}


### PR DESCRIPTION
## Summary

\`process_input\` has a raw passthrough that copies the original input bytes to stdout when (1) result is the unmodified input, (2) bytes are JSON-compact, and (3) \`raw_contains_non_canonical_number\` returns false. The third check missed the special-float literals (\`nan\`, \`NaN\`, \`Infinity\`, \`-NaN\`, \`-Infinity\`) that \`parse_json_value\` accepts but jq re-renders:

| Input | jq | jq-jit (before) |
|---|---|---|
| \`nan\` | \`null\` | \`nan\` |
| \`NaN\` | \`null\` | \`NaN\` |
| \`-NaN\` | \`null\` | \`-NaN\` |
| \`Infinity\` | \`1.7976931348623157e+308\` | \`Infinity\` |
| \`-Infinity\` | \`-1.7976931348623157e+308\` | \`-Infinity\` |

The output is invalid JSON — round-tripping through any strict parser would fail. The same input through \`. + 0\`, \`(.)\`, or any path that drops the passthrough already emits \`null\` / \`±1.7976931348623157e+308\` correctly, so the bug is specifically the raw-byte copy.

## Fix

Extend \`raw_contains_non_canonical_number\` (\`src/bin/jq-jit.rs:24\`) to bail when \`nan\`, \`NaN\`, or \`Infinity\` appear outside string contents. The function already skips string interiors (so \`\"NaN\"\` strings still passthrough verbatim), so the addition is three byte-prefix checks.

## Test plan

- [x] Seven new regression cases in \`tests/regression.test\` cover the five special-float input forms plus two passthrough-still-works cases (\`\"NaN\"\` string, object key \`\"Infinity\"\`).
- [x] \`cargo build --release\` (zero warnings)
- [x] \`cargo test --release\` (all green: 509 official + 1594 regression + diff_corpus + selfdiff + fuzz)
- [x] \`bench/comprehensive.sh\` (no FAIL/TIMEOUT, expected outcome since the change is in a one-off scan only fired by passthrough gating).

## Related

Lowercase \`infinity\`/\`inf\` forms are also accepted by jq's parser but currently rejected by jq-jit's input parser; that's a separate gap to file.

Closes #513