### PR TITLE
fix: from_entries error wording matches jq's stdlib desugaring

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1717,7 +1717,18 @@ fn rt_from_entries(v: &Value) -> Result<Value> {
                         };
                         obj.insert(KeyStr::from(key_str), val);
                     }
-                    _ => bail!("from_entries requires array of objects"),
+                    // jq's from_entries desugars to `map(...) | with_entries(.)`.
+                    // For null entries, `.key`/`.name` resolve to null, which
+                    // then reaches object construction and bails as
+                    // `Cannot use null (null) as object key` (#517).
+                    Value::Null => bail!("Cannot use null (null) as object key"),
+                    // For non-null non-object entries, jq's `.key` access on
+                    // the entry surfaces the standard `Cannot index <type>
+                    // with string "key"` error.
+                    other => bail!(
+                        "Cannot index {} with string \"key\"",
+                        other.type_name(),
+                    ),
                 }
             }
             Ok(Value::object_from_map(obj))
@@ -1725,7 +1736,10 @@ fn rt_from_entries(v: &Value) -> Result<Value> {
         // jq's from_entries desugars to `map(...) | add + {}`. On {} the map yields [],
         // add yields null, and null + {} is {} — so empty objects round-trip to {}.
         Value::Obj(ObjInner(o)) if o.is_empty() => Ok(Value::object_from_map(new_objmap())),
-        _ => bail!("{} cannot be converted from entries", v.type_name()),
+        // jq's stdlib starts with `map(...)` which iterates the input — non-array
+        // (and non-empty-object) inputs fail there with the standard
+        // `Cannot iterate over <type> (<value>)` wording (#481/#505/#517).
+        _ => bail!("Cannot iterate over {}", errdesc(v)),
     }
 }
 

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -8183,3 +8183,53 @@ null
 .
 [nan, NaN, Infinity, -inf, +inf, +NaN]
 [null,null,1.7976931348623157e+308,-1.7976931348623157e+308,1.7976931348623157e+308,null]
+
+# Issue #517: from_entries on number says "Cannot iterate over <type> (<value>)"
+try (1 | from_entries) catch .
+null
+"Cannot iterate over number (1)"
+
+# Issue #517: from_entries on null
+try (null | from_entries) catch .
+null
+"Cannot iterate over null (null)"
+
+# Issue #517: from_entries on string
+try ("abc" | from_entries) catch .
+null
+"Cannot iterate over string (\"abc\")"
+
+# Issue #517: from_entries with null entry surfaces null-key error
+try ([null] | from_entries) catch .
+null
+"Cannot use null (null) as object key"
+
+# Issue #517: from_entries with number entry surfaces .key index error
+try ([1] | from_entries) catch .
+null
+"Cannot index number with string \"key\""
+
+# Issue #517: from_entries with string entry
+try (["x"] | from_entries) catch .
+null
+"Cannot index string with string \"key\""
+
+# Issue #517: from_entries with boolean entry
+try ([true] | from_entries) catch .
+null
+"Cannot index boolean with string \"key\""
+
+# Issue #517: from_entries with array entry
+try ([[1,2]] | from_entries) catch .
+null
+"Cannot index array with string \"key\""
+
+# Issue #517: empty object input still round-trips to {} (not iteration error)
+{} | from_entries
+null
+{}
+
+# Issue #517: legitimate object array still works
+[{"key":"a","value":1}] | from_entries
+null
+{"a":1}


### PR DESCRIPTION
## Summary

\`rt_from_entries\` had two custom error sites that diverged from jq's stdlib (\`map(...) | with_entries(.)\`):

| Filter | jq | jq-jit (before) |
|---|---|---|
| \`1 \| from_entries\` | \`Cannot iterate over number (1)\` | \`number cannot be converted from entries\` |
| \`null \| from_entries\` | \`Cannot iterate over null (null)\` | \`null cannot be converted from entries\` |
| \`\"abc\" \| from_entries\` | \`Cannot iterate over string (\"abc\")\` | \`string cannot be converted from entries\` |
| \`[null] \| from_entries\` | \`Cannot use null (null) as object key\` | \`from_entries requires array of objects\` |
| \`[1] \| from_entries\` | \`Cannot index number with string \"key\"\` | \`from_entries requires array of objects\` |
| \`[\"x\"] \| from_entries\` | \`Cannot index string with string \"key\"\` | \`from_entries requires array of objects\` |
| \`[true] \| from_entries\` | \`Cannot index boolean with string \"key\"\` | \`from_entries requires array of objects\` |
| \`[[1,2]] \| from_entries\` | \`Cannot index array with string \"key\"\` | \`from_entries requires array of objects\` |

## Fix

- Non-array (and non-empty-object) input now bails with \`Cannot iterate over <errdesc>\` — matches the standard wording adopted across other iteration sites in #481/#505.
- Non-object array entries split into two cases: Null entries bail with \`Cannot use null (null) as object key\` (matches jq's downstream object-construction failure), and other non-object entries bail with \`Cannot index <type> with string \"key\"\` (matches jq's \`.key\` index error).

## Test plan

- [x] Ten new regression cases in \`tests/regression.test\` cover the eight error-wording forms plus two happy-path cases (empty object input round-trip and object array success).
- [x] \`cargo build --release\` (zero warnings)
- [x] \`cargo test --release\` (all green: 509 official + 1612 regression + diff_corpus + selfdiff + fuzz)
- [x] \`bench/comprehensive.sh\` running (no impact expected — the change is in error-path strings only)

Closes #517