### PR TITLE
fix: range/2 from/to type-error wording matches jq

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3339,8 +3339,12 @@ fn eval_recurse_default(val: &Value, cb: &mut dyn FnMut(Value) -> GenResult) -> 
 }
 
 fn eval_range(from: &Value, to: &Value, step: Option<&Value>, cb: &mut dyn FnMut(Value) -> GenResult) -> GenResult {
-    let f = match from { Value::Num(n, _) => *n, _ => bail!("range: from must be number") };
-    let t = match to { Value::Num(n, _) => *n, _ => bail!("range: to must be number") };
+    // jq emits a single "Range bounds must be numeric" error for both
+    // out-of-type from and to (#527). The step argument has lazier
+    // semantics in jq (the loop emits the first value before arithmetic
+    // fails) so we keep the previous wording for now.
+    let f = match from { Value::Num(n, _) => *n, _ => bail!("Range bounds must be numeric") };
+    let t = match to { Value::Num(n, _) => *n, _ => bail!("Range bounds must be numeric") };
     let s = match step { Some(Value::Num(n, _)) => *n, Some(_) => bail!("range: step must be number"), None => 1.0 };
     if s == 0.0 { return Ok(true); }
     let mut c = f;

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -8408,3 +8408,28 @@ try (strptime("%Y")) catch .
 try (strptime("%Y")) catch .
 null
 "strptime/1 requires string inputs and arguments"
+
+# Issue #527: range/2 with non-numeric `to` says "Range bounds must be numeric"
+try (range(0; "x")) catch .
+null
+"Range bounds must be numeric"
+
+# Issue #527: range/2 with non-numeric `from`
+try (range("x"; 5)) catch .
+null
+"Range bounds must be numeric"
+
+# Issue #527: null bounds also bail with the same wording
+try (range(null; 5)) catch .
+null
+"Range bounds must be numeric"
+
+# Issue #527: boolean bounds also bail with the same wording
+try (range(true; 5)) catch .
+null
+"Range bounds must be numeric"
+
+# Issue #527: numeric range/2 still works
+[range(0; 3)]
+null
+[0,1,2]


### PR DESCRIPTION
## Summary

\`eval_range\` bailed with \`range: from must be number\` / \`range: to must be number\` for non-numeric bounds. jq emits a single \`Range bounds must be numeric\` for both cases:

| Filter | jq | jq-jit (before) |
|---|---|---|
| \`range(\"x\"; 5)\` | \`Range bounds must be numeric\` | \`range: from must be number\` |
| \`range(0; \"x\")\` | \`Range bounds must be numeric\` | \`range: to must be number\` |
| \`range(null; 5)\` | \`Range bounds must be numeric\` | \`range: from must be number\` |
| \`range(true; 5)\` | \`Range bounds must be numeric\` | \`range: from must be number\` |

(For \`range(0; 5; \"x\")\` jq has lazier semantics: it emits \`0\` first, then errors when adding \`0 + \"x\"\` for the next iteration. Aligning that one is more involved and is left out of this fix.)

## Test plan

- [x] Five new regression cases in \`tests/regression.test\`.
- [x] \`cargo build --release\` (zero warnings)
- [x] \`cargo test --release\` running

Closes #527