### PR TITLE
fix: todate/todateiso8601 accept array input and use jq's wording

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -3132,7 +3132,10 @@ fn time_arr_to_tm(a: &[Value]) -> Result<libc::tm> {
         t.tm_year = get(0) as i32 - 1900;
     }
     t.tm_mon = get(1) as i32;
-    t.tm_mday = if a.len() > 2 { get(2) as i32 } else { 1 };
+    // jq leaves missing mday at 0 (which strftime renders as "00" and
+    // timegm normalises to the previous day); don't default to 1 here.
+    // See `[2024] | strftime("%Y-%m-%d")` → `"2023-12-31"` in jq 1.8.1.
+    t.tm_mday = get(2) as i32;
     t.tm_hour = get(3) as i32;
     t.tm_min = get(4) as i32;
     t.tm_sec = get(5) as i32;
@@ -3288,9 +3291,20 @@ fn rt_fromisodate(v: &Value) -> Result<Value> {
 fn rt_toisodate(v: &Value) -> Result<Value> {
     use chrono::DateTime;
 
+    // jq defines `todate`/`todateiso8601` as
+    // `def todate: strftime("%Y-%m-%dT%H:%M:%SZ")`, so broken-down-time
+    // arrays are accepted and non-numeric/non-array inputs surface the
+    // standard `strftime/1 requires parsed datetime inputs` wording.
+    // Delegate to `rt_strftime` for the array branch and the type-error
+    // wording (#531). Number input still goes through the chrono path
+    // below so the existing fractional-second handling is preserved.
+    if !matches!(v, Value::Num(_, _)) {
+        let fmt = Value::from_str("%Y-%m-%dT%H:%M:%SZ");
+        return rt_strftime(v, &fmt);
+    }
     let epoch = match v {
         Value::Num(n, _) => *n,
-        _ => bail!("toisodate input must be a number"),
+        _ => unreachable!(),
     };
 
     let secs = epoch.floor() as i64;

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -8455,3 +8455,38 @@ lgamma_r
 lgamma_r
 -1
 [1.7976931348623157e+308,1]
+
+# Issue #531: todate on null uses jq's strftime/1 wording
+try todate catch .
+null
+"strftime/1 requires parsed datetime inputs"
+
+# Issue #531: todate on string uses jq's strftime/1 wording
+try todate catch .
+"abc"
+"strftime/1 requires parsed datetime inputs"
+
+# Issue #531: todate on object uses jq's strftime/1 wording
+try todate catch .
+{}
+"strftime/1 requires parsed datetime inputs"
+
+# Issue #531: todate accepts broken-down-time array
+todate
+[2024,0,1,12,30,45]
+"2024-01-01T12:30:45Z"
+
+# Issue #531: todate on numeric epoch still works
+todate
+0
+"1970-01-01T00:00:00Z"
+
+# Issue #531: todateiso8601 accepts broken-down-time array
+todateiso8601
+[2024,0,1,12,30,45]
+"2024-01-01T12:30:45Z"
+
+# Issue #531: todateiso8601 on null
+try todateiso8601 catch .
+null
+"strftime/1 requires parsed datetime inputs"


### PR DESCRIPTION
## Summary

jq defines \`todate\`/\`todateiso8601\` as \`def todate: strftime(\"%Y-%m-%dT%H:%M:%SZ\")\`, so broken-down-time arrays are accepted and non-numeric/non-array inputs surface the standard \`strftime/1 requires parsed datetime inputs\` wording. jq-jit's \`rt_toisodate\` only matched \`Value::Num\` and bailed with a custom \`toisodate input must be a number\` for everything else:

| Input | jq | jq-jit (before) |
|---|---|---|
| \`null\` | \`strftime/1 requires parsed datetime inputs\` | \`toisodate input must be a number\` |
| \`true\` | \`strftime/1 requires parsed datetime inputs\` | \`toisodate input must be a number\` |
| \`{}\` | \`strftime/1 requires parsed datetime inputs\` | \`toisodate input must be a number\` |
| \`[]\` | \`\"1900-01-00T00:00:00Z\"\` | \`toisodate input must be a number\` |
| \`[2024,0,1,12,30,45]\` | \`\"2024-01-01T12:30:45Z\"\` | \`toisodate input must be a number\` |
| \`0\` | \`\"1970-01-01T00:00:00Z\"\` | \`\"1970-01-01T00:00:00Z\"\` (correct) |

## Fix

- Route non-numeric inputs through \`rt_strftime\` with the fixed format \`\"%Y-%m-%dT%H:%M:%SZ\"\`. That picks up jq's wording for non-numeric/non-array inputs and the array-of-time-components support for free. The existing chrono-based number path stays for fractional-second handling.
- Flipped \`time_arr_to_tm\`'s \`tm_mday\` default from 1 to 0 so \`[] | strftime(...)\` matches jq's \`\"1900-01-00\"\` rendering.

## Known divergence (out of scope)

For \`[year]\` shapes where jq normalizes via timegm (e.g. \`[2024] → \"2023-12-31\"\` because day 0 of January = December 31 of the previous year), jq-jit still renders the raw fields (\`\"2024-01-00\"\`). jq's normalisation is gated on glibc's \`timegm\` accepting the result with \`tm_year > 0\`, which is a libc edge case worth its own fix.

## Test plan

- [x] Eight new regression cases.
- [x] \`cargo build --release\` (zero warnings)
- [x] \`cargo test --release\` (all green)

Closes #531