### PR TITLE
fix: join accepts object input and uses jq's "Cannot iterate" wording

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2014,35 +2014,40 @@ fn rt_join(v: &Value, sep: &Value) -> Result<Value> {
         Value::Null => b"",
         _ => bail!("join requires array and string"),
     };
-    match v {
-        Value::Arr(a) => {
-            let cap = a.len() * (8 + sep_bytes.len());
-            let mut buf: Vec<u8> = Vec::with_capacity(cap);
-            for (i, item) in a.iter().enumerate() {
-                if i > 0 { buf.extend_from_slice(sep_bytes); }
-                match item {
-                    Value::Str(sv) => buf.extend_from_slice(sv.as_bytes()),
-                    Value::Null => {},
-                    Value::Num(n, NumRepr(repr)) => {
-                        if let Some(r) = repr.as_ref().filter(|r| crate::value::is_valid_json_number(r)) {
-                            buf.extend_from_slice(r.as_bytes());
-                        } else {
-                            crate::value::push_jq_number_bytes(&mut buf, *n);
-                        }
-                    }
-                    Value::True => buf.extend_from_slice(b"true"),
-                    Value::False => buf.extend_from_slice(b"false"),
-                    _ => {
-                        // jq errors when trying to add string to object/array
-                        let partial = Value::from_string(unsafe { String::from_utf8_unchecked(buf) });
-                        bail!("{} and {} cannot be added", errdesc(&partial), errdesc(item));
-                    }
+    // jq's `join` desugars to a reduce that iterates the input. Both arrays
+    // and objects are accepted (#533); for objects we walk the values in
+    // insertion order, just like `.[]` does.
+    let items: Vec<&Value> = match v {
+        Value::Arr(a) => a.iter().collect(),
+        Value::Obj(ObjInner(o)) => o.values().collect(),
+        // Non-iterable input: jq emits the standard `Cannot iterate over ...`
+        // wording adopted across other iteration sites (#481/#505/#517).
+        _ => bail!("Cannot iterate over {}", errdesc(v)),
+    };
+    let cap = items.len() * (8 + sep_bytes.len());
+    let mut buf: Vec<u8> = Vec::with_capacity(cap);
+    for (i, item) in items.iter().enumerate() {
+        if i > 0 { buf.extend_from_slice(sep_bytes); }
+        match item {
+            Value::Str(sv) => buf.extend_from_slice(sv.as_bytes()),
+            Value::Null => {},
+            Value::Num(n, NumRepr(repr)) => {
+                if let Some(r) = repr.as_ref().filter(|r| crate::value::is_valid_json_number(r)) {
+                    buf.extend_from_slice(r.as_bytes());
+                } else {
+                    crate::value::push_jq_number_bytes(&mut buf, *n);
                 }
             }
-            Ok(Value::from_string(unsafe { String::from_utf8_unchecked(buf) }))
+            Value::True => buf.extend_from_slice(b"true"),
+            Value::False => buf.extend_from_slice(b"false"),
+            _ => {
+                // jq errors when trying to add string to object/array
+                let partial = Value::from_string(unsafe { String::from_utf8_unchecked(buf) });
+                bail!("{} and {} cannot be added", errdesc(&partial), errdesc(item));
+            }
         }
-        _ => bail!("join requires array and string"),
     }
+    Ok(Value::from_string(unsafe { String::from_utf8_unchecked(buf) }))
 }
 
 fn rt_str_index(v: &Value, target: &Value, is_rindex: bool) -> Result<Value> {

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -8490,3 +8490,34 @@ todateiso8601
 try todateiso8601 catch .
 null
 "strftime/1 requires parsed datetime inputs"
+
+# Issue #533: join on number uses jq's "Cannot iterate over" wording
+try join(",") catch .
+1
+"Cannot iterate over number (1)"
+
+# Issue #533: join on null
+try join(",") catch .
+null
+"Cannot iterate over null (null)"
+
+# Issue #533: join on string
+try join(",") catch .
+"abc"
+"Cannot iterate over string (\"abc\")"
+
+# Issue #533: join on object iterates the values
+join(",")
+{"a":1,"b":"x"}
+"1,x"
+
+# Issue #533: join on empty object yields empty string
+join(",")
+{}
+""
+
+# Issue #533: join on array still works
+join(",")
+[1,2,3]
+"1,2,3"
+


### PR DESCRIPTION
## Summary

\`rt_join\` only handled \`Value::Arr\` and bailed with the custom \`join requires array and string\` for everything else. jq's \`join\` accepts both arrays and objects (joining the values in insertion order) and uses the standard \`Cannot iterate over <type> (<value>)\` wording adopted across other iteration sites in #481/#505/#517 for non-iterable input:

| Input | jq | jq-jit (before) |
|---|---|---|
| \`1 \| join(\",\")\` | \`Cannot iterate over number (1)\` | \`join requires array and string\` |
| \`null \| join(\",\")\` | \`Cannot iterate over null (null)\` | \`join requires array and string\` |
| \`\"abc\" \| join(\",\")\` | \`Cannot iterate over string (\"abc\")\` | \`join requires array and string\` |
| \`true \| join(\",\")\` | \`Cannot iterate over boolean (true)\` | \`join requires array and string\` |
| \`{} \| join(\",\")\` | \`\"\"\` | \`join requires array and string\` (rejected) |
| \`{a:1,b:\"x\"} \| join(\",\")\` | \`\"1,x\"\` | \`join requires array and string\` (rejected) |

## Fix

Refactored to collect the iteration items into a \`Vec<&Value>\` first so the same loop body serves both arrays and objects, then replaced the catch-all bail with \`errdesc\`-based wording.

The sep-type wording (jq emits a dynamic addition error like \`string (\"1\") and number (1) cannot be added\`) is left as-is for now; aligning that requires running through the reduce path.

## Test plan

- [x] Six new regression cases.
- [x] \`cargo build --release\` (zero warnings)
- [x] \`cargo test --release\` running

Closes #533