### PR TITLE
fix: flatten/1 errors on non-numeric depth instead of silent default

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -61,12 +61,25 @@ pub fn call_builtin(name: &str, args: &[Value]) -> Result<Value> {
         "reverse" => unary_op(args, rt_reverse),
         "flatten" if args.len() < 2 => unary_op(args, |v| rt_flatten(v, None)),
         "flatten" => {
+            // jq's stdlib desugars `flatten($d)` to roughly
+            // `if $d < 0 then error("flatten depth must not be negative")
+            //  else <reduce that subtracts 1 from $d each step> end`.
+            // jq's value ordering (null/false/true < 0 < string/array/object)
+            // makes each non-numeric type take a deterministic path (#537):
+            //   null / true / false → "negative" branch
+            //   string / array / object → arithmetic error in the reduce
             match &args[1] {
                 Value::Num(n, _) => {
                     if *n < 0.0 { bail!("flatten depth must not be negative"); }
                     rt_flatten(&args[0], Some(*n as usize))
                 }
-                _ => rt_flatten(&args[0], None)
+                Value::Null | Value::True | Value::False => {
+                    bail!("flatten depth must not be negative");
+                }
+                other => bail!(
+                    "{} and number (1) cannot be subtracted",
+                    errdesc(other),
+                ),
             }
         }
         "unique" => unary_op(args, rt_unique),

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -8561,3 +8561,43 @@ getpath([{start:0,end:2}])
 null
 null
 
+# Issue #537: flatten(null) errors with "depth must not be negative"
+try (flatten(null)) catch .
+[[1],[2]]
+"flatten depth must not be negative"
+
+# Issue #537: flatten(true) — bool < 0 in jq's ordering → same negative branch
+try (flatten(true)) catch .
+[[1],[2]]
+"flatten depth must not be negative"
+
+# Issue #537: flatten("a") surfaces the arithmetic error from $d - 1
+try (flatten("a")) catch .
+[[1],[2]]
+"string (\"a\") and number (1) cannot be subtracted"
+
+# Issue #537: flatten([]) also bails through arithmetic
+try (flatten([])) catch .
+[[1],[2]]
+"array ([]) and number (1) cannot be subtracted"
+
+# Issue #537: flatten({}) also bails through arithmetic
+try (flatten({})) catch .
+[[1],[2]]
+"object ({}) and number (1) cannot be subtracted"
+
+# Issue #537: flatten(-1) keeps the negative-depth error
+try (flatten(-1)) catch .
+[[1],[2]]
+"flatten depth must not be negative"
+
+# Issue #537: flatten(0) is identity
+flatten(0)
+[[1],[2]]
+[[1],[2]]
+
+# Issue #537: flatten(99) deep-flattens
+flatten(99)
+[[1],[2]]
+[1,2]
+


### PR DESCRIPTION
## Summary

\`flatten(\$d)\` with a non-numeric \`\$d\` was silently falling through to \`rt_flatten(..., None)\` (default = full flatten). jq's stdlib desugars to roughly:

\`\`\`jq
if \$d < 0 then error(\"flatten depth must not be negative\")
else <reduce that subtracts 1 from \$d each step>
end
\`\`\`

jq's value ordering (\`null/false/true < 0 < string/array/object\`) makes each non-numeric type take a deterministic path:

| Filter | jq | jq-jit (before) |
|---|---|---|
| \`flatten(null)\` | \`flatten depth must not be negative\` | \`[1,2]\` (silently full-flattens) |
| \`flatten(true)\` / \`flatten(false)\` | \`flatten depth must not be negative\` | \`[1,2]\` |
| \`flatten(\"a\")\` | \`string (\"a\") and number (1) cannot be subtracted\` | \`[1,2]\` |
| \`flatten([])\` | \`array ([]) and number (1) cannot be subtracted\` | \`[1,2]\` |
| \`flatten({})\` | \`object ({}) and number (1) cannot be subtracted\` | \`[1,2]\` |
| \`flatten(-1)\` | \`flatten depth must not be negative\` | (already correct) |
| \`flatten(0)\` / \`flatten(99)\` | identity / full-flatten | (already correct) |

## Fix

Match each case explicitly in the \`\"flatten\"\` arm: \`Null\` / \`True\` / \`False\` → negative-depth error; everything else → \`<type> (<value>) and number (1) cannot be subtracted\` via \`errdesc\`.

## Test plan

- [x] Eight new regression cases.
- [x] \`cargo build --release\` (zero warnings)
- [x] \`cargo test --release\` running

Closes #537