### PR TITLE
fix: limit/2 count type validation matches jq

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -2632,33 +2632,56 @@ pub fn eval(
 
         Expr::Limit { count, generator } => {
             eval(count, input.clone(), env, &mut |cv| {
-                if let Value::Num(n, NumRepr(None)) = &cv {
-                    let limit = *n as i64;
-                    if limit == 0 { return Ok(true); }
-                    if limit < 0 {
+                // Match `Num(n, _)` (any repr) so `limit(2.0; ...)` works
+                // — the prior `NumRepr(None)` constraint silently rejected
+                // float-formatted counts (#539).
+                match &cv {
+                    Value::Num(n, _) => {
+                        let limit = *n as i64;
+                        if limit == 0 { return Ok(true); }
+                        if limit < 0 {
+                            bail!("__jqerror__:\"limit doesn't support negative count\"");
+                        }
+                        let limit = limit as usize;
+                        let mut emitted = 0;
+                        let mut stopped_by_outer = false;
+                        let result = eval(generator, input.clone(), env, &mut |val| {
+                            emitted += 1;
+                            let cont = cb(val)?;
+                            if !cont {
+                                stopped_by_outer = true;
+                                Ok(false)
+                            } else if emitted >= limit {
+                                Ok(false)
+                            } else {
+                                Ok(true)
+                            }
+                        });
+                        match result {
+                            Ok(_) if stopped_by_outer => Ok(false),
+                            Ok(_) => Ok(true),
+                            Err(e) => Err(e),
+                        }
+                    }
+                    // jq's value ordering puts null/false/true below numbers,
+                    // so `$n < 0` is true for these and they take jq's
+                    // "negative count" branch (#539).
+                    Value::Null | Value::True | Value::False => {
                         bail!("__jqerror__:\"limit doesn't support negative count\"");
                     }
-                    let limit = limit as usize;
-                    let mut emitted = 0;
-                    let mut stopped_by_outer = false;
-                    let result = eval(generator, input.clone(), env, &mut |val| {
-                        emitted += 1;
-                        let cont = cb(val)?;
-                        if !cont {
-                            stopped_by_outer = true;
-                            Ok(false)
-                        } else if emitted >= limit {
-                            Ok(false)
-                        } else {
-                            Ok(true)
-                        }
-                    });
-                    match result {
-                        Ok(_) if stopped_by_outer => Ok(false),
-                        Ok(_) => Ok(true),
-                        Err(e) => Err(e),
+                    // String / array / object surface jq's `$n - 1`
+                    // arithmetic error from the limit reduce.
+                    other => {
+                        let msg = format!(
+                            "{} and number (1) cannot be subtracted",
+                            crate::runtime::errdesc_pub(other),
+                        );
+                        bail!(
+                            "__jqerror__:{}",
+                            crate::value::value_to_json_precise(&Value::from_string(msg)),
+                        );
                     }
-                } else { bail!("limit: count must be a number") }
+                }
             })
         }
 

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -8601,3 +8601,44 @@ flatten(99)
 [[1],[2]]
 [1,2]
 
+# Issue #539: limit accepts float-repr count
+[limit(2.0; .[])]
+[1,2,3]
+[1,2]
+
+# Issue #539: limit on null count uses jq's "negative count" wording
+try (limit(null; .[])) catch .
+[1,2,3]
+"limit doesn't support negative count"
+
+# Issue #539: limit on bool count
+try (limit(true; .[])) catch .
+[1,2,3]
+"limit doesn't support negative count"
+
+# Issue #539: limit on string count surfaces arithmetic error
+try (limit("a"; .[])) catch .
+[1,2,3]
+"string (\"a\") and number (1) cannot be subtracted"
+
+# Issue #539: limit on array count
+try (limit([]; .[])) catch .
+[1]
+"array ([]) and number (1) cannot be subtracted"
+
+# Issue #539: limit on object count
+try (limit({}; .[])) catch .
+[1]
+"object ({}) and number (1) cannot be subtracted"
+
+# Issue #539: numeric negative count keeps the original wording
+try (limit(-1; .[])) catch .
+[1,2,3]
+"limit doesn't support negative count"
+
+# Issue #539: zero count returns empty (no error)
+[limit(0; .[])]
+[1,2,3]
+[]
+
+


### PR DESCRIPTION
## Summary

Two issues in \`Expr::Limit\` eval (\`src/eval.rs:2633\`):

1. The pattern \`Value::Num(n, NumRepr(None))\` rejected counts with a preserved repr — \`limit(2.0; ...)\` fell through to the catch-all \`limit: count must be a number\` branch instead of working.
2. The catch-all bail used custom phrasing for every non-numeric count. jq emits one of two messages depending on type:
   - null / true / false → \`limit doesn't support negative count\` (jq's value ordering puts these below numbers, so \`\$n < 0\` is true).
   - string / array / object → \`<type> (<value>) and number (1) cannot be subtracted\` (jq's stdlib subtracts 1 from \`\$n\` during the limit reduce).

| Filter | input | jq | jq-jit (before) |
|---|---|---|---|
| \`limit(2.0; .[])\` | \`[1,2,3]\` | \`1, 2\` | \`limit: count must be a number\` |
| \`limit(null; .[])\` | \`[1,2,3]\` | \`limit doesn't support negative count\` | \`limit: count must be a number\` |
| \`limit(true; .[])\` | \`[1,2,3]\` | \`limit doesn't support negative count\` | \`limit: count must be a number\` |
| \`limit(\"a\"; .[])\` | \`[1,2,3]\` | \`string (\"a\") and number (1) cannot be subtracted\` | \`limit: count must be a number\` |
| \`limit([]; .[])\` | \`[1]\` | \`array ([]) and number (1) cannot be subtracted\` | \`limit: count must be a number\` |
| \`limit({}; .[])\` | \`[1]\` | \`object ({}) and number (1) cannot be subtracted\` | \`limit: count must be a number\` |

## Fix

Match \`Num(n, _)\` (drop the \`NumRepr(None)\` constraint) and split the non-numeric branch into the two cases jq uses. Wrap the bail strings in \`__jqerror__:\`-prefixed JSON so they round-trip through \`try ... catch .\` correctly.

## Test plan

- [x] Eight new regression cases.
- [x] \`cargo build --release\` (zero warnings)
- [x] \`cargo test --release\` running

Closes #539