### PR TITLE
fix: scan/match/test/capture use jq's "cannot be matched" wording

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2824,6 +2824,11 @@ fn rt_test(v: &Value, re: &Value) -> Result<Value> {
             let matched = with_regex(r, |regex| regex.is_match(s))?;
             Ok(Value::from_bool(matched))
         }
+        // jq distinguishes input-side and regex-side type errors. Non-string
+        // input → `<errdesc> cannot be matched, as it is not a string` (#541).
+        (other, _) if !matches!(other, Value::Str(_)) => {
+            bail!("{} cannot be matched, as it is not a string", errdesc(other));
+        }
         _ => bail!("test requires string and regex"),
     }
 }
@@ -2849,6 +2854,9 @@ fn rt_match(v: &Value, re: &Value) -> Result<Value> {
                     }
                 }
             })?
+        }
+        (other, _) if !matches!(other, Value::Str(_)) => {
+            bail!("{} cannot be matched, as it is not a string", errdesc(other));
         }
         _ => bail!("match requires string and regex"),
     }
@@ -2926,6 +2934,9 @@ fn rt_match_global(v: &Value, re: &Value) -> Result<Value> {
                 Ok(Value::Arr(Rc::new(results)))
             })?
         }
+        (other, _) if !matches!(other, Value::Str(_)) => {
+            bail!("{} cannot be matched, as it is not a string", errdesc(other));
+        }
         _ => bail!("match requires string and regex"),
     }
 }
@@ -2949,6 +2960,9 @@ fn rt_capture(v: &Value, re: &Value) -> Result<Value> {
                     None => bail!("capture failed"),
                 }
             })?
+        }
+        (other, _) if !matches!(other, Value::Str(_)) => {
+            bail!("{} cannot be matched, as it is not a string", errdesc(other));
         }
         _ => bail!("capture requires string and regex"),
     }
@@ -2976,6 +2990,9 @@ pub fn rt_capture_global(v: &Value, re: &Value) -> Result<Value> {
                 }
                 Ok(Value::Arr(Rc::new(results)))
             })?
+        }
+        (other, _) if !matches!(other, Value::Str(_)) => {
+            bail!("{} cannot be matched, as it is not a string", errdesc(other));
         }
         _ => bail!("capture requires string and regex"),
     }
@@ -3008,6 +3025,9 @@ fn rt_scan(v: &Value, re: &Value) -> Result<Value> {
                 };
                 Value::Arr(Rc::new(results))
             }).map(Ok)?
+        }
+        (other, _) if !matches!(other, Value::Str(_)) => {
+            bail!("{} cannot be matched, as it is not a string", errdesc(other));
         }
         _ => bail!("scan requires string and regex"),
     }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -8641,4 +8641,34 @@ try (limit(-1; .[])) catch .
 [1,2,3]
 []
 
+# Issue #541: scan on non-string uses jq's "cannot be matched" wording
+try (scan("a")) catch .
+0
+"number (0) cannot be matched, as it is not a string"
+
+# Issue #541: match on null
+try (match("a")) catch .
+null
+"null (null) cannot be matched, as it is not a string"
+
+# Issue #541: test on array
+try (test("a")) catch .
+[1]
+"array ([1]) cannot be matched, as it is not a string"
+
+# Issue #541: capture on object
+try (capture("(?<x>.)")) catch .
+{}
+"object ({}) cannot be matched, as it is not a string"
+
+# Issue #541: capture on boolean
+try (capture("(?<x>.)")) catch .
+true
+"boolean (true) cannot be matched, as it is not a string"
+
+# Issue #541: scan on string still works
+[scan("a")]
+"abcabc"
+["a","a"]
+
 


### PR DESCRIPTION
## Summary

Four regex builtins bailed with custom phrasing (\`scan requires string and regex\`, etc.) when the input wasn't a string. jq uses one wording for the input-side type error:

\`\`\`
<type> (<value>) cannot be matched, as it is not a string
\`\`\`

| Filter | input | jq | jq-jit (before) |
|---|---|---|---|
| \`scan(\"a\")\` | \`0\` | \`number (0) cannot be matched, as it is not a string\` | \`scan requires string and regex\` |
| \`match(\"a\")\` | \`null\` | \`null (null) cannot be matched, as it is not a string\` | \`match requires string and regex\` |
| \`test(\"a\")\` | \`[1]\` | \`array ([1]) cannot be matched, as it is not a string\` | \`test requires string and regex\` |
| \`capture(\"(?<x>.)\")\` | \`{}\` | \`object ({}) cannot be matched, as it is not a string\` | \`capture requires string and regex\` |

(\`split\`/\`splits\`/\`sub\`/\`gsub\` already align with jq's wording.)

## Fix

Add an \`(other, _) if !matches!(other, Value::Str(_))\` arm to each of the four builtins (\`rt_test\`, \`rt_match\` and \`rt_match_global\`, \`rt_capture\` and \`rt_capture_global\`, \`rt_scan\`) so input-side errors surface jq's wording via \`errdesc\`. The original catch-all stays for the rare case where input is a string but the regex argument isn't.

## Test plan

- [x] Six new regression cases.
- [x] \`cargo build --release\` (zero warnings)
- [x] \`cargo test --release\` running

Closes #541