### PR TITLE
fix: mktime rejects non-numeric array elements (and accepts [year])

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -3212,9 +3212,13 @@ fn rt_localtime(v: &Value) -> Result<Value> {
 
 fn time_arr_to_tm(a: &[Value]) -> Result<libc::tm> {
     let get = |i: usize| -> f64 { a.get(i).and_then(|v| v.as_f64()).unwrap_or(0.0) };
-    // Validate that first element is a number
-    if !a.is_empty() {
-        if let Value::Str(_) = &a[0] {
+    // Reject any non-numeric element in the broken-down-time array.
+    // jq's mktime walks each field and bails the moment it sees a non-
+    // number (string, null, bool, etc.) with `mktime requires parsed
+    // datetime inputs`. Without this check `[null]`, `[1, "a"]`, etc.
+    // silently fed `0.0` into libc's timegm and emitted `-1` (#547).
+    for v in a {
+        if !matches!(v, Value::Num(_, _)) {
             bail!("mktime requires parsed datetime inputs");
         }
     }
@@ -3242,12 +3246,6 @@ fn time_arr_to_tm(a: &[Value]) -> Result<libc::tm> {
 
 fn rt_mktime(v: &Value) -> Result<Value> {
     match v {
-        Value::Arr(a) if a.len() >= 2 => {
-            let mut t = time_arr_to_tm(a)?;
-            // Use timegm for UTC
-            let result = unsafe { libc::timegm(&mut t) };
-            Ok(Value::number(result as f64))
-        }
         Value::Arr(a) if a.is_empty() => {
             // jq's mktime on `[]` falls through to the broken-down-time
             // validator and bails with "invalid gmtime representation"
@@ -3255,12 +3253,12 @@ fn rt_mktime(v: &Value) -> Result<Value> {
             bail!("invalid gmtime representation");
         }
         Value::Arr(a) => {
-            // Single-element array: jq still calls into the broken-down-
-            // time validator, which trips on the missing fields.
-            if let Value::Str(_) = &a[0] {
-                bail!("mktime requires parsed datetime inputs");
-            }
-            bail!("mktime requires array of time components");
+            // `time_arr_to_tm` validates that each element is numeric
+            // (#547); single-element arrays like `[2024]` are accepted as
+            // a year-only broken-down time, matching jq.
+            let mut t = time_arr_to_tm(a)?;
+            let result = unsafe { libc::timegm(&mut t) };
+            Ok(Value::number(result as f64))
         }
         _ => bail!("mktime requires array inputs"),
     }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -8756,4 +8756,39 @@ gsub("l"; "X")
 "hello"
 "heXXo"
 
+# Issue #547: mktime with null element bails like jq
+try mktime catch .
+[null]
+"mktime requires parsed datetime inputs"
+
+# Issue #547: mktime with two nulls
+try mktime catch .
+[null, null]
+"mktime requires parsed datetime inputs"
+
+# Issue #547: mktime with mixed numeric+string
+try mktime catch .
+[1, "a"]
+"mktime requires parsed datetime inputs"
+
+# Issue #547: mktime with string in middle of fields
+try mktime catch .
+[1, 2, 3, 4, 5, "x"]
+"mktime requires parsed datetime inputs"
+
+# Issue #547: mktime accepts year-only [2024]
+mktime
+[2024]
+1703980800
+
+# Issue #547: mktime with full broken-down time still works
+mktime
+[2024,0,1,0,0,0]
+1704067200
+
+# Issue #547: empty array keeps the gmtime-validator wording
+try mktime catch .
+[]
+"invalid gmtime representation"
+
 


### PR DESCRIPTION
## Summary

Two issues in \`rt_mktime\`:

1. \`time_arr_to_tm\` only validated \`a[0]\` against \`Value::Str\`. Other non-numeric elements (null, bool, string in later positions) were silently coerced to \`0.0\` via \`v.as_f64().unwrap_or(0.0)\` and fed into libc's \`timegm\`, which returned \`-1\` for invalid dates.
2. The single-element \`Value::Arr(a)\` arm bailed with custom phrasing \`mktime requires array of time components\`. jq accepts year-only arrays like \`[2024]\` and runs them through \`timegm\`.

| Input | jq | jq-jit (before) |
|---|---|---|
| \`[null]\` | \`mktime requires parsed datetime inputs\` | \`mktime requires array of time components\` |
| \`[null, null]\` | \`mktime requires parsed datetime inputs\` | \`-1\` (silent coercion) |
| \`[1, \"a\"]\` | \`mktime requires parsed datetime inputs\` | \`-1\` |
| \`[2024]\` | \`1703980800\` | \`mktime requires array of time components\` |
| \`[]\` | \`invalid gmtime representation\` | (already correct) |

## Fix

- Validate every element in \`time_arr_to_tm\`: anything non-numeric bails with \`mktime requires parsed datetime inputs\`.
- Fold the single-element arm into the main arm so \`[year]\` runs through \`timegm\` like any other broken-down time.

The deeper \`invalid gmtime representation\` semantic for arrays of valid numbers that don't form a real time is a separate libc-validation concern left out of this fix.

## Test plan

- [x] Seven new regression cases.
- [x] \`cargo build --release\` (zero warnings)
- [x] \`cargo test --release\` running

Closes #547