### PR TITLE
fix: getpath handles object/array path elements like .[k]

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2265,28 +2265,34 @@ pub fn rt_getpath(v: &Value, path: &Value) -> Result<Value> {
                         let actual = if idx < 0 { (a.len() as i64 + idx) as usize } else { idx as usize };
                         current = a.get(actual).cloned().unwrap_or(Value::Null);
                     }
-                    // Slice path element `{start: N, end: M}`. Without this,
-                    // `.[N:M] |= f` would lose the LHS value (#535) — eval's
-                    // Update branch calls `rt_getpath` to fetch the current
-                    // slice value before applying the update closure, and
-                    // bailing here means the closure runs on `null` instead.
-                    (Value::Arr(a), Value::Obj(ObjInner(slice_spec)))
-                        if slice_spec.contains_key("start") && slice_spec.contains_key("end") =>
-                    {
+                    // Slice path element `{start, end}`. Originally added in
+                    // #536 for `.[N:M] |= f` (eval's Update branch fetches the
+                    // current slice value via getpath); now also serves
+                    // `getpath([{start, end}])` directly. jq treats *any*
+                    // object as a slice spec — start/end default to null/length
+                    // when missing, but if either present value isn't a number
+                    // or null, jq raises "Array/string slice indices must be
+                    // integers". `{}` falls into the "missing & wrong" bucket.
+                    (Value::Arr(a), Value::Obj(ObjInner(slice_spec))) => {
+                        validate_slice_spec(slice_spec)?;
                         let len = a.len() as i64;
                         let (si, ei) = slice_indices(slice_spec, len);
                         current = Value::Arr(Rc::new(a[si..ei].to_vec()));
                     }
-                    (Value::Str(s), Value::Obj(ObjInner(slice_spec)))
-                        if slice_spec.contains_key("start") && slice_spec.contains_key("end") =>
-                    {
-                        // String slice indexes by UTF-8 code points, matching
-                        // `.[N:M]` semantics on strings.
+                    (Value::Str(s), Value::Obj(ObjInner(slice_spec))) => {
+                        validate_slice_spec(slice_spec)?;
                         let chars: Vec<char> = s.chars().collect();
                         let len = chars.len() as i64;
                         let (si, ei) = slice_indices(slice_spec, len);
                         let sliced: String = chars[si..ei].iter().collect();
                         current = Value::from_string(sliced);
+                    }
+                    // `.[arr]` on an array returns subsequence positions
+                    // (jq aliases it to `indices(arr)` — see eval_index in
+                    // src/eval.rs and #467). getpath inherits the same
+                    // semantics so `getpath([[]])` returns `[]`, etc.
+                    (Value::Arr(_), Value::Arr(_)) => {
+                        current = call_builtin("indices", &[current.clone(), key.clone()])?;
                     }
                     // jq short-circuits getpath on null for string/number/object keys
                     // (matching `.[k]` on null), but still errors for null/bool/array keys.
@@ -2305,6 +2311,21 @@ pub fn rt_getpath(v: &Value, path: &Value) -> Result<Value> {
         }
         _ => bail!("Path must be specified as an array"),
     }
+}
+
+/// jq's `.[obj]` indexing requires both `start` and `end` keys to be present
+/// with values of `number` or `null` type, otherwise "Array/string slice
+/// indices must be integers" is raised. This mirrors `eval_index` in
+/// `src/eval.rs` so `getpath([obj])` and `.[obj]` produce identical errors.
+fn validate_slice_spec(spec: &crate::value::ObjMap) -> Result<()> {
+    let start = spec.get("start");
+    let end = spec.get("end");
+    let valid = matches!(start, Some(Value::Num(_, _) | Value::Null))
+        && matches!(end, Some(Value::Num(_, _) | Value::Null));
+    if !valid {
+        bail!("Array/string slice indices must be integers");
+    }
+    Ok(())
 }
 
 /// Resolve a `{start, end}` slice spec into normalised `(start, end)` byte/element

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -8792,3 +8792,48 @@ try mktime catch .
 "invalid gmtime representation"
 
 
+
+# Issue #549: getpath with empty object path element matches jq's slice-spec wording
+try (getpath([{}])) catch .
+[1,2,3]
+"Array/string slice indices must be integers"
+
+# Issue #549: getpath with single-key slice spec also requires both keys
+try (getpath([{start:1}])) catch .
+[1,2,3,4,5]
+"Array/string slice indices must be integers"
+
+# Issue #549: getpath with non-numeric/non-null start errors with jq's wording
+try (getpath([{start:"x", end:2}])) catch .
+[1,2,3]
+"Array/string slice indices must be integers"
+
+# Issue #549: getpath with full slice spec returns the slice (array)
+getpath([{start:1, end:3}])
+[1,2,3,4,5]
+[2,3]
+
+# Issue #549: getpath with full slice spec returns the slice (string, code points)
+getpath([{start:1, end:3}])
+"abcdef"
+"bc"
+
+# Issue #549: getpath with null endpoints means whole sequence
+getpath([{start:null, end:null}])
+[1,2,3]
+[1,2,3]
+
+# Issue #549: getpath with array path element returns subsequence positions on array
+getpath([[1,2]])
+[1,2,3,1,2,4]
+[0,3]
+
+# Issue #549: getpath with empty array path element on array returns []
+getpath([[]])
+[1,2,3]
+[]
+
+# Issue #549: getpath with array path element on string still errors (matches .[arr])
+try (getpath([[1,2]])) catch .
+"abc"
+"Cannot index string with array"


### PR DESCRIPTION
## Summary

`rt_getpath` recognised only `{start, end}` slice specs (both keys required) and rejected array path elements with `Cannot index array with array`. jq's `getpath` just iterates `.[$path[$i]]` and inherits every indexing shape that direct indexing supports — slice specs, partial-key error wording, and subarray search via array indices.

| Filter | input | jq | jq-jit (before) |
|---|---|---|---|
| `getpath([{}])` | `[1,2,3]` | `Array/string slice indices must be integers` | `Cannot index array with object` |
| `getpath([{}])` | `"abc"` | `Array/string slice indices must be integers` | `Cannot index string with object` |
| `getpath([{start:1}])` | `[1,2,3,4,5]` | `Array/string slice indices must be integers` | `Cannot index array with object` |
| `getpath([{start:1, end:3}])` | `[1,2,3,4,5]` | `[2,3]` | already worked (#536) |
| `getpath([[]])` | `[1,2,3]` | `[]` (empty subseq positions) | `Cannot index array with array` |
| `getpath([[1,2]])` | `[1,2,3,1,2,4]` | `[0,3]` | `Cannot index array with array` |

Direct indexing (`.[{}]`, `.[[]]`, `.[[1,2]]`) already produced the right result via `eval_index`, so the divergence was isolated to `rt_getpath`'s manual loop.

## Fix

Two adjustments in `src/runtime.rs`:

- New `validate_slice_spec` helper requires both `start` and `end` keys to be present with `number` or `null` values, raising `Array/string slice indices must be integers` otherwise. The existing slice arms now call it. This subsumes the old "both keys required" guard and adds proper rejection for `{}` and partial specs.
- New `(Arr, Arr)` path-element arm delegates to the `indices` builtin (same dispatch as eval's `(Arr, Arr)` indexing branch added in #467), returning subsequence positions on the receiver array.

The existing slice-update path (#536) is unchanged: paths produced by `.[N:M] |= f` always set both `start` and `end`, so they keep hitting the slice arm with no behavioral diff.

## Test plan

- [x] Nine new regression cases covering `{}`/partial-spec errors, full-slice success on array+string, `null` endpoints, subarray-positions on array, and the string-error case.
- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` all green

Closes #549