### PR TITLE
fix: JIT path |= F deletes path when F produces no values

### DIFF
--- a/src/jit.rs
+++ b/src/jit.rs
@@ -2816,6 +2816,34 @@ impl Flattener {
                         s.emit(JitOp::Label { id: after_lbl });
                     });
                     self.emit(JitOp::Drop { slot: old_val });
+                    if ok {
+                        // Empty closure → del(path) per jq's `path |= F`
+                        // semantics. Without this, `.a |= (.[]?)` on a scalar
+                        // `.a` value silently produced zero outputs because
+                        // the loop body above never ran. The literal-empty
+                        // case is rewritten to `del(path)` upstream by
+                        // simplify_expr (#155), but any runtime-empty
+                        // generator hits this path. See #552.
+                        let del_lbl = self.alloc_label();
+                        let end_lbl = self.alloc_label();
+                        self.emit(JitOp::BranchOnVar { var: first_var, nonzero_label: end_lbl, zero_label: del_lbl });
+                        self.emit(JitOp::Label { id: del_lbl });
+                        let path_for_del = self.alloc_slot();
+                        self.emit(JitOp::Clone { dst: path_for_del, src: path_arr });
+                        self.emit(JitOp::CollectBegin);
+                        self.emit(JitOp::CollectPush { src: path_for_del });
+                        let paths_arr = self.alloc_slot();
+                        self.emit(JitOp::CollectFinish { dst: paths_arr });
+                        let inp_for_del = self.alloc_slot();
+                        self.emit(JitOp::Clone { dst: inp_for_del, src: input_slot });
+                        let del_out = self.alloc_slot();
+                        self.emit_propagating(JitOp::CallBuiltin { dst: del_out, name: "delpaths".to_string(), args: vec![inp_for_del, paths_arr] });
+                        self.emit(JitOp::Drop { slot: inp_for_del });
+                        self.emit(JitOp::Drop { slot: paths_arr });
+                        self.emit_yield(del_out);
+                        self.emit(JitOp::Drop { slot: del_out });
+                        self.emit(JitOp::Label { id: end_lbl });
+                    }
                     self.emit(JitOp::Drop { slot: path_arr });
                     return ok;
                 }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -8837,3 +8837,33 @@ getpath([[]])
 try (getpath([[1,2]])) catch .
 "abc"
 "Cannot index string with array"
+
+# Issue #552: .a |= (.[]?) on object whose .a is a scalar deletes .a
+.a |= (.[]?)
+{"a":1,"b":2}
+{"b":2}
+
+# Issue #552: .a |= (.[]?) when .a is iterable takes first element
+.a |= (.[]?)
+{"a":[1,2,3]}
+{"a":1}
+
+# Issue #552: .a |= range(0;0) (empty generator) deletes .a
+.a |= range(0;0)
+{"a":1,"b":2}
+{"b":2}
+
+# Issue #552: .a |= (false | select(.)) (empty via select) deletes .a
+.a |= (false | select(.))
+{"a":1,"b":2}
+{"b":2}
+
+# Issue #552: .a |= (.[]?, 99) takes first non-empty value (preserves #208)
+.a |= (.[]?, 99)
+{"a":1,"b":2}
+{"a":99,"b":2}
+
+# Issue #552: literal empty path |= empty still works (interpreter rewrite, #155)
+.a |= empty
+{"a":1,"b":2}
+{"b":2}


### PR DESCRIPTION
## Summary

The JIT generator-update branch in `src/jit.rs` compiles `path |= F` for non-scalar `F` as a `for new_val in F: setpath(...)` loop with a "first only" flag (added in #208). When `F` produces zero values for the current input, the loop body never runs and no output is emitted at all.

jq's `path |= F` semantic when F is empty is **`del(path)`** — the modified container is emitted exactly once. #155 added this rewrite for the literal `Expr::Empty` AST node in `src/interpreter.rs:1886`, but any other generator that produces zero outputs at runtime hit the JIT gen-update path and silently dropped the input.

| Filter | input | jq | jq-jit (before) |
|---|---|---|---|
| `.a \|= (.[]?)` | `{"a":1,"b":2}` | `{"b":2}` | (no output) |
| `.a \|= range(0;0)` | `{"a":1,"b":2}` | `{"b":2}` | (no output) |
| `.a \|= (false \| select(.))` | `{"a":1,"b":2}` | `{"b":2}` | (no output) |
| `.a \|= empty` | `{"a":1,"b":2}` | `{"b":2}` | `{"b":2}` ✓ (already worked via #155 rewrite) |
| `.a \|= (.[]?, 99)` | `{"a":1,"b":2}` | `{"a":99,"b":2}` | `{"a":99,"b":2}` ✓ (non-empty case still works) |

## Fix

After the existing gen loop, branch on the "first" flag (`first_var`): if it's still zero, build a 1-element path-of-paths array via `CollectBegin`/`CollectPush`/`CollectFinish`, call `delpaths`, and yield the result. The literal-empty rewrite in `interpreter.rs` stays in place to skip the loop entirely for the common case.

## Test plan

- [x] Six new regression cases covering the four divergent forms above plus a sanity case for the literal-empty rewrite and the multi-output `(.[]?, 99)` first-take semantic.
- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` all green

Closes #552