### PR TITLE
fix: stop JIT getpath fast path swallowing type-mismatch errors

### DIFF
--- a/src/jit.rs
+++ b/src/jit.rs
@@ -7178,7 +7178,17 @@ extern "C" fn jit_rt_call_builtin(dst: *mut Value, name_ptr: *const u8, name_len
                 }
             }
         }
-        // Fast path: getpath([path]) — inline path traversal
+        // Fast path: getpath([path]) — inline path traversal.
+        //
+        // Only the type-matched arms (Obj+Str, Arr+Num, Null+Str/Num/Obj) are
+        // safe to short-circuit here; for any other (current, key) combination
+        // jq raises "Cannot index <type> with <kind>", which the slow path
+        // (`rt_getpath`) reproduces. The earlier version returned Null for
+        // unmatched arms (treating "ok=false but current==Null" as success),
+        // which made callers like the JIT Update branch silently see Null at
+        // a path that should have errored — e.g. `.a |= error` on a number
+        // ran the closure with `null` instead of erroring at the path step.
+        // See #554.
         if name == "getpath" && args.len() == 2 {
             if let Value::Arr(path) = &args[1] {
                 let mut current = args[0].clone();
@@ -7196,10 +7206,10 @@ extern "C" fn jit_rt_call_builtin(dst: *mut Value, name_ptr: *const u8, name_len
                         (Value::Null, Value::Str(_)) | (Value::Null, Value::Num(_, _)) | (Value::Null, Value::Obj(_)) => {
                             current = Value::Null;
                         }
-                        _ => { current = Value::Null; ok = false; break; }
+                        _ => { ok = false; break; }
                     }
                 }
-                if ok || matches!(current, Value::Null) {
+                if ok {
                     std::ptr::write(dst, current);
                     return 0;
                 }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -8867,3 +8867,33 @@ try (getpath([[1,2]])) catch .
 .a |= empty
 {"a":1,"b":2}
 {"b":2}
+
+# Issue #554: getpath fast path returned Null for type-mismatched keys instead of erroring (.a |= error on number)
+try (.a |= error) catch .
+0
+"Cannot index number with string \"a\""
+
+# Issue #554: same on string input
+try (.a |= error) catch .
+"x"
+"Cannot index string with string \"a\""
+
+# Issue #554: same on array input
+try (.a |= error) catch .
+[1]
+"Cannot index array with string \"a\""
+
+# Issue #554: getpath fast path no longer swallows null|getpath([null]) which jq errors on
+try (getpath([null])) catch .
+null
+"Cannot index null with null"
+
+# Issue #554: getpath fast path no longer swallows getpath with boolean key
+try (getpath([true])) catch .
+[1]
+"Cannot index array with boolean"
+
+# Issue #554: .a |= (1+.) still errors on non-object input (regression check)
+try (.a |= (1+.)) catch .
+0
+"Cannot index number with string \"a\""


### PR DESCRIPTION
## Summary

- The inlined `getpath` fast path in `jit_rt_call_builtin` returned `null`
  for any type-mismatched key (`number with string`, `null with null`, etc.)
  because the catch-all reset `current` to `Null` and the exit condition
  was `ok || current==Null`.
- The slow path (`rt_getpath`) was never consulted, so callers like the
  JIT Update branch silently saw `null` at a path that should have errored
  — `.a |= error` on a number returned `(not a string): null` instead of
  `Cannot index number with string "a"`.
- Drop the spurious `current = Null` assignment in the catch-all and
  tighten the exit condition to `if ok` so unmatched arms fall through
  to the slow path that reproduces jq's wording.

Closes #554

## Test plan

- [x] `cargo build --release` — zero warnings
- [x] `cargo test --release` — 424 regression + selfdiff/fuzz/etc. all green
- [x] Manual diff vs jq 1.8.1 on the affected forms (`.a |= error`,
      `getpath([null])`, `getpath([true])`, `try (.a |= (1+.)) catch .`)
- [x] `bench/comprehensive.sh` — see comment if any drift > 5%

🤖 Generated with [Claude Code](https://claude.com/claude-code)