### PR TITLE
fix: keep outer input for path-builtin bodies in eval let-binding fast path

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -681,14 +681,18 @@ fn expr_uses_outer_input(expr: &Expr) -> bool {
         | Expr::Alternative { primary: left, fallback: right }
         | Expr::Index { expr: left, key: right }
         | Expr::IndexOpt { expr: left, key: right }
-        | Expr::SetPath { path: left, value: right }
         | Expr::TryCatch { try_expr: left, catch_expr: right } => {
             expr_uses_outer_input(left) || expr_uses_outer_input(right)
         }
-        // Update/Assign: path_expr gets our input, update_expr gets path value
-        Expr::Update { path_expr, .. } | Expr::Assign { path_expr, .. } => {
-            expr_uses_outer_input(path_expr)
-        }
+        // GetPath/SetPath/DelPaths/Update/Assign always read `.` to produce
+        // their result, regardless of whether the path/value sub-expressions
+        // mention Input. The LetBinding fast path uses `expr_uses_outer_input`
+        // to decide whether the body still needs the bound input or whether it
+        // can run on `Value::Null` — saying "no" here for these forms made
+        // `. as $x | getpath(["a"])` quietly return `null` instead of the
+        // proper `Cannot index <type> with string "a"`. See #556.
+        Expr::GetPath { .. } | Expr::SetPath { .. } | Expr::DelPaths { .. }
+        | Expr::PathExpr { .. } | Expr::Update { .. } | Expr::Assign { .. } => true,
         Expr::IfThenElse { cond, then_branch, else_branch } => {
             expr_uses_outer_input(cond) || expr_uses_outer_input(then_branch) || expr_uses_outer_input(else_branch)
         }
@@ -699,8 +703,7 @@ fn expr_uses_outer_input(expr: &Expr) -> bool {
         | Expr::Recurse { input_expr }
         | Expr::Negate { operand: input_expr } | Expr::UnaryOp { operand: input_expr, .. }
         | Expr::Collect { generator: input_expr }
-        | Expr::PathExpr { expr: input_expr } | Expr::GetPath { path: input_expr }
-        | Expr::DelPaths { paths: input_expr } | Expr::Debug { expr: input_expr }
+        | Expr::Debug { expr: input_expr }
         | Expr::Stderr { expr: input_expr } | Expr::Format { expr: input_expr, .. } => {
             expr_uses_outer_input(input_expr)
         }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -8897,3 +8897,33 @@ try (getpath([true])) catch .
 try (.a |= (1+.)) catch .
 0
 "Cannot index number with string \"a\""
+
+# Issue #556: . as $x | getpath(["a"]) lost outer input and silently returned null on number
+try (. as $x | getpath(["a"])) catch .
+0
+"Cannot index number with string \"a\""
+
+# Issue #556: . as $x | setpath(...) lost outer input and silently emitted modified-null
+try (. as $x | setpath(["a"]; 1)) catch .
+[1,2,3]
+"Cannot index array with string \"a\""
+
+# Issue #556: . as $x | delpaths(...) lost outer input and silently returned null
+try (. as $x | delpaths([["a"]])) catch .
+0
+"Cannot delete fields from number"
+
+# Issue #556: regression — body that genuinely doesn't use outer input still skips clone
+. as $x | 99
+{"a":1}
+99
+
+# Issue #556: setpath after let with object input still works
+. as $x | setpath(["b"]; 2)
+{"a":1}
+{"a":1,"b":2}
+
+# Issue #556: nested let with non-Input value still uses outer input via path expressions
+. as $x | (.a as $y | getpath(["b"]))
+{"a":1,"b":2}
+2


### PR DESCRIPTION
## Summary

- `expr_uses_outer_input` mis-classified `Expr::GetPath`,
  `Expr::SetPath`, `Expr::DelPaths`, `Expr::PathExpr`, `Expr::Update`,
  and `Expr::Assign` by recursing into their path/value sub-expressions.
- When the path was a literal like `["a"]` (no `Input`), the function
  reported "doesn't use outer input" and the eval `LetBinding` fast path
  ran the body on `Value::Null` instead of the bound value.
- Path builtins on `null` short-circuit through the `(Null, Str)` arm,
  so `. as $x | getpath(["a"])` returned `null` instead of jq's
  `Cannot index <type> with string "a"`. Same root cause for `setpath`
  and `delpaths` after `. as $var`.
- Move those IR nodes into the always-true arm — they always read `.`
  to produce their result, regardless of sub-expression shape, matching
  `interpreter.rs::contains_input`.

Closes #556

## Test plan

- [x] `cargo build --release` — zero warnings
- [x] `cargo test --release` — all green (424 unit + regression files)
- [x] Manual diff vs jq 1.8.1 on `. as $x | getpath/setpath/delpaths(...)`
      across number/string/array inputs
- [x] `bench/comprehensive.sh` — no movement vs prior run

🤖 Generated with [Claude Code](https://claude.com/claude-code)