### PR TITLE
fix: keep number repr through string interpolation

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -4148,7 +4148,13 @@ fn eval_interp_parts(parts: &[StringPart], idx: usize, cur: String, input: Value
         StringPart::Literal(s) => { let mut n = cur; n.push_str(s); eval_interp_parts(parts, idx+1, n, input, env, cb) }
         StringPart::Expr(e) => {
             eval(e, input.clone(), env, &mut |val| {
-                let s = match &val { Value::Str(s) => s.to_string(), _ => crate::value::value_to_json(&val) };
+                // String interpolation runs `tostring` semantics on the
+                // interpolated value (see jq's manual). `value_to_json`
+                // discards the carried number repr, so `"\(0.0)"` would
+                // render as `"0"` instead of jq's `"0.0"`. Use
+                // `value_to_json_tojson` to keep the literal form when the
+                // f64 round-trips it exactly. See #560.
+                let s = match &val { Value::Str(s) => s.to_string(), _ => crate::value::value_to_json_tojson(&val) };
                 let mut n = cur.clone(); n.push_str(&s);
                 eval_interp_parts(parts, idx+1, n, input.clone(), env, cb)
             })

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -8957,3 +8957,33 @@ try (@base64d) catch .
 @base64d
 "aGVsbG8="
 "hello"
+
+# Issue #560: string interpolation preserved number literal repr (0.0 stays "0.0")
+"\(0.0)"
+null
+"0.0"
+
+# Issue #560: scientific repr preserved through interpolation
+"\(1e10)"
+null
+"1E+10"
+
+# Issue #560: literal repr survives a let binding before interpolation
+0.0 as $x | "\($x)"
+null
+"0.0"
+
+# Issue #560: small fraction stays in decimal form
+"\(1.5e-3)"
+null
+"0.0015"
+
+# Issue #560: tostring already worked — confirm no regression
+0.0 | tostring
+null
+"0.0"
+
+# Issue #560: integer literals still render without forced decimal
+"\(0)"
+null
+"0"


### PR DESCRIPTION
## Summary

- \`"\(N)"\` runs jq's \`tostring\` semantics on the interpolated value,
  but \`eval_interp_parts\` rendered non-string values with
  \`value_to_json\` — which discards the carried \`NumRepr\`.
- \`"\(0.0)"\` therefore became \`"0"\` and \`"\(1e10)"\` became
  \`"10000000000"\` while \`0.0 | tostring\` (which goes through
  \`rt_tostring\` → \`value_to_json_tojson\`) correctly returned
  \`"0.0"\`.
- Switch the interpolation path to \`value_to_json_tojson\` so the
  literal form survives when the f64 round-trips it exactly.
  Same family as the earlier repr-preservation passes
  (#75 / #110 / #190 / #475).

Closes #560

## Test plan

- [x] \`cargo build --release\` — zero warnings
- [x] \`cargo test --release\` — full suite green
- [x] Manual diff vs jq 1.8.1 on \`"\(0.0)"\`, \`"\(1e10)"\`,
      \`"\(1.5e-3)"\`, and \`. as $x | "\($x)"\` shapes
- [x] \`bench/comprehensive.sh\` — no movement vs prior run

🤖 Generated with [Claude Code](https://claude.com/claude-code)