### PR TITLE
fix: keep number repr through @json (mirror tojson semantics)

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3562,7 +3562,12 @@ pub fn eval_format(name: &str, val: &Value) -> Result<String> {
     let s = match val { Value::Str(s) => s.to_string(), _ => crate::value::value_to_json(val) };
     match name {
         "text" => Ok(s),
-        "json" => Ok(crate::value::value_to_json(val)),
+        // `@json` mirrors the `tojson` builtin, so it must preserve the
+        // carried number repr exactly the way `rt_tojson` does — otherwise
+        // `0.0 | @json | length` returned 1 (the value was the string
+        // `"0"`, even though the raw-byte CLI fast path printed `"0.0"` for
+        // the standalone `@json` form). See #562.
+        "json" => Ok(crate::value::value_to_json_tojson(val)),
         "html" => {
             let mut r = String::with_capacity(s.len());
             for c in s.chars() {

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -8987,3 +8987,33 @@ null
 "\(0)"
 null
 "0"
+
+# Issue #562: @json preserves number repr (matches tojson semantics)
+. | @json
+0.0
+"0.0"
+
+# Issue #562: chained @json preserves the outer string content
+. | @json | @json
+0.0
+"\"0.0\""
+
+# Issue #562: @json on array preserves nested number reprs
+. | @json
+[0.0, 1.5]
+"[0.0,1.5]"
+
+# Issue #562: @json on object preserves number reprs
+. | @json
+{"x":1.0,"y":2.5}
+"{\"x\":1.0,\"y\":2.5}"
+
+# Issue #562: @json | length now reports correct underlying string length
+. | @json | length
+0.0
+3
+
+# Issue #562: integer @json still renders without forced decimal
+. | @json
+0
+"0"


### PR DESCRIPTION
## Summary

- \`@json\` is the format-string spelling of \`tojson\` and should
  produce the same string. \`rt_tojson\` preserves the carried number
  repr via \`value_to_json_tojson\` (\`1.0 | tojson\` → \`"1.0"\`), but
  \`@json\` used the bare \`value_to_json\` helper, so the underlying
  \`Value::Str\` was \`"1"\` and \`0.0 | @json | length\` returned
  \`1\` instead of \`3\`.
- The bug was hidden for the standalone \`X | @json\` form by the CLI
  raw-byte fast path (\`is_tojson\`), which copies the input bytes
  through. Any composition (\`| length\`, \`| @json\`, \`+ ""\`)
  bypassed the fast path and saw the lossy value.
- Switch \`eval_format\`'s \`"json"\` arm to \`value_to_json_tojson\`.
  Same family as #75 / #110 / #190 / #475 / #560.

Closes #562

## Test plan

- [x] \`cargo build --release\` — zero warnings
- [x] \`cargo test --release\` — full suite green
- [x] Manual diff vs jq 1.8.1 on
      \`@json\` / \`@json | @json\` / \`@json | length\` shapes
- [x] \`bench/comprehensive.sh\` — no movement vs prior run

🤖 Generated with [Claude Code](https://claude.com/claude-code)