### PR TITLE
fix: keep number repr through @text/@uri/@html/@sh/@base64

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3463,7 +3463,12 @@ fn format_sh_scalar(val: &Value) -> Result<String> {
         Value::Null => Ok("null".to_string()),
         Value::True => Ok("true".to_string()),
         Value::False => Ok("false".to_string()),
-        Value::Num(n, _) => Ok(crate::value::format_jq_number(*n)),
+        // `value_to_json_tojson` keeps the carried number repr (`0.0` stays
+        // `"0.0"`) while gracefully falling back to f64-formatted form when
+        // the literal can't round-trip — same logic the `tostring` builtin
+        // uses. The bare `format_jq_number` arm dropped the repr so
+        // `0.0 | @sh` produced `"0"` instead of jq's `"0.0"`. See #564.
+        Value::Num(_, _) => Ok(crate::value::value_to_json_tojson(val)),
         _ => bail!(
             "{} ({}) can not be escaped for shell",
             val.type_name(),
@@ -3558,8 +3563,15 @@ pub fn eval_format(name: &str, val: &Value) -> Result<String> {
         _ => {}
     }
 
-    // For other formats, stringify the value first
-    let s = match val { Value::Str(s) => s.to_string(), _ => crate::value::value_to_json(val) };
+    // For other formats, stringify the value first.
+    //
+    // jq's `@text`, `@uri`, `@html`, `@sh`, `@base64`, `@base64d` all run
+    // their input through the equivalent of `tostring` first. `value_to_json`
+    // discarded the carried number repr, so `0.0 | @text` produced `"0"`
+    // instead of `"0.0"` (and `@base64` encoded `MA==` instead of jq's
+    // `MC4w`). `value_to_json_tojson` keeps the literal form when f64 can
+    // round-trip it, matching `rt_tostring`. See #564.
+    let s = match val { Value::Str(s) => s.to_string(), _ => crate::value::value_to_json_tojson(val) };
     match name {
         "text" => Ok(s),
         // `@json` mirrors the `tojson` builtin, so it must preserve the

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -9017,3 +9017,48 @@ null
 . | @json
 0
 "0"
+
+# Issue #564: @text preserves number repr
+. | @text
+0.0
+"0.0"
+
+# Issue #564: @uri preserves number repr in stringification
+. | @uri
+0.0
+"0.0"
+
+# Issue #564: @html preserves number repr
+. | @html
+0.0
+"0.0"
+
+# Issue #564: @sh on a single number keeps the literal form
+. | @sh
+0.0
+"0.0"
+
+# Issue #564: @sh on an array of numbers keeps each repr
+. | @sh
+[1.0, 2.0]
+"1.0 2.0"
+
+# Issue #564: @base64 of a number-bearing repr matches jq's encoding
+. | @base64
+0.0
+"MC4w"
+
+# Issue #564: @text on array preserves nested number reprs
+. | @text
+[1.0, 2.0]
+"[1.0,2.0]"
+
+# Issue #564: integer @text still has no forced decimal
+. | @text
+0
+"0"
+
+# Issue #564: @text | length now reports the correct underlying string length
+. | @text | length
+0.0
+3


### PR DESCRIPTION
## Summary

- The shared stringify step in \`eval_format\` (used by \`@text\`,
  \`@uri\`, \`@html\`, \`@sh\`, \`@base64\`, \`@base64d\`) called
  \`value_to_json\` on non-string inputs, dropping the carried
  \`NumRepr\`. \`0.0 | @text\` returned \`"0"\` and \`0.0 | @base64\`
  produced \`"MA=="\` instead of jq's \`"MC4w"\`.
- \`format_sh_scalar\`'s \`Value::Num\` arm had the parallel bug
  via \`format_jq_number\`.
- Switch both sites to \`value_to_json_tojson\` (matching \`rt_tostring\`).

The CLI raw-byte fast path printed the right bytes for the standalone
\`X | @text\` shape; the lossy value only surfaced once the result
flowed into another step (\`length\`, another \`@\`, \`+ ""\`).

Closes #564 — same family as #75 / #110 / #190 / #475 / #560 / #562.

## Test plan

- [x] \`cargo build --release\` — zero warnings
- [x] \`cargo test --release\` — full suite green
- [x] Manual diff vs jq 1.8.1 on \`@text\`, \`@uri\`, \`@html\`,
      \`@sh\`, \`@base64\` shapes across 0.0 / [1.0,2.0] / int / string
- [x] \`bench/comprehensive.sh\` — no movement vs prior run

🤖 Generated with [Claude Code](https://claude.com/claude-code)