### PR TITLE
fix: keep number repr through single-element `add`

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1307,18 +1307,30 @@ fn rt_add_all(v: &Value) -> Result<Value> {
             // Fast path: detect homogeneous types for O(n) pre-allocated merge
             match &a[0] {
                 Value::Num(_, _) => {
-                    // Check if all elements are numbers
+                    // Check if all elements are numbers (or null). Track the
+                    // sole non-null number so a `[N] | add` (or `[null, N]`)
+                    // can return that value verbatim and keep its repr — jq
+                    // returns `1.0` not `1` for `[1.0] | add`. See #566.
                     let mut sum = 0.0f64;
                     let mut all_num = true;
+                    let mut num_count = 0;
+                    let mut sole_num: Option<&Value> = None;
                     for item in a.iter() {
                         match item {
-                            Value::Num(n, _) => sum += n,
+                            Value::Num(n, _) => {
+                                sum += n;
+                                num_count += 1;
+                                sole_num = if num_count == 1 { Some(item) } else { None };
+                            }
                             Value::Null => {}
                             _ => { all_num = false; break; }
                         }
                     }
                     if all_num {
-                        return Ok(Value::number(sum));
+                        return Ok(match sole_num {
+                            Some(v) => v.clone(),
+                            None => Value::number(sum),
+                        });
                     }
                 }
                 Value::Arr(_) => {

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -9062,3 +9062,33 @@ null
 . | @text | length
 0.0
 3
+
+# Issue #566: [N] | add returns the original value with repr preserved
+[1.0] | add | tojson
+null
+"1.0"
+
+# Issue #566: scientific repr also preserved through single-element add
+[1.5e2] | add | tojson
+null
+"1.5E+2"
+
+# Issue #566: leading nulls don't suppress the sole-num repr
+[null, 1.0] | add | tojson
+null
+"1.0"
+
+# Issue #566: trailing nulls don't suppress the sole-num repr
+[1.0, null] | add | tojson
+null
+"1.0"
+
+# Issue #566: real addition still drops repr (jq decnum-less)
+[1.0, 2.0] | add | tojson
+null
+"3"
+
+# Issue #566: empty / all-null arrays still return null
+[null, null] | add
+null
+null


### PR DESCRIPTION
## Summary

- \`rt_add_all\`'s homogeneous-numeric fast path always wrote
  \`Value::number(sum)\`, dropping the carried \`NumRepr\`. jq keeps
  the repr when the array reduces to exactly one non-null number —
  \`[1.0] | add\` returns \`1.0\`, \`[null, 1.5e2] | add\` returns
  \`1.5E+2\`. The CLI fast paths printed the right bytes for the
  standalone \`add\`; the bug surfaced once the result fed into
  another step (\`| tojson\`, etc.).
- Track the sole non-null number during the scan and return its clone
  when no actual addition happened. \`[1.0, 2.0] | add\` still drops
  the repr — jq does the same for real arithmetic.

Closes #566 — same family as #75 / #110 / #560 / #562 / #564.

## Test plan

- [x] \`cargo build --release\` — zero warnings
- [x] \`cargo test --release\` — full suite green
- [x] Manual diff vs jq 1.8.1 on \`[N] | add\`, \`[null, N] | add\`,
      \`[N, null] | add\`, \`[N, M] | add\`, \`[null, null] | add\`
- [x] \`bench/comprehensive.sh\` — no movement vs prior run

🤖 Generated with [Claude Code](https://claude.com/claude-code)