### PR TITLE
fix: collapse fractional digits into effective exponent for pure-zero repr

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -5489,26 +5489,26 @@ pub fn normalize_jq_repr(repr: &str) -> Option<String> {
     }
     let leading_zeros = combined.bytes().take_while(|&b| b == b'0').count();
     if leading_zeros == combined.len() {
-        // Pure-zero value: jq keeps the explicit-exponent form when present.
-        // `0e10`  → `0E+10` (positive exp stays scientific)
-        // `0e-1`  → `0.0`   (negative exp expands to decimal — N+frac zeros)
-        // `0.0e-1` → `0.00` (frac digits add to the zero count)
-        // `0.0e0` → `0.0`   (no exp shift, drop the `e0`)
-        // See #452.
+        // Pure-zero value: jq's normalisation collapses fractional digits
+        // and the exponent into a single effective exponent and prints the
+        // shortest legal form. `0.0e1` becomes `0` (the `.0` shifts the
+        // effective exp from `+1` down to `0`); `0.0e2` becomes `0E+1`;
+        // `0.000e2` becomes `0.0`. See #452 / #570.
         if let Some(_) = e_pos {
-            if exp >= 1 {
-                return Some(format!("{}0E+{}", sign, exp));
+            let effective_exp = (exp as i64) - (mant_frac.len() as i64);
+            if effective_exp >= 1 {
+                return Some(format!("{}0E+{}", sign, effective_exp));
             }
-            // exp <= 0: expand to decimal `0.000...0` with `mant_frac.len() - exp` zeros.
-            // exp == 0 with no frac → "0"; exp == 0 with frac → keep frac zeros.
-            let total_zeros = (mant_frac.len() as i64) - exp as i64;
-            if total_zeros <= 0 {
+            if effective_exp == 0 {
                 return Some(format!("{}0", sign));
             }
-            let mut s = String::with_capacity(2 + total_zeros as usize);
+            // Negative effective exp: expand to decimal `0.000...0` with the
+            // appropriate number of trailing zeros.
+            let zeros = (-effective_exp) as usize;
+            let mut s = String::with_capacity(2 + zeros);
             s.push_str(sign);
             s.push_str("0.");
-            for _ in 0..total_zeros { s.push('0'); }
+            for _ in 0..zeros { s.push('0'); }
             return Some(s);
         }
         return None;

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -9132,3 +9132,43 @@ try (test("(?P<>x)")) catch .
 try (test("(?<")) catch .
 "abc"
 "Regex failure: end pattern with unmatched parenthesis"
+
+# Issue #570: zero-value normalization collapses fractional digits into the effective exponent
+"0.0e1" | fromjson
+null
+0
+
+# Issue #570: 0.0e2 normalises to 0E+1 (not 0E+2)
+"0.0e2" | fromjson
+null
+0E+1
+
+# Issue #570: 0.0e3 normalises to 0E+2
+"0.0e3" | fromjson
+null
+0E+2
+
+# Issue #570: 0.00e1 normalises to 0.0
+"0.00e1" | fromjson
+null
+0.0
+
+# Issue #570: 0.000e2 normalises to 0.0
+"0.000e2" | fromjson
+null
+0.0
+
+# Issue #570: pure zero with positive exp keeps scientific form
+"0e1" | fromjson
+null
+0E+1
+
+# Issue #570: 0.0e-1 still expands to 0.00 (regression check)
+"0.0e-1" | fromjson
+null
+0.00
+
+# Issue #570: non-zero values unaffected
+"0.5e1" | fromjson
+null
+5


### PR DESCRIPTION
## Summary

- \`normalize_jq_repr\` printed pure-zero values with the raw exponent
  (\`0.0e1\` → \`0E+1\`, \`0.000e2\` → \`0.00\`). jq's normalisation
  folds fractional digits into the exponent: \`0.0e1\` → \`0\`,
  \`0.0e2\` → \`0E+1\`, \`0.000e2\` → \`0.0\`.
- The non-zero arm already used the same shift formula
  (\`te = ndigits - 1 + exp - mant_frac.len()\`); the pure-zero arm
  picked the raw \`exp\`.
- Compute \`effective_exp = exp - mant_frac.len()\` and dispatch on its
  sign — positive renders as \`0E+effective_exp\`, zero as \`0\`,
  negative expands the decimal form with that many trailing zeros.

Closes #570

## Test plan

- [x] \`cargo build --release\` — zero warnings
- [x] \`cargo test --release\` — full suite green (compat_regression
      passed independently)
- [x] Manual diff vs jq 1.8.1 across \`0e0\`, \`0e1\`, \`0.0e0\`,
      \`0.0e1\`, \`0.0e2\`, \`0.0e3\`, \`0.0e-1\`, \`0.00e1\`,
      \`0.000e2\`, plus non-zero sanity cases (\`0.5e1\`, \`1.0e0\`,
      \`1e10\`).
- [x] \`bench/comprehensive.sh\` — no movement vs prior run

🤖 Generated with [Claude Code](https://claude.com/claude-code)