### PR TITLE
fix: align slice index error wording with jq's canonical phrasing

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3697,8 +3697,8 @@ pub fn eval_slice(base: &Value, from: &Value, to: &Value) -> Result<Value> {
     match base {
         Value::Arr(a) => {
             let len = a.len() as i64;
-            let fi = match from { Value::Num(n, _) => slice_index_start(*n, len), Value::Null => 0, _ => bail!("slice: need number") };
-            let ti = match to { Value::Num(n, _) => slice_index_end(*n, len), Value::Null => len as usize, _ => bail!("slice: need number") };
+            let fi = match from { Value::Num(n, _) => slice_index_start(*n, len), Value::Null => 0, _ => bail!("Array/string slice indices must be integers") };
+            let ti = match to { Value::Num(n, _) => slice_index_end(*n, len), Value::Null => len as usize, _ => bail!("Array/string slice indices must be integers") };
             Ok(if fi>=ti { Value::Arr(Rc::new(vec![])) } else { Value::Arr(Rc::new(a[fi..ti].to_vec())) })
         }
         Value::Str(s) => {
@@ -3706,14 +3706,14 @@ pub fn eval_slice(base: &Value, from: &Value, to: &Value) -> Result<Value> {
             // ASCII fast path: byte index == char index, no allocation needed
             if s_str.is_ascii() {
                 let len = s_str.len() as i64;
-                let fi = match from { Value::Num(n, _) => slice_index_start(*n, len), Value::Null => 0, _ => bail!("slice: need number") };
-                let ti = match to { Value::Num(n, _) => slice_index_end(*n, len), Value::Null => len as usize, _ => bail!("slice: need number") };
+                let fi = match from { Value::Num(n, _) => slice_index_start(*n, len), Value::Null => 0, _ => bail!("Array/string slice indices must be integers") };
+                let ti = match to { Value::Num(n, _) => slice_index_end(*n, len), Value::Null => len as usize, _ => bail!("Array/string slice indices must be integers") };
                 Ok(if fi>=ti { Value::from_str("") } else { Value::from_str(&s_str[fi..ti]) })
             } else {
                 // Unicode: count chars without allocation, use char_indices for byte offsets
                 let char_count = s_str.chars().count() as i64;
-                let fi = match from { Value::Num(n, _) => slice_index_start(*n, char_count), Value::Null => 0, _ => bail!("slice: need number") };
-                let ti = match to { Value::Num(n, _) => slice_index_end(*n, char_count), Value::Null => char_count as usize, _ => bail!("slice: need number") };
+                let fi = match from { Value::Num(n, _) => slice_index_start(*n, char_count), Value::Null => 0, _ => bail!("Array/string slice indices must be integers") };
+                let ti = match to { Value::Num(n, _) => slice_index_end(*n, char_count), Value::Null => char_count as usize, _ => bail!("Array/string slice indices must be integers") };
                 Ok(if fi>=ti { Value::from_str("") } else {
                     let mut ci = s_str.char_indices();
                     let start_byte = ci.nth(fi).map(|(pos, _)| pos).unwrap_or(s_str.len());

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -9172,3 +9172,28 @@ null
 "0.5e1" | fromjson
 null
 5
+
+# Issue #572: slice with string `from` raises jq's "Array/string slice indices must be integers"
+try (.["a":3]) catch .
+"abc"
+"Array/string slice indices must be integers"
+
+# Issue #572: slice with string `to` produces the same wording
+try (.[0:"x"]) catch .
+[1,2,3]
+"Array/string slice indices must be integers"
+
+# Issue #572: array endpoint also rejected with the canonical wording
+try (.[0:[]]) catch .
+[1,2,3]
+"Array/string slice indices must be integers"
+
+# Issue #572: null endpoints still slice (regression check)
+.[null:null]
+"abc"
+"abc"
+
+# Issue #572: float endpoints still slice (regression check)
+.[1.5:3]
+"abc"
+"bc"


### PR DESCRIPTION
## Summary

- \`eval_slice\` raised \`slice: need number\` for non-integer
  endpoints. jq uses
  \`Array/string slice indices must be integers\` (the same wording
  the slice-spec validator in \`runtime::validate_slice_spec\` already
  prints — see #549).
- Scripts matching on the catch value saw different strings
  depending on which slice path triggered.
- Replace the five \`bail!\` sites with the canonical phrasing.

Closes #572

## Test plan

- [x] \`cargo build --release\` — zero warnings
- [x] \`cargo test --release\` — full suite green (compat_regression
      passed independently)
- [x] Manual diff vs jq 1.8.1 across string/array/array-endpoint
      shapes plus null/float-endpoint regression sanity checks
- [x] \`bench/comprehensive.sh\` — pure error path, no movement
      expected (skipped — string change only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)