### PR TITLE
fix: route Cannot-iterate-over errors through errdesc

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1818,8 +1818,9 @@ pub fn eval(
                         }
                         Ok(true)
                     }
-                    _ => bail!("Cannot iterate over {} ({})",
-                        container.type_name(), crate::value::value_to_json(&container)),
+                    // Use errdesc so number reprs survive (`0.0` stays
+                    // `0.0`) and long values get jq's truncation. See #574.
+                    _ => bail!("Cannot iterate over {}", crate::runtime::errdesc_pub(&container)),
                 }
             })
         }
@@ -4248,8 +4249,10 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
                     _ => {
                         // jq errors `del(.[])` etc. when the current path
                         // points at a non-iterable (issue #54). Silent
-                        // "no paths" turned type errors into no-ops.
-                        bail!("Cannot iterate over {} ({})", base.type_name(), crate::value::value_to_json(&base))
+                        // "no paths" turned type errors into no-ops. Use
+                        // errdesc so number reprs survive (`0.0` stays
+                        // `0.0`) and long values get truncated. See #574.
+                        bail!("Cannot iterate over {}", crate::runtime::errdesc_pub(&base))
                     }
                 }
             });

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -6905,12 +6905,12 @@ extern "C" fn jit_rt_call_builtin(dst: *mut Value, name_ptr: *const u8, name_len
             return 0;
         }
         if name == "__each_error__" {
-            // Generate "Cannot iterate over TYPE (VALUE)" error
+            // Generate "Cannot iterate over TYPE (VALUE)" error. Use
+            // errdesc so number reprs survive (`0.0` stays `0.0`) and long
+            // values get jq's `...` truncation. See #574.
             if !args.is_empty() {
                 let v = &args[0];
-                let ty = v.type_name();
-                let json = crate::value::value_to_json(v);
-                set_jit_error(format!("Cannot iterate over {} ({})", ty, json));
+                set_jit_error(format!("Cannot iterate over {}", crate::runtime::errdesc_pub(v)));
                 std::ptr::write(dst, Value::Null);
                 return GEN_ERROR;
             }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1428,7 +1428,9 @@ fn rt_add_all(v: &Value) -> Result<Value> {
             }
             Ok(result)
         }
-        _ => bail!("Cannot iterate over {} ({})", v.type_name(), crate::value::value_to_json(v)),
+        // Use errdesc so number reprs survive (`0.0` stays `0.0`) and long
+        // values get jq's `...` truncation. See #574.
+        _ => bail!("Cannot iterate over {}", errdesc(v)),
     }
 }
 

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -9197,3 +9197,33 @@ try (.[0:[]]) catch .
 .[1.5:3]
 "abc"
 "bc"
+
+# Issue #574: Cannot iterate over number preserves the literal repr (0.0 stays 0.0)
+try (.[]) catch .
+0.0
+"Cannot iterate over number (0.0)"
+
+# Issue #574: scientific repr preserved through the iterate error
+try (.[]) catch .
+1e10
+"Cannot iterate over number (1E+10)"
+
+# Issue #574: -0.0 preserved (not collapsed to -0)
+try (.[]) catch .
+-0.0
+"Cannot iterate over number (-0.0)"
+
+# Issue #574: long string repr is truncated with "..." like jq's errdesc
+try (.[]) catch .
+"1234567890123456789"
+"Cannot iterate over string (\"1234567890...)"
+
+# Issue #574: integer numbers still render without forced decimal
+try (.[]) catch .
+0
+"Cannot iterate over number (0)"
+
+# Issue #574: bool/null still match jq (regression check)
+try (.[]) catch .
+true
+"Cannot iterate over boolean (true)"


### PR DESCRIPTION
## Summary

- Three sites emitted \`Cannot iterate over <type> (<value>)\` with
  bare \`value_to_json\`, dropping the carried number repr and missing
  the \`...\`-truncation jq applies past 14 bytes.
- \`0.0 | .[]\` reported \`(0)\`, \`1e10 | .[]\` reported
  \`(10000000000)\`, \`-0.0 | .[]\` reported \`(-0)\`, and a 19-char
  string printed full instead of \`"1234567890..."\`.
- \`errdesc\` already prints exactly jq's format (repr-aware,
  truncated). Reuse it for \`rt_add_all\`'s fallback arm,
  \`eval_path::Each\`, and the JIT \`__each_error__\` runtime helper.

Closes #574

## Test plan

- [x] \`cargo build --release\` — zero warnings
- [x] \`cargo test --release\` — full suite green (compat_regression
      passed independently)
- [x] Manual diff vs jq 1.8.1 across number-repr, long-string, int,
      bool, and null cases
- [x] \`bench/comprehensive.sh\` — pure error-path string change, no
      movement expected (skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)