### PR TITLE
fix: keep length on negative numbers consistent with jq's repr

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1069,7 +1069,12 @@ fn eval_one(expr: &Expr, input: &Value, env: &EnvRef) -> std::result::Result<Val
                     UnaryOp::Ceil => Value::number(n.ceil()),
                     UnaryOp::Round => Value::number(n.round()),
                     UnaryOp::Fabs | UnaryOp::Abs => Value::number(n.abs()),
-                    UnaryOp::Length => Value::number(n.abs()),
+                    // jq's `length` on a number is `abs` but preserves the
+                    // literal repr (`-1.0 | length` → `1.0`,
+                    // `-0.0 | length` → `0.0`). Delegate to `Value::length`
+                    // so this fast path matches the runtime `rt_length`
+                    // path. See #576.
+                    UnaryOp::Length => val.length().map_err(|_| ())?,
                     UnaryOp::Sqrt => Value::number(n.sqrt()),
                     _ => return eval_unaryop(*op, &val).map_err(|_| ()),
                 });

--- a/src/value.rs
+++ b/src/value.rs
@@ -652,8 +652,22 @@ impl Value {
                 bail!("{} ({}) has no length", self.type_name(), crate::value::value_to_json(self))
             }
             Value::Num(n, NumRepr(repr)) => {
-                if *n >= 0.0 { Ok(Value::number_opt(*n, repr.clone())) }
-                else { Ok(Value::number(n.abs())) }
+                // jq's `length` on a number is `abs`, but it preserves the
+                // literal repr — `-1.0 | length` → `1.0`, `-1e10 | length`
+                // → `1E+10`, `-0.0 | length` → `0.0`. The previous arm
+                // pass-threw the repr for any `n >= 0.0` (which includes
+                // `-0.0` → `0.0` in IEEE-754, leaving `"-0.0"` intact) and
+                // dropped the repr for actually-negative numbers (so
+                // `-1.0` came back as `1`, not `1.0`). Strip the leading
+                // `-` from the repr instead — this fixes both. See #576.
+                let new_repr = repr.as_ref().and_then(|r| {
+                    if !crate::value::is_valid_json_number(r) { return None; }
+                    Some(match r.strip_prefix('-') {
+                        Some(rest) => Rc::from(rest),
+                        None => r.clone(),
+                    })
+                });
+                Ok(Value::number_opt(n.abs(), new_repr))
             }
             Value::Str(s) => {
                 // jq counts Unicode codepoints

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -9227,3 +9227,33 @@ try (.[]) catch .
 try (.[]) catch .
 true
 "Cannot iterate over boolean (true)"
+
+# Issue #576: length on -0.0 strips sign and keeps fractional repr (matches jq)
+-0.0 | length
+null
+0.0
+
+# Issue #576: length on -0 collapses to 0
+-0 | length
+null
+0
+
+# Issue #576: length on -1.0 keeps the .0 form
+-1.0 | length
+null
+1.0
+
+# Issue #576: length on -1e10 keeps the scientific repr
+-1e10 | length
+null
+1E+10
+
+# Issue #576: length on 0.0 still keeps the .0
+0.0 | length
+null
+0.0
+
+# Issue #576: length on plain int unchanged
+-1 | length
+null
+1


### PR DESCRIPTION
## Summary

\`Value::length\` for numbers had two repr leaks:

- The \`n >= 0.0\` arm pass-threw the carried repr, so \`-0.0 | length\`
  returned \`-0.0\` (jq: \`0.0\`) — IEEE-754 puts \`-0.0\` in the
  non-negative branch.
- The negative arm built \`Value::number(n.abs())\` with no repr, so
  \`-1.0 | length\` returned \`1\` (jq: \`1.0\`) and \`-1e10 | length\`
  lost \`E+10\` to whatever the f64-default render produced.

Strip the leading \`-\` from the carried repr (if any) and return
\`Value::number_opt(n.abs(), stripped_repr)\`. That folds positive,
negative, and signed-zero into one arm that matches jq exactly.

The eval-side scalar fast path (\`eval.rs::eval_one\`) had the same
\`Value::number(n.abs())\` shortcut. Delegate it to \`Value::length\`
so both paths stay in sync.

Closes #576

## Test plan

- [x] \`cargo build --release\` — zero warnings
- [x] \`cargo test --release\` — full suite green (compat_regression
      passed independently)
- [x] Manual diff vs jq 1.8.1 across \`0\`, \`-0\`, \`0.0\`, \`-0.0\`,
      \`1.5\`, \`-1.5\`, \`1.0\`, \`-1.0\`, \`1e10\`, \`-1e10\`, \`null\`
- [x] \`bench/comprehensive.sh\` — no movement vs prior run

🤖 Generated with [Claude Code](https://claude.com/claude-code)