### PR TITLE
fix: split abs (preserves repr) from fabs (canonical f64)

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1068,7 +1068,13 @@ fn eval_one(expr: &Expr, input: &Value, env: &EnvRef) -> std::result::Result<Val
                     UnaryOp::Floor => Value::number(n.floor()),
                     UnaryOp::Ceil => Value::number(n.ceil()),
                     UnaryOp::Round => Value::number(n.round()),
-                    UnaryOp::Fabs | UnaryOp::Abs => Value::number(n.abs()),
+                    // jq's `abs` keeps the literal repr while `fabs`
+                    // returns the canonical f64 form (#578). The two
+                    // shared the same fast-path branch and dropped the
+                    // repr for both. Delegate to the runtime entry points
+                    // so the fast path matches `rt_abs` / `rt_fabs`.
+                    UnaryOp::Fabs => Value::number(n.abs()),
+                    UnaryOp::Abs => return eval_unaryop(*op, &val).map_err(|_| ()),
                     // jq's `length` on a number is `abs` but preserves the
                     // literal repr (`-1.0 | length` → `1.0`,
                     // `-0.0 | length` → `0.0`). Delegate to `Value::length`

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1473,19 +1473,37 @@ fn rt_round(v: &Value) -> Result<Value> {
 
 fn rt_fabs(v: &Value) -> Result<Value> {
     match v {
-        Value::Num(n, NumRepr(repr)) => {
-            if *n >= 0.0 { Ok(Value::number_opt(*n, repr.clone())) }
-            else { Ok(Value::number(n.abs())) }
-        }
+        // jq's `fabs` is the math-style absolute value: it always returns
+        // the canonical f64 form regardless of the input repr — `0.0 |
+        // fabs` → `0`, `-1.0 | fabs` → `1`, `-1e10 | fabs` →
+        // `10000000000`. The previous arm pass-threw the repr for any
+        // `n >= 0.0` (including signed zero), making `0.0 | fabs` come
+        // back as `0.0`. See #578.
+        Value::Num(n, _) => Ok(Value::number(n.abs())),
         _ => bail!("{} number required", errdesc(v)),
     }
 }
 
 fn rt_abs(v: &Value) -> Result<Value> {
     match v {
+        // jq's `abs` keeps the literal repr — `0.0 | abs` stays `0.0`,
+        // `-1.0 | abs` becomes `1.0`, `-1e10 | abs` becomes `1E+10`.
+        // Signed zero is left untouched (`-0.0 | abs` → `-0.0`,
+        // `-0 | abs` → `-0`); other negative numbers strip the leading
+        // `-` from the repr while flipping the f64 sign. See #578.
         Value::Num(n, NumRepr(repr)) => {
-            if *n >= 0.0 { Ok(Value::number_opt(*n, repr.clone())) }
-            else { Ok(Value::number(n.abs())) }
+            if n.is_sign_negative() && *n != 0.0 {
+                let new_repr = repr.as_ref().and_then(|r| {
+                    if !crate::value::is_valid_json_number(r) { return None; }
+                    Some(match r.strip_prefix('-') {
+                        Some(rest) => Rc::from(rest),
+                        None => r.clone(),
+                    })
+                });
+                Ok(Value::number_opt(n.abs(), new_repr))
+            } else {
+                Ok(Value::number_opt(*n, repr.clone()))
+            }
         }
         Value::Str(_) | Value::Arr(_) | Value::Obj(_) => Ok(v.clone()),
         _ => {

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -9257,3 +9257,43 @@ null
 -1 | length
 null
 1
+
+# Issue #578: abs preserves literal repr for non-zero numbers
+-1.0 | abs
+null
+1.0
+
+# Issue #578: abs preserves scientific repr
+-1e10 | abs
+null
+1E+10
+
+# Issue #578: abs leaves signed zero untouched
+-0.0 | abs
+null
+-0.0
+
+# Issue #578: abs on zero keeps fractional repr
+0.0 | abs
+null
+0.0
+
+# Issue #578: fabs always returns canonical f64 form (drops repr)
+0.0 | fabs
+null
+0
+
+# Issue #578: fabs on -1.0 drops the .0
+-1.0 | fabs
+null
+1
+
+# Issue #578: fabs on signed zero collapses to 0
+-0.0 | fabs
+null
+0
+
+# Issue #578: fabs on 1.5 keeps f64-canonical (already 1.5)
+-1.5 | fabs
+null
+1.5


### PR DESCRIPTION
## Summary

\`abs\` and \`fabs\` shared the same arm in \`runtime.rs\` and the
same fast path in \`eval.rs::eval_one\`. jq treats them differently:

| input    | \`abs\` (jq) | \`fabs\` (jq) |
| -------- | ------------ | ------------- |
| \`0.0\`  | \`0.0\`      | \`0\`         |
| \`-0.0\` | \`-0.0\`     | \`0\`         |
| \`-1.0\` | \`1.0\`      | \`1\`         |
| \`-1e10\`| \`1E+10\`    | \`10000000000\` |

The shared arm pass-threw the repr for any \`n >= 0.0\` (so \`fabs\`
over-preserved for signed zero) and dropped the repr for negative
non-zero numbers (so \`abs\` reported \`1\` instead of \`1.0\`).

- \`rt_fabs\`: always \`Value::number(n.abs())\` — drops the repr
  unconditionally.
- \`rt_abs\`: strip the leading \`-\` from the repr for negative
  non-zero values, pass-thru everything else (so signed zero is left
  unchanged, matching jq's decnum behaviour).
- \`eval.rs::eval_one\`: keep \`Fabs\` on the inline form, route
  \`Abs\` to \`eval_unaryop\` so \`rt_abs\` gets to preserve the repr.

Closes #578 — same family as #560 / #564 / #576.

## Test plan

- [x] \`cargo build --release\` — zero warnings
- [x] \`cargo test --release\` — full suite green (compat_regression
      passed independently)
- [x] Manual diff vs jq 1.8.1 across the eight signed/unsigned cases
      plus error-path inputs (string/array/null/bool)
- [x] \`bench/comprehensive.sh\` — pure number op, no movement
      expected (skipped — error-path-adjacent change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)