### PR TITLE
fix: route utf8bytelength/length/negate errors through errdesc

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1113,7 +1113,11 @@ fn rt_length(v: &Value) -> Result<Value> {
 fn rt_utf8bytelength(v: &Value) -> Result<Value> {
     match v {
         Value::Str(s) => Ok(Value::number(s.len() as f64)),
-        _ => bail!("{} ({}) only strings have UTF-8 byte length", v.type_name(), crate::value::value_to_json(v)),
+        // errdesc preserves number repr (`0.0` stays `0.0`) and applies
+        // jq's `...` truncation for long previews. The previous
+        // value_to_json call dropped the repr so `0.0` came back as `0`.
+        // See #580.
+        _ => bail!("{} only strings have UTF-8 byte length", errdesc(v)),
     }
 }
 
@@ -1215,7 +1219,8 @@ fn rt_reverse(v: &Value) -> Result<Value> {
         Value::Str(_) => bail!("Cannot index string with number"),
         Value::Obj(_) => bail!("Cannot index object with number"),
         Value::Num(_, _) => bail!("Cannot index number with number"),
-        Value::True | Value::False => bail!("{} ({}) has no length", v.type_name(), crate::value::value_to_json(v)),
+        // errdesc keeps repr/truncation consistent across error sites (#580).
+        Value::True | Value::False => bail!("{} has no length", errdesc(v)),
         _ => bail!("{} cannot be reversed", v.type_name()),
     }
 }
@@ -1507,7 +1512,8 @@ fn rt_abs(v: &Value) -> Result<Value> {
         }
         Value::Str(_) | Value::Arr(_) | Value::Obj(_) => Ok(v.clone()),
         _ => {
-            bail!("{} ({}) cannot be negated", v.type_name(), crate::value::value_to_json(v))
+            // errdesc keeps the wording consistent with jq for repr (#580).
+            bail!("{} cannot be negated", errdesc(v))
         }
     }
 }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -9297,3 +9297,33 @@ null
 -1.5 | fabs
 null
 1.5
+
+# Issue #580: utf8bytelength error keeps number repr (`0.0` not collapsed to `0`)
+try (utf8bytelength) catch .
+0.0
+"number (0.0) only strings have UTF-8 byte length"
+
+# Issue #580: scientific number repr survives
+try (utf8bytelength) catch .
+1e10
+"number (1E+10) only strings have UTF-8 byte length"
+
+# Issue #580: -0.0 preserved (not -0)
+try (utf8bytelength) catch .
+-0.0
+"number (-0.0) only strings have UTF-8 byte length"
+
+# Issue #580: bool length error uses errdesc wording (regression check)
+try (length) catch .
+true
+"boolean (true) has no length"
+
+# Issue #580: negate string error uses errdesc wording
+try (-.) catch .
+"abc"
+"string (\"abc\") cannot be negated"
+
+# Issue #580: long string truncation in negate error
+try (-.) catch .
+"1234567890123456789"
+"string (\"1234567890...) cannot be negated"


### PR DESCRIPTION
## Summary

Three sister error sites in \`runtime.rs\` formatted the offending
value with bare \`value_to_json\`:

- \`rt_utf8bytelength\` — \`0.0 | utf8bytelength\` reported
  \`number (0)\` (jq: \`number (0.0)\`); \`1e10\` lost \`E+10\`.
- \`rt_length\`'s bool arm — long-value previews not truncated.
- \`rt_abs\`'s "cannot be negated" arm — same family.

\`errdesc\` already prints the format jq uses (repr-aware,
\`...\`-truncated past 14 bytes). Reuse it for all three.

Closes #580 — same family as #574 / #560 / #564 / #576.

## Test plan

- [x] \`cargo build --release\` — zero warnings
- [x] \`cargo test --release\` — full suite green (compat_regression
      passed independently)
- [x] Manual diff vs jq 1.8.1 across the three sites and a long-string
      truncation regression
- [x] \`bench/comprehensive.sh\` — pure error-path string change, no
      movement expected (skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)