### PR TITLE
fix: range/3 with non-numeric step matches jq's lazy semantics

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3394,12 +3394,25 @@ fn eval_recurse_default(val: &Value, cb: &mut dyn FnMut(Value) -> GenResult) -> 
 
 fn eval_range(from: &Value, to: &Value, step: Option<&Value>, cb: &mut dyn FnMut(Value) -> GenResult) -> GenResult {
     // jq emits a single "Range bounds must be numeric" error for both
-    // out-of-type from and to (#527). The step argument has lazier
-    // semantics in jq (the loop emits the first value before arithmetic
-    // fails) so we keep the previous wording for now.
+    // out-of-type from and to (#527).
     let f = match from { Value::Num(n, _) => *n, _ => bail!("Range bounds must be numeric") };
     let t = match to { Value::Num(n, _) => *n, _ => bail!("Range bounds must be numeric") };
-    let s = match step { Some(Value::Num(n, _)) => *n, Some(_) => bail!("range: step must be number"), None => 1.0 };
+    // jq's `range/3` desugars to `from | while(. < upto; . + by)`. The
+    // step is consumed lazily, so `range(0; 10; "a")` emits `0` first and
+    // then surfaces jq's `+`-error on the next iteration. `null`/`true`/
+    // `false` steps silently emit nothing (jq's range short-circuits
+    // before yielding anything when the addition would be an identity or
+    // a type error it would have already filtered). See #582.
+    let s = match step {
+        Some(Value::Num(n, _)) => *n,
+        Some(Value::Null) | Some(Value::True) | Some(Value::False) => return Ok(true),
+        Some(non_num) => {
+            if !cb(from.clone())? { return Ok(false); }
+            let _ = crate::runtime::rt_add(from, non_num)?;
+            return Ok(true);
+        }
+        None => 1.0,
+    };
     if s == 0.0 { return Ok(true); }
     let mut c = f;
     let mut first = true;

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -9327,3 +9327,38 @@ try (-.) catch .
 try (-.) catch .
 "1234567890123456789"
 "string (\"1234567890...) cannot be negated"
+
+# Issue #582: range with non-arithmetic step emits `from` first then errors via `+`
+[try (range(0; 10; "a")) catch .]
+null
+[0,"number (0) and string (\"a\") cannot be added"]
+
+# Issue #582: range with array step matches jq's lazy add error
+[try (range(0; 10; [])) catch .]
+null
+[0,"number (0) and array ([]) cannot be added"]
+
+# Issue #582: range with object step matches jq
+[try (range(0; 10; {})) catch .]
+null
+[0,"number (0) and object ({}) cannot be added"]
+
+# Issue #582: range with null step silently emits nothing
+[range(0; 10; null)]
+null
+[]
+
+# Issue #582: range with bool step silently emits nothing
+[range(0; 10; true)]
+null
+[]
+
+# Issue #582: range with step=0 still empty (regression check)
+[range(0; 10; 0)]
+null
+[]
+
+# Issue #582: numeric step still works
+[range(0; 5)]
+null
+[0,1,2,3,4]


### PR DESCRIPTION
## Summary

\`eval_range\` validated the step argument eagerly:
\`range(0; 10; "a")\` errored with \`range: step must be number\`
instead of jq's "emit \`from\` first, then surface the \`+\`-error"
behaviour. \`range/3\` desugars to
\`from | while(. < upto; . + by)\`, so the step is consumed lazily
and the type matters:

| step type           | jq behaviour                                  |
| ------------------- | --------------------------------------------- |
| \`string\`/\`array\`/\`object\` | emit \`from\`, then \`+\` error      |
| \`null\`/\`true\`/\`false\`     | silently emit nothing               |
| \`number\`          | normal loop                                   |

Yield \`from\` and route through \`rt_add\` for arithmetic-incompatible
cases, and short-circuit to "no output" for null/bool steps.

Closes #582

## Test plan

- [x] \`cargo build --release\` — zero warnings
- [x] \`cargo test --release\` — full suite green (compat_regression
      passed independently)
- [x] Manual diff vs jq 1.8.1 across string/array/object/null/bool
      steps and standard numeric step regression
- [x] \`bench/comprehensive.sh\` — no movement vs prior run

🤖 Generated with [Claude Code](https://claude.com/claude-code)