### PR TITLE
fix: preserve number repr in object-key error message

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3438,9 +3438,8 @@ fn object_key_from_value(kv: &Value) -> Result<KeyStr> {
     match kv {
         Value::Str(s) => Ok(KeyStr::from(s.as_str())),
         _ => bail!(
-            "Cannot use {} ({}) as object key",
-            kv.type_name(),
-            crate::value::value_to_json(kv)
+            "Cannot use {} as object key",
+            crate::runtime::errdesc_pub(kv)
         ),
     }
 }

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -6677,9 +6677,8 @@ extern "C" fn jit_rt_obj_insert(obj: *mut Value, key: *mut Value, val: *mut Valu
                 Value::Str(s) => s,
                 other => {
                     set_jit_error(format!(
-                        "Cannot use {} ({}) as object key",
-                        other.type_name(),
-                        crate::value::value_to_json(&other)
+                        "Cannot use {} as object key",
+                        crate::runtime::errdesc_pub(&other)
                     ));
                     drop(other);
                     drop(val_val);

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1767,9 +1767,8 @@ fn rt_from_entries(v: &Value) -> Result<Value> {
                         let key_str = match &key {
                             Value::Str(s) => s.to_string(),
                             other => bail!(
-                                "Cannot use {} ({}) as object key",
-                                other.type_name(),
-                                crate::value::value_to_json(other),
+                                "Cannot use {} as object key",
+                                errdesc(other),
                             ),
                         };
                         obj.insert(KeyStr::from(key_str), val);

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -9362,3 +9362,18 @@ null
 [range(0; 5)]
 null
 [0,1,2,3,4]
+
+# Issue #584: object key error preserves number repr
+try ({(.): 1}) catch .
+0.0
+"Cannot use number (0.0) as object key"
+
+# Issue #584: object key error preserves negative-zero repr
+try ({(.): 1}) catch .
+-0.0
+"Cannot use number (-0.0) as object key"
+
+# Issue #584: object key error preserves exponent repr
+try ({(.): 1}) catch .
+1e10
+"Cannot use number (1E+10) as object key"


### PR DESCRIPTION
## Summary

- Object construction with a non-string key dropped jq's number repr — `0.0` → `(0)`, `-0.0` → `(-0)`, `1e10` → `(10000000000)`.
- All three sites (eval `object_key_from_value`, JIT `jit_rt_obj_insert`, runtime `from_entries` key build) now use the `errdesc` helper, which emits jq's repr-aware `<type> (<json>)` shape with the 14-byte truncation jq applies to long previews.

## Test plan

- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (all green)
- [x] Spot-check `try ({(.): 1}) catch .` for `0`, `0.0`, `-0.0`, `1e10`, `1.5`, `12345678901234.0`, `[1,2,3]`, `{}` — matches jq exactly
- [x] Bench skipped (pure error-path string change)

Closes #584