### PR TITLE
fix: preserve number repr in debug/stderr output

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3098,7 +3098,7 @@ pub fn eval(
 
         Expr::Debug { expr: de } => {
             eval(de, input.clone(), env, &mut |val| {
-                eprintln!("[\"DEBUG:\",{}]", crate::value::value_to_json(&val));
+                eprintln!("[\"DEBUG:\",{}]", crate::value::value_to_json_tojson(&val));
                 cb(input.clone())
             })
         }
@@ -3110,7 +3110,7 @@ pub fn eval(
                 // through to `cb` unchanged.
                 match &val {
                     Value::Str(s) => eprint!("{}", s.as_str()),
-                    _ => eprint!("{}", crate::value::value_to_json(&val)),
+                    _ => eprint!("{}", crate::value::value_to_json_tojson(&val)),
                 }
                 cb(input.clone())
             })

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -7000,15 +7000,15 @@ extern "C" fn jit_rt_call_builtin(dst: *mut Value, name_ptr: *const u8, name_len
                 let label = &args[1];
                 match label {
                     Value::Str(s) if !s.is_empty() => {
-                        eprintln!("[\"DEBUG:\",{}]", crate::value::value_to_json(input));
+                        eprintln!("[\"DEBUG:\",{}]", crate::value::value_to_json_tojson(input));
                     }
                     _ => {
-                        eprintln!("[\"DEBUG:\",{}]", crate::value::value_to_json(input));
+                        eprintln!("[\"DEBUG:\",{}]", crate::value::value_to_json_tojson(input));
                     }
                 }
                 std::ptr::write(dst, input.clone());
             } else if !args.is_empty() {
-                eprintln!("[\"DEBUG:\",{}]", crate::value::value_to_json(&args[0]));
+                eprintln!("[\"DEBUG:\",{}]", crate::value::value_to_json_tojson(&args[0]));
                 std::ptr::write(dst, args[0].clone());
             } else {
                 std::ptr::write(dst, Value::Null);
@@ -7017,7 +7017,7 @@ extern "C" fn jit_rt_call_builtin(dst: *mut Value, name_ptr: *const u8, name_len
         }
         if name == "stderr" {
             if !args.is_empty() {
-                eprint!("{}", crate::value::value_to_json(&args[0]));
+                eprint!("{}", crate::value::value_to_json_tojson(&args[0]));
                 std::ptr::write(dst, args[0].clone());
             } else {
                 std::ptr::write(dst, Value::Null);

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -144,11 +144,11 @@ pub fn call_builtin(name: &str, args: &[Value]) -> Result<Value> {
         "env" | "$ENV" => Ok(rt_env()),
         "builtins" => Ok(rt_builtins()),
         "debug" => unary_op(args, |v| {
-            eprintln!("[\"DEBUG:\",{}]", crate::value::value_to_json(v));
+            eprintln!("[\"DEBUG:\",{}]", crate::value::value_to_json_tojson(v));
             Ok(v.clone())
         }),
         "stderr" => unary_op(args, |v| {
-            eprint!("{}", crate::value::value_to_json(v));
+            eprint!("{}", crate::value::value_to_json_tojson(v));
             Ok(v.clone())
         }),
         "input" | "inputs" => {


### PR DESCRIPTION
## Summary

- `debug` and `stderr` formatted the value preview with `value_to_json`, dropping jq's number repr — `0.0` printed as `0`, `-0.0` as `-0`, `1e10` as `10000000000`, and the same for nested arrays/objects.
- Switched all five sites (eval `Expr::Debug`/`Expr::Stderr`, runtime `debug`/`stderr`, JIT `debug`/`stderr`) to `value_to_json_tojson`, which honours the same repr rules `tojson` does.

## Test plan

- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (all green)
- [x] Spot-check `debug` and `stderr` against jq for `0`, `0.0`, `-0.0`, `1e10`, `1.5`, `"abc"`, `[1.0]`, `{"a":0.0}` — matches exactly
- [x] Bench skipped — debug/stderr is a stderr-output formatting change, not on hot paths

Closes #588