### PR TITLE
fix: path(.f?) suppresses path when base type rejects the access

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -4418,8 +4418,21 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
             }
         }
         Expr::IndexOpt { expr: be, key: ke } => {
+            // jq suppresses paths whose access would error: `path(.a?)` on
+            // a non-object/non-null base emits no path. Mirror the type
+            // check from the non-`?` Index path but skip silently on
+            // mismatch instead of bailing. See #?.
+            let input_for_check = input.clone();
             eval_path(be, input.clone(), env, &mut |bp| {
                 eval(ke, input.clone(), env, &mut |key| {
+                    let base_val = crate::runtime::rt_getpath(&input_for_check, &bp).unwrap_or(Value::Null);
+                    match (&base_val, &key) {
+                        (Value::Obj(_), Value::Str(_)) => {}
+                        (Value::Arr(_), Value::Num(_, _)) => {}
+                        (Value::Arr(_), Value::Arr(_)) => {}
+                        (Value::Null, _) => {}
+                        _ => return Ok(true),
+                    }
                     let mut p = match &bp { Value::Arr(a) => a.as_ref().clone(), _ => vec![] };
                     p.push(key); cb(Value::Arr(Rc::new(p)))
                 })

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -9387,3 +9387,43 @@ null
 try (nth(-1; range(5))) catch .
 null
 "nth doesn't support negative indices"
+
+# Issue #590: path(.f?) suppresses path on non-object/non-null base
+[path(.a?)]
+0
+[]
+
+# Issue #590: path(.f?) on null still emits (null accepts any field)
+[path(.a?)]
+null
+[["a"]]
+
+# Issue #590: path(.f?) on object emits
+[path(.a?)]
+{"a":1}
+[["a"]]
+
+# Issue #590: path(.f?) on missing object key still emits
+[path(.a?)]
+{}
+[["a"]]
+
+# Issue #590: path(.f?) on array suppressed
+[path(.a?)]
+[1,2,3]
+[]
+
+# Issue #590: path(.f?) on string suppressed
+[path(.a?)]
+"abc"
+[]
+
+# Issue #590: nested path(.a?.b?)
+[path(.a?.b?)]
+{}
+[["a","b"]]
+
+# Issue #590: nested path(.a?.b?) suppressed at outer
+[path(.a?.b?)]
+0
+[]


### PR DESCRIPTION
## Summary

- `path(.a?)` should emit no path when the access would error (`?` is meant to swallow type errors silently). jq-jit's path-mode `Expr::IndexOpt` blindly appended the key, so `0`, `"abc"`, `[1,2,3]`, `true`, etc. all produced `[["a"]]` instead of `[]`.
- Mirror the existing `Expr::Index` base-type check (object+string, array+number, array+array, null+anything) and skip silently on mismatch instead of bailing.
- `path(.[]?)` was unaffected — `EachOpt` already gates on iterability.

## Test plan

- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (424 unit + regression + selfdiff all green)
- [x] Spot-check `[path(.a?)]`, `[path(.a?.b?)]`, `[path(.[0]?)]` for object/null/array/string/number/bool — matches jq exactly
- [x] `./bench/comprehensive.sh` — no regression vs v1.4.5 baseline

Closes #590