### PR TITLE
fix: path(.[KEY]) on null rejects bool/null/array keys

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -4225,7 +4225,10 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
                         // this path still fail in rt_setpath with `Cannot
                         // update field at array index of array`. See #467.
                         (Value::Arr(_), Value::Arr(_)) => {}
-                        (Value::Null, _) => {}
+                        // null accepts string/number/object keys (the slicing
+                        // form), but jq errors on bool/null/array keys with
+                        // `Cannot index null with <type>` (#594).
+                        (Value::Null, Value::Str(_) | Value::Num(_, _) | Value::Obj(_)) => {}
                         _ => {
                             // jq's wording: string keys keep the quoted
                             // value (`string "x"`), other key types use
@@ -4421,7 +4424,7 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
             // jq suppresses paths whose access would error: `path(.a?)` on
             // a non-object/non-null base emits no path. Mirror the type
             // check from the non-`?` Index path but skip silently on
-            // mismatch instead of bailing. See #?.
+            // mismatch instead of bailing. See #590, #594.
             let input_for_check = input.clone();
             eval_path(be, input.clone(), env, &mut |bp| {
                 eval(ke, input.clone(), env, &mut |key| {
@@ -4430,7 +4433,7 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
                         (Value::Obj(_), Value::Str(_)) => {}
                         (Value::Arr(_), Value::Num(_, _)) => {}
                         (Value::Arr(_), Value::Arr(_)) => {}
-                        (Value::Null, _) => {}
+                        (Value::Null, Value::Str(_) | Value::Num(_, _) | Value::Obj(_)) => {}
                         _ => return Ok(true),
                     }
                     let mut p = match &bp { Value::Arr(a) => a.as_ref().clone(), _ => vec![] };

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -9417,3 +9417,38 @@ true
 try (. | (.[]) |= . + 1) catch .
 0
 "Cannot iterate over number (0)"
+
+# Issue #594: path(.[KEY]) on null errors for bool key
+try (path(.[true])) catch .
+null
+"Cannot index null with boolean"
+
+# Issue #594: path(.[KEY]) on null errors for null key
+try (path(.[null])) catch .
+null
+"Cannot index null with null"
+
+# Issue #594: path(.[KEY]) on null errors for array key
+try (path(.[[1]])) catch .
+null
+"Cannot index null with array"
+
+# Issue #594: path(.[KEY]?) on null suppresses bool key
+[path(.[true]?)]
+null
+[]
+
+# Issue #594: path(.[KEY]?) on null suppresses array key
+[path(.[[1]]?)]
+null
+[]
+
+# Issue #594: string key on null still emits path
+path(.["a"])
+null
+["a"]
+
+# Issue #594: number key on null still emits path
+path(.[0])
+null
+[0]


### PR DESCRIPTION
## Summary

- jq's null indexing is narrower than the jq-jit path-mode rules: strings, numbers, and objects produce the path `[KEY]`, but booleans, nulls, and arrays raise `Cannot index null with <type>`.
- Both `Expr::Index` and `Expr::IndexOpt` had a catch-all `(Value::Null, _)` arm that silently emitted the path for every key type.
- Tighten the null arm to accept only string/number/object keys; the existing rejection arm now produces jq's wording for the other key types. The `?` form (#590) suppresses these rejections silently.

## Test plan

- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (all green)
- [x] Spot-check `try (path(.[KEY])) catch .` and `[path(.[KEY]?)]` on `null` for `true`, `false`, `null`, `[1]`, `0`, `"a"`, `{"a":1}`, `1.5`, `-0.0`, `1e10` — matches jq exactly
- [x] Sanity-check `path(.a)` on null still emits `["a"]`
- [x] `./bench/comprehensive.sh` — no regression vs current main (del/select|del/tree-update all within noise of pre-fix baseline)

Closes #594