### PR TITLE
fix: path(.[OBJ]) handles slice objects on array/string

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -4203,6 +4203,16 @@ fn eval_interp_parts(parts: &[StringPart], idx: usize, cur: String, input: Value
     }
 }
 
+/// jq treats `.[OBJ]` on array/string as a slice when OBJ has both
+/// `start` and `end` keys whose values are Num or Null. Extra keys are
+/// allowed; floats are accepted (truncated downstream by rt_slice).
+/// See #596.
+fn is_valid_slice_object(v: &Value) -> bool {
+    let Value::Obj(crate::value::ObjInner(o)) = v else { return false; };
+    let valid = |k: &str| matches!(o.get(k), Some(Value::Num(_, _) | Value::Null));
+    valid("start") && valid("end")
+}
+
 fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) -> GenResult) -> GenResult {
     match expr {
         Expr::Input => cb(Value::Arr(Rc::new(vec![]))),
@@ -4225,6 +4235,15 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
                         // this path still fail in rt_setpath with `Cannot
                         // update field at array index of array`. See #467.
                         (Value::Arr(_), Value::Arr(_)) => {}
+                        // jq treats `.[OBJ]` on array/string as a slice when
+                        // OBJ has both `start` and `end` keys with Num/Null
+                        // values. Otherwise it errors with `Array/string
+                        // slice indices must be integers`. See #596.
+                        (Value::Arr(_) | Value::Str(_), Value::Obj(_)) => {
+                            if !is_valid_slice_object(&key) {
+                                bail!("Array/string slice indices must be integers");
+                            }
+                        }
                         // null accepts string/number/object keys (the slicing
                         // form), but jq errors on bool/null/array keys with
                         // `Cannot index null with <type>` (#594).
@@ -4424,7 +4443,7 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
             // jq suppresses paths whose access would error: `path(.a?)` on
             // a non-object/non-null base emits no path. Mirror the type
             // check from the non-`?` Index path but skip silently on
-            // mismatch instead of bailing. See #590, #594.
+            // mismatch instead of bailing. See #590, #594, #596.
             let input_for_check = input.clone();
             eval_path(be, input.clone(), env, &mut |bp| {
                 eval(ke, input.clone(), env, &mut |key| {
@@ -4433,6 +4452,9 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
                         (Value::Obj(_), Value::Str(_)) => {}
                         (Value::Arr(_), Value::Num(_, _)) => {}
                         (Value::Arr(_), Value::Arr(_)) => {}
+                        (Value::Arr(_) | Value::Str(_), Value::Obj(_)) => {
+                            if !is_valid_slice_object(&key) { return Ok(true); }
+                        }
                         (Value::Null, Value::Str(_) | Value::Num(_, _) | Value::Obj(_)) => {}
                         _ => return Ok(true),
                     }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2670,6 +2670,18 @@ fn delete_path(v: &Value, path: &Value) -> Result<Value> {
                         Ok(v.clone())
                     }
                 }
+                // jq slice-delete: `del(.[{"start":s,"end":e}])` removes
+                // elements [s..e). Reaches here from `del(.[s:e])` and
+                // explicit `del(.[OBJ])` slice paths emitted by Index in
+                // path mode (#596).
+                (Value::Arr(a), Value::Obj(ObjInner(spec))) => {
+                    validate_slice_spec(spec)?;
+                    let (si, ei) = slice_indices(spec, a.len() as i64);
+                    if si >= ei { return Ok(v.clone()); }
+                    let mut new_arr = (**a).clone();
+                    new_arr.drain(si..ei);
+                    Ok(Value::Arr(Rc::new(new_arr)))
+                }
                 // Match jq 1.8.1's error wording for type-incompatible paths (issue #77).
                 (Value::Obj(_), key) => bail!("Cannot delete {} field of object", index_err_desc(key)),
                 (Value::Arr(_), key) => bail!("Cannot delete {} element of array", index_err_desc(key)),

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -9452,3 +9452,38 @@ null
 path(.[0])
 null
 [0]
+
+# Issue #596: path(.[OBJ_SLICE]) on array emits the slice path
+path(.[{"start":1,"end":3}])
+[1,2,3,4,5]
+[{"start":1,"end":3}]
+
+# Issue #596: path(.[OBJ_SLICE]) on string emits the slice path
+path(.[{"start":1,"end":3}])
+"abcdef"
+[{"start":1,"end":3}]
+
+# Issue #596: path(.[OBJ]) without start/end errors with slice wording
+try (path(.[{}])) catch .
+[1,2,3]
+"Array/string slice indices must be integers"
+
+# Issue #596: path(.[OBJ]) with non-num start errors
+try (path(.[{"start":"a","end":1}])) catch .
+[1,2,3]
+"Array/string slice indices must be integers"
+
+# Issue #596: path(.[OBJ_SLICE]?) on array suppresses on invalid slice
+[path(.[{}]?)]
+[1,2,3]
+[]
+
+# Issue #596: del(.[OBJ_SLICE]) removes the slice range
+del(.[{"start":1,"end":3}])
+[1,2,3,4,5]
+[1,4,5]
+
+# Issue #596: del with negative slice obj
+del(.[{"start":-2,"end":-1}])
+[1,2,3,4,5]
+[1,2,3,5]


### PR DESCRIPTION
## Summary

- jq treats `.[OBJ]` on array/string as a slice when OBJ has both `start` and `end` keys (Num or Null values); the path is emitted as `[OBJ]`. jq-jit's path-mode `Index`/`IndexOpt` had no entry for `(Arr|Str, Obj)`, so it always errored with `Cannot index <type> with object`, breaking `del(.[OBJ_SLICE])` and explicit `path(.[OBJ])`.
- Add an `(Arr | Str, Obj)` arm using a new `is_valid_slice_object` helper: emits the path on valid slice, bails with `Array/string slice indices must be integers` otherwise. `IndexOpt` skips silently on invalid.
- Extend `delete_path` so `del(.[OBJ_SLICE])` reuses the existing `validate_slice_spec`/`slice_indices` runtime helpers and removes the sliced range. Negative indices and `null` endpoints follow the standard slice rules.

## Test plan

- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (all green)
- [x] Spot-check `path(.[OBJ])` and `del(.[OBJ])` for `[1,2,3,4,5]`, `"abcdef"`, `{}`, mixed valid/invalid slice keys, negative indices, null endpoints — matches jq exactly
- [x] `del(.[s:e])` (the slice-syntax form) still works as before
- [x] `./bench/comprehensive.sh` — del/select|del within noise of pre-fix baseline

Closes #596