### PR TITLE
fix: until f64 fused paths preserve input number when body never runs

### DIFF
--- a/src/jit.rs
+++ b/src/jit.rs
@@ -1270,12 +1270,18 @@ impl Flattener {
                     let s_var = self.alloc_var();
                     self.emit(JitOp::F64Const { dst_var: s_var, val: update_const });
                     let cmp = self.alloc_var();
-                    let head = self.alloc_label();
                     let body = self.alloc_label();
                     let done = self.alloc_label();
-                    self.emit(JitOp::Label { id: head });
+                    let fused_out = result_slot.unwrap_or_else(|| self.alloc_slot());
+                    // Pre-check cond on the input. If true on entry, the loop body
+                    // never runs, and jq yields the input verbatim — preserve its
+                    // textual representation by cloning input_slot instead of
+                    // round-tripping through F64Num.
+                    let yield_input = self.alloc_label();
+                    let after = self.alloc_label();
                     self.emit(JitOp::F64Cmp { dst_var: cmp, a_var: acc, b_var: k_var, cc: cond_cc });
-                    self.emit(JitOp::BranchOnVar { var: cmp, nonzero_label: done, zero_label: body });
+                    self.emit(JitOp::BranchOnVar { var: cmp, nonzero_label: yield_input, zero_label: body });
+                    // do-while loop: body, then post-check.
                     self.emit(JitOp::Label { id: body });
                     match update_op {
                         0 => self.emit(JitOp::F64Add { dst_var: acc, a_var: acc, b_var: s_var }),
@@ -1283,10 +1289,14 @@ impl Flattener {
                         2 => self.emit(JitOp::F64Mul { dst_var: acc, a_var: acc, b_var: s_var }),
                         _ => unreachable!(),
                     }
-                    self.emit(JitOp::Jump { label: head });
+                    self.emit(JitOp::F64Cmp { dst_var: cmp, a_var: acc, b_var: k_var, cc: cond_cc });
+                    self.emit(JitOp::BranchOnVar { var: cmp, nonzero_label: done, zero_label: body });
                     self.emit(JitOp::Label { id: done });
-                    let fused_out = result_slot.unwrap_or_else(|| self.alloc_slot());
                     self.emit(JitOp::F64Num { dst: fused_out, src_var: acc });
+                    self.emit(JitOp::Jump { label: after });
+                    self.emit(JitOp::Label { id: yield_input });
+                    self.emit(JitOp::Clone { dst: fused_out, src: input_slot });
+                    self.emit(JitOp::Label { id: after });
                     emit_fused_tail(self, fused_out);
                     fused_out
                 } else if general_f64 {
@@ -1303,21 +1313,30 @@ impl Flattener {
                         self.emit(JitOp::Drop { slot });
                         var_map.push((vi, fvar));
                     }
-                    let head = self.alloc_label();
                     let body = self.alloc_label();
                     let done = self.alloc_label();
-                    self.emit(JitOp::Label { id: head });
-                    let cond_v = self.compile_f64_expr_multi(cond, acc, &var_map);
-                    self.emit(JitOp::BranchOnVar { var: cond_v, nonzero_label: done, zero_label: body });
+                    let fused_out = result_slot.unwrap_or_else(|| self.alloc_slot());
+                    // Pre-check cond on the input. If true on entry, yield input
+                    // verbatim to preserve its textual representation (see narrow
+                    // path comment above for the same reasoning).
+                    let yield_input = self.alloc_label();
+                    let after = self.alloc_label();
+                    let cond_pre = self.compile_f64_expr_multi(cond, acc, &var_map);
+                    self.emit(JitOp::BranchOnVar { var: cond_pre, nonzero_label: yield_input, zero_label: body });
+                    // do-while loop: body, then post-check.
                     self.emit(JitOp::Label { id: body });
                     let new_acc = self.compile_f64_expr_multi(update, acc, &var_map);
                     if new_acc != acc {
                         self.emit(JitOp::F64Move { dst_var: acc, src_var: new_acc });
                     }
-                    self.emit(JitOp::Jump { label: head });
+                    let cond_v = self.compile_f64_expr_multi(cond, acc, &var_map);
+                    self.emit(JitOp::BranchOnVar { var: cond_v, nonzero_label: done, zero_label: body });
                     self.emit(JitOp::Label { id: done });
-                    let fused_out = result_slot.unwrap_or_else(|| self.alloc_slot());
                     self.emit(JitOp::F64Num { dst: fused_out, src_var: acc });
+                    self.emit(JitOp::Jump { label: after });
+                    self.emit(JitOp::Label { id: yield_input });
+                    self.emit(JitOp::Clone { dst: fused_out, src: input_slot });
+                    self.emit(JitOp::Label { id: after });
                     emit_fused_tail(self, fused_out);
                     fused_out
                 } else {

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -9473,3 +9473,23 @@ numbers
 first(.[] | numbers)
 [1e10, "a", 2.0]
 1E+10
+
+# Issue #601: until(cond; update) preserves input number representation when body never runs
+until(. > 100; . * 2)
+1e10
+1E+10
+
+# Issue #601: until with general fused f64 path preserves input
+until(. > 100; . + 1)
+1.5e2
+1.5E+2
+
+# Issue #601: until still iterates correctly when body must run (regression guard)
+until(. > 100; . * 2)
+50
+200
+
+# Issue #601: until on non-numeric input still falls back to generic path (regression guard)
+until(. > 5; . + 1)
+"hello"
+"hello"


### PR DESCRIPTION
## Summary

\`until(cond; update)\` JIT fused paths re-canonicalized the input number via an f64 round-trip even when the loop body never ran. jq preserves the input's textual representation in this case; jq-jit emitted the decimal expansion.

\`\`\`
$ echo '1e10' | jq     -c 'until(. > 100; . * 2)'   1E+10
$ echo '1e10' | jq-jit -c 'until(. > 100; . * 2)'   10000000000
\`\`\`

Restructured both \`narrow_fused\` and \`general_f64\` paths into a do-while shape with an explicit pre-check on the input cond. On pre-check success, clone \`input_slot\` instead of going through \`F64Num\`. The do-while body has the same ops-per-iteration (update + cmp + branch), so the hot path's cost is unchanged.

## Test plan

- [x] \`cargo build --release\` (zero warnings)
- [x] \`cargo test --release\` (all green)
- [x] Regression cases added covering the fix and the iterate-correctly guard
- [x] \`bench/comprehensive.sh\` — \`until (100M)\` matches the pre-fix baseline on this machine (~0.34s, environmental noise vs the v1.4.4 history value)
- [x] Spot-checked diverse inputs: \`1e10\`, \`1.5e2\`, \`1E5\`, \`1e-5\`, \`100\`, \`1.0\` all match jq

Closes #601