### PR TITLE
fix: fromjson preserves source repr for decimals below 1e-4

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -4717,7 +4717,12 @@ fn parse_json_number(b: &[u8], pos: usize) -> Result<(Value, usize)> {
     // Rust's Display roundtrips identically — skip format_jq_number to avoid String allocation.
     if !has_exp && has_dot && (i - digits_start) <= 16 {
         let last = b[i - 1];
-        if last != b'0' && (b[digits_start] != b'0' || digits_start + 1 == i || b[digits_start + 1] == b'.') {
+        // The fast path skips storing the repr because the default renderer is
+        // expected to reproduce it. But `push_jq_number_str` switches to
+        // scientific notation for `abs < 1e-4`, so a decimal-form input like
+        // "0.00001" (= 1e-5) would render as "1e-05" without its repr (#603).
+        // Require `abs >= 1e-4` to stay in the fast path.
+        if last != b'0' && (b[digits_start] != b'0' || digits_start + 1 == i || b[digits_start + 1] == b'.') && n.abs() >= 1e-4 {
             return Ok((Value::number(n), i));
         }
         // Integer value with decimal notation (e.g., "1.0", "2.00") — format_jq_number would

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -9493,3 +9493,23 @@ until(. > 100; . * 2)
 until(. > 5; . + 1)
 "hello"
 "hello"
+
+# Issue #603: fromjson on small decimal preserves repr (no scientific reformat)
+fromjson
+"0.00001"
+0.00001
+
+# Issue #603: another small decimal that previously became scientific
+fromjson
+"0.00009"
+0.00009
+
+# Issue #603: tojson | fromjson round-trips identically for small decimals
+. | fromjson | tojson
+"0.000099"
+"0.000099"
+
+# Issue #603: 1e-4 boundary still works (regression guard)
+fromjson
+"0.0001"
+0.0001


### PR DESCRIPTION
## Summary

`parse_json_number`'s fast path returned `Value::number(n)` (no repr) on the assumption that the default renderer would reproduce the input verbatim. That breaks for decimal-form inputs below 1e-4 — `push_jq_number_str` switches to scientific notation in that range, so a parsed `0.00001` rendered as `1e-05`.

```
$ echo '"0.00001"' | jq     -c 'fromjson'   0.00001
$ echo '"0.00001"' | jq-jit -c 'fromjson'   1e-05    # before fix
```

Add `n.abs() >= 1e-4` to the fast-path predicate so smaller decimals fall through to the slow path that stores the original repr.

## Test plan

- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (all green)
- [x] Regression cases added covering small decimals and the 1e-4 boundary
- [x] All `/tmp/diff_cases*.sh` probes still clean
- [x] `bench/comprehensive.sh` — fromjson workloads within environmental noise of pre-fix on the same machine; microbench on 100K `fromjson "0.5"` shows identical timings

Closes #603