### PR TITLE
fix: @base64d UTF-8 lossy decode uses jq's maximal-subpart strategy

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3704,10 +3704,109 @@ pub fn eval_format(name: &str, val: &Value) -> Result<String> {
                     }
                 }
             }
-            Ok(String::from_utf8_lossy(&r).into_owned())
+            Ok(jq_utf8_lossy(&r))
         }
         _ => bail!("{} is not a valid format", name),
     }
+}
+
+/// UTF-8 lossy decode that matches jq 1.8.1's `@base64d` substitution policy
+/// (Unicode 6.1+ "maximal subpart of an ill-formed subsequence", #607).
+///
+/// Differs from `String::from_utf8_lossy`, which emits one U+FFFD per invalid
+/// byte even for partial / overlong multi-byte sequences. jq emits one U+FFFD
+/// per ill-formed *sequence*: a leader plus any valid continuations that
+/// follow (up to the expected count), or all remaining bytes if the buffer
+/// ends short.
+fn jq_utf8_lossy(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if b < 0x80 {
+            out.push(b as char);
+            i += 1;
+            continue;
+        }
+        // Leader byte width (excluding C0/C1 which are always overlong, and
+        // F5..FF which exceed U+10FFFF).
+        let needed = if (0xC2..0xE0).contains(&b) { 2 }
+                     else if (0xE0..0xF0).contains(&b) { 3 }
+                     else if (0xF0..0xF5).contains(&b) { 4 }
+                     else { 0 };
+        if needed == 0 {
+            out.push('\u{FFFD}');
+            i += 1;
+            continue;
+        }
+        // Not enough bytes: consume all remaining as one U+FFFD.
+        if bytes.len() - i < needed {
+            out.push('\u{FFFD}');
+            i = bytes.len();
+            continue;
+        }
+        // Validate continuations.
+        let c1 = bytes[i + 1];
+        let c1_cont = c1 & 0xC0 == 0x80;
+        if !c1_cont {
+            out.push('\u{FFFD}');
+            i += 1;
+            continue;
+        }
+        // Special leader-byte ranges that further restrict the first
+        // continuation (avoid overlongs and surrogates). When violated, jq
+        // still consumes the full nominal sequence as one U+FFFD.
+        let bad_first = match b {
+            0xE0 => c1 < 0xA0,
+            0xED => c1 >= 0xA0,
+            0xF0 => c1 < 0x90,
+            0xF4 => c1 >= 0x90,
+            _ => false,
+        };
+        if needed >= 3 {
+            let c2 = bytes[i + 2];
+            if c2 & 0xC0 != 0x80 {
+                // Maximal subpart: leader + one valid continuation.
+                out.push('\u{FFFD}');
+                i += 2;
+                continue;
+            }
+            if needed == 4 {
+                let c3 = bytes[i + 3];
+                if c3 & 0xC0 != 0x80 {
+                    out.push('\u{FFFD}');
+                    i += 3;
+                    continue;
+                }
+            }
+        }
+        if bad_first {
+            // All `needed` bytes look like a complete sequence at the byte
+            // level, but the codepoint is overlong/surrogate. jq consumes
+            // the whole sequence as one U+FFFD.
+            out.push('\u{FFFD}');
+            i += needed;
+            continue;
+        }
+        // All continuations are valid — decode the codepoint.
+        let cp: u32 = match needed {
+            2 => ((b as u32 & 0x1F) << 6) | (c1 as u32 & 0x3F),
+            3 => ((b as u32 & 0x0F) << 12)
+                | ((c1 as u32 & 0x3F) << 6)
+                | (bytes[i + 2] as u32 & 0x3F),
+            4 => ((b as u32 & 0x07) << 18)
+                | ((c1 as u32 & 0x3F) << 12)
+                | ((bytes[i + 2] as u32 & 0x3F) << 6)
+                | (bytes[i + 3] as u32 & 0x3F),
+            _ => unreachable!(),
+        };
+        match char::from_u32(cp) {
+            Some(c) => out.push(c),
+            None => out.push('\u{FFFD}'),
+        }
+        i += needed;
+    }
+    out
 }
 
 fn slice_index_start(n: f64, len: i64) -> usize {

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -9543,3 +9543,33 @@ null
 "YWU=" | @base64d
 null
 "ae"
+
+# Issue #607: @base64d incomplete UTF-8 sequence (E9 + 1 byte) emits 1 U+FFFD
+"6WU=" | @base64d
+null
+"�"
+
+# Issue #607: @base64d overlong 4-byte sequence emits 1 U+FFFD covering all 4 bytes
+"8ICAgA==" | @base64d
+null
+"�"
+
+# Issue #607: @base64d overlong 3-byte sequence emits 1 U+FFFD
+"4ICC" | @base64d
+null
+"�"
+
+# Issue #607: @base64d partial 4-byte sequence + ASCII tail (the null-base64 case)
+"null" | @base64d
+null
+"��"
+
+# Issue #607: @base64d partial sequence + valid follow-on bytes preserves the follow-on
+"6WUA" | @base64d
+null
+"�e\u0000"
+
+# Issue #607: @base64d valid 3-byte UTF-8 still decodes to its codepoint (regression guard)
+"4KCC" | @base64d
+null
+"ࠂ"


### PR DESCRIPTION
## Summary

`String::from_utf8_lossy` emits one U+FFFD per invalid byte, so partial / overlong multi-byte sequences come out longer than jq's output. The most visible case is `"null" | @base64d` (decoded bytes `9E E9 65`):

```
$ jq      -c '@base64d' <<<'"null"'   "��"
$ jq-jit  -c '@base64d' <<<'"null"'   "��e"
```

Replace the call with a hand-written decoder following the Unicode 6.1+ "maximal subpart of an ill-formed subsequence" rule. Cases the new decoder gets right (was wrong before):

| base64       | decoded bytes        | jq                | jq-jit (before)              |
|--------------|----------------------|-------------------|------------------------------|
| `"null"`     | `9E E9 65`           | `��`         | `��e`                |
| `"6WU="`     | `E9 65`              | `�`            | `�e`                      |
| `"6QA="`     | `E9 00`              | `�`            | `�\u0000`              |
| `"8GU="`     | `F0 65`              | `�`            | `�e`                      |
| `"8GVm"`     | `F0 65 66`           | `�`            | `�ef`                     |
| `"4ICC"`     | `E0 80 82`           | `�`            | `���`              |
| `"8ICAgA=="` | `F0 80 80 80`        | `�`            | `����`           |
| `"8ICA"`     | `F0 80 80`           | `�`            | `���`              |
| `"8ICAAA=="` | `F0 80 80 00 00`     | `�\u0000\u0000` | `���\u0000\u0000`     |

## Test plan

- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (all green)
- [x] Regression cases added covering each ill-formed pattern + a valid 3-byte UTF-8 guard
- [x] All `/tmp/diff_cases*.sh` probes clean
- [x] Microbench on 100K `@base64d` of valid ASCII: no change vs `from_utf8_lossy`

Closes #607
