### PR TITLE
fix: number repr canonicalization for tiny decimals and pure-zero with frac

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -33,7 +33,7 @@ fn raw_contains_non_canonical_number(bytes: &[u8]) -> bool {
     // which dominate typical NDJSON. (#598 regression fix.)
     static LUT: [bool; 256] = {
         let mut t = [false; 256];
-        let chars: &[u8] = &[b'"', b'+', b'e', b'E', b'n', b'N', b'i', b'I'];
+        let chars: &[u8] = &[b'"', b'+', b'e', b'E', b'n', b'N', b'i', b'I', b'.'];
         let mut k = 0;
         while k < chars.len() { t[chars[k] as usize] = true; k += 1; }
         t
@@ -80,6 +80,18 @@ fn raw_contains_non_canonical_number(bytes: &[u8]) -> bool {
                     if prev.is_ascii_digit() || prev == b'.' {
                         return true;
                     }
+                }
+                i += 1;
+            }
+            b'.' => {
+                // Numbers with a fractional part of 6+ leading zeros need
+                // canonicalisation: jq's decnum normalises anything with
+                // effective exponent < -6 to scientific form. e.g.
+                // `0.0000001` → `1E-7`, `0.0000000` → `0E-7` (#611).
+                if bytes.get(i + 1..i + 7) == Some(&[b'0'; 6][..])
+                    && i > 0 && bytes[i - 1].is_ascii_digit()
+                {
+                    return true;
                 }
                 i += 1;
             }

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -953,7 +953,7 @@ pub fn apply_obj_merge_computed_raw(
 fn raw_contains_non_canonical_number(bytes: &[u8]) -> bool {
     static LUT: [bool; 256] = {
         let mut t = [false; 256];
-        let chars: &[u8] = &[b'"', b'+', b'e', b'E', b'n', b'N', b'i', b'I'];
+        let chars: &[u8] = &[b'"', b'+', b'e', b'E', b'n', b'N', b'i', b'I', b'.'];
         let mut k = 0;
         while k < chars.len() { t[chars[k] as usize] = true; k += 1; }
         t
@@ -986,6 +986,18 @@ fn raw_contains_non_canonical_number(bytes: &[u8]) -> bool {
                     if prev.is_ascii_digit() || prev == b'.' {
                         return true;
                     }
+                }
+                i += 1;
+            }
+            b'.' => {
+                // 6+ leading zeros in the fractional part means effective
+                // exponent < -6, which jq's decnum normalises to scientific
+                // (#611). Need the previous byte to be a digit so we don't
+                // mistake `[.foo]` style tokens for numeric literals.
+                if bytes.get(i + 1..i + 7) == Some(&[b'0'; 6][..])
+                    && i > 0 && bytes[i - 1].is_ascii_digit()
+                {
+                    return true;
                 }
                 i += 1;
             }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -477,21 +477,26 @@ fn normalize_num_repr(s: &str) -> String {
         let first_sig = digits.iter().position(|c| *c != '0').unwrap_or(digits.len());
 
         if first_sig >= digits.len() {
-            // All-zero mantissa. jq's decnum keeps the explicit-exponent
-            // form: `0e1` → `0E+1`, `0e-1` → `0.0`, `0.0e-1` → `0.00`,
-            // `-0e10` → `-0E+10`. Hand the canonical normalisation off to
-            // `normalize_jq_repr`'s all-zero branch (#452).
-            if exp >= 1 {
-                return format!("{}0E+{}", sign, exp);
+            // All-zero mantissa. jq's decnum collapses the fractional digits
+            // and the exponent into one effective exponent before deciding
+            // the print form: `0e1` → `0E+1`, `0.00e1` → `0.0`, `0e-7` →
+            // `0E-7`, `0.0e-7` → `0E-8` (#452 / #611). Mirror
+            // `normalize_jq_repr`'s pure-zero branch.
+            let effective_exp = (exp as i64) - (frac_part.len() as i64);
+            if effective_exp >= 1 {
+                return format!("{}0E+{}", sign, effective_exp);
             }
-            let total_zeros = (frac_part.len() as i64) - exp;
-            if total_zeros <= 0 {
+            if effective_exp == 0 {
                 return format!("{}0", sign);
             }
-            let mut out = String::with_capacity(2 + total_zeros as usize);
+            if effective_exp < -6 {
+                return format!("{}0E{}", sign, effective_exp);
+            }
+            let zeros = (-effective_exp) as usize;
+            let mut out = String::with_capacity(2 + zeros);
             out.push_str(sign);
             out.push_str("0.");
-            for _ in 0..total_zeros {
+            for _ in 0..zeros {
                 out.push('0');
             }
             return out;

--- a/src/value.rs
+++ b/src/value.rs
@@ -5487,9 +5487,20 @@ pub fn normalize_jq_repr(repr: &str) -> Option<String> {
         }
         idx += 1;
     }
-    // No exponent and no leading `+`: nothing to normalize.
+    // Plain decimals (no exponent, no leading sign-needing-strip) only need
+    // normalisation when they contain `0.` followed by 6+ leading zeros —
+    // anything shorter has te >= -6 and is already canonical. This cheap
+    // pre-check keeps the common-case hot path (`tojson` over numeric NDJSON)
+    // out of the te-computing slow path. (#611)
     if e_pos.is_none() && sign != "-" && bytes.first() != Some(&b'+') {
-        return None;
+        // dot_pos was filled by the scan above; reuse it instead of re-scanning.
+        let needs_normalize = match dot_pos {
+            Some(d) => bytes.get(d + 1..d + 7) == Some(&[b'0'; 6][..]),
+            None => false,
+        };
+        if !needs_normalize {
+            return None;
+        }
     }
     let mantissa_end = e_pos.unwrap_or(bytes.len());
     let mant_int_end = dot_pos.unwrap_or(mantissa_end);
@@ -5512,32 +5523,38 @@ pub fn normalize_jq_repr(repr: &str) -> Option<String> {
         // and the exponent into a single effective exponent and prints the
         // shortest legal form. `0.0e1` becomes `0` (the `.0` shifts the
         // effective exp from `+1` down to `0`); `0.0e2` becomes `0E+1`;
-        // `0.000e2` becomes `0.0`. See #452 / #570.
-        if let Some(_) = e_pos {
-            let effective_exp = (exp as i64) - (mant_frac.len() as i64);
-            if effective_exp >= 1 {
-                return Some(format!("{}0E+{}", sign, effective_exp));
-            }
-            if effective_exp == 0 {
-                return Some(format!("{}0", sign));
-            }
-            // Negative effective exp: expand to decimal `0.000...0` with the
-            // appropriate number of trailing zeros.
-            let zeros = (-effective_exp) as usize;
-            let mut s = String::with_capacity(2 + zeros);
-            s.push_str(sign);
-            s.push_str("0.");
-            for _ in 0..zeros { s.push('0'); }
-            return Some(s);
+        // `0.000e2` becomes `0.0` (#452, #570, #611). Plain decimals like
+        // `0.0000000` also normalise to `0E-7` once frac_len exceeds 6.
+        let effective_exp = (exp as i64) - (mant_frac.len() as i64);
+        if effective_exp >= 1 {
+            return Some(format!("{}0E+{}", sign, effective_exp));
         }
-        return None;
+        if effective_exp == 0 && e_pos.is_some() {
+            return Some(format!("{}0", sign));
+        }
+        if effective_exp < -6 {
+            return Some(format!("{}0E{}", sign, effective_exp));
+        }
+        // Plain decimal pure-zeros in [-6, 0] are already canonical
+        // (`0.000000` stays as-is, `0` and `0.0` stay as-is).
+        if e_pos.is_none() {
+            return None;
+        }
+        let zeros = (-effective_exp) as usize;
+        let mut s = String::with_capacity(2 + zeros);
+        s.push_str(sign);
+        s.push_str("0.");
+        for _ in 0..zeros { s.push('0'); }
+        return Some(s);
     }
     let sig: &str = &combined[leading_zeros..];
     let ndigits = sig.len() as i32;
     let te = ndigits - 1 + exp - (mant_frac.len() as i32);
-    // Bail if the input was a plain decimal (no exponent) — those are
-    // already canonical, except for the leading-`+` case handled below.
-    if e_pos.is_none() {
+    // For plain decimals (no exponent), the source is usually already canonical
+    // — except when te falls outside libdecnum's decimal-vs-scientific window
+    // ([0, ndigits) for the integer part, te >= -6 for the fraction). In those
+    // cases jq's decnum still re-normalises (e.g. `0.0000001` → `1E-7`, #611).
+    if e_pos.is_none() && te >= -6 && te < ndigits {
         return None;
     }
     if te >= ndigits || te < -6 {

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -9618,3 +9618,43 @@ try (setpath([{"start":0,"end":1}]; "x")) catch .
 try (.[{}] = "x") catch .
 null
 "Array/string slice indices must be integers"
+
+# Issue #611: plain decimal input <= 1e-7 normalizes to scientific
+.
+0.0000001
+1E-7
+
+# Issue #611: plain decimal input >1e-7 keeps decimal form (regression guard)
+.
+0.000001
+0.000001
+
+# Issue #611: pure-zero with explicit fractional digits + exponent uses effective_exp
+0.00e1
+null
+0.0
+
+# Issue #611: pure-zero with very negative effective exponent goes scientific
+0e-7
+null
+0E-7
+
+# Issue #611: identity on pure-zero with 7+ frac zeros also normalizes
+.
+0.0000000
+0E-7
+
+# Issue #611: 0.000000 (6 frac zeros) stays decimal (regression guard)
+.
+0.000000
+0.000000
+
+# Issue #611: tojson preserves through canonicalization pipeline
+0.0000001 | tojson
+null
+"1E-7"
+
+# Issue #611: negative tiny decimal also normalizes
+.
+-0.0000001
+-1E-7


### PR DESCRIPTION
## Summary

Two related normalization gaps fixed:

1. **Plain decimal input <= 1e-7** kept its decimal expansion instead of jq's scientific form:
   ```
   $ echo '0.0000001' | jq      -c '.'   1E-7
   $ echo '0.0000001' | jq-jit  -c '.'   0.0000001   # before
   ```
   The te < -6 threshold matches libdecnum.

2. **Pure-zero literals with fractional digits + exponent** computed the wrong effective exponent:
   ```
   $ jq      -c '0.00e1'   0.0
   $ jq-jit  -c '0.00e1'   0E+1   # before
   ```

## Changes

- `normalize_jq_repr` (src/value.rs): drop the early-return for plain decimals; extend pure-zero branch to cover plain decimals (`0.0000000` → `0E-7`); cheap pre-filter keeps the common hot path at baseline cost.
- `normalize_num_repr` (src/parser.rs): rewrite the all-zero branch to use `effective_exp = exp - frac_part.len()`.
- `raw_contains_non_canonical_number` (src/bin/jq-jit.rs and src/fast_path.rs): flag `0.` followed by 6+ zeros so identity raw-byte fast path canonicalises.

## Test plan

- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (all green)
- [x] Regression cases added covering plain decimal threshold, pure-zero variants, identity / tojson chains, and a negative-tiny case
- [x] Existing diff probes clean (only unrelated `builtins | length` and `-infinite` divergences remain)
- [x] `tojson` 2M-record bench: ~0.12s after pre-filter (baseline ~0.11s, naive fix without filter was ~0.18s)

Closes #611