### PR TITLE
fix: JSON input parser handles lone-surrogate \uXXXX (Closes #615)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -16,7 +16,38 @@ fn raw_contains_del_byte(bytes: &[u8]) -> bool {
     memchr::memchr(0x7F, bytes).is_some()
 }
 
+/// Returns true if `bytes` contains `\uD[8-F]X` — a JSON `\u` escape that
+/// decodes to a surrogate codepoint. Identity passthrough must defer to
+/// the slow parser for these so jq's lone-surrogate semantics apply
+/// (lone high → error, lone low → U+FFFD, valid pair → UTF-8). This
+/// helper is a focused alternative to the full canonicaliser scan when
+/// only the surrogate case matters (#615). Caller is expected to gate
+/// on a cheap `memchr(b'\\', ...)` first so backslash-free records
+/// skip this scan entirely.
 #[inline]
+fn raw_contains_surrogate_escape(bytes: &[u8]) -> bool {
+    let mut i = 0;
+    while i + 5 < bytes.len() {
+        match memchr::memchr(b'\\', &bytes[i..]) {
+            Some(off) => {
+                let p = i + off;
+                if p + 5 < bytes.len()
+                    && bytes[p + 1] == b'u'
+                    && (bytes[p + 2] == b'D' || bytes[p + 2] == b'd')
+                    && matches!(bytes[p + 3],
+                        b'8' | b'9' | b'A' | b'B' | b'C' | b'D' | b'E' | b'F'
+                             | b'a' | b'b' | b'c' | b'd' | b'e' | b'f')
+                {
+                    return true;
+                }
+                i = p + 1;
+            }
+            None => return false,
+        }
+    }
+    false
+}
+
 /// Returns true if `bytes` contains a JSON number whose lexical form
 /// would normalise differently from jq's canonical output (e.g. `1e10`
 /// → `1E+10`, `+1` → `1`, `1e-5` → `0.00001`). Used to disable raw-byte
@@ -55,6 +86,20 @@ fn raw_contains_non_canonical_number(bytes: &[u8]) -> bool {
                         Some(off) => {
                             i += off;
                             if bytes[i] == b'"' { i += 1; break; }
+                            // \uD[8-F]XX is a surrogate codepoint — jq either
+                            // errors (lone high), replaces with U+FFFD (lone
+                            // low), or decodes to UTF-8 (valid pair). Identity
+                            // passthrough must defer to the slow parser to
+                            // pick the right behavior (#615).
+                            if i + 5 < bytes.len()
+                                && bytes[i + 1] == b'u'
+                                && (bytes[i + 2] == b'D' || bytes[i + 2] == b'd')
+                                && matches!(bytes[i + 3],
+                                    b'8' | b'9' | b'A' | b'B' | b'C' | b'D' | b'E' | b'F'
+                                         | b'a' | b'b' | b'c' | b'd' | b'e' | b'f')
+                            {
+                                return true;
+                            }
                             // backslash: skip the escape sequence
                             i = i.saturating_add(2);
                         }
@@ -21120,13 +21165,25 @@ fn real_main() {
                     }
                     all_compact && checked > 0
                 } else { false };
-                if whole_compact2 {
+                // Surrogate handling (#615) requires the slow parser, but
+                // only matters when the body contains `\u` escapes — gated
+                // on a single SIMD `memchr(b'\\')` over the whole body so
+                // the backslash-free common case (typical NDJSON) skips
+                // the surrogate scan entirely. The per-record loop reuses
+                // this flag instead of repeating memchr per record.
+                let body_has_escapes = memchr::memchr(b'\\', cbody).is_some();
+                let bulk_safe = whole_compact2
+                    && (!body_has_escapes || !raw_contains_surrogate_escape(cbody));
+                if bulk_safe {
                     let _ = out.write_all(cbody);
                     Ok(())
                 } else {
                     json_stream_raw(content, |start, end| {
                         let raw = &content_bytes[start..end];
-                        if is_json_compact(raw) {
+                        if body_has_escapes && raw_contains_surrogate_escape(raw) {
+                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                            process_input(&v, Some(raw), &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                        } else if is_json_compact(raw) {
                             compact_buf.extend_from_slice(raw);
                             compact_buf.push(b'\n');
                         } else {

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -970,6 +970,18 @@ fn raw_contains_non_canonical_number(bytes: &[u8]) -> bool {
                         Some(off) => {
                             i += off;
                             if bytes[i] == b'"' { i += 1; break; }
+                            // \uD[8-F]XX is a surrogate codepoint — defer to
+                            // the slow parser to handle lone surrogates and
+                            // pair decoding (#615).
+                            if i + 5 < bytes.len()
+                                && bytes[i + 1] == b'u'
+                                && (bytes[i + 2] == b'D' || bytes[i + 2] == b'd')
+                                && matches!(bytes[i + 3],
+                                    b'8' | b'9' | b'A' | b'B' | b'C' | b'D' | b'E' | b'F'
+                                         | b'a' | b'b' | b'c' | b'd' | b'e' | b'f')
+                            {
+                                return true;
+                            }
                             i = i.saturating_add(2);
                         }
                         None => return false,

--- a/src/value.rs
+++ b/src/value.rs
@@ -4579,22 +4579,28 @@ fn parse_json_string_raw(b: &[u8], pos: usize) -> Result<(String, usize)> {
                             .map_err(|_| anyhow::anyhow!("Invalid characters in \\uXXXX escape"))?;
                         i += 4;
                         if (0xD800..=0xDBFF).contains(&cp) {
-                            if i + 6 <= b.len() && b[i+1] == b'\\' && b[i+2] == b'u' {
-                                let hex2 = std::str::from_utf8(&b[i+3..i+7]).unwrap_or("0000");
-                                let cp2 = u16::from_str_radix(hex2, 16).unwrap_or(0);
-                                if (0xDC00..=0xDFFF).contains(&cp2) {
-                                    let full = 0x10000 + ((cp as u32 - 0xD800) << 10) + (cp2 as u32 - 0xDC00);
-                                    if let Some(c) = char::from_u32(full) {
-                                        let mut tmp = [0u8; 4];
-                                        buf.extend_from_slice(c.encode_utf8(&mut tmp).as_bytes());
-                                    }
-                                    i += 6;
-                                } else {
-                                    buf.extend_from_slice("\u{FFFD}".as_bytes());
-                                }
-                            } else {
-                                buf.extend_from_slice("\u{FFFD}".as_bytes());
+                            // High surrogate: jq requires a valid low-surrogate
+                            // pair to follow. Anything else (EOF, non-`\u`,
+                            // or wrong codepoint range) is a parse error.
+                            if i + 7 > b.len() || b[i+1] != b'\\' || b[i+2] != b'u' {
+                                bail!("Invalid \\uXXXX\\uXXXX surrogate pair escape");
                             }
+                            let hex2 = std::str::from_utf8(&b[i+3..i+7])
+                                .map_err(|_| anyhow::anyhow!("Invalid \\uXXXX\\uXXXX surrogate pair escape"))?;
+                            let cp2 = u16::from_str_radix(hex2, 16)
+                                .map_err(|_| anyhow::anyhow!("Invalid \\uXXXX\\uXXXX surrogate pair escape"))?;
+                            if !(0xDC00..=0xDFFF).contains(&cp2) {
+                                bail!("Invalid \\uXXXX\\uXXXX surrogate pair escape");
+                            }
+                            let full = 0x10000 + ((cp as u32 - 0xD800) << 10) + (cp2 as u32 - 0xDC00);
+                            if let Some(c) = char::from_u32(full) {
+                                let mut tmp = [0u8; 4];
+                                buf.extend_from_slice(c.encode_utf8(&mut tmp).as_bytes());
+                            }
+                            i += 6;
+                        } else if (0xDC00..=0xDFFF).contains(&cp) {
+                            // Lone low surrogate: jq accepts and replaces with U+FFFD (#615).
+                            buf.extend_from_slice("\u{FFFD}".as_bytes());
                         } else if let Some(c) = char::from_u32(cp as u32) {
                             let mut tmp = [0u8; 4];
                             buf.extend_from_slice(c.encode_utf8(&mut tmp).as_bytes());

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -9658,3 +9658,28 @@ null
 .
 -0.0000001
 -1E-7
+
+# Issue #615: JSON input parser replaces lone low surrogate with U+FFFD (length)
+length
+"\udc00"
+1
+
+# Issue #615: JSON input parser preserves neighbours around lone low surrogate
+length
+"a\udc00b"
+3
+
+# Issue #615: identity passthrough on JSON input replaces lone low surrogate
+.
+"\udc00"
+"�"
+
+# Issue #615: identity passthrough decodes valid surrogate pair to UTF-8
+.
+"💩"
+"💩"
+
+# Issue #615: identity passthrough on non-surrogate \u escape stays valid
+length
+"é"
+1


### PR DESCRIPTION
Mirrors the surrogate-handling fix from #511 (filter-string parser) into the JSON input parser, plus the file-input identity fast path that was bypassing the parser entirely.

## Repro

```
$ printf '%s' '"\ud800"' | /opt/homebrew/opt/jq/bin/jq -c '.'
jq: parse error: Invalid \uXXXX\uXXXX surrogate pair escape at line 1, column 8
$ printf '%s' '"\ud800"' | ./target/release/jq-jit -c '.'    # before
"\ud800"

$ printf '%s' '"\udc00"' | /opt/homebrew/opt/jq/bin/jq -c '.'
"�"
$ printf '%s' '"\udc00"' | ./target/release/jq-jit -c '.'    # before
"\udc00"

$ printf '%s' '"\udc00"' | /opt/homebrew/opt/jq/bin/jq -c 'length'
1
$ printf '%s' '"\udc00"' | ./target/release/jq-jit -c 'length'    # before
0
```

After the fix, `length` returns the right count, lone low surrogate becomes U+FFFD, lone high surrogate is rejected at parse time. Same applies whether the JSON arrives via stdin or via a file argument.

## Changes

- **`src/value.rs:parse_json_string_raw`** — lone high surrogate now bails with `Invalid \uXXXX\uXXXX surrogate pair escape` (matching jq); lone low surrogate emits U+FFFD instead of being silently dropped. Bounds check tightened to `i + 7 <= b.len()` since `&b[i+3..i+7]` requires that.
- **`src/bin/jq-jit.rs`, `src/fast_path.rs:raw_contains_non_canonical_number`** — while skipping string contents, detect `\uD[8-F]X` (surrogate codepoint) and bail. This forces value-level identity passthrough (`process_input` at line ~3287) and the apply-site canon checks to defer to the slow parser.
- **`src/bin/jq-jit.rs` file-input identity fast path (line ~21102)** — was completely bypassing the JSON parser via `json_stream_raw`. Added a single SIMD `memchr(b'\\')` over the body as a cheap pre-filter; only when escapes are present does the focused `raw_contains_surrogate_escape` scan run. The per-record loop reuses the body-level flag instead of repeating memchr per record.
- **`tests/regression.test`** — 5 cases for #615.

## Tests

`cargo test --release` all green (official 509 + regression + selfdiff + fuzz_restricted). Diff probe shows no new divergences.

## Bench

| Benchmark | v1.4.5 | this PR | delta |
|---|---|---|---|
| identity -c | 0.081s | 0.090s | +11% |
| identity (pretty) | 0.105s | 0.107s | +2% |
| tojson | 0.110s | 0.111s | +1% |
| tojson\|fromjson | 0.081s | 0.090s | +11% |
| tojson/fromjson(100K) | 0.022s | 0.023s | +5% |
| null propagation(2M) | 0.087s | 0.091s | +5% |

The 11% regression on identity -c and tojson|fromjson comes from the unconditional `memchr(b'\\')` over the 100MB NDJSON body — a fixed cost paid once per file, not per record. Backslash-free bodies (typical NDJSON) skip the expensive surrogate scan after that one memchr; only files with escapes pay the focused scan. Above the 5% guidance threshold but inside the acceptable 5-30% band — the cost is intrinsic to the safety check.

`jaq: tree-update` shows 0.225s in this run, but matches the pre-existing #551 regression (32x from baseline 0.007s on this branch and on `main`); not introduced by this PR.

Closes #615
