### PR TITLE
release v1.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,7 +450,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jq-jit"
-version = "1.4.5"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jq-jit"
-version = "1.4.5"
+version = "1.5.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A JIT-compiling implementation of jq using Cranelift"

--- a/docs/benchmark-history.md
+++ b/docs/benchmark-history.md
@@ -6,287 +6,287 @@ Recent slice (last 5 columns). Full history lives in
 
 ```text
 --- NDJSON workloads (2M objects) ---
-  Benchmark                v1.1.0  v1.4.3  v1.4.4  3d440ca  v1.4.5
-  ---                      ------  ------  ------  -------  ------
-  empty                    0.018s  0.017s  0.017s  0.017s   0.017s
-  identity -c              0.077s  0.082s  0.082s  0.078s   0.081s
-  identity (pretty)        0.099s  0.108s  0.099s  0.101s   0.105s
-  field access .name       0.066s  0.080s  0.080s  0.087s   0.091s
-  nested .x,.y,.name       0.096s  0.111s  0.123s  0.144s   0.143s
-  arithmetic .x + .y       0.064s  0.064s  0.094s  0.082s   0.081s
-  select .x > 1500000      0.047s  0.066s  0.115s  0.069s   0.073s
-  string concat            0.074s  0.090s  0.089s  0.096s   0.096s
-  object construct         0.083s  0.087s  0.127s  0.112s   0.114s
-  array construct          0.081s  0.097s  0.102s  0.116s   0.120s
-  .[]                      0.081s  0.085s  0.098s  0.100s   0.099s
-  to_entries               0.142s  0.104s  0.112s  0.161s   0.156s
-  keys                     0.085s  0.088s  0.102s  0.098s   0.101s
-  keys_unsorted            0.075s  0.078s  0.091s  0.094s   0.093s
-  length                   0.065s  0.073s  0.085s  0.080s   0.083s
-  has("x")                 0.025s  0.030s  0.030s  0.029s   0.030s
-  type                     0.019s  0.019s  0.019s  0.022s   0.022s
-  del(.name)               0.088s  0.098s  0.095s  0.098s   0.099s
-  @csv                     -       -       -       0.140s   0.137s
-  split/join               -       -       -       0.093s   0.098s
-  select|field             -       -       -       0.112s   0.112s
-  select|remap             -       -       -       0.095s   0.096s
-  computed remap           -       -       -       0.211s   0.214s
-  [.x,.y]|add              -       -       -       0.082s   0.083s
-  [.x,.y]|avg              -       -       -       0.110s   0.112s
-  map(*2)|add              -       -       -       0.110s   0.113s
-  keys|length              -       -       -       0.254s   0.254s
-  .+{z=0}                  -       -       -       0.143s   0.147s
-  split|first              -       -       -       0.092s   0.098s
-  slice[0..5]              -       -       -       0.095s   0.100s
-  dynkey {(.name)}         -       -       -       0.118s   0.121s
-  .x += 1                  -       -       -       0.069s   0.070s
-  {a}+{b} merge            -       -       -       0.143s   0.147s
-  .x*2+1                   -       -       -       0.049s   0.050s
-  .x+.y*2                  -       -       -       0.102s   0.105s
-  .x > .y                  -       -       -       0.076s   0.077s
-  to_entries|len           -       -       -       0.397s   0.395s
-  .x|.+1 (pipe)            -       -       -       0.047s   0.048s
-  .x|.*2|.+1               -       -       -       0.049s   0.050s
-  .name|.+"_x"             -       -       -       0.098s   0.098s
-  .x>N | not               -       -       -       0.040s   0.041s
-  and (2 cmp)              -       -       -       0.080s   0.080s
-  if-then-else             -       -       -       0.043s   0.043s
-  sel(and)|field           -       -       -       0.076s   0.076s
-  sel(and)|remap           -       -       -       0.074s   0.076s
-  arith|cmp                -       -       -       0.044s   0.047s
-  if cmp .field            -       -       -       0.102s   0.107s
-  split|length             -       -       -       0.094s   0.099s
-  [x,y]|min                -       -       -       0.090s   0.092s
-  [x,y]|max                -       -       -       0.091s   0.095s
-  [x,y]|sort|.[0]          -       -       -       0.087s   0.090s
-  .name|len>5              -       -       -       0.096s   0.100s
-  sel(len>5)|.x            -       -       -       0.125s   0.127s
-  if .x>.y .name           -       -       -       0.087s   0.090s
-  sel(.x>.y)|.name         -       -       -       0.071s   0.072s
-  .x*2|tostring            -       -       -       0.047s   0.048s
-  .x*.x+1                  -       -       -       0.056s   0.057s
-  {k=.name,v=tostr}        -       -       -       0.160s   0.162s
-  str add chain            -       -       -       0.386s   0.398s
-  if>.y .name|empty        -       -       -       0.071s   0.073s
-  if .x%2==0               -       -       -       0.045s   0.047s
-  if .x*2+1>1M             -       -       -       0.045s   0.048s
-  sel(.x%2==0)|.name       -       -       -       0.074s   0.076s
-  sel(.x*2+1>1M)           -       -       -       0.142s   0.144s
-  .x|@json                 -       -       -       0.045s   0.045s
-  .x|@text                 -       -       -       0.045s   0.045s
-  .name|@json              -       -       -       0.104s   0.107s
-  sel|[arr]                -       -       -       0.148s   0.150s
-  sel(and)|[arr]           -       -       -       0.076s   0.078s
-  if>.y [arr]              -       -       -       0.199s   0.199s
-  if sw then .f            -       -       -       0.135s   0.138s
-  dynkey {(.n)=.x*2}       -       -       -       0.131s   0.132s
-  sel(and)|.x*.y           -       -       -       0.075s   0.077s
-  sel>N|str chain          -       -       -       0.158s   0.158s
-  .f+"_"+arith_ts          -       -       -       0.145s   0.148s
-  sel(sw)|str ch           -       -       -       0.317s   0.310s
-  split|rev|join           -       -       -       0.123s   0.122s
-  dynkey+static            -       -       -       0.324s   0.331s
-  if>.y str chain          -       -       -       0.186s   0.189s
-  remap+str chain          -       -       -       0.171s   0.178s
-  sel(len>8)               -       -       -       0.163s   0.170s
-  up|split|join            -       -       -       0.101s   0.104s
-  .name|index              -       -       -       0.126s   0.128s
-  .name|index+1            -       -       -       0.127s   0.133s
-  .name|rindex             -       -       -       0.131s   0.134s
-  .name|indices            -       -       -       0.153s   0.160s
-  [x,y]|sort               -       -       -       0.154s   0.156s
-  .name|scan               -       -       -       0.218s   0.219s
-  .name|gsub               -       -       -       0.175s   0.178s
-  walk(if num .+1)         -       -       -       0.140s   0.141s
-  tojson                   -       -       -       0.106s   0.110s
-  {name,x}                 -       -       -       0.144s   0.144s
-  .z//.name                -       -       -       0.165s   0.164s
-  .x|=test(re)             -       -       -       0.123s   0.124s
-  ./sep|first              -       -       -       0.131s   0.132s
-  .y=(.x*2)                -       -       -       0.112s   0.115s
-  .y=(.x+.y)               -       -       -       0.161s   0.159s
-  objects                  -       -       -       0.081s   0.085s
-  .tag|=if..then N         -       -       -       0.613s   0.614s
-  .x=(.x+1)                -       -       -       0.070s   0.072s
-  sel>N|.y+=1              -       -       -       0.085s   0.087s
-  sel(and)|.x+=1           -       -       -       0.100s   0.102s
-  sel(sw)|.x+=1            -       -       -       0.132s   0.133s
-  match(re)                -       -       -       0.369s   0.367s
-  capture(re)              -       -       -       0.306s   0.303s
-  first(.name,.x)          -       -       -       0.090s   0.093s
-  if .x==null              -       -       -       0.043s   0.044s
-  we(sw(.key))             -       -       -       0.111s   0.111s
-  sel(sw or ew)            -       -       -       0.211s   0.214s
-  path(.name,.x)           -       -       -       0.276s   0.277s
-  sel(str+num+num)         -       -       -       0.142s   0.145s
-  nested if|field          -       -       -       0.076s   0.077s
-  .f|floor|.*2             -       -       -       0.050s   0.051s
-  split|len>1              -       -       -       0.122s   0.124s
-  .name|len|.*2            -       -       -       0.106s   0.107s
-  if len>5 .x .y           -       -       -       0.137s   0.133s
-  sel(len>5)|remap         -       -       -       0.230s   0.233s
-  .x|tostr|len             -       -       -       0.056s   0.056s
-  if .x>.y .x .y           -       -       -       0.093s   0.094s
-  split|last|tonum         -       -       -       0.100s   0.104s
-  split|rev|.[0]           -       -       -       0.097s   0.099s
-  split|.[0]+.[1]          -       -       -       0.122s   0.123s
-  .[]|strings              -       -       -       0.096s   0.095s
-  .[]|numbers              -       -       -       0.107s   0.106s
-  [x,y]|any(>1M)           -       -       -       0.082s   0.082s
-  sel(dc|sw)               -       -       -       0.104s   0.107s
-  [[x,y],[n]]|flat         -       -       -       0.475s   0.475s
-  .x|floor|.*2             -       -       -       0.051s   0.051s
-  tojson|fromjson          -       -       -       0.083s   0.081s
-  [.x]|add                 -       -       -       0.048s   0.048s
-  if>N {o}+.               -       -       -       0.123s   0.125s
-  if>N .+{o}               -       -       -       0.124s   0.125s
-  if .n=="s" .+{o}         -       -       -       0.167s   0.161s
-  sel(.n>"s")              -       -       -       0.095s   0.094s
-  [x,y,z]|min              -       -       -       0.311s   0.312s
-  if .n|len>5 l s          -       -       -       0.107s   0.106s
-  if .x|flr>N b s          -       -       -       0.047s   0.045s
-  if .n|test l e           -       -       -       0.111s   0.112s
-  if .n|sw l e             -       -       -       0.090s   0.091s
-  if .n|ew l e             -       -       -       0.092s   0.091s
-  .n|len|tostr             -       -       -       0.097s   0.099s
+  Benchmark                v1.4.3  v1.4.4  3d440ca  v1.4.5  v1.5.0
+  ---                      ------  ------  -------  ------  ------
+  empty                    0.017s  0.017s  0.017s   0.017s  0.017s
+  identity -c              0.082s  0.082s  0.078s   0.081s  0.085s
+  identity (pretty)        0.108s  0.099s  0.101s   0.105s  0.111s
+  field access .name       0.080s  0.080s  0.087s   0.091s  0.097s
+  nested .x,.y,.name       0.111s  0.123s  0.144s   0.143s  0.150s
+  arithmetic .x + .y       0.064s  0.094s  0.082s   0.081s  0.084s
+  select .x > 1500000      0.066s  0.115s  0.069s   0.073s  0.082s
+  string concat            0.090s  0.089s  0.096s   0.096s  0.094s
+  object construct         0.087s  0.127s  0.112s   0.114s  0.116s
+  array construct          0.097s  0.102s  0.116s   0.120s  0.106s
+  .[]                      0.085s  0.098s  0.100s   0.099s  0.101s
+  to_entries               0.104s  0.112s  0.161s   0.156s  0.162s
+  keys                     0.088s  0.102s  0.098s   0.101s  0.105s
+  keys_unsorted            0.078s  0.091s  0.094s   0.093s  0.094s
+  length                   0.073s  0.085s  0.080s   0.083s  0.088s
+  has("x")                 0.030s  0.030s  0.029s   0.030s  0.036s
+  type                     0.019s  0.019s  0.022s   0.022s  0.023s
+  del(.name)               0.098s  0.095s  0.098s   0.099s  0.105s
+  @csv                     -       -       0.140s   0.137s  0.125s
+  split/join               -       -       0.093s   0.098s  0.092s
+  select|field             -       -       0.112s   0.112s  0.099s
+  select|remap             -       -       0.095s   0.096s  0.099s
+  computed remap           -       -       0.211s   0.214s  0.189s
+  [.x,.y]|add              -       -       0.082s   0.083s  0.085s
+  [.x,.y]|avg              -       -       0.110s   0.112s  0.110s
+  map(*2)|add              -       -       0.110s   0.113s  0.104s
+  keys|length              -       -       0.254s   0.254s  0.252s
+  .+{z=0}                  -       -       0.143s   0.147s  0.147s
+  split|first              -       -       0.092s   0.098s  0.089s
+  slice[0..5]              -       -       0.095s   0.100s  0.094s
+  dynkey {(.name)}         -       -       0.118s   0.121s  0.108s
+  .x += 1                  -       -       0.069s   0.070s  0.126s
+  {a}+{b} merge            -       -       0.143s   0.147s  0.130s
+  .x*2+1                   -       -       0.049s   0.050s  0.059s
+  .x+.y*2                  -       -       0.102s   0.105s  0.098s
+  .x > .y                  -       -       0.076s   0.077s  0.078s
+  to_entries|len           -       -       0.397s   0.395s  0.398s
+  .x|.+1 (pipe)            -       -       0.047s   0.048s  0.056s
+  .x|.*2|.+1               -       -       0.049s   0.050s  0.060s
+  .name|.+"_x"             -       -       0.098s   0.098s  0.093s
+  .x>N | not               -       -       0.040s   0.041s  0.049s
+  and (2 cmp)              -       -       0.080s   0.080s  0.081s
+  if-then-else             -       -       0.043s   0.043s  0.052s
+  sel(and)|field           -       -       0.076s   0.076s  0.077s
+  sel(and)|remap           -       -       0.074s   0.076s  0.079s
+  arith|cmp                -       -       0.044s   0.047s  0.053s
+  if cmp .field            -       -       0.102s   0.107s  0.114s
+  split|length             -       -       0.094s   0.099s  0.090s
+  [x,y]|min                -       -       0.090s   0.092s  0.090s
+  [x,y]|max                -       -       0.091s   0.095s  0.093s
+  [x,y]|sort|.[0]          -       -       0.087s   0.090s  0.090s
+  .name|len>5              -       -       0.096s   0.100s  0.091s
+  sel(len>5)|.x            -       -       0.125s   0.127s  0.110s
+  if .x>.y .name           -       -       0.087s   0.090s  0.089s
+  sel(.x>.y)|.name         -       -       0.071s   0.072s  0.073s
+  .x*2|tostring            -       -       0.047s   0.048s  0.055s
+  .x*.x+1                  -       -       0.056s   0.057s  0.065s
+  {k=.name,v=tostr}        -       -       0.160s   0.162s  0.151s
+  str add chain            -       -       0.386s   0.398s  0.386s
+  if>.y .name|empty        -       -       0.071s   0.073s  0.074s
+  if .x%2==0               -       -       0.045s   0.047s  0.055s
+  if .x*2+1>1M             -       -       0.045s   0.048s  0.055s
+  sel(.x%2==0)|.name       -       -       0.074s   0.076s  0.082s
+  sel(.x*2+1>1M)           -       -       0.142s   0.144s  0.157s
+  .x|@json                 -       -       0.045s   0.045s  0.048s
+  .x|@text                 -       -       0.045s   0.045s  0.048s
+  .name|@json              -       -       0.104s   0.107s  0.104s
+  sel|[arr]                -       -       0.148s   0.150s  0.142s
+  sel(and)|[arr]           -       -       0.076s   0.078s  0.078s
+  if>.y [arr]              -       -       0.199s   0.199s  0.180s
+  if sw then .f            -       -       0.135s   0.138s  0.140s
+  dynkey {(.n)=.x*2}       -       -       0.131s   0.132s  0.117s
+  sel(and)|.x*.y           -       -       0.075s   0.077s  0.080s
+  sel>N|str chain          -       -       0.158s   0.158s  0.157s
+  .f+"_"+arith_ts          -       -       0.145s   0.148s  0.137s
+  sel(sw)|str ch           -       -       0.317s   0.310s  0.306s
+  split|rev|join           -       -       0.123s   0.122s  0.114s
+  dynkey+static            -       -       0.324s   0.331s  0.333s
+  if>.y str chain          -       -       0.186s   0.189s  0.171s
+  remap+str chain          -       -       0.171s   0.178s  0.153s
+  sel(len>8)               -       -       0.163s   0.170s  0.160s
+  up|split|join            -       -       0.101s   0.104s  0.099s
+  .name|index              -       -       0.126s   0.128s  0.122s
+  .name|index+1            -       -       0.127s   0.133s  0.125s
+  .name|rindex             -       -       0.131s   0.134s  0.128s
+  .name|indices            -       -       0.153s   0.160s  0.156s
+  [x,y]|sort               -       -       0.154s   0.156s  0.152s
+  .name|scan               -       -       0.218s   0.219s  0.206s
+  .name|gsub               -       -       0.175s   0.178s  0.167s
+  walk(if num .+1)         -       -       0.140s   0.141s  0.139s
+  tojson                   -       -       0.106s   0.110s  0.106s
+  {name,x}                 -       -       0.144s   0.144s  0.128s
+  .z//.name                -       -       0.165s   0.164s  0.153s
+  .x|=test(re)             -       -       0.123s   0.124s  0.178s
+  ./sep|first              -       -       0.131s   0.132s  0.187s
+  .y=(.x*2)                -       -       0.112s   0.115s  0.178s
+  .y=(.x+.y)               -       -       0.161s   0.159s  0.228s
+  objects                  -       -       0.081s   0.085s  0.133s
+  .tag|=if..then N         -       -       0.613s   0.614s  0.598s
+  .x=(.x+1)                -       -       0.070s   0.072s  0.128s
+  sel>N|.y+=1              -       -       0.085s   0.087s  0.120s
+  sel(and)|.x+=1           -       -       0.100s   0.102s  0.111s
+  sel(sw)|.x+=1            -       -       0.132s   0.133s  0.161s
+  match(re)                -       -       0.369s   0.367s  0.362s
+  capture(re)              -       -       0.306s   0.303s  0.298s
+  first(.name,.x)          -       -       0.090s   0.093s  0.102s
+  if .x==null              -       -       0.043s   0.044s  0.046s
+  we(sw(.key))             -       -       0.111s   0.111s  0.109s
+  sel(sw or ew)            -       -       0.211s   0.214s  0.206s
+  path(.name,.x)           -       -       0.276s   0.277s  0.273s
+  sel(str+num+num)         -       -       0.142s   0.145s  0.153s
+  nested if|field          -       -       0.076s   0.077s  0.078s
+  .f|floor|.*2             -       -       0.050s   0.051s  0.060s
+  split|len>1              -       -       0.122s   0.124s  0.117s
+  .name|len|.*2            -       -       0.106s   0.107s  0.101s
+  if len>5 .x .y           -       -       0.137s   0.133s  0.114s
+  sel(len>5)|remap         -       -       0.230s   0.233s  0.207s
+  .x|tostr|len             -       -       0.056s   0.056s  0.059s
+  if .x>.y .x .y           -       -       0.093s   0.094s  0.093s
+  split|last|tonum         -       -       0.100s   0.104s  0.097s
+  split|rev|.[0]           -       -       0.097s   0.099s  0.092s
+  split|.[0]+.[1]          -       -       0.122s   0.123s  0.113s
+  .[]|strings              -       -       0.096s   0.095s  0.107s
+  .[]|numbers              -       -       0.107s   0.106s  0.126s
+  [x,y]|any(>1M)           -       -       0.082s   0.082s  0.084s
+  sel(dc|sw)               -       -       0.104s   0.107s  0.096s
+  [[x,y],[n]]|flat         -       -       0.475s   0.475s  0.456s
+  .x|floor|.*2             -       -       0.051s   0.051s  0.059s
+  tojson|fromjson          -       -       0.083s   0.081s  0.087s
+  [.x]|add                 -       -       0.048s   0.048s  0.059s
+  if>N {o}+.               -       -       0.123s   0.125s  0.133s
+  if>N .+{o}               -       -       0.124s   0.125s  0.134s
+  if .n=="s" .+{o}         -       -       0.167s   0.161s  0.164s
+  sel(.n>"s")              -       -       0.095s   0.094s  0.089s
+  [x,y,z]|min              -       -       0.311s   0.312s  0.303s
+  if .n|len>5 l s          -       -       0.107s   0.106s  0.102s
+  if .x|flr>N b s          -       -       0.047s   0.045s  0.054s
+  if .n|test l e           -       -       0.111s   0.112s  0.107s
+  if .n|sw l e             -       -       0.090s   0.091s  0.085s
+  if .n|ew l e             -       -       0.092s   0.091s  0.086s
+  .n|len|tostr             -       -       0.097s   0.099s  0.093s
 
 --- String operations (2M objects) ---
-  Benchmark                v1.1.0  v1.4.3  v1.4.4  3d440ca  v1.4.5
-  ---                      ------  ------  ------  -------  ------
-  ascii_downcase           0.084s  0.090s  0.088s  0.110s   0.112s
-  ascii_upcase             0.083s  0.090s  0.088s  0.108s   0.109s
-  ltrimstr                 0.082s  0.090s  0.090s  0.101s   0.102s
-  rtrimstr                 0.083s  0.089s  0.090s  0.105s   0.107s
-  split                    0.149s  0.150s  0.151s  0.169s   0.172s
-  case+split               0.109s  0.117s  0.116s  0.126s   0.128s
-  join                     0.078s  0.087s  0.092s  0.101s   0.104s
-  startswith               0.080s  0.084s  0.086s  0.101s   0.103s
-  endswith                 0.079s  0.085s  0.088s  0.103s   0.104s
-  tostring                 0.043s  0.043s  0.095s  0.052s   0.053s
-  tonumber                 0.092s  0.108s  0.104s  0.117s   0.117s
-  string interpolation     0.097s  0.104s  0.106s  0.135s   0.134s
+  Benchmark                v1.4.3  v1.4.4  3d440ca  v1.4.5  v1.5.0
+  ---                      ------  ------  -------  ------  ------
+  ascii_downcase           0.090s  0.088s  0.110s   0.112s  0.105s
+  ascii_upcase             0.090s  0.088s  0.108s   0.109s  0.103s
+  ltrimstr                 0.090s  0.090s  0.101s   0.102s  0.098s
+  rtrimstr                 0.089s  0.090s  0.105s   0.107s  0.099s
+  split                    0.150s  0.151s  0.169s   0.172s  0.166s
+  case+split               0.117s  0.116s  0.126s   0.128s  0.116s
+  join                     0.087s  0.092s  0.101s   0.104s  0.095s
+  startswith               0.084s  0.086s  0.101s   0.103s  0.096s
+  endswith                 0.085s  0.088s  0.103s   0.104s  0.098s
+  tostring                 0.043s  0.095s  0.052s   0.053s  0.061s
+  tonumber                 0.108s  0.104s  0.117s   0.117s  0.114s
+  string interpolation     0.104s  0.106s  0.135s   0.134s  0.121s
 
 --- String ops (200K objects) ---
-  Benchmark                v1.1.0  v1.4.3  v1.4.4  3d440ca  v1.4.5
-  ---                      ------  ------  ------  -------  ------
-  test (regex)             0.011s  0.013s  0.013s  0.014s   0.014s
-  match (regex)            0.037s  0.031s  0.032s  0.033s   0.033s
-  @base64                  0.010s  0.011s  0.011s  0.013s   0.012s
-  @uri                     0.011s  0.011s  0.011s  0.013s   0.013s
-  @html                    0.010s  0.012s  0.011s  0.013s   0.013s
-  @csv (array)             0.013s  0.013s  0.014s  0.020s   0.018s
-  @tsv (array)             0.013s  0.013s  0.014s  0.018s   0.017s
-  gsub                     0.018s  0.018s  0.018s  0.020s   0.020s
-  case+gsub                0.176s  0.181s  0.180s  0.193s   0.193s
-  case+test                0.110s  0.116s  0.115s  0.130s   0.130s
-  ltrim+tonum+arith        0.083s  0.107s  0.107s  0.118s   0.118s
+  Benchmark                v1.4.3  v1.4.4  3d440ca  v1.4.5  v1.5.0
+  ---                      ------  ------  -------  ------  ------
+  test (regex)             0.013s  0.013s  0.014s   0.014s  0.015s
+  match (regex)            0.031s  0.032s  0.033s   0.033s  0.033s
+  @base64                  0.011s  0.011s  0.013s   0.012s  0.012s
+  @uri                     0.011s  0.011s  0.013s   0.013s  0.012s
+  @html                    0.012s  0.011s  0.013s   0.013s  0.012s
+  @csv (array)             0.013s  0.014s  0.020s   0.018s  0.016s
+  @tsv (array)             0.013s  0.014s  0.018s   0.017s  0.015s
+  gsub                     0.018s  0.018s  0.020s   0.020s  0.018s
+  case+gsub                0.181s  0.180s  0.193s   0.193s  0.178s
+  case+test                0.116s  0.115s  0.130s   0.130s  0.122s
+  ltrim+tonum+arith        0.107s  0.107s  0.118s   0.118s  0.114s
 
 --- Numeric & math (2M objects) ---
-  Benchmark                v1.1.0  v1.4.3  v1.4.4  3d440ca  v1.4.5
-  ---                      ------  ------  ------  -------  ------
-  floor                    0.041s  0.042s  0.091s  0.048s   0.048s
-  sqrt                     0.071s  0.072s  0.115s  0.078s   0.078s
-  modulo                   0.070s  0.045s  0.095s  0.051s   0.051s
-  if-elif-else             0.107s  0.102s  0.134s  0.125s   0.124s
-  select|del               0.069s  0.073s  0.126s  0.079s   0.079s
-  select|merge             0.101s  0.105s  0.157s  0.110s   0.107s
-  select(test)|merge       0.020s  0.022s  0.021s  0.022s   0.022s
+  Benchmark                v1.4.3  v1.4.4  3d440ca  v1.4.5  v1.5.0
+  ---                      ------  ------  -------  ------  ------
+  floor                    0.042s  0.091s  0.048s   0.048s  0.056s
+  sqrt                     0.072s  0.115s  0.078s   0.078s  0.078s
+  modulo                   0.045s  0.095s  0.051s   0.051s  0.057s
+  if-elif-else             0.102s  0.134s  0.125s   0.124s  0.124s
+  select|del               0.073s  0.126s  0.079s   0.079s  0.091s
+  select|merge             0.105s  0.157s  0.110s   0.107s  0.117s
+  select(test)|merge       0.022s  0.021s  0.022s   0.022s  0.021s
 
 --- Array generators ---
-  Benchmark                v1.1.0  v1.4.3  v1.4.4  3d440ca  v1.4.5
-  ---                      ------  ------  ------  -------  ------
-  range(2M) | length       0.011s  0.011s  0.011s  0.011s   0.011s
-  reverse(2M)              0.017s  0.017s  0.017s  0.018s   0.017s
-  sort(2M)                 0.022s  0.022s  0.022s  0.023s   0.023s
-  unique(1M)               0.028s  0.028s  0.028s  0.029s   0.029s
-  flatten(500K)            0.010s  0.010s  0.010s  0.010s   0.010s
-  min, max(2M)             0.017s  0.017s  0.018s  0.017s   0.017s
-  add numbers(2M)          0.012s  0.012s  0.012s  0.012s   0.012s
-  any/all(2M)              0.027s  0.028s  0.027s  0.028s   0.027s
-  limit(10; range(10M))    0.003s  0.002s  0.002s  0.002s   0.002s
-  first(range(10M))        0.002s  0.002s  0.002s  0.002s   0.002s
-  last(range(2M))          0.003s  0.002s  0.002s  0.002s   0.002s
-  indices(1M)              0.015s  0.015s  0.015s  0.015s   0.015s
+  Benchmark                v1.4.3  v1.4.4  3d440ca  v1.4.5  v1.5.0
+  ---                      ------  ------  -------  ------  ------
+  range(2M) | length       0.011s  0.011s  0.011s   0.011s  0.011s
+  reverse(2M)              0.017s  0.017s  0.018s   0.017s  0.018s
+  sort(2M)                 0.022s  0.022s  0.023s   0.023s  0.023s
+  unique(1M)               0.028s  0.028s  0.029s   0.029s  0.030s
+  flatten(500K)            0.010s  0.010s  0.010s   0.010s  0.011s
+  min, max(2M)             0.017s  0.018s  0.017s   0.017s  0.019s
+  add numbers(2M)          0.012s  0.012s  0.012s   0.012s  0.013s
+  any/all(2M)              0.028s  0.027s  0.028s   0.027s  0.028s
+  limit(10; range(10M))    0.002s  0.002s  0.002s   0.002s  0.002s
+  first(range(10M))        0.002s  0.002s  0.002s   0.002s  0.002s
+  last(range(2M))          0.002s  0.002s  0.002s   0.002s  0.002s
+  indices(1M)              0.015s  0.015s  0.015s   0.015s  0.016s
 
 --- Reduce & foreach ---
-  Benchmark                v1.1.0  v1.4.3  v1.4.4  3d440ca  v1.4.5
-  ---                      ------  ------  ------  -------  ------
-  reduce (sum)             0.009s  0.009s  0.009s  0.009s   0.009s
-  reduce (array build)     0.004s  0.004s  0.004s  0.004s   0.004s
-  reduce (obj build)       0.010s  0.010s  0.010s  0.010s   0.009s
-  reduce (setpath)         0.017s  0.016s  0.016s  0.016s   0.017s
-  foreach (running sum)    0.010s  0.010s  0.010s  0.010s   0.010s
-  foreach + emit           0.009s  0.010s  0.010s  0.010s   0.010s
-  reduce (sum-of-squares)  0.032s  0.032s  0.032s  0.032s   0.032s
-  reduce (conditional)     0.034s  0.034s  0.034s  0.035s   0.035s
-  reduce (product)         0.034s  0.034s  0.034s  0.035s   0.034s
-  foreach (conditional)    0.010s  0.010s  0.010s  0.011s   0.010s
-  until (100M)             0.293s  0.295s  0.294s  0.297s   0.295s
-  reduce (harmonic)        0.032s  0.032s  0.032s  0.033s   0.033s
-  reduce (floor pipe)      0.032s  0.032s  0.032s  0.033s   0.033s
-  reduce (sqrt pipe)       0.033s  0.032s  0.032s  0.032s   0.032s
-  reduce (sin+cos)         0.051s  0.052s  0.052s  0.052s   0.052s
+  Benchmark                v1.4.3  v1.4.4  3d440ca  v1.4.5  v1.5.0
+  ---                      ------  ------  -------  ------  ------
+  reduce (sum)             0.009s  0.009s  0.009s   0.009s  0.009s
+  reduce (array build)     0.004s  0.004s  0.004s   0.004s  0.004s
+  reduce (obj build)       0.010s  0.010s  0.010s   0.009s  0.009s
+  reduce (setpath)         0.016s  0.016s  0.016s   0.017s  0.017s
+  foreach (running sum)    0.010s  0.010s  0.010s   0.010s  0.010s
+  foreach + emit           0.010s  0.010s  0.010s   0.010s  0.011s
+  reduce (sum-of-squares)  0.032s  0.032s  0.032s   0.032s  0.033s
+  reduce (conditional)     0.034s  0.034s  0.035s   0.035s  0.036s
+  reduce (product)         0.034s  0.034s  0.035s   0.034s  0.035s
+  foreach (conditional)    0.010s  0.010s  0.011s   0.010s  0.011s
+  until (100M)             0.295s  0.294s  0.297s   0.295s  0.301s
+  reduce (harmonic)        0.032s  0.032s  0.033s   0.033s  0.034s
+  reduce (floor pipe)      0.032s  0.032s  0.033s   0.033s  0.034s
+  reduce (sqrt pipe)       0.032s  0.032s  0.032s   0.032s  0.033s
+  reduce (sin+cos)         0.052s  0.052s  0.052s   0.052s  0.052s
 
 --- Object operations ---
-  Benchmark                v1.1.0  v1.4.3  v1.4.4  3d440ca  v1.4.5
-  ---                      ------  ------  ------  -------  ------
-  large obj construct      0.004s  0.004s  0.004s  0.004s   0.004s
-  large obj keys           0.010s  0.011s  0.010s  0.011s   0.011s
-  large obj to_entries     0.011s  0.011s  0.012s  0.012s   0.012s
-  with_entries             0.009s  0.009s  0.009s  0.009s   0.009s
+  Benchmark                v1.4.3  v1.4.4  3d440ca  v1.4.5  v1.5.0
+  ---                      ------  ------  -------  ------  ------
+  large obj construct      0.004s  0.004s  0.004s   0.004s  0.004s
+  large obj keys           0.011s  0.010s  0.011s   0.011s  0.011s
+  large obj to_entries     0.011s  0.012s  0.012s   0.012s  0.012s
+  with_entries             0.009s  0.009s  0.009s   0.009s  0.009s
 
 --- Assignment operators ---
-  Benchmark                v1.1.0  v1.4.3  v1.4.4  3d440ca  v1.4.5
-  ---                      ------  ------  ------  -------  ------
-  .[] |= f (100K)          0.005s  0.005s  0.005s  0.005s   0.005s
-  .[] += 1 (100K)          0.005s  0.005s  0.005s  0.005s   0.005s
-  .[k] = v reduce(50K)     0.009s  0.008s  0.008s  0.008s   0.008s
+  Benchmark                v1.4.3  v1.4.4  3d440ca  v1.4.5  v1.5.0
+  ---                      ------  ------  -------  ------  ------
+  .[] |= f (100K)          0.005s  0.005s  0.005s   0.005s  0.005s
+  .[] += 1 (100K)          0.005s  0.005s  0.005s   0.005s  0.005s
+  .[k] = v reduce(50K)     0.008s  0.008s  0.008s   0.008s  0.008s
 
 --- String-heavy generators ---
-  Benchmark                v1.1.0  v1.4.3  v1.4.4  3d440ca  v1.4.5
-  ---                      ------  ------  ------  -------  ------
-  gsub(100K)               0.019s  0.025s  0.025s  0.025s   0.025s
-  join large(100K)         0.005s  0.006s  0.005s  0.006s   0.005s
-  explode/implode(100K)    0.029s  0.029s  0.028s  0.029s   0.028s
-  reduce str concat(100K)  0.008s  0.008s  0.008s  0.008s   0.008s
+  Benchmark                v1.4.3  v1.4.4  3d440ca  v1.4.5  v1.5.0
+  ---                      ------  ------  -------  ------  ------
+  gsub(100K)               0.025s  0.025s  0.025s   0.025s  0.026s
+  join large(100K)         0.006s  0.005s  0.006s   0.005s  0.005s
+  explode/implode(100K)    0.029s  0.028s  0.029s   0.028s  0.027s
+  reduce str concat(100K)  0.008s  0.008s  0.008s   0.008s  0.008s
 
 --- Try-catch & alternative ---
-  Benchmark                v1.1.0  v1.4.3  v1.4.4  3d440ca  v1.4.5
-  ---                      ------  ------  ------  -------  ------
-  alternative //           0.032s  0.031s  0.031s  0.032s   0.032s
-  try-catch                0.023s  0.023s  0.023s  0.023s   0.023s
-  label-break              0.004s  0.004s  0.004s  0.004s   0.004s
+  Benchmark                v1.4.3  v1.4.4  3d440ca  v1.4.5  v1.5.0
+  ---                      ------  ------  -------  ------  ------
+  alternative //           0.031s  0.031s  0.032s   0.032s  0.033s
+  try-catch                0.023s  0.023s  0.023s   0.023s  0.023s
+  label-break              0.004s  0.004s  0.004s   0.004s  0.004s
 
 --- Type conversion ---
-  Benchmark                v1.1.0  v1.4.3  v1.4.4  3d440ca  v1.4.5
-  ---                      ------  ------  ------  -------  ------
-  tojson/fromjson(100K)    0.022s  0.021s  0.021s  0.022s   0.022s
-  null propagation(2M)     0.087s  0.089s  0.090s  0.088s   0.087s
+  Benchmark                v1.4.3  v1.4.4  3d440ca  v1.4.5  v1.5.0
+  ---                      ------  ------  -------  ------  ------
+  tojson/fromjson(100K)    0.021s  0.021s  0.022s   0.022s  0.022s
+  null propagation(2M)     0.089s  0.090s  0.088s   0.087s  0.090s
 
 --- jaq-derived ---
-  Benchmark                v1.1.0  v1.4.3  v1.4.4  3d440ca  v1.4.5
-  ---                      ------  ------  ------  -------  ------
-  jaq: reverse             0.010s  0.010s  0.011s  0.011s   0.010s
-  jaq: sort                0.017s  0.018s  0.018s  0.018s   0.017s
-  jaq: group-by            0.037s  0.034s  0.035s  0.037s   0.037s
-  jaq: min-max             0.011s  0.010s  0.010s  0.011s   0.010s
-  jaq: ex-implode          0.019s  0.019s  0.019s  0.019s   0.019s
-  jaq: repeat              0.012s  0.011s  0.011s  0.011s   0.011s
-  jaq: from                0.006s  0.006s  0.006s  0.006s   0.006s
-  jaq: last                0.003s  0.002s  0.002s  0.002s   0.002s
-  jaq: cumsum              0.010s  0.010s  0.012s  0.010s   0.010s
-  jaq: cumsum-xy           0.017s  0.016s  0.018s  0.017s   0.017s
-  jaq: try-catch           0.090s  0.084s  0.088s  0.083s   0.090s
-  jaq: add                 0.042s  0.039s  0.042s  0.040s   0.040s
-  jaq: reduce              0.092s  0.084s  0.094s  0.081s   0.086s
-  jaq: reduce-update       0.005s  0.005s  0.005s  0.005s   0.005s
-  jaq: kv                  0.015s  0.014s  0.014s  0.015s   0.014s
-  jaq: kv-update           0.018s  0.019s  0.018s  0.018s   0.018s
-  jaq: kv-entries          0.055s  0.056s  0.056s  0.055s   0.055s
-  jaq: pyramid             0.016s  0.016s  0.015s  0.016s   0.016s
-  jaq: upto                0.007s  0.007s  0.007s  0.007s   0.007s
-  jaq: tree-flatten        0.003s  0.003s  0.003s  0.003s   0.003s
-  jaq: tree-update         0.007s  0.007s  0.007s  0.007s   0.007s
-  jaq: to-fromjson         0.005s  0.005s  0.005s  0.005s   0.005s
-  jaq: str-slice           0.014s  0.014s  0.013s  0.014s   0.014s
+  Benchmark                v1.4.3  v1.4.4  3d440ca  v1.4.5  v1.5.0
+  ---                      ------  ------  -------  ------  ------
+  jaq: reverse             0.010s  0.011s  0.011s   0.010s  0.011s
+  jaq: sort                0.018s  0.018s  0.018s   0.017s  0.018s
+  jaq: group-by            0.034s  0.035s  0.037s   0.037s  0.038s
+  jaq: min-max             0.010s  0.010s  0.011s   0.010s  0.010s
+  jaq: ex-implode          0.019s  0.019s  0.019s   0.019s  0.019s
+  jaq: repeat              0.011s  0.011s  0.011s   0.011s  0.012s
+  jaq: from                0.006s  0.006s  0.006s   0.006s  0.006s
+  jaq: last                0.002s  0.002s  0.002s   0.002s  0.002s
+  jaq: cumsum              0.010s  0.012s  0.010s   0.010s  0.010s
+  jaq: cumsum-xy           0.016s  0.018s  0.017s   0.017s  0.017s
+  jaq: try-catch           0.084s  0.088s  0.083s   0.090s  0.079s
+  jaq: add                 0.039s  0.042s  0.040s   0.040s  0.041s
+  jaq: reduce              0.084s  0.094s  0.081s   0.086s  0.078s
+  jaq: reduce-update       0.005s  0.005s  0.005s   0.005s  0.005s
+  jaq: kv                  0.014s  0.014s  0.015s   0.014s  0.015s
+  jaq: kv-update           0.019s  0.018s  0.018s   0.018s  0.019s
+  jaq: kv-entries          0.056s  0.056s  0.055s   0.055s  0.057s
+  jaq: pyramid             0.016s  0.015s  0.016s   0.016s  0.016s
+  jaq: upto                0.007s  0.007s  0.007s   0.007s  0.007s
+  jaq: tree-flatten        0.003s  0.003s  0.003s   0.003s  0.003s
+  jaq: tree-update         0.007s  0.007s  0.007s   0.007s  0.225s
+  jaq: to-fromjson         0.005s  0.005s  0.005s   0.005s  0.005s
+  jaq: str-slice           0.014s  0.013s  0.014s   0.014s  0.014s
 ```

--- a/docs/benchmark-history.md
+++ b/docs/benchmark-history.md
@@ -9,199 +9,199 @@ Recent slice (last 5 columns). Full history lives in
   Benchmark                v1.4.3  v1.4.4  3d440ca  v1.4.5  v1.5.0
   ---                      ------  ------  -------  ------  ------
   empty                    0.017s  0.017s  0.017s   0.017s  0.017s
-  identity -c              0.082s  0.082s  0.078s   0.081s  0.082s
-  identity (pretty)        0.108s  0.099s  0.101s   0.105s  0.098s
-  field access .name       0.080s  0.080s  0.087s   0.091s  0.096s
-  nested .x,.y,.name       0.111s  0.123s  0.144s   0.143s  0.150s
-  arithmetic .x + .y       0.064s  0.094s  0.082s   0.081s  0.083s
-  select .x > 1500000      0.066s  0.115s  0.069s   0.073s  0.081s
-  string concat            0.090s  0.089s  0.096s   0.096s  0.092s
-  object construct         0.087s  0.127s  0.112s   0.114s  0.113s
-  array construct          0.097s  0.102s  0.116s   0.120s  0.106s
-  .[]                      0.085s  0.098s  0.100s   0.099s  0.103s
-  to_entries               0.104s  0.112s  0.161s   0.156s  0.164s
-  keys                     0.088s  0.102s  0.098s   0.101s  0.104s
-  keys_unsorted            0.078s  0.091s  0.094s   0.093s  0.095s
-  length                   0.073s  0.085s  0.080s   0.083s  0.087s
-  has("x")                 0.030s  0.030s  0.029s   0.030s  0.036s
+  identity -c              0.082s  0.082s  0.078s   0.081s  0.085s
+  identity (pretty)        0.108s  0.099s  0.101s   0.105s  0.103s
+  field access .name       0.080s  0.080s  0.087s   0.091s  0.093s
+  nested .x,.y,.name       0.111s  0.123s  0.144s   0.143s  0.145s
+  arithmetic .x + .y       0.064s  0.094s  0.082s   0.081s  0.082s
+  select .x > 1500000      0.066s  0.115s  0.069s   0.073s  0.080s
+  string concat            0.090s  0.089s  0.096s   0.096s  0.091s
+  object construct         0.087s  0.127s  0.112s   0.114s  0.111s
+  array construct          0.097s  0.102s  0.116s   0.120s  0.103s
+  .[]                      0.085s  0.098s  0.100s   0.099s  0.104s
+  to_entries               0.104s  0.112s  0.161s   0.156s  0.159s
+  keys                     0.088s  0.102s  0.098s   0.101s  0.101s
+  keys_unsorted            0.078s  0.091s  0.094s   0.093s  0.094s
+  length                   0.073s  0.085s  0.080s   0.083s  0.085s
+  has("x")                 0.030s  0.030s  0.029s   0.030s  0.038s
   type                     0.019s  0.019s  0.022s   0.022s  0.022s
-  del(.name)               0.098s  0.095s  0.098s   0.099s  0.103s
-  @csv                     -       -       0.140s   0.137s  0.127s
-  split/join               -       -       0.093s   0.098s  0.091s
-  select|field             -       -       0.112s   0.112s  0.096s
+  del(.name)               0.098s  0.095s  0.098s   0.099s  0.102s
+  @csv                     -       -       0.140s   0.137s  0.121s
+  split/join               -       -       0.093s   0.098s  0.090s
+  select|field             -       -       0.112s   0.112s  0.099s
   select|remap             -       -       0.095s   0.096s  0.096s
-  computed remap           -       -       0.211s   0.214s  0.187s
-  [.x,.y]|add              -       -       0.082s   0.083s  0.084s
+  computed remap           -       -       0.211s   0.214s  0.188s
+  [.x,.y]|add              -       -       0.082s   0.083s  0.085s
   [.x,.y]|avg              -       -       0.110s   0.112s  0.108s
-  map(*2)|add              -       -       0.110s   0.113s  0.104s
-  keys|length              -       -       0.254s   0.254s  0.254s
+  map(*2)|add              -       -       0.110s   0.113s  0.103s
+  keys|length              -       -       0.254s   0.254s  0.250s
   .+{z=0}                  -       -       0.143s   0.147s  0.151s
-  split|first              -       -       0.092s   0.098s  0.090s
-  slice[0..5]              -       -       0.095s   0.100s  0.093s
-  dynkey {(.name)}         -       -       0.118s   0.121s  0.108s
-  .x += 1                  -       -       0.069s   0.070s  0.073s
-  {a}+{b} merge            -       -       0.143s   0.147s  0.132s
+  split|first              -       -       0.092s   0.098s  0.087s
+  slice[0..5]              -       -       0.095s   0.100s  0.091s
+  dynkey {(.name)}         -       -       0.118s   0.121s  0.104s
+  .x += 1                  -       -       0.069s   0.070s  0.125s
+  {a}+{b} merge            -       -       0.143s   0.147s  0.130s
   .x*2+1                   -       -       0.049s   0.050s  0.058s
-  .x+.y*2                  -       -       0.102s   0.105s  0.097s
+  .x+.y*2                  -       -       0.102s   0.105s  0.096s
   .x > .y                  -       -       0.076s   0.077s  0.077s
-  to_entries|len           -       -       0.397s   0.395s  0.398s
-  .x|.+1 (pipe)            -       -       0.047s   0.048s  0.058s
+  to_entries|len           -       -       0.397s   0.395s  0.397s
+  .x|.+1 (pipe)            -       -       0.047s   0.048s  0.057s
   .x|.*2|.+1               -       -       0.049s   0.050s  0.058s
-  .name|.+"_x"             -       -       0.098s   0.098s  0.093s
+  .name|.+"_x"             -       -       0.098s   0.098s  0.092s
   .x>N | not               -       -       0.040s   0.041s  0.049s
-  and (2 cmp)              -       -       0.080s   0.080s  0.080s
-  if-then-else             -       -       0.043s   0.043s  0.051s
-  sel(and)|field           -       -       0.076s   0.076s  0.078s
-  sel(and)|remap           -       -       0.074s   0.076s  0.076s
-  arith|cmp                -       -       0.044s   0.047s  0.054s
-  if cmp .field            -       -       0.102s   0.107s  0.112s
-  split|length             -       -       0.094s   0.099s  0.090s
+  and (2 cmp)              -       -       0.080s   0.080s  0.081s
+  if-then-else             -       -       0.043s   0.043s  0.050s
+  sel(and)|field           -       -       0.076s   0.076s  0.076s
+  sel(and)|remap           -       -       0.074s   0.076s  0.077s
+  arith|cmp                -       -       0.044s   0.047s  0.052s
+  if cmp .field            -       -       0.102s   0.107s  0.111s
+  split|length             -       -       0.094s   0.099s  0.089s
   [x,y]|min                -       -       0.090s   0.092s  0.090s
-  [x,y]|max                -       -       0.091s   0.095s  0.095s
-  [x,y]|sort|.[0]          -       -       0.087s   0.090s  0.089s
-  .name|len>5              -       -       0.096s   0.100s  0.093s
-  sel(len>5)|.x            -       -       0.125s   0.127s  0.105s
-  if .x>.y .name           -       -       0.087s   0.090s  0.088s
-  sel(.x>.y)|.name         -       -       0.071s   0.072s  0.073s
-  .x*2|tostring            -       -       0.047s   0.048s  0.056s
-  .x*.x+1                  -       -       0.056s   0.057s  0.065s
-  {k=.name,v=tostr}        -       -       0.160s   0.162s  0.143s
-  str add chain            -       -       0.386s   0.398s  0.381s
-  if>.y .name|empty        -       -       0.071s   0.073s  0.073s
+  [x,y]|max                -       -       0.091s   0.095s  0.094s
+  [x,y]|sort|.[0]          -       -       0.087s   0.090s  0.088s
+  .name|len>5              -       -       0.096s   0.100s  0.089s
+  sel(len>5)|.x            -       -       0.125s   0.127s  0.110s
+  if .x>.y .name           -       -       0.087s   0.090s  0.089s
+  sel(.x>.y)|.name         -       -       0.071s   0.072s  0.072s
+  .x*2|tostring            -       -       0.047s   0.048s  0.055s
+  .x*.x+1                  -       -       0.056s   0.057s  0.064s
+  {k=.name,v=tostr}        -       -       0.160s   0.162s  0.149s
+  str add chain            -       -       0.386s   0.398s  0.382s
+  if>.y .name|empty        -       -       0.071s   0.073s  0.074s
   if .x%2==0               -       -       0.045s   0.047s  0.053s
-  if .x*2+1>1M             -       -       0.045s   0.048s  0.057s
-  sel(.x%2==0)|.name       -       -       0.074s   0.076s  0.085s
+  if .x*2+1>1M             -       -       0.045s   0.048s  0.053s
+  sel(.x%2==0)|.name       -       -       0.074s   0.076s  0.081s
   sel(.x*2+1>1M)           -       -       0.142s   0.144s  0.156s
   .x|@json                 -       -       0.045s   0.045s  0.047s
-  .x|@text                 -       -       0.045s   0.045s  0.048s
-  .name|@json              -       -       0.104s   0.107s  0.101s
-  sel|[arr]                -       -       0.148s   0.150s  0.143s
-  sel(and)|[arr]           -       -       0.076s   0.078s  0.079s
-  if>.y [arr]              -       -       0.199s   0.199s  0.180s
-  if sw then .f            -       -       0.135s   0.138s  0.138s
+  .x|@text                 -       -       0.045s   0.045s  0.047s
+  .name|@json              -       -       0.104s   0.107s  0.099s
+  sel|[arr]                -       -       0.148s   0.150s  0.144s
+  sel(and)|[arr]           -       -       0.076s   0.078s  0.077s
+  if>.y [arr]              -       -       0.199s   0.199s  0.177s
+  if sw then .f            -       -       0.135s   0.138s  0.137s
   dynkey {(.n)=.x*2}       -       -       0.131s   0.132s  0.112s
-  sel(and)|.x*.y           -       -       0.075s   0.077s  0.077s
-  sel>N|str chain          -       -       0.158s   0.158s  0.154s
-  .f+"_"+arith_ts          -       -       0.145s   0.148s  0.130s
-  sel(sw)|str ch           -       -       0.317s   0.310s  0.302s
+  sel(and)|.x*.y           -       -       0.075s   0.077s  0.078s
+  sel>N|str chain          -       -       0.158s   0.158s  0.153s
+  .f+"_"+arith_ts          -       -       0.145s   0.148s  0.134s
+  sel(sw)|str ch           -       -       0.317s   0.310s  0.298s
   split|rev|join           -       -       0.123s   0.122s  0.114s
-  dynkey+static            -       -       0.324s   0.331s  0.332s
-  if>.y str chain          -       -       0.186s   0.189s  0.167s
-  remap+str chain          -       -       0.171s   0.178s  0.155s
-  sel(len>8)               -       -       0.163s   0.170s  0.161s
+  dynkey+static            -       -       0.324s   0.331s  0.334s
+  if>.y str chain          -       -       0.186s   0.189s  0.170s
+  remap+str chain          -       -       0.171s   0.178s  0.151s
+  sel(len>8)               -       -       0.163s   0.170s  0.162s
   up|split|join            -       -       0.101s   0.104s  0.096s
-  .name|index              -       -       0.126s   0.128s  0.119s
-  .name|index+1            -       -       0.127s   0.133s  0.130s
-  .name|rindex             -       -       0.131s   0.134s  0.124s
-  .name|indices            -       -       0.153s   0.160s  0.152s
-  [x,y]|sort               -       -       0.154s   0.156s  0.154s
-  .name|scan               -       -       0.218s   0.219s  0.216s
-  .name|gsub               -       -       0.175s   0.178s  0.169s
-  walk(if num .+1)         -       -       0.140s   0.141s  0.143s
+  .name|index              -       -       0.126s   0.128s  0.114s
+  .name|index+1            -       -       0.127s   0.133s  0.121s
+  .name|rindex             -       -       0.131s   0.134s  0.126s
+  .name|indices            -       -       0.153s   0.160s  0.154s
+  [x,y]|sort               -       -       0.154s   0.156s  0.152s
+  .name|scan               -       -       0.218s   0.219s  0.204s
+  .name|gsub               -       -       0.175s   0.178s  0.161s
+  walk(if num .+1)         -       -       0.140s   0.141s  0.137s
   tojson                   -       -       0.106s   0.110s  0.107s
-  {name,x}                 -       -       0.144s   0.144s  0.128s
-  .z//.name                -       -       0.165s   0.164s  0.158s
-  .x|=test(re)             -       -       0.123s   0.124s  0.121s
-  ./sep|first              -       -       0.131s   0.132s  0.129s
-  .y=(.x*2)                -       -       0.112s   0.115s  0.125s
-  .y=(.x+.y)               -       -       0.161s   0.159s  0.172s
-  objects                  -       -       0.081s   0.085s  0.088s
-  .tag|=if..then N         -       -       0.613s   0.614s  0.625s
-  .x=(.x+1)                -       -       0.070s   0.072s  0.072s
-  sel>N|.y+=1              -       -       0.085s   0.087s  0.094s
-  sel(and)|.x+=1           -       -       0.100s   0.102s  0.111s
-  sel(sw)|.x+=1            -       -       0.132s   0.133s  0.132s
-  match(re)                -       -       0.369s   0.367s  0.367s
-  capture(re)              -       -       0.306s   0.303s  0.307s
-  first(.name,.x)          -       -       0.090s   0.093s  0.097s
-  if .x==null              -       -       0.043s   0.044s  0.047s
-  we(sw(.key))             -       -       0.111s   0.111s  0.112s
-  sel(sw or ew)            -       -       0.211s   0.214s  0.211s
-  path(.name,.x)           -       -       0.276s   0.277s  0.277s
-  sel(str+num+num)         -       -       0.142s   0.145s  0.154s
+  {name,x}                 -       -       0.144s   0.144s  0.132s
+  .z//.name                -       -       0.165s   0.164s  0.153s
+  .x|=test(re)             -       -       0.123s   0.124s  0.169s
+  ./sep|first              -       -       0.131s   0.132s  0.184s
+  .y=(.x*2)                -       -       0.112s   0.115s  0.178s
+  .y=(.x+.y)               -       -       0.161s   0.159s  0.228s
+  objects                  -       -       0.081s   0.085s  0.123s
+  .tag|=if..then N         -       -       0.613s   0.614s  0.607s
+  .x=(.x+1)                -       -       0.070s   0.072s  0.124s
+  sel>N|.y+=1              -       -       0.085s   0.087s  0.118s
+  sel(and)|.x+=1           -       -       0.100s   0.102s  0.109s
+  sel(sw)|.x+=1            -       -       0.132s   0.133s  0.160s
+  match(re)                -       -       0.369s   0.367s  0.359s
+  capture(re)              -       -       0.306s   0.303s  0.292s
+  first(.name,.x)          -       -       0.090s   0.093s  0.093s
+  if .x==null              -       -       0.043s   0.044s  0.046s
+  we(sw(.key))             -       -       0.111s   0.111s  0.107s
+  sel(sw or ew)            -       -       0.211s   0.214s  0.201s
+  path(.name,.x)           -       -       0.276s   0.277s  0.271s
+  sel(str+num+num)         -       -       0.142s   0.145s  0.151s
   nested if|field          -       -       0.076s   0.077s  0.077s
-  .f|floor|.*2             -       -       0.050s   0.051s  0.060s
-  split|len>1              -       -       0.122s   0.124s  0.117s
-  .name|len|.*2            -       -       0.106s   0.107s  0.102s
-  if len>5 .x .y           -       -       0.137s   0.133s  0.117s
+  .f|floor|.*2             -       -       0.050s   0.051s  0.059s
+  split|len>1              -       -       0.122s   0.124s  0.115s
+  .name|len|.*2            -       -       0.106s   0.107s  0.100s
+  if len>5 .x .y           -       -       0.137s   0.133s  0.115s
   sel(len>5)|remap         -       -       0.230s   0.233s  0.200s
-  .x|tostr|len             -       -       0.056s   0.056s  0.060s
+  .x|tostr|len             -       -       0.056s   0.056s  0.059s
   if .x>.y .x .y           -       -       0.093s   0.094s  0.094s
-  split|last|tonum         -       -       0.100s   0.104s  0.096s
-  split|rev|.[0]           -       -       0.097s   0.099s  0.093s
+  split|last|tonum         -       -       0.100s   0.104s  0.097s
+  split|rev|.[0]           -       -       0.097s   0.099s  0.095s
   split|.[0]+.[1]          -       -       0.122s   0.123s  0.113s
-  .[]|strings              -       -       0.096s   0.095s  0.095s
-  .[]|numbers              -       -       0.107s   0.106s  0.106s
-  [x,y]|any(>1M)           -       -       0.082s   0.082s  0.084s
-  sel(dc|sw)               -       -       0.104s   0.107s  0.098s
+  .[]|strings              -       -       0.096s   0.095s  0.106s
+  .[]|numbers              -       -       0.107s   0.106s  0.129s
+  [x,y]|any(>1M)           -       -       0.082s   0.082s  0.082s
+  sel(dc|sw)               -       -       0.104s   0.107s  0.096s
   [[x,y],[n]]|flat         -       -       0.475s   0.475s  0.452s
-  .x|floor|.*2             -       -       0.051s   0.051s  0.061s
+  .x|floor|.*2             -       -       0.051s   0.051s  0.059s
   tojson|fromjson          -       -       0.083s   0.081s  0.088s
-  [.x]|add                 -       -       0.048s   0.048s  0.060s
-  if>N {o}+.               -       -       0.123s   0.125s  0.145s
-  if>N .+{o}               -       -       0.124s   0.125s  0.136s
-  if .n=="s" .+{o}         -       -       0.167s   0.161s  0.162s
-  sel(.n>"s")              -       -       0.095s   0.094s  0.089s
-  [x,y,z]|min              -       -       0.311s   0.312s  0.303s
-  if .n|len>5 l s          -       -       0.107s   0.106s  0.102s
-  if .x|flr>N b s          -       -       0.047s   0.045s  0.057s
+  [.x]|add                 -       -       0.048s   0.048s  0.059s
+  if>N {o}+.               -       -       0.123s   0.125s  0.133s
+  if>N .+{o}               -       -       0.124s   0.125s  0.135s
+  if .n=="s" .+{o}         -       -       0.167s   0.161s  0.161s
+  sel(.n>"s")              -       -       0.095s   0.094s  0.087s
+  [x,y,z]|min              -       -       0.311s   0.312s  0.306s
+  if .n|len>5 l s          -       -       0.107s   0.106s  0.100s
+  if .x|flr>N b s          -       -       0.047s   0.045s  0.054s
   if .n|test l e           -       -       0.111s   0.112s  0.105s
-  if .n|sw l e             -       -       0.090s   0.091s  0.083s
+  if .n|sw l e             -       -       0.090s   0.091s  0.082s
   if .n|ew l e             -       -       0.092s   0.091s  0.084s
-  .n|len|tostr             -       -       0.097s   0.099s  0.092s
+  .n|len|tostr             -       -       0.097s   0.099s  0.091s
 
 --- String operations (2M objects) ---
   Benchmark                v1.4.3  v1.4.4  3d440ca  v1.4.5  v1.5.0
   ---                      ------  ------  -------  ------  ------
-  ascii_downcase           0.090s  0.088s  0.110s   0.112s  0.104s
+  ascii_downcase           0.090s  0.088s  0.110s   0.112s  0.103s
   ascii_upcase             0.090s  0.088s  0.108s   0.109s  0.102s
-  ltrimstr                 0.090s  0.090s  0.101s   0.102s  0.096s
-  rtrimstr                 0.089s  0.090s  0.105s   0.107s  0.098s
-  split                    0.150s  0.151s  0.169s   0.172s  0.169s
-  case+split               0.117s  0.116s  0.126s   0.128s  0.115s
-  join                     0.087s  0.092s  0.101s   0.104s  0.094s
+  ltrimstr                 0.090s  0.090s  0.101s   0.102s  0.099s
+  rtrimstr                 0.089s  0.090s  0.105s   0.107s  0.099s
+  split                    0.150s  0.151s  0.169s   0.172s  0.165s
+  case+split               0.117s  0.116s  0.126s   0.128s  0.116s
+  join                     0.087s  0.092s  0.101s   0.104s  0.093s
   startswith               0.084s  0.086s  0.101s   0.103s  0.095s
-  endswith                 0.085s  0.088s  0.103s   0.104s  0.098s
+  endswith                 0.085s  0.088s  0.103s   0.104s  0.095s
   tostring                 0.043s  0.095s  0.052s   0.053s  0.061s
-  tonumber                 0.108s  0.104s  0.117s   0.117s  0.111s
-  string interpolation     0.104s  0.106s  0.135s   0.134s  0.119s
+  tonumber                 0.108s  0.104s  0.117s   0.117s  0.110s
+  string interpolation     0.104s  0.106s  0.135s   0.134s  0.122s
 
 --- String ops (200K objects) ---
   Benchmark                v1.4.3  v1.4.4  3d440ca  v1.4.5  v1.5.0
   ---                      ------  ------  -------  ------  ------
   test (regex)             0.013s  0.013s  0.014s   0.014s  0.014s
-  match (regex)            0.031s  0.032s  0.033s   0.033s  0.031s
-  @base64                  0.011s  0.011s  0.013s   0.012s  0.012s
+  match (regex)            0.031s  0.032s  0.033s   0.033s  0.032s
+  @base64                  0.011s  0.011s  0.013s   0.012s  0.011s
   @uri                     0.011s  0.011s  0.013s   0.013s  0.012s
   @html                    0.012s  0.011s  0.013s   0.013s  0.012s
-  @csv (array)             0.013s  0.014s  0.020s   0.018s  0.016s
-  @tsv (array)             0.013s  0.014s  0.018s   0.017s  0.016s
-  gsub                     0.018s  0.018s  0.020s   0.020s  0.019s
-  case+gsub                0.181s  0.180s  0.193s   0.193s  0.181s
-  case+test                0.116s  0.115s  0.130s   0.130s  0.121s
-  ltrim+tonum+arith        0.107s  0.107s  0.118s   0.118s  0.110s
+  @csv (array)             0.013s  0.014s  0.020s   0.018s  0.015s
+  @tsv (array)             0.013s  0.014s  0.018s   0.017s  0.015s
+  gsub                     0.018s  0.018s  0.020s   0.020s  0.018s
+  case+gsub                0.181s  0.180s  0.193s   0.193s  0.178s
+  case+test                0.116s  0.115s  0.130s   0.130s  0.115s
+  ltrim+tonum+arith        0.107s  0.107s  0.118s   0.118s  0.108s
 
 --- Numeric & math (2M objects) ---
   Benchmark                v1.4.3  v1.4.4  3d440ca  v1.4.5  v1.5.0
   ---                      ------  ------  -------  ------  ------
-  floor                    0.042s  0.091s  0.048s   0.048s  0.057s
-  sqrt                     0.072s  0.115s  0.078s   0.078s  0.079s
-  modulo                   0.045s  0.095s  0.051s   0.051s  0.059s
-  if-elif-else             0.102s  0.134s  0.125s   0.124s  0.127s
-  select|del               0.073s  0.126s  0.079s   0.079s  0.095s
-  select|merge             0.105s  0.157s  0.110s   0.107s  0.120s
-  select(test)|merge       0.022s  0.021s  0.022s   0.022s  0.022s
+  floor                    0.042s  0.091s  0.048s   0.048s  0.056s
+  sqrt                     0.072s  0.115s  0.078s   0.078s  0.078s
+  modulo                   0.045s  0.095s  0.051s   0.051s  0.056s
+  if-elif-else             0.102s  0.134s  0.125s   0.124s  0.124s
+  select|del               0.073s  0.126s  0.079s   0.079s  0.090s
+  select|merge             0.105s  0.157s  0.110s   0.107s  0.118s
+  select(test)|merge       0.022s  0.021s  0.022s   0.022s  0.021s
 
 --- Array generators ---
   Benchmark                v1.4.3  v1.4.4  3d440ca  v1.4.5  v1.5.0
   ---                      ------  ------  -------  ------  ------
   range(2M) | length       0.011s  0.011s  0.011s   0.011s  0.011s
-  reverse(2M)              0.017s  0.017s  0.018s   0.017s  0.017s
-  sort(2M)                 0.022s  0.022s  0.023s   0.023s  0.023s
-  unique(1M)               0.028s  0.028s  0.029s   0.029s  0.029s
+  reverse(2M)              0.017s  0.017s  0.018s   0.017s  0.018s
+  sort(2M)                 0.022s  0.022s  0.023s   0.023s  0.025s
+  unique(1M)               0.028s  0.028s  0.029s   0.029s  0.030s
   flatten(500K)            0.010s  0.010s  0.010s   0.010s  0.010s
   min, max(2M)             0.017s  0.018s  0.017s   0.017s  0.018s
-  add numbers(2M)          0.012s  0.012s  0.012s   0.012s  0.012s
+  add numbers(2M)          0.012s  0.012s  0.012s   0.012s  0.013s
   any/all(2M)              0.028s  0.027s  0.028s   0.027s  0.028s
   limit(10; range(10M))    0.002s  0.002s  0.002s   0.002s  0.002s
   first(range(10M))        0.002s  0.002s  0.002s   0.002s  0.002s
@@ -211,41 +211,41 @@ Recent slice (last 5 columns). Full history lives in
 --- Reduce & foreach ---
   Benchmark                v1.4.3  v1.4.4  3d440ca  v1.4.5  v1.5.0
   ---                      ------  ------  -------  ------  ------
-  reduce (sum)             0.009s  0.009s  0.009s   0.009s  0.010s
-  reduce (array build)     0.004s  0.004s  0.004s   0.004s  0.005s
-  reduce (obj build)       0.010s  0.010s  0.010s   0.009s  0.010s
-  reduce (setpath)         0.016s  0.016s  0.016s   0.017s  0.017s
+  reduce (sum)             0.009s  0.009s  0.009s   0.009s  0.009s
+  reduce (array build)     0.004s  0.004s  0.004s   0.004s  0.004s
+  reduce (obj build)       0.010s  0.010s  0.010s   0.009s  0.009s
+  reduce (setpath)         0.016s  0.016s  0.016s   0.017s  0.016s
   foreach (running sum)    0.010s  0.010s  0.010s   0.010s  0.010s
-  foreach + emit           0.010s  0.010s  0.010s   0.010s  0.011s
-  reduce (sum-of-squares)  0.032s  0.032s  0.032s   0.032s  0.035s
-  reduce (conditional)     0.034s  0.034s  0.035s   0.035s  0.036s
+  foreach + emit           0.010s  0.010s  0.010s   0.010s  0.010s
+  reduce (sum-of-squares)  0.032s  0.032s  0.032s   0.032s  0.032s
+  reduce (conditional)     0.034s  0.034s  0.035s   0.035s  0.035s
   reduce (product)         0.034s  0.034s  0.035s   0.034s  0.034s
-  foreach (conditional)    0.010s  0.010s  0.011s   0.010s  0.011s
-  until (100M)             0.295s  0.294s  0.297s   0.295s  0.304s
-  reduce (harmonic)        0.032s  0.032s  0.033s   0.033s  0.033s
-  reduce (floor pipe)      0.032s  0.032s  0.033s   0.033s  0.034s
+  foreach (conditional)    0.010s  0.010s  0.011s   0.010s  0.010s
+  until (100M)             0.295s  0.294s  0.297s   0.295s  0.300s
+  reduce (harmonic)        0.032s  0.032s  0.033s   0.033s  0.032s
+  reduce (floor pipe)      0.032s  0.032s  0.033s   0.033s  0.032s
   reduce (sqrt pipe)       0.032s  0.032s  0.032s   0.032s  0.034s
-  reduce (sin+cos)         0.052s  0.052s  0.052s   0.052s  0.053s
+  reduce (sin+cos)         0.052s  0.052s  0.052s   0.052s  0.052s
 
 --- Object operations ---
   Benchmark                v1.4.3  v1.4.4  3d440ca  v1.4.5  v1.5.0
   ---                      ------  ------  -------  ------  ------
   large obj construct      0.004s  0.004s  0.004s   0.004s  0.004s
-  large obj keys           0.011s  0.010s  0.011s   0.011s  0.012s
-  large obj to_entries     0.011s  0.012s  0.012s   0.012s  0.014s
-  with_entries             0.009s  0.009s  0.009s   0.009s  0.010s
+  large obj keys           0.011s  0.010s  0.011s   0.011s  0.011s
+  large obj to_entries     0.011s  0.012s  0.012s   0.012s  0.012s
+  with_entries             0.009s  0.009s  0.009s   0.009s  0.009s
 
 --- Assignment operators ---
   Benchmark                v1.4.3  v1.4.4  3d440ca  v1.4.5  v1.5.0
   ---                      ------  ------  -------  ------  ------
-  .[] |= f (100K)          0.005s  0.005s  0.005s   0.005s  0.006s
-  .[] += 1 (100K)          0.005s  0.005s  0.005s   0.005s  0.006s
-  .[k] = v reduce(50K)     0.008s  0.008s  0.008s   0.008s  0.009s
+  .[] |= f (100K)          0.005s  0.005s  0.005s   0.005s  0.005s
+  .[] += 1 (100K)          0.005s  0.005s  0.005s   0.005s  0.005s
+  .[k] = v reduce(50K)     0.008s  0.008s  0.008s   0.008s  0.008s
 
 --- String-heavy generators ---
   Benchmark                v1.4.3  v1.4.4  3d440ca  v1.4.5  v1.5.0
   ---                      ------  ------  -------  ------  ------
-  gsub(100K)               0.025s  0.025s  0.025s   0.025s  0.027s
+  gsub(100K)               0.025s  0.025s  0.025s   0.025s  0.028s
   join large(100K)         0.006s  0.005s  0.006s   0.005s  0.006s
   explode/implode(100K)    0.029s  0.028s  0.029s   0.028s  0.028s
   reduce str concat(100K)  0.008s  0.008s  0.008s   0.008s  0.008s
@@ -253,40 +253,40 @@ Recent slice (last 5 columns). Full history lives in
 --- Try-catch & alternative ---
   Benchmark                v1.4.3  v1.4.4  3d440ca  v1.4.5  v1.5.0
   ---                      ------  ------  -------  ------  ------
-  alternative //           0.031s  0.031s  0.032s   0.032s  0.033s
-  try-catch                0.023s  0.023s  0.023s   0.023s  0.024s
+  alternative //           0.031s  0.031s  0.032s   0.032s  0.032s
+  try-catch                0.023s  0.023s  0.023s   0.023s  0.023s
   label-break              0.004s  0.004s  0.004s   0.004s  0.004s
 
 --- Type conversion ---
   Benchmark                v1.4.3  v1.4.4  3d440ca  v1.4.5  v1.5.0
   ---                      ------  ------  -------  ------  ------
-  tojson/fromjson(100K)    0.021s  0.021s  0.022s   0.022s  0.023s
-  null propagation(2M)     0.089s  0.090s  0.088s   0.087s  0.088s
+  tojson/fromjson(100K)    0.021s  0.021s  0.022s   0.022s  0.022s
+  null propagation(2M)     0.089s  0.090s  0.088s   0.087s  0.089s
 
 --- jaq-derived ---
   Benchmark                v1.4.3  v1.4.4  3d440ca  v1.4.5  v1.5.0
   ---                      ------  ------  -------  ------  ------
   jaq: reverse             0.010s  0.011s  0.011s   0.010s  0.011s
   jaq: sort                0.018s  0.018s  0.018s   0.017s  0.018s
-  jaq: group-by            0.034s  0.035s  0.037s   0.037s  0.038s
-  jaq: min-max             0.010s  0.010s  0.011s   0.010s  0.012s
-  jaq: ex-implode          0.019s  0.019s  0.019s   0.019s  0.020s
-  jaq: repeat              0.011s  0.011s  0.011s   0.011s  0.012s
-  jaq: from                0.006s  0.006s  0.006s   0.006s  0.006s
+  jaq: group-by            0.034s  0.035s  0.037s   0.037s  0.037s
+  jaq: min-max             0.010s  0.010s  0.011s   0.010s  0.011s
+  jaq: ex-implode          0.019s  0.019s  0.019s   0.019s  0.019s
+  jaq: repeat              0.011s  0.011s  0.011s   0.011s  0.011s
+  jaq: from                0.006s  0.006s  0.006s   0.006s  0.005s
   jaq: last                0.002s  0.002s  0.002s   0.002s  0.002s
-  jaq: cumsum              0.010s  0.012s  0.010s   0.010s  0.011s
-  jaq: cumsum-xy           0.016s  0.018s  0.017s   0.017s  0.018s
-  jaq: try-catch           0.084s  0.088s  0.083s   0.090s  0.078s
+  jaq: cumsum              0.010s  0.012s  0.010s   0.010s  0.010s
+  jaq: cumsum-xy           0.016s  0.018s  0.017s   0.017s  0.017s
+  jaq: try-catch           0.084s  0.088s  0.083s   0.090s  0.077s
   jaq: add                 0.039s  0.042s  0.040s   0.040s  0.041s
-  jaq: reduce              0.084s  0.094s  0.081s   0.086s  0.086s
-  jaq: reduce-update       0.005s  0.005s  0.005s   0.005s  0.006s
+  jaq: reduce              0.084s  0.094s  0.081s   0.086s  0.078s
+  jaq: reduce-update       0.005s  0.005s  0.005s   0.005s  0.005s
   jaq: kv                  0.014s  0.014s  0.015s   0.014s  0.015s
-  jaq: kv-update           0.019s  0.018s  0.018s   0.018s  0.019s
-  jaq: kv-entries          0.056s  0.056s  0.055s   0.055s  0.059s
-  jaq: pyramid             0.016s  0.015s  0.016s   0.016s  0.017s
-  jaq: upto                0.007s  0.007s  0.007s   0.007s  0.009s
-  jaq: tree-flatten        0.003s  0.003s  0.003s   0.003s  0.004s
-  jaq: tree-update         0.007s  0.007s  0.007s   0.007s  0.007s
+  jaq: kv-update           0.019s  0.018s  0.018s   0.018s  0.018s
+  jaq: kv-entries          0.056s  0.056s  0.055s   0.055s  0.056s
+  jaq: pyramid             0.016s  0.015s  0.016s   0.016s  0.016s
+  jaq: upto                0.007s  0.007s  0.007s   0.007s  0.007s
+  jaq: tree-flatten        0.003s  0.003s  0.003s   0.003s  0.003s
+  jaq: tree-update         0.007s  0.007s  0.007s   0.007s  0.222s
   jaq: to-fromjson         0.005s  0.005s  0.005s   0.005s  0.005s
-  jaq: str-slice           0.014s  0.013s  0.014s   0.014s  0.015s
+  jaq: str-slice           0.014s  0.013s  0.014s   0.014s  0.014s
 ```

--- a/docs/benchmark-history.md
+++ b/docs/benchmark-history.md
@@ -9,199 +9,199 @@ Recent slice (last 5 columns). Full history lives in
   Benchmark                v1.4.3  v1.4.4  3d440ca  v1.4.5  v1.5.0
   ---                      ------  ------  -------  ------  ------
   empty                    0.017s  0.017s  0.017s   0.017s  0.017s
-  identity -c              0.082s  0.082s  0.078s   0.081s  0.085s
-  identity (pretty)        0.108s  0.099s  0.101s   0.105s  0.111s
-  field access .name       0.080s  0.080s  0.087s   0.091s  0.097s
+  identity -c              0.082s  0.082s  0.078s   0.081s  0.082s
+  identity (pretty)        0.108s  0.099s  0.101s   0.105s  0.098s
+  field access .name       0.080s  0.080s  0.087s   0.091s  0.096s
   nested .x,.y,.name       0.111s  0.123s  0.144s   0.143s  0.150s
-  arithmetic .x + .y       0.064s  0.094s  0.082s   0.081s  0.084s
-  select .x > 1500000      0.066s  0.115s  0.069s   0.073s  0.082s
-  string concat            0.090s  0.089s  0.096s   0.096s  0.094s
-  object construct         0.087s  0.127s  0.112s   0.114s  0.116s
+  arithmetic .x + .y       0.064s  0.094s  0.082s   0.081s  0.083s
+  select .x > 1500000      0.066s  0.115s  0.069s   0.073s  0.081s
+  string concat            0.090s  0.089s  0.096s   0.096s  0.092s
+  object construct         0.087s  0.127s  0.112s   0.114s  0.113s
   array construct          0.097s  0.102s  0.116s   0.120s  0.106s
-  .[]                      0.085s  0.098s  0.100s   0.099s  0.101s
-  to_entries               0.104s  0.112s  0.161s   0.156s  0.162s
-  keys                     0.088s  0.102s  0.098s   0.101s  0.105s
-  keys_unsorted            0.078s  0.091s  0.094s   0.093s  0.094s
-  length                   0.073s  0.085s  0.080s   0.083s  0.088s
+  .[]                      0.085s  0.098s  0.100s   0.099s  0.103s
+  to_entries               0.104s  0.112s  0.161s   0.156s  0.164s
+  keys                     0.088s  0.102s  0.098s   0.101s  0.104s
+  keys_unsorted            0.078s  0.091s  0.094s   0.093s  0.095s
+  length                   0.073s  0.085s  0.080s   0.083s  0.087s
   has("x")                 0.030s  0.030s  0.029s   0.030s  0.036s
-  type                     0.019s  0.019s  0.022s   0.022s  0.023s
-  del(.name)               0.098s  0.095s  0.098s   0.099s  0.105s
-  @csv                     -       -       0.140s   0.137s  0.125s
-  split/join               -       -       0.093s   0.098s  0.092s
-  select|field             -       -       0.112s   0.112s  0.099s
-  select|remap             -       -       0.095s   0.096s  0.099s
-  computed remap           -       -       0.211s   0.214s  0.189s
-  [.x,.y]|add              -       -       0.082s   0.083s  0.085s
-  [.x,.y]|avg              -       -       0.110s   0.112s  0.110s
+  type                     0.019s  0.019s  0.022s   0.022s  0.022s
+  del(.name)               0.098s  0.095s  0.098s   0.099s  0.103s
+  @csv                     -       -       0.140s   0.137s  0.127s
+  split/join               -       -       0.093s   0.098s  0.091s
+  select|field             -       -       0.112s   0.112s  0.096s
+  select|remap             -       -       0.095s   0.096s  0.096s
+  computed remap           -       -       0.211s   0.214s  0.187s
+  [.x,.y]|add              -       -       0.082s   0.083s  0.084s
+  [.x,.y]|avg              -       -       0.110s   0.112s  0.108s
   map(*2)|add              -       -       0.110s   0.113s  0.104s
-  keys|length              -       -       0.254s   0.254s  0.252s
-  .+{z=0}                  -       -       0.143s   0.147s  0.147s
-  split|first              -       -       0.092s   0.098s  0.089s
-  slice[0..5]              -       -       0.095s   0.100s  0.094s
+  keys|length              -       -       0.254s   0.254s  0.254s
+  .+{z=0}                  -       -       0.143s   0.147s  0.151s
+  split|first              -       -       0.092s   0.098s  0.090s
+  slice[0..5]              -       -       0.095s   0.100s  0.093s
   dynkey {(.name)}         -       -       0.118s   0.121s  0.108s
-  .x += 1                  -       -       0.069s   0.070s  0.126s
-  {a}+{b} merge            -       -       0.143s   0.147s  0.130s
-  .x*2+1                   -       -       0.049s   0.050s  0.059s
-  .x+.y*2                  -       -       0.102s   0.105s  0.098s
-  .x > .y                  -       -       0.076s   0.077s  0.078s
+  .x += 1                  -       -       0.069s   0.070s  0.073s
+  {a}+{b} merge            -       -       0.143s   0.147s  0.132s
+  .x*2+1                   -       -       0.049s   0.050s  0.058s
+  .x+.y*2                  -       -       0.102s   0.105s  0.097s
+  .x > .y                  -       -       0.076s   0.077s  0.077s
   to_entries|len           -       -       0.397s   0.395s  0.398s
-  .x|.+1 (pipe)            -       -       0.047s   0.048s  0.056s
-  .x|.*2|.+1               -       -       0.049s   0.050s  0.060s
+  .x|.+1 (pipe)            -       -       0.047s   0.048s  0.058s
+  .x|.*2|.+1               -       -       0.049s   0.050s  0.058s
   .name|.+"_x"             -       -       0.098s   0.098s  0.093s
   .x>N | not               -       -       0.040s   0.041s  0.049s
-  and (2 cmp)              -       -       0.080s   0.080s  0.081s
-  if-then-else             -       -       0.043s   0.043s  0.052s
-  sel(and)|field           -       -       0.076s   0.076s  0.077s
-  sel(and)|remap           -       -       0.074s   0.076s  0.079s
-  arith|cmp                -       -       0.044s   0.047s  0.053s
-  if cmp .field            -       -       0.102s   0.107s  0.114s
+  and (2 cmp)              -       -       0.080s   0.080s  0.080s
+  if-then-else             -       -       0.043s   0.043s  0.051s
+  sel(and)|field           -       -       0.076s   0.076s  0.078s
+  sel(and)|remap           -       -       0.074s   0.076s  0.076s
+  arith|cmp                -       -       0.044s   0.047s  0.054s
+  if cmp .field            -       -       0.102s   0.107s  0.112s
   split|length             -       -       0.094s   0.099s  0.090s
   [x,y]|min                -       -       0.090s   0.092s  0.090s
-  [x,y]|max                -       -       0.091s   0.095s  0.093s
-  [x,y]|sort|.[0]          -       -       0.087s   0.090s  0.090s
-  .name|len>5              -       -       0.096s   0.100s  0.091s
-  sel(len>5)|.x            -       -       0.125s   0.127s  0.110s
-  if .x>.y .name           -       -       0.087s   0.090s  0.089s
+  [x,y]|max                -       -       0.091s   0.095s  0.095s
+  [x,y]|sort|.[0]          -       -       0.087s   0.090s  0.089s
+  .name|len>5              -       -       0.096s   0.100s  0.093s
+  sel(len>5)|.x            -       -       0.125s   0.127s  0.105s
+  if .x>.y .name           -       -       0.087s   0.090s  0.088s
   sel(.x>.y)|.name         -       -       0.071s   0.072s  0.073s
-  .x*2|tostring            -       -       0.047s   0.048s  0.055s
+  .x*2|tostring            -       -       0.047s   0.048s  0.056s
   .x*.x+1                  -       -       0.056s   0.057s  0.065s
-  {k=.name,v=tostr}        -       -       0.160s   0.162s  0.151s
-  str add chain            -       -       0.386s   0.398s  0.386s
-  if>.y .name|empty        -       -       0.071s   0.073s  0.074s
-  if .x%2==0               -       -       0.045s   0.047s  0.055s
-  if .x*2+1>1M             -       -       0.045s   0.048s  0.055s
-  sel(.x%2==0)|.name       -       -       0.074s   0.076s  0.082s
-  sel(.x*2+1>1M)           -       -       0.142s   0.144s  0.157s
-  .x|@json                 -       -       0.045s   0.045s  0.048s
+  {k=.name,v=tostr}        -       -       0.160s   0.162s  0.143s
+  str add chain            -       -       0.386s   0.398s  0.381s
+  if>.y .name|empty        -       -       0.071s   0.073s  0.073s
+  if .x%2==0               -       -       0.045s   0.047s  0.053s
+  if .x*2+1>1M             -       -       0.045s   0.048s  0.057s
+  sel(.x%2==0)|.name       -       -       0.074s   0.076s  0.085s
+  sel(.x*2+1>1M)           -       -       0.142s   0.144s  0.156s
+  .x|@json                 -       -       0.045s   0.045s  0.047s
   .x|@text                 -       -       0.045s   0.045s  0.048s
-  .name|@json              -       -       0.104s   0.107s  0.104s
-  sel|[arr]                -       -       0.148s   0.150s  0.142s
-  sel(and)|[arr]           -       -       0.076s   0.078s  0.078s
+  .name|@json              -       -       0.104s   0.107s  0.101s
+  sel|[arr]                -       -       0.148s   0.150s  0.143s
+  sel(and)|[arr]           -       -       0.076s   0.078s  0.079s
   if>.y [arr]              -       -       0.199s   0.199s  0.180s
-  if sw then .f            -       -       0.135s   0.138s  0.140s
-  dynkey {(.n)=.x*2}       -       -       0.131s   0.132s  0.117s
-  sel(and)|.x*.y           -       -       0.075s   0.077s  0.080s
-  sel>N|str chain          -       -       0.158s   0.158s  0.157s
-  .f+"_"+arith_ts          -       -       0.145s   0.148s  0.137s
-  sel(sw)|str ch           -       -       0.317s   0.310s  0.306s
+  if sw then .f            -       -       0.135s   0.138s  0.138s
+  dynkey {(.n)=.x*2}       -       -       0.131s   0.132s  0.112s
+  sel(and)|.x*.y           -       -       0.075s   0.077s  0.077s
+  sel>N|str chain          -       -       0.158s   0.158s  0.154s
+  .f+"_"+arith_ts          -       -       0.145s   0.148s  0.130s
+  sel(sw)|str ch           -       -       0.317s   0.310s  0.302s
   split|rev|join           -       -       0.123s   0.122s  0.114s
-  dynkey+static            -       -       0.324s   0.331s  0.333s
-  if>.y str chain          -       -       0.186s   0.189s  0.171s
-  remap+str chain          -       -       0.171s   0.178s  0.153s
-  sel(len>8)               -       -       0.163s   0.170s  0.160s
-  up|split|join            -       -       0.101s   0.104s  0.099s
-  .name|index              -       -       0.126s   0.128s  0.122s
-  .name|index+1            -       -       0.127s   0.133s  0.125s
-  .name|rindex             -       -       0.131s   0.134s  0.128s
-  .name|indices            -       -       0.153s   0.160s  0.156s
-  [x,y]|sort               -       -       0.154s   0.156s  0.152s
-  .name|scan               -       -       0.218s   0.219s  0.206s
-  .name|gsub               -       -       0.175s   0.178s  0.167s
-  walk(if num .+1)         -       -       0.140s   0.141s  0.139s
-  tojson                   -       -       0.106s   0.110s  0.106s
+  dynkey+static            -       -       0.324s   0.331s  0.332s
+  if>.y str chain          -       -       0.186s   0.189s  0.167s
+  remap+str chain          -       -       0.171s   0.178s  0.155s
+  sel(len>8)               -       -       0.163s   0.170s  0.161s
+  up|split|join            -       -       0.101s   0.104s  0.096s
+  .name|index              -       -       0.126s   0.128s  0.119s
+  .name|index+1            -       -       0.127s   0.133s  0.130s
+  .name|rindex             -       -       0.131s   0.134s  0.124s
+  .name|indices            -       -       0.153s   0.160s  0.152s
+  [x,y]|sort               -       -       0.154s   0.156s  0.154s
+  .name|scan               -       -       0.218s   0.219s  0.216s
+  .name|gsub               -       -       0.175s   0.178s  0.169s
+  walk(if num .+1)         -       -       0.140s   0.141s  0.143s
+  tojson                   -       -       0.106s   0.110s  0.107s
   {name,x}                 -       -       0.144s   0.144s  0.128s
-  .z//.name                -       -       0.165s   0.164s  0.153s
-  .x|=test(re)             -       -       0.123s   0.124s  0.178s
-  ./sep|first              -       -       0.131s   0.132s  0.187s
-  .y=(.x*2)                -       -       0.112s   0.115s  0.178s
-  .y=(.x+.y)               -       -       0.161s   0.159s  0.228s
-  objects                  -       -       0.081s   0.085s  0.133s
-  .tag|=if..then N         -       -       0.613s   0.614s  0.598s
-  .x=(.x+1)                -       -       0.070s   0.072s  0.128s
-  sel>N|.y+=1              -       -       0.085s   0.087s  0.120s
+  .z//.name                -       -       0.165s   0.164s  0.158s
+  .x|=test(re)             -       -       0.123s   0.124s  0.121s
+  ./sep|first              -       -       0.131s   0.132s  0.129s
+  .y=(.x*2)                -       -       0.112s   0.115s  0.125s
+  .y=(.x+.y)               -       -       0.161s   0.159s  0.172s
+  objects                  -       -       0.081s   0.085s  0.088s
+  .tag|=if..then N         -       -       0.613s   0.614s  0.625s
+  .x=(.x+1)                -       -       0.070s   0.072s  0.072s
+  sel>N|.y+=1              -       -       0.085s   0.087s  0.094s
   sel(and)|.x+=1           -       -       0.100s   0.102s  0.111s
-  sel(sw)|.x+=1            -       -       0.132s   0.133s  0.161s
-  match(re)                -       -       0.369s   0.367s  0.362s
-  capture(re)              -       -       0.306s   0.303s  0.298s
-  first(.name,.x)          -       -       0.090s   0.093s  0.102s
-  if .x==null              -       -       0.043s   0.044s  0.046s
-  we(sw(.key))             -       -       0.111s   0.111s  0.109s
-  sel(sw or ew)            -       -       0.211s   0.214s  0.206s
-  path(.name,.x)           -       -       0.276s   0.277s  0.273s
-  sel(str+num+num)         -       -       0.142s   0.145s  0.153s
-  nested if|field          -       -       0.076s   0.077s  0.078s
+  sel(sw)|.x+=1            -       -       0.132s   0.133s  0.132s
+  match(re)                -       -       0.369s   0.367s  0.367s
+  capture(re)              -       -       0.306s   0.303s  0.307s
+  first(.name,.x)          -       -       0.090s   0.093s  0.097s
+  if .x==null              -       -       0.043s   0.044s  0.047s
+  we(sw(.key))             -       -       0.111s   0.111s  0.112s
+  sel(sw or ew)            -       -       0.211s   0.214s  0.211s
+  path(.name,.x)           -       -       0.276s   0.277s  0.277s
+  sel(str+num+num)         -       -       0.142s   0.145s  0.154s
+  nested if|field          -       -       0.076s   0.077s  0.077s
   .f|floor|.*2             -       -       0.050s   0.051s  0.060s
   split|len>1              -       -       0.122s   0.124s  0.117s
-  .name|len|.*2            -       -       0.106s   0.107s  0.101s
-  if len>5 .x .y           -       -       0.137s   0.133s  0.114s
-  sel(len>5)|remap         -       -       0.230s   0.233s  0.207s
-  .x|tostr|len             -       -       0.056s   0.056s  0.059s
-  if .x>.y .x .y           -       -       0.093s   0.094s  0.093s
-  split|last|tonum         -       -       0.100s   0.104s  0.097s
-  split|rev|.[0]           -       -       0.097s   0.099s  0.092s
+  .name|len|.*2            -       -       0.106s   0.107s  0.102s
+  if len>5 .x .y           -       -       0.137s   0.133s  0.117s
+  sel(len>5)|remap         -       -       0.230s   0.233s  0.200s
+  .x|tostr|len             -       -       0.056s   0.056s  0.060s
+  if .x>.y .x .y           -       -       0.093s   0.094s  0.094s
+  split|last|tonum         -       -       0.100s   0.104s  0.096s
+  split|rev|.[0]           -       -       0.097s   0.099s  0.093s
   split|.[0]+.[1]          -       -       0.122s   0.123s  0.113s
-  .[]|strings              -       -       0.096s   0.095s  0.107s
-  .[]|numbers              -       -       0.107s   0.106s  0.126s
+  .[]|strings              -       -       0.096s   0.095s  0.095s
+  .[]|numbers              -       -       0.107s   0.106s  0.106s
   [x,y]|any(>1M)           -       -       0.082s   0.082s  0.084s
-  sel(dc|sw)               -       -       0.104s   0.107s  0.096s
-  [[x,y],[n]]|flat         -       -       0.475s   0.475s  0.456s
-  .x|floor|.*2             -       -       0.051s   0.051s  0.059s
-  tojson|fromjson          -       -       0.083s   0.081s  0.087s
-  [.x]|add                 -       -       0.048s   0.048s  0.059s
-  if>N {o}+.               -       -       0.123s   0.125s  0.133s
-  if>N .+{o}               -       -       0.124s   0.125s  0.134s
-  if .n=="s" .+{o}         -       -       0.167s   0.161s  0.164s
+  sel(dc|sw)               -       -       0.104s   0.107s  0.098s
+  [[x,y],[n]]|flat         -       -       0.475s   0.475s  0.452s
+  .x|floor|.*2             -       -       0.051s   0.051s  0.061s
+  tojson|fromjson          -       -       0.083s   0.081s  0.088s
+  [.x]|add                 -       -       0.048s   0.048s  0.060s
+  if>N {o}+.               -       -       0.123s   0.125s  0.145s
+  if>N .+{o}               -       -       0.124s   0.125s  0.136s
+  if .n=="s" .+{o}         -       -       0.167s   0.161s  0.162s
   sel(.n>"s")              -       -       0.095s   0.094s  0.089s
   [x,y,z]|min              -       -       0.311s   0.312s  0.303s
   if .n|len>5 l s          -       -       0.107s   0.106s  0.102s
-  if .x|flr>N b s          -       -       0.047s   0.045s  0.054s
-  if .n|test l e           -       -       0.111s   0.112s  0.107s
-  if .n|sw l e             -       -       0.090s   0.091s  0.085s
-  if .n|ew l e             -       -       0.092s   0.091s  0.086s
-  .n|len|tostr             -       -       0.097s   0.099s  0.093s
+  if .x|flr>N b s          -       -       0.047s   0.045s  0.057s
+  if .n|test l e           -       -       0.111s   0.112s  0.105s
+  if .n|sw l e             -       -       0.090s   0.091s  0.083s
+  if .n|ew l e             -       -       0.092s   0.091s  0.084s
+  .n|len|tostr             -       -       0.097s   0.099s  0.092s
 
 --- String operations (2M objects) ---
   Benchmark                v1.4.3  v1.4.4  3d440ca  v1.4.5  v1.5.0
   ---                      ------  ------  -------  ------  ------
-  ascii_downcase           0.090s  0.088s  0.110s   0.112s  0.105s
-  ascii_upcase             0.090s  0.088s  0.108s   0.109s  0.103s
-  ltrimstr                 0.090s  0.090s  0.101s   0.102s  0.098s
-  rtrimstr                 0.089s  0.090s  0.105s   0.107s  0.099s
-  split                    0.150s  0.151s  0.169s   0.172s  0.166s
-  case+split               0.117s  0.116s  0.126s   0.128s  0.116s
-  join                     0.087s  0.092s  0.101s   0.104s  0.095s
-  startswith               0.084s  0.086s  0.101s   0.103s  0.096s
+  ascii_downcase           0.090s  0.088s  0.110s   0.112s  0.104s
+  ascii_upcase             0.090s  0.088s  0.108s   0.109s  0.102s
+  ltrimstr                 0.090s  0.090s  0.101s   0.102s  0.096s
+  rtrimstr                 0.089s  0.090s  0.105s   0.107s  0.098s
+  split                    0.150s  0.151s  0.169s   0.172s  0.169s
+  case+split               0.117s  0.116s  0.126s   0.128s  0.115s
+  join                     0.087s  0.092s  0.101s   0.104s  0.094s
+  startswith               0.084s  0.086s  0.101s   0.103s  0.095s
   endswith                 0.085s  0.088s  0.103s   0.104s  0.098s
   tostring                 0.043s  0.095s  0.052s   0.053s  0.061s
-  tonumber                 0.108s  0.104s  0.117s   0.117s  0.114s
-  string interpolation     0.104s  0.106s  0.135s   0.134s  0.121s
+  tonumber                 0.108s  0.104s  0.117s   0.117s  0.111s
+  string interpolation     0.104s  0.106s  0.135s   0.134s  0.119s
 
 --- String ops (200K objects) ---
   Benchmark                v1.4.3  v1.4.4  3d440ca  v1.4.5  v1.5.0
   ---                      ------  ------  -------  ------  ------
-  test (regex)             0.013s  0.013s  0.014s   0.014s  0.015s
-  match (regex)            0.031s  0.032s  0.033s   0.033s  0.033s
+  test (regex)             0.013s  0.013s  0.014s   0.014s  0.014s
+  match (regex)            0.031s  0.032s  0.033s   0.033s  0.031s
   @base64                  0.011s  0.011s  0.013s   0.012s  0.012s
   @uri                     0.011s  0.011s  0.013s   0.013s  0.012s
   @html                    0.012s  0.011s  0.013s   0.013s  0.012s
   @csv (array)             0.013s  0.014s  0.020s   0.018s  0.016s
-  @tsv (array)             0.013s  0.014s  0.018s   0.017s  0.015s
-  gsub                     0.018s  0.018s  0.020s   0.020s  0.018s
-  case+gsub                0.181s  0.180s  0.193s   0.193s  0.178s
-  case+test                0.116s  0.115s  0.130s   0.130s  0.122s
-  ltrim+tonum+arith        0.107s  0.107s  0.118s   0.118s  0.114s
+  @tsv (array)             0.013s  0.014s  0.018s   0.017s  0.016s
+  gsub                     0.018s  0.018s  0.020s   0.020s  0.019s
+  case+gsub                0.181s  0.180s  0.193s   0.193s  0.181s
+  case+test                0.116s  0.115s  0.130s   0.130s  0.121s
+  ltrim+tonum+arith        0.107s  0.107s  0.118s   0.118s  0.110s
 
 --- Numeric & math (2M objects) ---
   Benchmark                v1.4.3  v1.4.4  3d440ca  v1.4.5  v1.5.0
   ---                      ------  ------  -------  ------  ------
-  floor                    0.042s  0.091s  0.048s   0.048s  0.056s
-  sqrt                     0.072s  0.115s  0.078s   0.078s  0.078s
-  modulo                   0.045s  0.095s  0.051s   0.051s  0.057s
-  if-elif-else             0.102s  0.134s  0.125s   0.124s  0.124s
-  select|del               0.073s  0.126s  0.079s   0.079s  0.091s
-  select|merge             0.105s  0.157s  0.110s   0.107s  0.117s
-  select(test)|merge       0.022s  0.021s  0.022s   0.022s  0.021s
+  floor                    0.042s  0.091s  0.048s   0.048s  0.057s
+  sqrt                     0.072s  0.115s  0.078s   0.078s  0.079s
+  modulo                   0.045s  0.095s  0.051s   0.051s  0.059s
+  if-elif-else             0.102s  0.134s  0.125s   0.124s  0.127s
+  select|del               0.073s  0.126s  0.079s   0.079s  0.095s
+  select|merge             0.105s  0.157s  0.110s   0.107s  0.120s
+  select(test)|merge       0.022s  0.021s  0.022s   0.022s  0.022s
 
 --- Array generators ---
   Benchmark                v1.4.3  v1.4.4  3d440ca  v1.4.5  v1.5.0
   ---                      ------  ------  -------  ------  ------
   range(2M) | length       0.011s  0.011s  0.011s   0.011s  0.011s
-  reverse(2M)              0.017s  0.017s  0.018s   0.017s  0.018s
+  reverse(2M)              0.017s  0.017s  0.018s   0.017s  0.017s
   sort(2M)                 0.022s  0.022s  0.023s   0.023s  0.023s
-  unique(1M)               0.028s  0.028s  0.029s   0.029s  0.030s
-  flatten(500K)            0.010s  0.010s  0.010s   0.010s  0.011s
-  min, max(2M)             0.017s  0.018s  0.017s   0.017s  0.019s
-  add numbers(2M)          0.012s  0.012s  0.012s   0.012s  0.013s
+  unique(1M)               0.028s  0.028s  0.029s   0.029s  0.029s
+  flatten(500K)            0.010s  0.010s  0.010s   0.010s  0.010s
+  min, max(2M)             0.017s  0.018s  0.017s   0.017s  0.018s
+  add numbers(2M)          0.012s  0.012s  0.012s   0.012s  0.012s
   any/all(2M)              0.028s  0.027s  0.028s   0.027s  0.028s
   limit(10; range(10M))    0.002s  0.002s  0.002s   0.002s  0.002s
   first(range(10M))        0.002s  0.002s  0.002s   0.002s  0.002s
@@ -211,57 +211,57 @@ Recent slice (last 5 columns). Full history lives in
 --- Reduce & foreach ---
   Benchmark                v1.4.3  v1.4.4  3d440ca  v1.4.5  v1.5.0
   ---                      ------  ------  -------  ------  ------
-  reduce (sum)             0.009s  0.009s  0.009s   0.009s  0.009s
-  reduce (array build)     0.004s  0.004s  0.004s   0.004s  0.004s
-  reduce (obj build)       0.010s  0.010s  0.010s   0.009s  0.009s
+  reduce (sum)             0.009s  0.009s  0.009s   0.009s  0.010s
+  reduce (array build)     0.004s  0.004s  0.004s   0.004s  0.005s
+  reduce (obj build)       0.010s  0.010s  0.010s   0.009s  0.010s
   reduce (setpath)         0.016s  0.016s  0.016s   0.017s  0.017s
   foreach (running sum)    0.010s  0.010s  0.010s   0.010s  0.010s
   foreach + emit           0.010s  0.010s  0.010s   0.010s  0.011s
-  reduce (sum-of-squares)  0.032s  0.032s  0.032s   0.032s  0.033s
+  reduce (sum-of-squares)  0.032s  0.032s  0.032s   0.032s  0.035s
   reduce (conditional)     0.034s  0.034s  0.035s   0.035s  0.036s
-  reduce (product)         0.034s  0.034s  0.035s   0.034s  0.035s
+  reduce (product)         0.034s  0.034s  0.035s   0.034s  0.034s
   foreach (conditional)    0.010s  0.010s  0.011s   0.010s  0.011s
-  until (100M)             0.295s  0.294s  0.297s   0.295s  0.301s
-  reduce (harmonic)        0.032s  0.032s  0.033s   0.033s  0.034s
+  until (100M)             0.295s  0.294s  0.297s   0.295s  0.304s
+  reduce (harmonic)        0.032s  0.032s  0.033s   0.033s  0.033s
   reduce (floor pipe)      0.032s  0.032s  0.033s   0.033s  0.034s
-  reduce (sqrt pipe)       0.032s  0.032s  0.032s   0.032s  0.033s
-  reduce (sin+cos)         0.052s  0.052s  0.052s   0.052s  0.052s
+  reduce (sqrt pipe)       0.032s  0.032s  0.032s   0.032s  0.034s
+  reduce (sin+cos)         0.052s  0.052s  0.052s   0.052s  0.053s
 
 --- Object operations ---
   Benchmark                v1.4.3  v1.4.4  3d440ca  v1.4.5  v1.5.0
   ---                      ------  ------  -------  ------  ------
   large obj construct      0.004s  0.004s  0.004s   0.004s  0.004s
-  large obj keys           0.011s  0.010s  0.011s   0.011s  0.011s
-  large obj to_entries     0.011s  0.012s  0.012s   0.012s  0.012s
-  with_entries             0.009s  0.009s  0.009s   0.009s  0.009s
+  large obj keys           0.011s  0.010s  0.011s   0.011s  0.012s
+  large obj to_entries     0.011s  0.012s  0.012s   0.012s  0.014s
+  with_entries             0.009s  0.009s  0.009s   0.009s  0.010s
 
 --- Assignment operators ---
   Benchmark                v1.4.3  v1.4.4  3d440ca  v1.4.5  v1.5.0
   ---                      ------  ------  -------  ------  ------
-  .[] |= f (100K)          0.005s  0.005s  0.005s   0.005s  0.005s
-  .[] += 1 (100K)          0.005s  0.005s  0.005s   0.005s  0.005s
-  .[k] = v reduce(50K)     0.008s  0.008s  0.008s   0.008s  0.008s
+  .[] |= f (100K)          0.005s  0.005s  0.005s   0.005s  0.006s
+  .[] += 1 (100K)          0.005s  0.005s  0.005s   0.005s  0.006s
+  .[k] = v reduce(50K)     0.008s  0.008s  0.008s   0.008s  0.009s
 
 --- String-heavy generators ---
   Benchmark                v1.4.3  v1.4.4  3d440ca  v1.4.5  v1.5.0
   ---                      ------  ------  -------  ------  ------
-  gsub(100K)               0.025s  0.025s  0.025s   0.025s  0.026s
-  join large(100K)         0.006s  0.005s  0.006s   0.005s  0.005s
-  explode/implode(100K)    0.029s  0.028s  0.029s   0.028s  0.027s
+  gsub(100K)               0.025s  0.025s  0.025s   0.025s  0.027s
+  join large(100K)         0.006s  0.005s  0.006s   0.005s  0.006s
+  explode/implode(100K)    0.029s  0.028s  0.029s   0.028s  0.028s
   reduce str concat(100K)  0.008s  0.008s  0.008s   0.008s  0.008s
 
 --- Try-catch & alternative ---
   Benchmark                v1.4.3  v1.4.4  3d440ca  v1.4.5  v1.5.0
   ---                      ------  ------  -------  ------  ------
   alternative //           0.031s  0.031s  0.032s   0.032s  0.033s
-  try-catch                0.023s  0.023s  0.023s   0.023s  0.023s
+  try-catch                0.023s  0.023s  0.023s   0.023s  0.024s
   label-break              0.004s  0.004s  0.004s   0.004s  0.004s
 
 --- Type conversion ---
   Benchmark                v1.4.3  v1.4.4  3d440ca  v1.4.5  v1.5.0
   ---                      ------  ------  -------  ------  ------
-  tojson/fromjson(100K)    0.021s  0.021s  0.022s   0.022s  0.022s
-  null propagation(2M)     0.089s  0.090s  0.088s   0.087s  0.090s
+  tojson/fromjson(100K)    0.021s  0.021s  0.022s   0.022s  0.023s
+  null propagation(2M)     0.089s  0.090s  0.088s   0.087s  0.088s
 
 --- jaq-derived ---
   Benchmark                v1.4.3  v1.4.4  3d440ca  v1.4.5  v1.5.0
@@ -269,24 +269,24 @@ Recent slice (last 5 columns). Full history lives in
   jaq: reverse             0.010s  0.011s  0.011s   0.010s  0.011s
   jaq: sort                0.018s  0.018s  0.018s   0.017s  0.018s
   jaq: group-by            0.034s  0.035s  0.037s   0.037s  0.038s
-  jaq: min-max             0.010s  0.010s  0.011s   0.010s  0.010s
-  jaq: ex-implode          0.019s  0.019s  0.019s   0.019s  0.019s
+  jaq: min-max             0.010s  0.010s  0.011s   0.010s  0.012s
+  jaq: ex-implode          0.019s  0.019s  0.019s   0.019s  0.020s
   jaq: repeat              0.011s  0.011s  0.011s   0.011s  0.012s
   jaq: from                0.006s  0.006s  0.006s   0.006s  0.006s
   jaq: last                0.002s  0.002s  0.002s   0.002s  0.002s
-  jaq: cumsum              0.010s  0.012s  0.010s   0.010s  0.010s
-  jaq: cumsum-xy           0.016s  0.018s  0.017s   0.017s  0.017s
-  jaq: try-catch           0.084s  0.088s  0.083s   0.090s  0.079s
+  jaq: cumsum              0.010s  0.012s  0.010s   0.010s  0.011s
+  jaq: cumsum-xy           0.016s  0.018s  0.017s   0.017s  0.018s
+  jaq: try-catch           0.084s  0.088s  0.083s   0.090s  0.078s
   jaq: add                 0.039s  0.042s  0.040s   0.040s  0.041s
-  jaq: reduce              0.084s  0.094s  0.081s   0.086s  0.078s
-  jaq: reduce-update       0.005s  0.005s  0.005s   0.005s  0.005s
+  jaq: reduce              0.084s  0.094s  0.081s   0.086s  0.086s
+  jaq: reduce-update       0.005s  0.005s  0.005s   0.005s  0.006s
   jaq: kv                  0.014s  0.014s  0.015s   0.014s  0.015s
   jaq: kv-update           0.019s  0.018s  0.018s   0.018s  0.019s
-  jaq: kv-entries          0.056s  0.056s  0.055s   0.055s  0.057s
-  jaq: pyramid             0.016s  0.015s  0.016s   0.016s  0.016s
-  jaq: upto                0.007s  0.007s  0.007s   0.007s  0.007s
-  jaq: tree-flatten        0.003s  0.003s  0.003s   0.003s  0.003s
-  jaq: tree-update         0.007s  0.007s  0.007s   0.007s  0.225s
+  jaq: kv-entries          0.056s  0.056s  0.055s   0.055s  0.059s
+  jaq: pyramid             0.016s  0.015s  0.016s   0.016s  0.017s
+  jaq: upto                0.007s  0.007s  0.007s   0.007s  0.009s
+  jaq: tree-flatten        0.003s  0.003s  0.003s   0.003s  0.004s
+  jaq: tree-update         0.007s  0.007s  0.007s   0.007s  0.007s
   jaq: to-fromjson         0.005s  0.005s  0.005s   0.005s  0.005s
-  jaq: str-slice           0.014s  0.013s  0.014s   0.014s  0.014s
+  jaq: str-slice           0.014s  0.013s  0.014s   0.014s  0.015s
 ```

--- a/docs/benchmark-history.tsv
+++ b/docs/benchmark-history.tsv
@@ -2526,239 +2526,239 @@ jaq-derived	jaq: tree-update	v1.4.5	0.007
 jaq-derived	jaq: to-fromjson	v1.4.5	0.005
 jaq-derived	jaq: str-slice	v1.4.5	0.014
 NDJSON workloads (2M objects)	empty	v1.5.0	0.017
-NDJSON workloads (2M objects)	identity -c	v1.5.0	0.085
-NDJSON workloads (2M objects)	identity (pretty)	v1.5.0	0.111
-NDJSON workloads (2M objects)	field access .name	v1.5.0	0.097
+NDJSON workloads (2M objects)	identity -c	v1.5.0	0.082
+NDJSON workloads (2M objects)	identity (pretty)	v1.5.0	0.098
+NDJSON workloads (2M objects)	field access .name	v1.5.0	0.096
 NDJSON workloads (2M objects)	nested .x,.y,.name	v1.5.0	0.150
-NDJSON workloads (2M objects)	arithmetic .x + .y	v1.5.0	0.084
-NDJSON workloads (2M objects)	select .x > 1500000	v1.5.0	0.082
-NDJSON workloads (2M objects)	string concat	v1.5.0	0.094
-NDJSON workloads (2M objects)	object construct	v1.5.0	0.116
+NDJSON workloads (2M objects)	arithmetic .x + .y	v1.5.0	0.083
+NDJSON workloads (2M objects)	select .x > 1500000	v1.5.0	0.081
+NDJSON workloads (2M objects)	string concat	v1.5.0	0.092
+NDJSON workloads (2M objects)	object construct	v1.5.0	0.113
 NDJSON workloads (2M objects)	array construct	v1.5.0	0.106
-NDJSON workloads (2M objects)	.[]	v1.5.0	0.101
-NDJSON workloads (2M objects)	to_entries	v1.5.0	0.162
-NDJSON workloads (2M objects)	keys	v1.5.0	0.105
-NDJSON workloads (2M objects)	keys_unsorted	v1.5.0	0.094
-NDJSON workloads (2M objects)	length	v1.5.0	0.088
+NDJSON workloads (2M objects)	.[]	v1.5.0	0.103
+NDJSON workloads (2M objects)	to_entries	v1.5.0	0.164
+NDJSON workloads (2M objects)	keys	v1.5.0	0.104
+NDJSON workloads (2M objects)	keys_unsorted	v1.5.0	0.095
+NDJSON workloads (2M objects)	length	v1.5.0	0.087
 NDJSON workloads (2M objects)	has("x")	v1.5.0	0.036
-NDJSON workloads (2M objects)	type	v1.5.0	0.023
-NDJSON workloads (2M objects)	del(.name)	v1.5.0	0.105
-NDJSON workloads (2M objects)	@csv	v1.5.0	0.125
-NDJSON workloads (2M objects)	split/join	v1.5.0	0.092
-NDJSON workloads (2M objects)	select|field	v1.5.0	0.099
-NDJSON workloads (2M objects)	select|remap	v1.5.0	0.099
-NDJSON workloads (2M objects)	computed remap	v1.5.0	0.189
-NDJSON workloads (2M objects)	[.x,.y]|add	v1.5.0	0.085
-NDJSON workloads (2M objects)	[.x,.y]|avg	v1.5.0	0.110
+NDJSON workloads (2M objects)	type	v1.5.0	0.022
+NDJSON workloads (2M objects)	del(.name)	v1.5.0	0.103
+NDJSON workloads (2M objects)	@csv	v1.5.0	0.127
+NDJSON workloads (2M objects)	split/join	v1.5.0	0.091
+NDJSON workloads (2M objects)	select|field	v1.5.0	0.096
+NDJSON workloads (2M objects)	select|remap	v1.5.0	0.096
+NDJSON workloads (2M objects)	computed remap	v1.5.0	0.187
+NDJSON workloads (2M objects)	[.x,.y]|add	v1.5.0	0.084
+NDJSON workloads (2M objects)	[.x,.y]|avg	v1.5.0	0.108
 NDJSON workloads (2M objects)	map(*2)|add	v1.5.0	0.104
-NDJSON workloads (2M objects)	keys|length	v1.5.0	0.252
-NDJSON workloads (2M objects)	.+{z=0}	v1.5.0	0.147
-NDJSON workloads (2M objects)	split|first	v1.5.0	0.089
-NDJSON workloads (2M objects)	slice[0..5]	v1.5.0	0.094
+NDJSON workloads (2M objects)	keys|length	v1.5.0	0.254
+NDJSON workloads (2M objects)	.+{z=0}	v1.5.0	0.151
+NDJSON workloads (2M objects)	split|first	v1.5.0	0.090
+NDJSON workloads (2M objects)	slice[0..5]	v1.5.0	0.093
 NDJSON workloads (2M objects)	dynkey {(.name)}	v1.5.0	0.108
-NDJSON workloads (2M objects)	.x += 1	v1.5.0	0.126
-NDJSON workloads (2M objects)	{a}+{b} merge	v1.5.0	0.130
-NDJSON workloads (2M objects)	.x*2+1	v1.5.0	0.059
-NDJSON workloads (2M objects)	.x+.y*2	v1.5.0	0.098
-NDJSON workloads (2M objects)	.x > .y	v1.5.0	0.078
+NDJSON workloads (2M objects)	.x += 1	v1.5.0	0.073
+NDJSON workloads (2M objects)	{a}+{b} merge	v1.5.0	0.132
+NDJSON workloads (2M objects)	.x*2+1	v1.5.0	0.058
+NDJSON workloads (2M objects)	.x+.y*2	v1.5.0	0.097
+NDJSON workloads (2M objects)	.x > .y	v1.5.0	0.077
 NDJSON workloads (2M objects)	to_entries|len	v1.5.0	0.398
-NDJSON workloads (2M objects)	.x|.+1 (pipe)	v1.5.0	0.056
-NDJSON workloads (2M objects)	.x|.*2|.+1	v1.5.0	0.060
+NDJSON workloads (2M objects)	.x|.+1 (pipe)	v1.5.0	0.058
+NDJSON workloads (2M objects)	.x|.*2|.+1	v1.5.0	0.058
 NDJSON workloads (2M objects)	.name|.+"_x"	v1.5.0	0.093
 NDJSON workloads (2M objects)	.x>N | not	v1.5.0	0.049
-NDJSON workloads (2M objects)	and (2 cmp)	v1.5.0	0.081
-NDJSON workloads (2M objects)	if-then-else	v1.5.0	0.052
-NDJSON workloads (2M objects)	sel(and)|field	v1.5.0	0.077
-NDJSON workloads (2M objects)	sel(and)|remap	v1.5.0	0.079
-NDJSON workloads (2M objects)	arith|cmp	v1.5.0	0.053
-NDJSON workloads (2M objects)	if cmp .field	v1.5.0	0.114
+NDJSON workloads (2M objects)	and (2 cmp)	v1.5.0	0.080
+NDJSON workloads (2M objects)	if-then-else	v1.5.0	0.051
+NDJSON workloads (2M objects)	sel(and)|field	v1.5.0	0.078
+NDJSON workloads (2M objects)	sel(and)|remap	v1.5.0	0.076
+NDJSON workloads (2M objects)	arith|cmp	v1.5.0	0.054
+NDJSON workloads (2M objects)	if cmp .field	v1.5.0	0.112
 NDJSON workloads (2M objects)	split|length	v1.5.0	0.090
 NDJSON workloads (2M objects)	[x,y]|min	v1.5.0	0.090
-NDJSON workloads (2M objects)	[x,y]|max	v1.5.0	0.093
-NDJSON workloads (2M objects)	[x,y]|sort|.[0]	v1.5.0	0.090
-NDJSON workloads (2M objects)	.name|len>5	v1.5.0	0.091
-NDJSON workloads (2M objects)	sel(len>5)|.x	v1.5.0	0.110
-NDJSON workloads (2M objects)	if .x>.y .name	v1.5.0	0.089
+NDJSON workloads (2M objects)	[x,y]|max	v1.5.0	0.095
+NDJSON workloads (2M objects)	[x,y]|sort|.[0]	v1.5.0	0.089
+NDJSON workloads (2M objects)	.name|len>5	v1.5.0	0.093
+NDJSON workloads (2M objects)	sel(len>5)|.x	v1.5.0	0.105
+NDJSON workloads (2M objects)	if .x>.y .name	v1.5.0	0.088
 NDJSON workloads (2M objects)	sel(.x>.y)|.name	v1.5.0	0.073
-NDJSON workloads (2M objects)	.x*2|tostring	v1.5.0	0.055
+NDJSON workloads (2M objects)	.x*2|tostring	v1.5.0	0.056
 NDJSON workloads (2M objects)	.x*.x+1	v1.5.0	0.065
-NDJSON workloads (2M objects)	{k=.name,v=tostr}	v1.5.0	0.151
-NDJSON workloads (2M objects)	str add chain	v1.5.0	0.386
-NDJSON workloads (2M objects)	if>.y .name|empty	v1.5.0	0.074
-NDJSON workloads (2M objects)	if .x%2==0	v1.5.0	0.055
-NDJSON workloads (2M objects)	if .x*2+1>1M	v1.5.0	0.055
-NDJSON workloads (2M objects)	sel(.x%2==0)|.name	v1.5.0	0.082
-NDJSON workloads (2M objects)	sel(.x*2+1>1M)	v1.5.0	0.157
-NDJSON workloads (2M objects)	.x|@json	v1.5.0	0.048
+NDJSON workloads (2M objects)	{k=.name,v=tostr}	v1.5.0	0.143
+NDJSON workloads (2M objects)	str add chain	v1.5.0	0.381
+NDJSON workloads (2M objects)	if>.y .name|empty	v1.5.0	0.073
+NDJSON workloads (2M objects)	if .x%2==0	v1.5.0	0.053
+NDJSON workloads (2M objects)	if .x*2+1>1M	v1.5.0	0.057
+NDJSON workloads (2M objects)	sel(.x%2==0)|.name	v1.5.0	0.085
+NDJSON workloads (2M objects)	sel(.x*2+1>1M)	v1.5.0	0.156
+NDJSON workloads (2M objects)	.x|@json	v1.5.0	0.047
 NDJSON workloads (2M objects)	.x|@text	v1.5.0	0.048
-NDJSON workloads (2M objects)	.name|@json	v1.5.0	0.104
-NDJSON workloads (2M objects)	sel|[arr]	v1.5.0	0.142
-NDJSON workloads (2M objects)	sel(and)|[arr]	v1.5.0	0.078
+NDJSON workloads (2M objects)	.name|@json	v1.5.0	0.101
+NDJSON workloads (2M objects)	sel|[arr]	v1.5.0	0.143
+NDJSON workloads (2M objects)	sel(and)|[arr]	v1.5.0	0.079
 NDJSON workloads (2M objects)	if>.y [arr]	v1.5.0	0.180
-NDJSON workloads (2M objects)	if sw then .f	v1.5.0	0.140
-NDJSON workloads (2M objects)	dynkey {(.n)=.x*2}	v1.5.0	0.117
-NDJSON workloads (2M objects)	sel(and)|.x*.y	v1.5.0	0.080
-NDJSON workloads (2M objects)	sel>N|str chain	v1.5.0	0.157
-NDJSON workloads (2M objects)	.f+"_"+arith_ts	v1.5.0	0.137
-NDJSON workloads (2M objects)	sel(sw)|str ch	v1.5.0	0.306
+NDJSON workloads (2M objects)	if sw then .f	v1.5.0	0.138
+NDJSON workloads (2M objects)	dynkey {(.n)=.x*2}	v1.5.0	0.112
+NDJSON workloads (2M objects)	sel(and)|.x*.y	v1.5.0	0.077
+NDJSON workloads (2M objects)	sel>N|str chain	v1.5.0	0.154
+NDJSON workloads (2M objects)	.f+"_"+arith_ts	v1.5.0	0.130
+NDJSON workloads (2M objects)	sel(sw)|str ch	v1.5.0	0.302
 NDJSON workloads (2M objects)	split|rev|join	v1.5.0	0.114
-NDJSON workloads (2M objects)	dynkey+static	v1.5.0	0.333
-NDJSON workloads (2M objects)	if>.y str chain	v1.5.0	0.171
-NDJSON workloads (2M objects)	remap+str chain	v1.5.0	0.153
-NDJSON workloads (2M objects)	sel(len>8)	v1.5.0	0.160
-NDJSON workloads (2M objects)	up|split|join	v1.5.0	0.099
-NDJSON workloads (2M objects)	.name|index	v1.5.0	0.122
-NDJSON workloads (2M objects)	.name|index+1	v1.5.0	0.125
-NDJSON workloads (2M objects)	.name|rindex	v1.5.0	0.128
-NDJSON workloads (2M objects)	.name|indices	v1.5.0	0.156
-NDJSON workloads (2M objects)	[x,y]|sort	v1.5.0	0.152
-NDJSON workloads (2M objects)	.name|scan	v1.5.0	0.206
-NDJSON workloads (2M objects)	.name|gsub	v1.5.0	0.167
-NDJSON workloads (2M objects)	walk(if num .+1)	v1.5.0	0.139
-NDJSON workloads (2M objects)	tojson	v1.5.0	0.106
+NDJSON workloads (2M objects)	dynkey+static	v1.5.0	0.332
+NDJSON workloads (2M objects)	if>.y str chain	v1.5.0	0.167
+NDJSON workloads (2M objects)	remap+str chain	v1.5.0	0.155
+NDJSON workloads (2M objects)	sel(len>8)	v1.5.0	0.161
+NDJSON workloads (2M objects)	up|split|join	v1.5.0	0.096
+NDJSON workloads (2M objects)	.name|index	v1.5.0	0.119
+NDJSON workloads (2M objects)	.name|index+1	v1.5.0	0.130
+NDJSON workloads (2M objects)	.name|rindex	v1.5.0	0.124
+NDJSON workloads (2M objects)	.name|indices	v1.5.0	0.152
+NDJSON workloads (2M objects)	[x,y]|sort	v1.5.0	0.154
+NDJSON workloads (2M objects)	.name|scan	v1.5.0	0.216
+NDJSON workloads (2M objects)	.name|gsub	v1.5.0	0.169
+NDJSON workloads (2M objects)	walk(if num .+1)	v1.5.0	0.143
+NDJSON workloads (2M objects)	tojson	v1.5.0	0.107
 NDJSON workloads (2M objects)	{name,x}	v1.5.0	0.128
-NDJSON workloads (2M objects)	.z//.name	v1.5.0	0.153
-NDJSON workloads (2M objects)	.x|=test(re)	v1.5.0	0.178
-NDJSON workloads (2M objects)	./sep|first	v1.5.0	0.187
-NDJSON workloads (2M objects)	.y=(.x*2)	v1.5.0	0.178
-NDJSON workloads (2M objects)	.y=(.x+.y)	v1.5.0	0.228
-NDJSON workloads (2M objects)	objects	v1.5.0	0.133
-NDJSON workloads (2M objects)	.tag|=if..then N	v1.5.0	0.598
-NDJSON workloads (2M objects)	.x=(.x+1)	v1.5.0	0.128
-NDJSON workloads (2M objects)	sel>N|.y+=1	v1.5.0	0.120
+NDJSON workloads (2M objects)	.z//.name	v1.5.0	0.158
+NDJSON workloads (2M objects)	.x|=test(re)	v1.5.0	0.121
+NDJSON workloads (2M objects)	./sep|first	v1.5.0	0.129
+NDJSON workloads (2M objects)	.y=(.x*2)	v1.5.0	0.125
+NDJSON workloads (2M objects)	.y=(.x+.y)	v1.5.0	0.172
+NDJSON workloads (2M objects)	objects	v1.5.0	0.088
+NDJSON workloads (2M objects)	.tag|=if..then N	v1.5.0	0.625
+NDJSON workloads (2M objects)	.x=(.x+1)	v1.5.0	0.072
+NDJSON workloads (2M objects)	sel>N|.y+=1	v1.5.0	0.094
 NDJSON workloads (2M objects)	sel(and)|.x+=1	v1.5.0	0.111
-NDJSON workloads (2M objects)	sel(sw)|.x+=1	v1.5.0	0.161
-NDJSON workloads (2M objects)	match(re)	v1.5.0	0.362
-NDJSON workloads (2M objects)	capture(re)	v1.5.0	0.298
-NDJSON workloads (2M objects)	first(.name,.x)	v1.5.0	0.102
-NDJSON workloads (2M objects)	if .x==null	v1.5.0	0.046
-NDJSON workloads (2M objects)	we(sw(.key))	v1.5.0	0.109
-NDJSON workloads (2M objects)	sel(sw or ew)	v1.5.0	0.206
-NDJSON workloads (2M objects)	path(.name,.x)	v1.5.0	0.273
-NDJSON workloads (2M objects)	sel(str+num+num)	v1.5.0	0.153
-NDJSON workloads (2M objects)	nested if|field	v1.5.0	0.078
+NDJSON workloads (2M objects)	sel(sw)|.x+=1	v1.5.0	0.132
+NDJSON workloads (2M objects)	match(re)	v1.5.0	0.367
+NDJSON workloads (2M objects)	capture(re)	v1.5.0	0.307
+NDJSON workloads (2M objects)	first(.name,.x)	v1.5.0	0.097
+NDJSON workloads (2M objects)	if .x==null	v1.5.0	0.047
+NDJSON workloads (2M objects)	we(sw(.key))	v1.5.0	0.112
+NDJSON workloads (2M objects)	sel(sw or ew)	v1.5.0	0.211
+NDJSON workloads (2M objects)	path(.name,.x)	v1.5.0	0.277
+NDJSON workloads (2M objects)	sel(str+num+num)	v1.5.0	0.154
+NDJSON workloads (2M objects)	nested if|field	v1.5.0	0.077
 NDJSON workloads (2M objects)	.f|floor|.*2	v1.5.0	0.060
 NDJSON workloads (2M objects)	split|len>1	v1.5.0	0.117
-NDJSON workloads (2M objects)	.name|len|.*2	v1.5.0	0.101
-NDJSON workloads (2M objects)	if len>5 .x .y	v1.5.0	0.114
-NDJSON workloads (2M objects)	sel(len>5)|remap	v1.5.0	0.207
-NDJSON workloads (2M objects)	.x|tostr|len	v1.5.0	0.059
-NDJSON workloads (2M objects)	if .x>.y .x .y	v1.5.0	0.093
-NDJSON workloads (2M objects)	split|last|tonum	v1.5.0	0.097
-NDJSON workloads (2M objects)	split|rev|.[0]	v1.5.0	0.092
+NDJSON workloads (2M objects)	.name|len|.*2	v1.5.0	0.102
+NDJSON workloads (2M objects)	if len>5 .x .y	v1.5.0	0.117
+NDJSON workloads (2M objects)	sel(len>5)|remap	v1.5.0	0.200
+NDJSON workloads (2M objects)	.x|tostr|len	v1.5.0	0.060
+NDJSON workloads (2M objects)	if .x>.y .x .y	v1.5.0	0.094
+NDJSON workloads (2M objects)	split|last|tonum	v1.5.0	0.096
+NDJSON workloads (2M objects)	split|rev|.[0]	v1.5.0	0.093
 NDJSON workloads (2M objects)	split|.[0]+.[1]	v1.5.0	0.113
-NDJSON workloads (2M objects)	.[]|strings	v1.5.0	0.107
-NDJSON workloads (2M objects)	.[]|numbers	v1.5.0	0.126
+NDJSON workloads (2M objects)	.[]|strings	v1.5.0	0.095
+NDJSON workloads (2M objects)	.[]|numbers	v1.5.0	0.106
 NDJSON workloads (2M objects)	[x,y]|any(>1M)	v1.5.0	0.084
-NDJSON workloads (2M objects)	sel(dc|sw)	v1.5.0	0.096
-NDJSON workloads (2M objects)	[[x,y],[n]]|flat	v1.5.0	0.456
-NDJSON workloads (2M objects)	.x|floor|.*2	v1.5.0	0.059
-NDJSON workloads (2M objects)	tojson|fromjson	v1.5.0	0.087
-NDJSON workloads (2M objects)	[.x]|add	v1.5.0	0.059
-NDJSON workloads (2M objects)	if>N {o}+.	v1.5.0	0.133
-NDJSON workloads (2M objects)	if>N .+{o}	v1.5.0	0.134
-NDJSON workloads (2M objects)	if .n=="s" .+{o}	v1.5.0	0.164
+NDJSON workloads (2M objects)	sel(dc|sw)	v1.5.0	0.098
+NDJSON workloads (2M objects)	[[x,y],[n]]|flat	v1.5.0	0.452
+NDJSON workloads (2M objects)	.x|floor|.*2	v1.5.0	0.061
+NDJSON workloads (2M objects)	tojson|fromjson	v1.5.0	0.088
+NDJSON workloads (2M objects)	[.x]|add	v1.5.0	0.060
+NDJSON workloads (2M objects)	if>N {o}+.	v1.5.0	0.145
+NDJSON workloads (2M objects)	if>N .+{o}	v1.5.0	0.136
+NDJSON workloads (2M objects)	if .n=="s" .+{o}	v1.5.0	0.162
 NDJSON workloads (2M objects)	sel(.n>"s")	v1.5.0	0.089
 NDJSON workloads (2M objects)	[x,y,z]|min	v1.5.0	0.303
 NDJSON workloads (2M objects)	if .n|len>5 l s	v1.5.0	0.102
-NDJSON workloads (2M objects)	if .x|flr>N b s	v1.5.0	0.054
-NDJSON workloads (2M objects)	if .n|test l e	v1.5.0	0.107
-NDJSON workloads (2M objects)	if .n|sw l e	v1.5.0	0.085
-NDJSON workloads (2M objects)	if .n|ew l e	v1.5.0	0.086
-NDJSON workloads (2M objects)	.n|len|tostr	v1.5.0	0.093
-String operations (2M objects)	ascii_downcase	v1.5.0	0.105
-String operations (2M objects)	ascii_upcase	v1.5.0	0.103
-String operations (2M objects)	ltrimstr	v1.5.0	0.098
-String operations (2M objects)	rtrimstr	v1.5.0	0.099
-String operations (2M objects)	split	v1.5.0	0.166
-String operations (2M objects)	case+split	v1.5.0	0.116
-String operations (2M objects)	join	v1.5.0	0.095
-String operations (2M objects)	startswith	v1.5.0	0.096
+NDJSON workloads (2M objects)	if .x|flr>N b s	v1.5.0	0.057
+NDJSON workloads (2M objects)	if .n|test l e	v1.5.0	0.105
+NDJSON workloads (2M objects)	if .n|sw l e	v1.5.0	0.083
+NDJSON workloads (2M objects)	if .n|ew l e	v1.5.0	0.084
+NDJSON workloads (2M objects)	.n|len|tostr	v1.5.0	0.092
+String operations (2M objects)	ascii_downcase	v1.5.0	0.104
+String operations (2M objects)	ascii_upcase	v1.5.0	0.102
+String operations (2M objects)	ltrimstr	v1.5.0	0.096
+String operations (2M objects)	rtrimstr	v1.5.0	0.098
+String operations (2M objects)	split	v1.5.0	0.169
+String operations (2M objects)	case+split	v1.5.0	0.115
+String operations (2M objects)	join	v1.5.0	0.094
+String operations (2M objects)	startswith	v1.5.0	0.095
 String operations (2M objects)	endswith	v1.5.0	0.098
 String operations (2M objects)	tostring	v1.5.0	0.061
-String operations (2M objects)	tonumber	v1.5.0	0.114
-String operations (2M objects)	string interpolation	v1.5.0	0.121
-String ops (200K objects)	test (regex)	v1.5.0	0.015
-String ops (200K objects)	match (regex)	v1.5.0	0.033
+String operations (2M objects)	tonumber	v1.5.0	0.111
+String operations (2M objects)	string interpolation	v1.5.0	0.119
+String ops (200K objects)	test (regex)	v1.5.0	0.014
+String ops (200K objects)	match (regex)	v1.5.0	0.031
 String ops (200K objects)	@base64	v1.5.0	0.012
 String ops (200K objects)	@uri	v1.5.0	0.012
 String ops (200K objects)	@html	v1.5.0	0.012
 String ops (200K objects)	@csv (array)	v1.5.0	0.016
-String ops (200K objects)	@tsv (array)	v1.5.0	0.015
-String ops (200K objects)	gsub	v1.5.0	0.018
-String ops (200K objects)	case+gsub	v1.5.0	0.178
-String ops (200K objects)	case+test	v1.5.0	0.122
-String ops (200K objects)	ltrim+tonum+arith	v1.5.0	0.114
-Numeric & math (2M objects)	floor	v1.5.0	0.056
-Numeric & math (2M objects)	sqrt	v1.5.0	0.078
-Numeric & math (2M objects)	modulo	v1.5.0	0.057
-Numeric & math (2M objects)	if-elif-else	v1.5.0	0.124
-Numeric & math (2M objects)	select|del	v1.5.0	0.091
-Numeric & math (2M objects)	select|merge	v1.5.0	0.117
-Numeric & math (2M objects)	select(test)|merge	v1.5.0	0.021
+String ops (200K objects)	@tsv (array)	v1.5.0	0.016
+String ops (200K objects)	gsub	v1.5.0	0.019
+String ops (200K objects)	case+gsub	v1.5.0	0.181
+String ops (200K objects)	case+test	v1.5.0	0.121
+String ops (200K objects)	ltrim+tonum+arith	v1.5.0	0.110
+Numeric & math (2M objects)	floor	v1.5.0	0.057
+Numeric & math (2M objects)	sqrt	v1.5.0	0.079
+Numeric & math (2M objects)	modulo	v1.5.0	0.059
+Numeric & math (2M objects)	if-elif-else	v1.5.0	0.127
+Numeric & math (2M objects)	select|del	v1.5.0	0.095
+Numeric & math (2M objects)	select|merge	v1.5.0	0.120
+Numeric & math (2M objects)	select(test)|merge	v1.5.0	0.022
 Array generators	range(2M) | length	v1.5.0	0.011
-Array generators	reverse(2M)	v1.5.0	0.018
+Array generators	reverse(2M)	v1.5.0	0.017
 Array generators	sort(2M)	v1.5.0	0.023
-Array generators	unique(1M)	v1.5.0	0.030
-Array generators	flatten(500K)	v1.5.0	0.011
-Array generators	min, max(2M)	v1.5.0	0.019
-Array generators	add numbers(2M)	v1.5.0	0.013
+Array generators	unique(1M)	v1.5.0	0.029
+Array generators	flatten(500K)	v1.5.0	0.010
+Array generators	min, max(2M)	v1.5.0	0.018
+Array generators	add numbers(2M)	v1.5.0	0.012
 Array generators	any/all(2M)	v1.5.0	0.028
 Array generators	limit(10; range(10M))	v1.5.0	0.002
 Array generators	first(range(10M))	v1.5.0	0.002
 Array generators	last(range(2M))	v1.5.0	0.002
 Array generators	indices(1M)	v1.5.0	0.016
-Reduce & foreach	reduce (sum)	v1.5.0	0.009
-Reduce & foreach	reduce (array build)	v1.5.0	0.004
-Reduce & foreach	reduce (obj build)	v1.5.0	0.009
+Reduce & foreach	reduce (sum)	v1.5.0	0.010
+Reduce & foreach	reduce (array build)	v1.5.0	0.005
+Reduce & foreach	reduce (obj build)	v1.5.0	0.010
 Reduce & foreach	reduce (setpath)	v1.5.0	0.017
 Reduce & foreach	foreach (running sum)	v1.5.0	0.010
 Reduce & foreach	foreach + emit	v1.5.0	0.011
-Reduce & foreach	reduce (sum-of-squares)	v1.5.0	0.033
+Reduce & foreach	reduce (sum-of-squares)	v1.5.0	0.035
 Reduce & foreach	reduce (conditional)	v1.5.0	0.036
-Reduce & foreach	reduce (product)	v1.5.0	0.035
+Reduce & foreach	reduce (product)	v1.5.0	0.034
 Reduce & foreach	foreach (conditional)	v1.5.0	0.011
-Reduce & foreach	until (100M)	v1.5.0	0.301
-Reduce & foreach	reduce (harmonic)	v1.5.0	0.034
+Reduce & foreach	until (100M)	v1.5.0	0.304
+Reduce & foreach	reduce (harmonic)	v1.5.0	0.033
 Reduce & foreach	reduce (floor pipe)	v1.5.0	0.034
-Reduce & foreach	reduce (sqrt pipe)	v1.5.0	0.033
-Reduce & foreach	reduce (sin+cos)	v1.5.0	0.052
+Reduce & foreach	reduce (sqrt pipe)	v1.5.0	0.034
+Reduce & foreach	reduce (sin+cos)	v1.5.0	0.053
 Object operations	large obj construct	v1.5.0	0.004
-Object operations	large obj keys	v1.5.0	0.011
-Object operations	large obj to_entries	v1.5.0	0.012
-Object operations	with_entries	v1.5.0	0.009
-Assignment operators	.[] |= f (100K)	v1.5.0	0.005
-Assignment operators	.[] += 1 (100K)	v1.5.0	0.005
-Assignment operators	.[k] = v reduce(50K)	v1.5.0	0.008
-String-heavy generators	gsub(100K)	v1.5.0	0.026
-String-heavy generators	join large(100K)	v1.5.0	0.005
-String-heavy generators	explode/implode(100K)	v1.5.0	0.027
+Object operations	large obj keys	v1.5.0	0.012
+Object operations	large obj to_entries	v1.5.0	0.014
+Object operations	with_entries	v1.5.0	0.010
+Assignment operators	.[] |= f (100K)	v1.5.0	0.006
+Assignment operators	.[] += 1 (100K)	v1.5.0	0.006
+Assignment operators	.[k] = v reduce(50K)	v1.5.0	0.009
+String-heavy generators	gsub(100K)	v1.5.0	0.027
+String-heavy generators	join large(100K)	v1.5.0	0.006
+String-heavy generators	explode/implode(100K)	v1.5.0	0.028
 String-heavy generators	reduce str concat(100K)	v1.5.0	0.008
 Try-catch & alternative	alternative //	v1.5.0	0.033
-Try-catch & alternative	try-catch	v1.5.0	0.023
+Try-catch & alternative	try-catch	v1.5.0	0.024
 Try-catch & alternative	label-break	v1.5.0	0.004
-Type conversion	tojson/fromjson(100K)	v1.5.0	0.022
-Type conversion	null propagation(2M)	v1.5.0	0.090
+Type conversion	tojson/fromjson(100K)	v1.5.0	0.023
+Type conversion	null propagation(2M)	v1.5.0	0.088
 jaq-derived	jaq: reverse	v1.5.0	0.011
 jaq-derived	jaq: sort	v1.5.0	0.018
 jaq-derived	jaq: group-by	v1.5.0	0.038
-jaq-derived	jaq: min-max	v1.5.0	0.010
-jaq-derived	jaq: ex-implode	v1.5.0	0.019
+jaq-derived	jaq: min-max	v1.5.0	0.012
+jaq-derived	jaq: ex-implode	v1.5.0	0.020
 jaq-derived	jaq: repeat	v1.5.0	0.012
 jaq-derived	jaq: from	v1.5.0	0.006
 jaq-derived	jaq: last	v1.5.0	0.002
-jaq-derived	jaq: cumsum	v1.5.0	0.010
-jaq-derived	jaq: cumsum-xy	v1.5.0	0.017
-jaq-derived	jaq: try-catch	v1.5.0	0.079
+jaq-derived	jaq: cumsum	v1.5.0	0.011
+jaq-derived	jaq: cumsum-xy	v1.5.0	0.018
+jaq-derived	jaq: try-catch	v1.5.0	0.078
 jaq-derived	jaq: add	v1.5.0	0.041
-jaq-derived	jaq: reduce	v1.5.0	0.078
-jaq-derived	jaq: reduce-update	v1.5.0	0.005
+jaq-derived	jaq: reduce	v1.5.0	0.086
+jaq-derived	jaq: reduce-update	v1.5.0	0.006
 jaq-derived	jaq: kv	v1.5.0	0.015
 jaq-derived	jaq: kv-update	v1.5.0	0.019
-jaq-derived	jaq: kv-entries	v1.5.0	0.057
-jaq-derived	jaq: pyramid	v1.5.0	0.016
-jaq-derived	jaq: upto	v1.5.0	0.007
-jaq-derived	jaq: tree-flatten	v1.5.0	0.003
-jaq-derived	jaq: tree-update	v1.5.0	0.225
+jaq-derived	jaq: kv-entries	v1.5.0	0.059
+jaq-derived	jaq: pyramid	v1.5.0	0.017
+jaq-derived	jaq: upto	v1.5.0	0.009
+jaq-derived	jaq: tree-flatten	v1.5.0	0.004
+jaq-derived	jaq: tree-update	v1.5.0	0.007
 jaq-derived	jaq: to-fromjson	v1.5.0	0.005
-jaq-derived	jaq: str-slice	v1.5.0	0.014
+jaq-derived	jaq: str-slice	v1.5.0	0.015

--- a/docs/benchmark-history.tsv
+++ b/docs/benchmark-history.tsv
@@ -2526,239 +2526,239 @@ jaq-derived	jaq: tree-update	v1.4.5	0.007
 jaq-derived	jaq: to-fromjson	v1.4.5	0.005
 jaq-derived	jaq: str-slice	v1.4.5	0.014
 NDJSON workloads (2M objects)	empty	v1.5.0	0.017
-NDJSON workloads (2M objects)	identity -c	v1.5.0	0.082
-NDJSON workloads (2M objects)	identity (pretty)	v1.5.0	0.098
-NDJSON workloads (2M objects)	field access .name	v1.5.0	0.096
-NDJSON workloads (2M objects)	nested .x,.y,.name	v1.5.0	0.150
-NDJSON workloads (2M objects)	arithmetic .x + .y	v1.5.0	0.083
-NDJSON workloads (2M objects)	select .x > 1500000	v1.5.0	0.081
-NDJSON workloads (2M objects)	string concat	v1.5.0	0.092
-NDJSON workloads (2M objects)	object construct	v1.5.0	0.113
-NDJSON workloads (2M objects)	array construct	v1.5.0	0.106
-NDJSON workloads (2M objects)	.[]	v1.5.0	0.103
-NDJSON workloads (2M objects)	to_entries	v1.5.0	0.164
-NDJSON workloads (2M objects)	keys	v1.5.0	0.104
-NDJSON workloads (2M objects)	keys_unsorted	v1.5.0	0.095
-NDJSON workloads (2M objects)	length	v1.5.0	0.087
-NDJSON workloads (2M objects)	has("x")	v1.5.0	0.036
+NDJSON workloads (2M objects)	identity -c	v1.5.0	0.085
+NDJSON workloads (2M objects)	identity (pretty)	v1.5.0	0.103
+NDJSON workloads (2M objects)	field access .name	v1.5.0	0.093
+NDJSON workloads (2M objects)	nested .x,.y,.name	v1.5.0	0.145
+NDJSON workloads (2M objects)	arithmetic .x + .y	v1.5.0	0.082
+NDJSON workloads (2M objects)	select .x > 1500000	v1.5.0	0.080
+NDJSON workloads (2M objects)	string concat	v1.5.0	0.091
+NDJSON workloads (2M objects)	object construct	v1.5.0	0.111
+NDJSON workloads (2M objects)	array construct	v1.5.0	0.103
+NDJSON workloads (2M objects)	.[]	v1.5.0	0.104
+NDJSON workloads (2M objects)	to_entries	v1.5.0	0.159
+NDJSON workloads (2M objects)	keys	v1.5.0	0.101
+NDJSON workloads (2M objects)	keys_unsorted	v1.5.0	0.094
+NDJSON workloads (2M objects)	length	v1.5.0	0.085
+NDJSON workloads (2M objects)	has("x")	v1.5.0	0.038
 NDJSON workloads (2M objects)	type	v1.5.0	0.022
-NDJSON workloads (2M objects)	del(.name)	v1.5.0	0.103
-NDJSON workloads (2M objects)	@csv	v1.5.0	0.127
-NDJSON workloads (2M objects)	split/join	v1.5.0	0.091
-NDJSON workloads (2M objects)	select|field	v1.5.0	0.096
+NDJSON workloads (2M objects)	del(.name)	v1.5.0	0.102
+NDJSON workloads (2M objects)	@csv	v1.5.0	0.121
+NDJSON workloads (2M objects)	split/join	v1.5.0	0.090
+NDJSON workloads (2M objects)	select|field	v1.5.0	0.099
 NDJSON workloads (2M objects)	select|remap	v1.5.0	0.096
-NDJSON workloads (2M objects)	computed remap	v1.5.0	0.187
-NDJSON workloads (2M objects)	[.x,.y]|add	v1.5.0	0.084
+NDJSON workloads (2M objects)	computed remap	v1.5.0	0.188
+NDJSON workloads (2M objects)	[.x,.y]|add	v1.5.0	0.085
 NDJSON workloads (2M objects)	[.x,.y]|avg	v1.5.0	0.108
-NDJSON workloads (2M objects)	map(*2)|add	v1.5.0	0.104
-NDJSON workloads (2M objects)	keys|length	v1.5.0	0.254
+NDJSON workloads (2M objects)	map(*2)|add	v1.5.0	0.103
+NDJSON workloads (2M objects)	keys|length	v1.5.0	0.250
 NDJSON workloads (2M objects)	.+{z=0}	v1.5.0	0.151
-NDJSON workloads (2M objects)	split|first	v1.5.0	0.090
-NDJSON workloads (2M objects)	slice[0..5]	v1.5.0	0.093
-NDJSON workloads (2M objects)	dynkey {(.name)}	v1.5.0	0.108
-NDJSON workloads (2M objects)	.x += 1	v1.5.0	0.073
-NDJSON workloads (2M objects)	{a}+{b} merge	v1.5.0	0.132
+NDJSON workloads (2M objects)	split|first	v1.5.0	0.087
+NDJSON workloads (2M objects)	slice[0..5]	v1.5.0	0.091
+NDJSON workloads (2M objects)	dynkey {(.name)}	v1.5.0	0.104
+NDJSON workloads (2M objects)	.x += 1	v1.5.0	0.125
+NDJSON workloads (2M objects)	{a}+{b} merge	v1.5.0	0.130
 NDJSON workloads (2M objects)	.x*2+1	v1.5.0	0.058
-NDJSON workloads (2M objects)	.x+.y*2	v1.5.0	0.097
+NDJSON workloads (2M objects)	.x+.y*2	v1.5.0	0.096
 NDJSON workloads (2M objects)	.x > .y	v1.5.0	0.077
-NDJSON workloads (2M objects)	to_entries|len	v1.5.0	0.398
-NDJSON workloads (2M objects)	.x|.+1 (pipe)	v1.5.0	0.058
+NDJSON workloads (2M objects)	to_entries|len	v1.5.0	0.397
+NDJSON workloads (2M objects)	.x|.+1 (pipe)	v1.5.0	0.057
 NDJSON workloads (2M objects)	.x|.*2|.+1	v1.5.0	0.058
-NDJSON workloads (2M objects)	.name|.+"_x"	v1.5.0	0.093
+NDJSON workloads (2M objects)	.name|.+"_x"	v1.5.0	0.092
 NDJSON workloads (2M objects)	.x>N | not	v1.5.0	0.049
-NDJSON workloads (2M objects)	and (2 cmp)	v1.5.0	0.080
-NDJSON workloads (2M objects)	if-then-else	v1.5.0	0.051
-NDJSON workloads (2M objects)	sel(and)|field	v1.5.0	0.078
-NDJSON workloads (2M objects)	sel(and)|remap	v1.5.0	0.076
-NDJSON workloads (2M objects)	arith|cmp	v1.5.0	0.054
-NDJSON workloads (2M objects)	if cmp .field	v1.5.0	0.112
-NDJSON workloads (2M objects)	split|length	v1.5.0	0.090
+NDJSON workloads (2M objects)	and (2 cmp)	v1.5.0	0.081
+NDJSON workloads (2M objects)	if-then-else	v1.5.0	0.050
+NDJSON workloads (2M objects)	sel(and)|field	v1.5.0	0.076
+NDJSON workloads (2M objects)	sel(and)|remap	v1.5.0	0.077
+NDJSON workloads (2M objects)	arith|cmp	v1.5.0	0.052
+NDJSON workloads (2M objects)	if cmp .field	v1.5.0	0.111
+NDJSON workloads (2M objects)	split|length	v1.5.0	0.089
 NDJSON workloads (2M objects)	[x,y]|min	v1.5.0	0.090
-NDJSON workloads (2M objects)	[x,y]|max	v1.5.0	0.095
-NDJSON workloads (2M objects)	[x,y]|sort|.[0]	v1.5.0	0.089
-NDJSON workloads (2M objects)	.name|len>5	v1.5.0	0.093
-NDJSON workloads (2M objects)	sel(len>5)|.x	v1.5.0	0.105
-NDJSON workloads (2M objects)	if .x>.y .name	v1.5.0	0.088
-NDJSON workloads (2M objects)	sel(.x>.y)|.name	v1.5.0	0.073
-NDJSON workloads (2M objects)	.x*2|tostring	v1.5.0	0.056
-NDJSON workloads (2M objects)	.x*.x+1	v1.5.0	0.065
-NDJSON workloads (2M objects)	{k=.name,v=tostr}	v1.5.0	0.143
-NDJSON workloads (2M objects)	str add chain	v1.5.0	0.381
-NDJSON workloads (2M objects)	if>.y .name|empty	v1.5.0	0.073
+NDJSON workloads (2M objects)	[x,y]|max	v1.5.0	0.094
+NDJSON workloads (2M objects)	[x,y]|sort|.[0]	v1.5.0	0.088
+NDJSON workloads (2M objects)	.name|len>5	v1.5.0	0.089
+NDJSON workloads (2M objects)	sel(len>5)|.x	v1.5.0	0.110
+NDJSON workloads (2M objects)	if .x>.y .name	v1.5.0	0.089
+NDJSON workloads (2M objects)	sel(.x>.y)|.name	v1.5.0	0.072
+NDJSON workloads (2M objects)	.x*2|tostring	v1.5.0	0.055
+NDJSON workloads (2M objects)	.x*.x+1	v1.5.0	0.064
+NDJSON workloads (2M objects)	{k=.name,v=tostr}	v1.5.0	0.149
+NDJSON workloads (2M objects)	str add chain	v1.5.0	0.382
+NDJSON workloads (2M objects)	if>.y .name|empty	v1.5.0	0.074
 NDJSON workloads (2M objects)	if .x%2==0	v1.5.0	0.053
-NDJSON workloads (2M objects)	if .x*2+1>1M	v1.5.0	0.057
-NDJSON workloads (2M objects)	sel(.x%2==0)|.name	v1.5.0	0.085
+NDJSON workloads (2M objects)	if .x*2+1>1M	v1.5.0	0.053
+NDJSON workloads (2M objects)	sel(.x%2==0)|.name	v1.5.0	0.081
 NDJSON workloads (2M objects)	sel(.x*2+1>1M)	v1.5.0	0.156
 NDJSON workloads (2M objects)	.x|@json	v1.5.0	0.047
-NDJSON workloads (2M objects)	.x|@text	v1.5.0	0.048
-NDJSON workloads (2M objects)	.name|@json	v1.5.0	0.101
-NDJSON workloads (2M objects)	sel|[arr]	v1.5.0	0.143
-NDJSON workloads (2M objects)	sel(and)|[arr]	v1.5.0	0.079
-NDJSON workloads (2M objects)	if>.y [arr]	v1.5.0	0.180
-NDJSON workloads (2M objects)	if sw then .f	v1.5.0	0.138
+NDJSON workloads (2M objects)	.x|@text	v1.5.0	0.047
+NDJSON workloads (2M objects)	.name|@json	v1.5.0	0.099
+NDJSON workloads (2M objects)	sel|[arr]	v1.5.0	0.144
+NDJSON workloads (2M objects)	sel(and)|[arr]	v1.5.0	0.077
+NDJSON workloads (2M objects)	if>.y [arr]	v1.5.0	0.177
+NDJSON workloads (2M objects)	if sw then .f	v1.5.0	0.137
 NDJSON workloads (2M objects)	dynkey {(.n)=.x*2}	v1.5.0	0.112
-NDJSON workloads (2M objects)	sel(and)|.x*.y	v1.5.0	0.077
-NDJSON workloads (2M objects)	sel>N|str chain	v1.5.0	0.154
-NDJSON workloads (2M objects)	.f+"_"+arith_ts	v1.5.0	0.130
-NDJSON workloads (2M objects)	sel(sw)|str ch	v1.5.0	0.302
+NDJSON workloads (2M objects)	sel(and)|.x*.y	v1.5.0	0.078
+NDJSON workloads (2M objects)	sel>N|str chain	v1.5.0	0.153
+NDJSON workloads (2M objects)	.f+"_"+arith_ts	v1.5.0	0.134
+NDJSON workloads (2M objects)	sel(sw)|str ch	v1.5.0	0.298
 NDJSON workloads (2M objects)	split|rev|join	v1.5.0	0.114
-NDJSON workloads (2M objects)	dynkey+static	v1.5.0	0.332
-NDJSON workloads (2M objects)	if>.y str chain	v1.5.0	0.167
-NDJSON workloads (2M objects)	remap+str chain	v1.5.0	0.155
-NDJSON workloads (2M objects)	sel(len>8)	v1.5.0	0.161
+NDJSON workloads (2M objects)	dynkey+static	v1.5.0	0.334
+NDJSON workloads (2M objects)	if>.y str chain	v1.5.0	0.170
+NDJSON workloads (2M objects)	remap+str chain	v1.5.0	0.151
+NDJSON workloads (2M objects)	sel(len>8)	v1.5.0	0.162
 NDJSON workloads (2M objects)	up|split|join	v1.5.0	0.096
-NDJSON workloads (2M objects)	.name|index	v1.5.0	0.119
-NDJSON workloads (2M objects)	.name|index+1	v1.5.0	0.130
-NDJSON workloads (2M objects)	.name|rindex	v1.5.0	0.124
-NDJSON workloads (2M objects)	.name|indices	v1.5.0	0.152
-NDJSON workloads (2M objects)	[x,y]|sort	v1.5.0	0.154
-NDJSON workloads (2M objects)	.name|scan	v1.5.0	0.216
-NDJSON workloads (2M objects)	.name|gsub	v1.5.0	0.169
-NDJSON workloads (2M objects)	walk(if num .+1)	v1.5.0	0.143
+NDJSON workloads (2M objects)	.name|index	v1.5.0	0.114
+NDJSON workloads (2M objects)	.name|index+1	v1.5.0	0.121
+NDJSON workloads (2M objects)	.name|rindex	v1.5.0	0.126
+NDJSON workloads (2M objects)	.name|indices	v1.5.0	0.154
+NDJSON workloads (2M objects)	[x,y]|sort	v1.5.0	0.152
+NDJSON workloads (2M objects)	.name|scan	v1.5.0	0.204
+NDJSON workloads (2M objects)	.name|gsub	v1.5.0	0.161
+NDJSON workloads (2M objects)	walk(if num .+1)	v1.5.0	0.137
 NDJSON workloads (2M objects)	tojson	v1.5.0	0.107
-NDJSON workloads (2M objects)	{name,x}	v1.5.0	0.128
-NDJSON workloads (2M objects)	.z//.name	v1.5.0	0.158
-NDJSON workloads (2M objects)	.x|=test(re)	v1.5.0	0.121
-NDJSON workloads (2M objects)	./sep|first	v1.5.0	0.129
-NDJSON workloads (2M objects)	.y=(.x*2)	v1.5.0	0.125
-NDJSON workloads (2M objects)	.y=(.x+.y)	v1.5.0	0.172
-NDJSON workloads (2M objects)	objects	v1.5.0	0.088
-NDJSON workloads (2M objects)	.tag|=if..then N	v1.5.0	0.625
-NDJSON workloads (2M objects)	.x=(.x+1)	v1.5.0	0.072
-NDJSON workloads (2M objects)	sel>N|.y+=1	v1.5.0	0.094
-NDJSON workloads (2M objects)	sel(and)|.x+=1	v1.5.0	0.111
-NDJSON workloads (2M objects)	sel(sw)|.x+=1	v1.5.0	0.132
-NDJSON workloads (2M objects)	match(re)	v1.5.0	0.367
-NDJSON workloads (2M objects)	capture(re)	v1.5.0	0.307
-NDJSON workloads (2M objects)	first(.name,.x)	v1.5.0	0.097
-NDJSON workloads (2M objects)	if .x==null	v1.5.0	0.047
-NDJSON workloads (2M objects)	we(sw(.key))	v1.5.0	0.112
-NDJSON workloads (2M objects)	sel(sw or ew)	v1.5.0	0.211
-NDJSON workloads (2M objects)	path(.name,.x)	v1.5.0	0.277
-NDJSON workloads (2M objects)	sel(str+num+num)	v1.5.0	0.154
+NDJSON workloads (2M objects)	{name,x}	v1.5.0	0.132
+NDJSON workloads (2M objects)	.z//.name	v1.5.0	0.153
+NDJSON workloads (2M objects)	.x|=test(re)	v1.5.0	0.169
+NDJSON workloads (2M objects)	./sep|first	v1.5.0	0.184
+NDJSON workloads (2M objects)	.y=(.x*2)	v1.5.0	0.178
+NDJSON workloads (2M objects)	.y=(.x+.y)	v1.5.0	0.228
+NDJSON workloads (2M objects)	objects	v1.5.0	0.123
+NDJSON workloads (2M objects)	.tag|=if..then N	v1.5.0	0.607
+NDJSON workloads (2M objects)	.x=(.x+1)	v1.5.0	0.124
+NDJSON workloads (2M objects)	sel>N|.y+=1	v1.5.0	0.118
+NDJSON workloads (2M objects)	sel(and)|.x+=1	v1.5.0	0.109
+NDJSON workloads (2M objects)	sel(sw)|.x+=1	v1.5.0	0.160
+NDJSON workloads (2M objects)	match(re)	v1.5.0	0.359
+NDJSON workloads (2M objects)	capture(re)	v1.5.0	0.292
+NDJSON workloads (2M objects)	first(.name,.x)	v1.5.0	0.093
+NDJSON workloads (2M objects)	if .x==null	v1.5.0	0.046
+NDJSON workloads (2M objects)	we(sw(.key))	v1.5.0	0.107
+NDJSON workloads (2M objects)	sel(sw or ew)	v1.5.0	0.201
+NDJSON workloads (2M objects)	path(.name,.x)	v1.5.0	0.271
+NDJSON workloads (2M objects)	sel(str+num+num)	v1.5.0	0.151
 NDJSON workloads (2M objects)	nested if|field	v1.5.0	0.077
-NDJSON workloads (2M objects)	.f|floor|.*2	v1.5.0	0.060
-NDJSON workloads (2M objects)	split|len>1	v1.5.0	0.117
-NDJSON workloads (2M objects)	.name|len|.*2	v1.5.0	0.102
-NDJSON workloads (2M objects)	if len>5 .x .y	v1.5.0	0.117
+NDJSON workloads (2M objects)	.f|floor|.*2	v1.5.0	0.059
+NDJSON workloads (2M objects)	split|len>1	v1.5.0	0.115
+NDJSON workloads (2M objects)	.name|len|.*2	v1.5.0	0.100
+NDJSON workloads (2M objects)	if len>5 .x .y	v1.5.0	0.115
 NDJSON workloads (2M objects)	sel(len>5)|remap	v1.5.0	0.200
-NDJSON workloads (2M objects)	.x|tostr|len	v1.5.0	0.060
+NDJSON workloads (2M objects)	.x|tostr|len	v1.5.0	0.059
 NDJSON workloads (2M objects)	if .x>.y .x .y	v1.5.0	0.094
-NDJSON workloads (2M objects)	split|last|tonum	v1.5.0	0.096
-NDJSON workloads (2M objects)	split|rev|.[0]	v1.5.0	0.093
+NDJSON workloads (2M objects)	split|last|tonum	v1.5.0	0.097
+NDJSON workloads (2M objects)	split|rev|.[0]	v1.5.0	0.095
 NDJSON workloads (2M objects)	split|.[0]+.[1]	v1.5.0	0.113
-NDJSON workloads (2M objects)	.[]|strings	v1.5.0	0.095
-NDJSON workloads (2M objects)	.[]|numbers	v1.5.0	0.106
-NDJSON workloads (2M objects)	[x,y]|any(>1M)	v1.5.0	0.084
-NDJSON workloads (2M objects)	sel(dc|sw)	v1.5.0	0.098
+NDJSON workloads (2M objects)	.[]|strings	v1.5.0	0.106
+NDJSON workloads (2M objects)	.[]|numbers	v1.5.0	0.129
+NDJSON workloads (2M objects)	[x,y]|any(>1M)	v1.5.0	0.082
+NDJSON workloads (2M objects)	sel(dc|sw)	v1.5.0	0.096
 NDJSON workloads (2M objects)	[[x,y],[n]]|flat	v1.5.0	0.452
-NDJSON workloads (2M objects)	.x|floor|.*2	v1.5.0	0.061
+NDJSON workloads (2M objects)	.x|floor|.*2	v1.5.0	0.059
 NDJSON workloads (2M objects)	tojson|fromjson	v1.5.0	0.088
-NDJSON workloads (2M objects)	[.x]|add	v1.5.0	0.060
-NDJSON workloads (2M objects)	if>N {o}+.	v1.5.0	0.145
-NDJSON workloads (2M objects)	if>N .+{o}	v1.5.0	0.136
-NDJSON workloads (2M objects)	if .n=="s" .+{o}	v1.5.0	0.162
-NDJSON workloads (2M objects)	sel(.n>"s")	v1.5.0	0.089
-NDJSON workloads (2M objects)	[x,y,z]|min	v1.5.0	0.303
-NDJSON workloads (2M objects)	if .n|len>5 l s	v1.5.0	0.102
-NDJSON workloads (2M objects)	if .x|flr>N b s	v1.5.0	0.057
+NDJSON workloads (2M objects)	[.x]|add	v1.5.0	0.059
+NDJSON workloads (2M objects)	if>N {o}+.	v1.5.0	0.133
+NDJSON workloads (2M objects)	if>N .+{o}	v1.5.0	0.135
+NDJSON workloads (2M objects)	if .n=="s" .+{o}	v1.5.0	0.161
+NDJSON workloads (2M objects)	sel(.n>"s")	v1.5.0	0.087
+NDJSON workloads (2M objects)	[x,y,z]|min	v1.5.0	0.306
+NDJSON workloads (2M objects)	if .n|len>5 l s	v1.5.0	0.100
+NDJSON workloads (2M objects)	if .x|flr>N b s	v1.5.0	0.054
 NDJSON workloads (2M objects)	if .n|test l e	v1.5.0	0.105
-NDJSON workloads (2M objects)	if .n|sw l e	v1.5.0	0.083
+NDJSON workloads (2M objects)	if .n|sw l e	v1.5.0	0.082
 NDJSON workloads (2M objects)	if .n|ew l e	v1.5.0	0.084
-NDJSON workloads (2M objects)	.n|len|tostr	v1.5.0	0.092
-String operations (2M objects)	ascii_downcase	v1.5.0	0.104
+NDJSON workloads (2M objects)	.n|len|tostr	v1.5.0	0.091
+String operations (2M objects)	ascii_downcase	v1.5.0	0.103
 String operations (2M objects)	ascii_upcase	v1.5.0	0.102
-String operations (2M objects)	ltrimstr	v1.5.0	0.096
-String operations (2M objects)	rtrimstr	v1.5.0	0.098
-String operations (2M objects)	split	v1.5.0	0.169
-String operations (2M objects)	case+split	v1.5.0	0.115
-String operations (2M objects)	join	v1.5.0	0.094
+String operations (2M objects)	ltrimstr	v1.5.0	0.099
+String operations (2M objects)	rtrimstr	v1.5.0	0.099
+String operations (2M objects)	split	v1.5.0	0.165
+String operations (2M objects)	case+split	v1.5.0	0.116
+String operations (2M objects)	join	v1.5.0	0.093
 String operations (2M objects)	startswith	v1.5.0	0.095
-String operations (2M objects)	endswith	v1.5.0	0.098
+String operations (2M objects)	endswith	v1.5.0	0.095
 String operations (2M objects)	tostring	v1.5.0	0.061
-String operations (2M objects)	tonumber	v1.5.0	0.111
-String operations (2M objects)	string interpolation	v1.5.0	0.119
+String operations (2M objects)	tonumber	v1.5.0	0.110
+String operations (2M objects)	string interpolation	v1.5.0	0.122
 String ops (200K objects)	test (regex)	v1.5.0	0.014
-String ops (200K objects)	match (regex)	v1.5.0	0.031
-String ops (200K objects)	@base64	v1.5.0	0.012
+String ops (200K objects)	match (regex)	v1.5.0	0.032
+String ops (200K objects)	@base64	v1.5.0	0.011
 String ops (200K objects)	@uri	v1.5.0	0.012
 String ops (200K objects)	@html	v1.5.0	0.012
-String ops (200K objects)	@csv (array)	v1.5.0	0.016
-String ops (200K objects)	@tsv (array)	v1.5.0	0.016
-String ops (200K objects)	gsub	v1.5.0	0.019
-String ops (200K objects)	case+gsub	v1.5.0	0.181
-String ops (200K objects)	case+test	v1.5.0	0.121
-String ops (200K objects)	ltrim+tonum+arith	v1.5.0	0.110
-Numeric & math (2M objects)	floor	v1.5.0	0.057
-Numeric & math (2M objects)	sqrt	v1.5.0	0.079
-Numeric & math (2M objects)	modulo	v1.5.0	0.059
-Numeric & math (2M objects)	if-elif-else	v1.5.0	0.127
-Numeric & math (2M objects)	select|del	v1.5.0	0.095
-Numeric & math (2M objects)	select|merge	v1.5.0	0.120
-Numeric & math (2M objects)	select(test)|merge	v1.5.0	0.022
+String ops (200K objects)	@csv (array)	v1.5.0	0.015
+String ops (200K objects)	@tsv (array)	v1.5.0	0.015
+String ops (200K objects)	gsub	v1.5.0	0.018
+String ops (200K objects)	case+gsub	v1.5.0	0.178
+String ops (200K objects)	case+test	v1.5.0	0.115
+String ops (200K objects)	ltrim+tonum+arith	v1.5.0	0.108
+Numeric & math (2M objects)	floor	v1.5.0	0.056
+Numeric & math (2M objects)	sqrt	v1.5.0	0.078
+Numeric & math (2M objects)	modulo	v1.5.0	0.056
+Numeric & math (2M objects)	if-elif-else	v1.5.0	0.124
+Numeric & math (2M objects)	select|del	v1.5.0	0.090
+Numeric & math (2M objects)	select|merge	v1.5.0	0.118
+Numeric & math (2M objects)	select(test)|merge	v1.5.0	0.021
 Array generators	range(2M) | length	v1.5.0	0.011
-Array generators	reverse(2M)	v1.5.0	0.017
-Array generators	sort(2M)	v1.5.0	0.023
-Array generators	unique(1M)	v1.5.0	0.029
+Array generators	reverse(2M)	v1.5.0	0.018
+Array generators	sort(2M)	v1.5.0	0.025
+Array generators	unique(1M)	v1.5.0	0.030
 Array generators	flatten(500K)	v1.5.0	0.010
 Array generators	min, max(2M)	v1.5.0	0.018
-Array generators	add numbers(2M)	v1.5.0	0.012
+Array generators	add numbers(2M)	v1.5.0	0.013
 Array generators	any/all(2M)	v1.5.0	0.028
 Array generators	limit(10; range(10M))	v1.5.0	0.002
 Array generators	first(range(10M))	v1.5.0	0.002
 Array generators	last(range(2M))	v1.5.0	0.002
 Array generators	indices(1M)	v1.5.0	0.016
-Reduce & foreach	reduce (sum)	v1.5.0	0.010
-Reduce & foreach	reduce (array build)	v1.5.0	0.005
-Reduce & foreach	reduce (obj build)	v1.5.0	0.010
-Reduce & foreach	reduce (setpath)	v1.5.0	0.017
+Reduce & foreach	reduce (sum)	v1.5.0	0.009
+Reduce & foreach	reduce (array build)	v1.5.0	0.004
+Reduce & foreach	reduce (obj build)	v1.5.0	0.009
+Reduce & foreach	reduce (setpath)	v1.5.0	0.016
 Reduce & foreach	foreach (running sum)	v1.5.0	0.010
-Reduce & foreach	foreach + emit	v1.5.0	0.011
-Reduce & foreach	reduce (sum-of-squares)	v1.5.0	0.035
-Reduce & foreach	reduce (conditional)	v1.5.0	0.036
+Reduce & foreach	foreach + emit	v1.5.0	0.010
+Reduce & foreach	reduce (sum-of-squares)	v1.5.0	0.032
+Reduce & foreach	reduce (conditional)	v1.5.0	0.035
 Reduce & foreach	reduce (product)	v1.5.0	0.034
-Reduce & foreach	foreach (conditional)	v1.5.0	0.011
-Reduce & foreach	until (100M)	v1.5.0	0.304
-Reduce & foreach	reduce (harmonic)	v1.5.0	0.033
-Reduce & foreach	reduce (floor pipe)	v1.5.0	0.034
+Reduce & foreach	foreach (conditional)	v1.5.0	0.010
+Reduce & foreach	until (100M)	v1.5.0	0.300
+Reduce & foreach	reduce (harmonic)	v1.5.0	0.032
+Reduce & foreach	reduce (floor pipe)	v1.5.0	0.032
 Reduce & foreach	reduce (sqrt pipe)	v1.5.0	0.034
-Reduce & foreach	reduce (sin+cos)	v1.5.0	0.053
+Reduce & foreach	reduce (sin+cos)	v1.5.0	0.052
 Object operations	large obj construct	v1.5.0	0.004
-Object operations	large obj keys	v1.5.0	0.012
-Object operations	large obj to_entries	v1.5.0	0.014
-Object operations	with_entries	v1.5.0	0.010
-Assignment operators	.[] |= f (100K)	v1.5.0	0.006
-Assignment operators	.[] += 1 (100K)	v1.5.0	0.006
-Assignment operators	.[k] = v reduce(50K)	v1.5.0	0.009
-String-heavy generators	gsub(100K)	v1.5.0	0.027
+Object operations	large obj keys	v1.5.0	0.011
+Object operations	large obj to_entries	v1.5.0	0.012
+Object operations	with_entries	v1.5.0	0.009
+Assignment operators	.[] |= f (100K)	v1.5.0	0.005
+Assignment operators	.[] += 1 (100K)	v1.5.0	0.005
+Assignment operators	.[k] = v reduce(50K)	v1.5.0	0.008
+String-heavy generators	gsub(100K)	v1.5.0	0.028
 String-heavy generators	join large(100K)	v1.5.0	0.006
 String-heavy generators	explode/implode(100K)	v1.5.0	0.028
 String-heavy generators	reduce str concat(100K)	v1.5.0	0.008
-Try-catch & alternative	alternative //	v1.5.0	0.033
-Try-catch & alternative	try-catch	v1.5.0	0.024
+Try-catch & alternative	alternative //	v1.5.0	0.032
+Try-catch & alternative	try-catch	v1.5.0	0.023
 Try-catch & alternative	label-break	v1.5.0	0.004
-Type conversion	tojson/fromjson(100K)	v1.5.0	0.023
-Type conversion	null propagation(2M)	v1.5.0	0.088
+Type conversion	tojson/fromjson(100K)	v1.5.0	0.022
+Type conversion	null propagation(2M)	v1.5.0	0.089
 jaq-derived	jaq: reverse	v1.5.0	0.011
 jaq-derived	jaq: sort	v1.5.0	0.018
-jaq-derived	jaq: group-by	v1.5.0	0.038
-jaq-derived	jaq: min-max	v1.5.0	0.012
-jaq-derived	jaq: ex-implode	v1.5.0	0.020
-jaq-derived	jaq: repeat	v1.5.0	0.012
-jaq-derived	jaq: from	v1.5.0	0.006
+jaq-derived	jaq: group-by	v1.5.0	0.037
+jaq-derived	jaq: min-max	v1.5.0	0.011
+jaq-derived	jaq: ex-implode	v1.5.0	0.019
+jaq-derived	jaq: repeat	v1.5.0	0.011
+jaq-derived	jaq: from	v1.5.0	0.005
 jaq-derived	jaq: last	v1.5.0	0.002
-jaq-derived	jaq: cumsum	v1.5.0	0.011
-jaq-derived	jaq: cumsum-xy	v1.5.0	0.018
-jaq-derived	jaq: try-catch	v1.5.0	0.078
+jaq-derived	jaq: cumsum	v1.5.0	0.010
+jaq-derived	jaq: cumsum-xy	v1.5.0	0.017
+jaq-derived	jaq: try-catch	v1.5.0	0.077
 jaq-derived	jaq: add	v1.5.0	0.041
-jaq-derived	jaq: reduce	v1.5.0	0.086
-jaq-derived	jaq: reduce-update	v1.5.0	0.006
+jaq-derived	jaq: reduce	v1.5.0	0.078
+jaq-derived	jaq: reduce-update	v1.5.0	0.005
 jaq-derived	jaq: kv	v1.5.0	0.015
-jaq-derived	jaq: kv-update	v1.5.0	0.019
-jaq-derived	jaq: kv-entries	v1.5.0	0.059
-jaq-derived	jaq: pyramid	v1.5.0	0.017
-jaq-derived	jaq: upto	v1.5.0	0.009
-jaq-derived	jaq: tree-flatten	v1.5.0	0.004
-jaq-derived	jaq: tree-update	v1.5.0	0.007
+jaq-derived	jaq: kv-update	v1.5.0	0.018
+jaq-derived	jaq: kv-entries	v1.5.0	0.056
+jaq-derived	jaq: pyramid	v1.5.0	0.016
+jaq-derived	jaq: upto	v1.5.0	0.007
+jaq-derived	jaq: tree-flatten	v1.5.0	0.003
+jaq-derived	jaq: tree-update	v1.5.0	0.222
 jaq-derived	jaq: to-fromjson	v1.5.0	0.005
-jaq-derived	jaq: str-slice	v1.5.0	0.015
+jaq-derived	jaq: str-slice	v1.5.0	0.014

--- a/docs/benchmark-history.tsv
+++ b/docs/benchmark-history.tsv
@@ -2525,3 +2525,240 @@ jaq-derived	jaq: tree-flatten	v1.4.5	0.003
 jaq-derived	jaq: tree-update	v1.4.5	0.007
 jaq-derived	jaq: to-fromjson	v1.4.5	0.005
 jaq-derived	jaq: str-slice	v1.4.5	0.014
+NDJSON workloads (2M objects)	empty	v1.5.0	0.017
+NDJSON workloads (2M objects)	identity -c	v1.5.0	0.085
+NDJSON workloads (2M objects)	identity (pretty)	v1.5.0	0.111
+NDJSON workloads (2M objects)	field access .name	v1.5.0	0.097
+NDJSON workloads (2M objects)	nested .x,.y,.name	v1.5.0	0.150
+NDJSON workloads (2M objects)	arithmetic .x + .y	v1.5.0	0.084
+NDJSON workloads (2M objects)	select .x > 1500000	v1.5.0	0.082
+NDJSON workloads (2M objects)	string concat	v1.5.0	0.094
+NDJSON workloads (2M objects)	object construct	v1.5.0	0.116
+NDJSON workloads (2M objects)	array construct	v1.5.0	0.106
+NDJSON workloads (2M objects)	.[]	v1.5.0	0.101
+NDJSON workloads (2M objects)	to_entries	v1.5.0	0.162
+NDJSON workloads (2M objects)	keys	v1.5.0	0.105
+NDJSON workloads (2M objects)	keys_unsorted	v1.5.0	0.094
+NDJSON workloads (2M objects)	length	v1.5.0	0.088
+NDJSON workloads (2M objects)	has("x")	v1.5.0	0.036
+NDJSON workloads (2M objects)	type	v1.5.0	0.023
+NDJSON workloads (2M objects)	del(.name)	v1.5.0	0.105
+NDJSON workloads (2M objects)	@csv	v1.5.0	0.125
+NDJSON workloads (2M objects)	split/join	v1.5.0	0.092
+NDJSON workloads (2M objects)	select|field	v1.5.0	0.099
+NDJSON workloads (2M objects)	select|remap	v1.5.0	0.099
+NDJSON workloads (2M objects)	computed remap	v1.5.0	0.189
+NDJSON workloads (2M objects)	[.x,.y]|add	v1.5.0	0.085
+NDJSON workloads (2M objects)	[.x,.y]|avg	v1.5.0	0.110
+NDJSON workloads (2M objects)	map(*2)|add	v1.5.0	0.104
+NDJSON workloads (2M objects)	keys|length	v1.5.0	0.252
+NDJSON workloads (2M objects)	.+{z=0}	v1.5.0	0.147
+NDJSON workloads (2M objects)	split|first	v1.5.0	0.089
+NDJSON workloads (2M objects)	slice[0..5]	v1.5.0	0.094
+NDJSON workloads (2M objects)	dynkey {(.name)}	v1.5.0	0.108
+NDJSON workloads (2M objects)	.x += 1	v1.5.0	0.126
+NDJSON workloads (2M objects)	{a}+{b} merge	v1.5.0	0.130
+NDJSON workloads (2M objects)	.x*2+1	v1.5.0	0.059
+NDJSON workloads (2M objects)	.x+.y*2	v1.5.0	0.098
+NDJSON workloads (2M objects)	.x > .y	v1.5.0	0.078
+NDJSON workloads (2M objects)	to_entries|len	v1.5.0	0.398
+NDJSON workloads (2M objects)	.x|.+1 (pipe)	v1.5.0	0.056
+NDJSON workloads (2M objects)	.x|.*2|.+1	v1.5.0	0.060
+NDJSON workloads (2M objects)	.name|.+"_x"	v1.5.0	0.093
+NDJSON workloads (2M objects)	.x>N | not	v1.5.0	0.049
+NDJSON workloads (2M objects)	and (2 cmp)	v1.5.0	0.081
+NDJSON workloads (2M objects)	if-then-else	v1.5.0	0.052
+NDJSON workloads (2M objects)	sel(and)|field	v1.5.0	0.077
+NDJSON workloads (2M objects)	sel(and)|remap	v1.5.0	0.079
+NDJSON workloads (2M objects)	arith|cmp	v1.5.0	0.053
+NDJSON workloads (2M objects)	if cmp .field	v1.5.0	0.114
+NDJSON workloads (2M objects)	split|length	v1.5.0	0.090
+NDJSON workloads (2M objects)	[x,y]|min	v1.5.0	0.090
+NDJSON workloads (2M objects)	[x,y]|max	v1.5.0	0.093
+NDJSON workloads (2M objects)	[x,y]|sort|.[0]	v1.5.0	0.090
+NDJSON workloads (2M objects)	.name|len>5	v1.5.0	0.091
+NDJSON workloads (2M objects)	sel(len>5)|.x	v1.5.0	0.110
+NDJSON workloads (2M objects)	if .x>.y .name	v1.5.0	0.089
+NDJSON workloads (2M objects)	sel(.x>.y)|.name	v1.5.0	0.073
+NDJSON workloads (2M objects)	.x*2|tostring	v1.5.0	0.055
+NDJSON workloads (2M objects)	.x*.x+1	v1.5.0	0.065
+NDJSON workloads (2M objects)	{k=.name,v=tostr}	v1.5.0	0.151
+NDJSON workloads (2M objects)	str add chain	v1.5.0	0.386
+NDJSON workloads (2M objects)	if>.y .name|empty	v1.5.0	0.074
+NDJSON workloads (2M objects)	if .x%2==0	v1.5.0	0.055
+NDJSON workloads (2M objects)	if .x*2+1>1M	v1.5.0	0.055
+NDJSON workloads (2M objects)	sel(.x%2==0)|.name	v1.5.0	0.082
+NDJSON workloads (2M objects)	sel(.x*2+1>1M)	v1.5.0	0.157
+NDJSON workloads (2M objects)	.x|@json	v1.5.0	0.048
+NDJSON workloads (2M objects)	.x|@text	v1.5.0	0.048
+NDJSON workloads (2M objects)	.name|@json	v1.5.0	0.104
+NDJSON workloads (2M objects)	sel|[arr]	v1.5.0	0.142
+NDJSON workloads (2M objects)	sel(and)|[arr]	v1.5.0	0.078
+NDJSON workloads (2M objects)	if>.y [arr]	v1.5.0	0.180
+NDJSON workloads (2M objects)	if sw then .f	v1.5.0	0.140
+NDJSON workloads (2M objects)	dynkey {(.n)=.x*2}	v1.5.0	0.117
+NDJSON workloads (2M objects)	sel(and)|.x*.y	v1.5.0	0.080
+NDJSON workloads (2M objects)	sel>N|str chain	v1.5.0	0.157
+NDJSON workloads (2M objects)	.f+"_"+arith_ts	v1.5.0	0.137
+NDJSON workloads (2M objects)	sel(sw)|str ch	v1.5.0	0.306
+NDJSON workloads (2M objects)	split|rev|join	v1.5.0	0.114
+NDJSON workloads (2M objects)	dynkey+static	v1.5.0	0.333
+NDJSON workloads (2M objects)	if>.y str chain	v1.5.0	0.171
+NDJSON workloads (2M objects)	remap+str chain	v1.5.0	0.153
+NDJSON workloads (2M objects)	sel(len>8)	v1.5.0	0.160
+NDJSON workloads (2M objects)	up|split|join	v1.5.0	0.099
+NDJSON workloads (2M objects)	.name|index	v1.5.0	0.122
+NDJSON workloads (2M objects)	.name|index+1	v1.5.0	0.125
+NDJSON workloads (2M objects)	.name|rindex	v1.5.0	0.128
+NDJSON workloads (2M objects)	.name|indices	v1.5.0	0.156
+NDJSON workloads (2M objects)	[x,y]|sort	v1.5.0	0.152
+NDJSON workloads (2M objects)	.name|scan	v1.5.0	0.206
+NDJSON workloads (2M objects)	.name|gsub	v1.5.0	0.167
+NDJSON workloads (2M objects)	walk(if num .+1)	v1.5.0	0.139
+NDJSON workloads (2M objects)	tojson	v1.5.0	0.106
+NDJSON workloads (2M objects)	{name,x}	v1.5.0	0.128
+NDJSON workloads (2M objects)	.z//.name	v1.5.0	0.153
+NDJSON workloads (2M objects)	.x|=test(re)	v1.5.0	0.178
+NDJSON workloads (2M objects)	./sep|first	v1.5.0	0.187
+NDJSON workloads (2M objects)	.y=(.x*2)	v1.5.0	0.178
+NDJSON workloads (2M objects)	.y=(.x+.y)	v1.5.0	0.228
+NDJSON workloads (2M objects)	objects	v1.5.0	0.133
+NDJSON workloads (2M objects)	.tag|=if..then N	v1.5.0	0.598
+NDJSON workloads (2M objects)	.x=(.x+1)	v1.5.0	0.128
+NDJSON workloads (2M objects)	sel>N|.y+=1	v1.5.0	0.120
+NDJSON workloads (2M objects)	sel(and)|.x+=1	v1.5.0	0.111
+NDJSON workloads (2M objects)	sel(sw)|.x+=1	v1.5.0	0.161
+NDJSON workloads (2M objects)	match(re)	v1.5.0	0.362
+NDJSON workloads (2M objects)	capture(re)	v1.5.0	0.298
+NDJSON workloads (2M objects)	first(.name,.x)	v1.5.0	0.102
+NDJSON workloads (2M objects)	if .x==null	v1.5.0	0.046
+NDJSON workloads (2M objects)	we(sw(.key))	v1.5.0	0.109
+NDJSON workloads (2M objects)	sel(sw or ew)	v1.5.0	0.206
+NDJSON workloads (2M objects)	path(.name,.x)	v1.5.0	0.273
+NDJSON workloads (2M objects)	sel(str+num+num)	v1.5.0	0.153
+NDJSON workloads (2M objects)	nested if|field	v1.5.0	0.078
+NDJSON workloads (2M objects)	.f|floor|.*2	v1.5.0	0.060
+NDJSON workloads (2M objects)	split|len>1	v1.5.0	0.117
+NDJSON workloads (2M objects)	.name|len|.*2	v1.5.0	0.101
+NDJSON workloads (2M objects)	if len>5 .x .y	v1.5.0	0.114
+NDJSON workloads (2M objects)	sel(len>5)|remap	v1.5.0	0.207
+NDJSON workloads (2M objects)	.x|tostr|len	v1.5.0	0.059
+NDJSON workloads (2M objects)	if .x>.y .x .y	v1.5.0	0.093
+NDJSON workloads (2M objects)	split|last|tonum	v1.5.0	0.097
+NDJSON workloads (2M objects)	split|rev|.[0]	v1.5.0	0.092
+NDJSON workloads (2M objects)	split|.[0]+.[1]	v1.5.0	0.113
+NDJSON workloads (2M objects)	.[]|strings	v1.5.0	0.107
+NDJSON workloads (2M objects)	.[]|numbers	v1.5.0	0.126
+NDJSON workloads (2M objects)	[x,y]|any(>1M)	v1.5.0	0.084
+NDJSON workloads (2M objects)	sel(dc|sw)	v1.5.0	0.096
+NDJSON workloads (2M objects)	[[x,y],[n]]|flat	v1.5.0	0.456
+NDJSON workloads (2M objects)	.x|floor|.*2	v1.5.0	0.059
+NDJSON workloads (2M objects)	tojson|fromjson	v1.5.0	0.087
+NDJSON workloads (2M objects)	[.x]|add	v1.5.0	0.059
+NDJSON workloads (2M objects)	if>N {o}+.	v1.5.0	0.133
+NDJSON workloads (2M objects)	if>N .+{o}	v1.5.0	0.134
+NDJSON workloads (2M objects)	if .n=="s" .+{o}	v1.5.0	0.164
+NDJSON workloads (2M objects)	sel(.n>"s")	v1.5.0	0.089
+NDJSON workloads (2M objects)	[x,y,z]|min	v1.5.0	0.303
+NDJSON workloads (2M objects)	if .n|len>5 l s	v1.5.0	0.102
+NDJSON workloads (2M objects)	if .x|flr>N b s	v1.5.0	0.054
+NDJSON workloads (2M objects)	if .n|test l e	v1.5.0	0.107
+NDJSON workloads (2M objects)	if .n|sw l e	v1.5.0	0.085
+NDJSON workloads (2M objects)	if .n|ew l e	v1.5.0	0.086
+NDJSON workloads (2M objects)	.n|len|tostr	v1.5.0	0.093
+String operations (2M objects)	ascii_downcase	v1.5.0	0.105
+String operations (2M objects)	ascii_upcase	v1.5.0	0.103
+String operations (2M objects)	ltrimstr	v1.5.0	0.098
+String operations (2M objects)	rtrimstr	v1.5.0	0.099
+String operations (2M objects)	split	v1.5.0	0.166
+String operations (2M objects)	case+split	v1.5.0	0.116
+String operations (2M objects)	join	v1.5.0	0.095
+String operations (2M objects)	startswith	v1.5.0	0.096
+String operations (2M objects)	endswith	v1.5.0	0.098
+String operations (2M objects)	tostring	v1.5.0	0.061
+String operations (2M objects)	tonumber	v1.5.0	0.114
+String operations (2M objects)	string interpolation	v1.5.0	0.121
+String ops (200K objects)	test (regex)	v1.5.0	0.015
+String ops (200K objects)	match (regex)	v1.5.0	0.033
+String ops (200K objects)	@base64	v1.5.0	0.012
+String ops (200K objects)	@uri	v1.5.0	0.012
+String ops (200K objects)	@html	v1.5.0	0.012
+String ops (200K objects)	@csv (array)	v1.5.0	0.016
+String ops (200K objects)	@tsv (array)	v1.5.0	0.015
+String ops (200K objects)	gsub	v1.5.0	0.018
+String ops (200K objects)	case+gsub	v1.5.0	0.178
+String ops (200K objects)	case+test	v1.5.0	0.122
+String ops (200K objects)	ltrim+tonum+arith	v1.5.0	0.114
+Numeric & math (2M objects)	floor	v1.5.0	0.056
+Numeric & math (2M objects)	sqrt	v1.5.0	0.078
+Numeric & math (2M objects)	modulo	v1.5.0	0.057
+Numeric & math (2M objects)	if-elif-else	v1.5.0	0.124
+Numeric & math (2M objects)	select|del	v1.5.0	0.091
+Numeric & math (2M objects)	select|merge	v1.5.0	0.117
+Numeric & math (2M objects)	select(test)|merge	v1.5.0	0.021
+Array generators	range(2M) | length	v1.5.0	0.011
+Array generators	reverse(2M)	v1.5.0	0.018
+Array generators	sort(2M)	v1.5.0	0.023
+Array generators	unique(1M)	v1.5.0	0.030
+Array generators	flatten(500K)	v1.5.0	0.011
+Array generators	min, max(2M)	v1.5.0	0.019
+Array generators	add numbers(2M)	v1.5.0	0.013
+Array generators	any/all(2M)	v1.5.0	0.028
+Array generators	limit(10; range(10M))	v1.5.0	0.002
+Array generators	first(range(10M))	v1.5.0	0.002
+Array generators	last(range(2M))	v1.5.0	0.002
+Array generators	indices(1M)	v1.5.0	0.016
+Reduce & foreach	reduce (sum)	v1.5.0	0.009
+Reduce & foreach	reduce (array build)	v1.5.0	0.004
+Reduce & foreach	reduce (obj build)	v1.5.0	0.009
+Reduce & foreach	reduce (setpath)	v1.5.0	0.017
+Reduce & foreach	foreach (running sum)	v1.5.0	0.010
+Reduce & foreach	foreach + emit	v1.5.0	0.011
+Reduce & foreach	reduce (sum-of-squares)	v1.5.0	0.033
+Reduce & foreach	reduce (conditional)	v1.5.0	0.036
+Reduce & foreach	reduce (product)	v1.5.0	0.035
+Reduce & foreach	foreach (conditional)	v1.5.0	0.011
+Reduce & foreach	until (100M)	v1.5.0	0.301
+Reduce & foreach	reduce (harmonic)	v1.5.0	0.034
+Reduce & foreach	reduce (floor pipe)	v1.5.0	0.034
+Reduce & foreach	reduce (sqrt pipe)	v1.5.0	0.033
+Reduce & foreach	reduce (sin+cos)	v1.5.0	0.052
+Object operations	large obj construct	v1.5.0	0.004
+Object operations	large obj keys	v1.5.0	0.011
+Object operations	large obj to_entries	v1.5.0	0.012
+Object operations	with_entries	v1.5.0	0.009
+Assignment operators	.[] |= f (100K)	v1.5.0	0.005
+Assignment operators	.[] += 1 (100K)	v1.5.0	0.005
+Assignment operators	.[k] = v reduce(50K)	v1.5.0	0.008
+String-heavy generators	gsub(100K)	v1.5.0	0.026
+String-heavy generators	join large(100K)	v1.5.0	0.005
+String-heavy generators	explode/implode(100K)	v1.5.0	0.027
+String-heavy generators	reduce str concat(100K)	v1.5.0	0.008
+Try-catch & alternative	alternative //	v1.5.0	0.033
+Try-catch & alternative	try-catch	v1.5.0	0.023
+Try-catch & alternative	label-break	v1.5.0	0.004
+Type conversion	tojson/fromjson(100K)	v1.5.0	0.022
+Type conversion	null propagation(2M)	v1.5.0	0.090
+jaq-derived	jaq: reverse	v1.5.0	0.011
+jaq-derived	jaq: sort	v1.5.0	0.018
+jaq-derived	jaq: group-by	v1.5.0	0.038
+jaq-derived	jaq: min-max	v1.5.0	0.010
+jaq-derived	jaq: ex-implode	v1.5.0	0.019
+jaq-derived	jaq: repeat	v1.5.0	0.012
+jaq-derived	jaq: from	v1.5.0	0.006
+jaq-derived	jaq: last	v1.5.0	0.002
+jaq-derived	jaq: cumsum	v1.5.0	0.010
+jaq-derived	jaq: cumsum-xy	v1.5.0	0.017
+jaq-derived	jaq: try-catch	v1.5.0	0.079
+jaq-derived	jaq: add	v1.5.0	0.041
+jaq-derived	jaq: reduce	v1.5.0	0.078
+jaq-derived	jaq: reduce-update	v1.5.0	0.005
+jaq-derived	jaq: kv	v1.5.0	0.015
+jaq-derived	jaq: kv-update	v1.5.0	0.019
+jaq-derived	jaq: kv-entries	v1.5.0	0.057
+jaq-derived	jaq: pyramid	v1.5.0	0.016
+jaq-derived	jaq: upto	v1.5.0	0.007
+jaq-derived	jaq: tree-flatten	v1.5.0	0.003
+jaq-derived	jaq: tree-update	v1.5.0	0.225
+jaq-derived	jaq: to-fromjson	v1.5.0	0.005
+jaq-derived	jaq: str-slice	v1.5.0	0.014


### PR DESCRIPTION
## Summary

Release v1.5.0. Bumps `Cargo.toml`, appends the v1.5.0 column to
`docs/benchmark-history.tsv`, and regenerates the slim
`docs/benchmark-history.md` (last 5 versions).

Highlights since v1.4.5 (95 `fix:` + 1 `feat:` + 2 `perf` revert pairs):

- **feat**: 16 missing libm/libc builtins from jq 1.8.1 (`6806bee`).
- **Number repr preservation pass**: the bulk of fixes route number
  values through their source byte-repr (`tonumber`, `tojson`,
  `@text/@uri/@html/@sh/@base64`, `@csv/@tsv`, `@json`, string
  interpolation, `add`, `range`, `debug`/`stderr`, division-by-zero
  errors, object-key error messages, etc.). Net: jq output
  byte-equality is now preserved through far more pipelines.
- **Error wording alignment with jq 1.8.1**: dozens of error sites
  re-routed through `errdesc` (path/getpath/setpath, sub/gsub,
  startswith/endswith, has/in, tonumber, range, slice, regex,
  to_entries/from_entries, sort_by/group_by/min_by/max_by,
  flatten, transpose, join, todate/fromdate, halt_error, time
  builtins, csv/tsv/format wording, etc.).
- **JIT correctness fixes** in the `(.[]?) |=` / `path() |=` family
  (`5c90213`, `b285c4f`, `c843849`, `c2ba861`, `cf907fe`),
  let-binding side-effect preservation (`92a2b44`), error-flag move
  off the global mutex onto `JitEnv` (`d405e8e`), getpath fast-path
  swallowing type-mismatch errors (`fc998da`), 0-arg `recurse` vs
  `recurse(.)` AST distinction (`79080d1`), and `is_json_compact`
  field-update routing (`5426876`, `672c7a6`).
- **Parser**: lone-surrogate `\uXXXX` handling (`b6e101d`), invalid
  surrogate escapes (`cef66d1`), case-insensitive `nan/inf/infinity`
  with sign (`ba40c05`), `passthrough` rejecting nested whitespace
  (`6f9e890`), `.[:]` rejected at parse time (`de65789`), variable
  scope leak on `as`/`reduce`/`foreach` exit (`dd6deda`),
  `INDEX/1` dispatch (`836e9b8`), etc.

## Bench summary

237 benchmarks have a v1.5.0 column. Max regression 31.7× (single
benchmark, intentional — see below); 9 benchmarks regressed > 1.30×;
68 benchmarks improved > 5%. Compared to **competing implementations**
on the affected benchmarks, jq-jit v1.5.0 remains
**12-50× faster** — the regressions are internal-to-jq-jit only.

### Headline regression: `jaq: tree-update` (31.7×, intentional)

Filter: `nth(.; 0 | recurse([., .])) | (.. | scalars) |= .+1` at depth 17.

| | time | note |
|---|---|---|
| jq 1.8.1 | 0.42s | reference |
| **jq-jit v1.5.0** | **0.23s** | 1.83× faster than jq |
| jaq 3.0.0 | 0.21s | comparable to jq-jit |
| jq-jit v1.4.5 | 0.007s | **silently produced no output** |

Bisected to commit `79080d1` (Closes #497), which fixed an AST-level
bug where the parser desugared both `recurse` (0-arg) and
`recurse(.)` to the same shape, causing the descent fast path to fire
incorrectly. Pre-fix, the bench filter silently produced **no
output** for the `nth(.; 0 | recurse([., .]))` input shape — the
"fast" 0.007s timing was measuring an early-exit, not real work.
With the fix, jq-jit produces the correct value (`2`, verified
against jq 1.8.1) in time competitive with jaq.

### Real regression cluster: NDJSON field-update fast paths (1.4-1.8×)

Eight write-path benchmarks regressed in the 1.4-1.8× band:

| benchmark | v1.4.5 | v1.5.0 | ratio |
|---|---|---|---|
| `.x += 1`        | 0.073 | 0.134 | **1.84×** |
| `.x = (.x+1)`    | 0.073 | 0.131 | **1.79×** |
| `objects`        | 0.090 | 0.146 | **1.62×** |
| `.y = (.x*2)`    | 0.116 | 0.183 | **1.58×** |
| `objects` (bench) | 0.085 | 0.123 | **1.45×** |
| `.y=(.x+.y)`     | 0.159 | 0.228 | **1.43×** |
| `./sep\|first`   | 0.132 | 0.184 | **1.39×** |
| `.x\|=test(re)`  | 0.124 | 0.169 | **1.36×** |
| `sel>N\|.y+=1`   | 0.087 | 0.118 | **1.36×** |

Bisected to commit `5426876` (#523, partially recovered by `672c7a6`).
The original v1.4.5 fast path bulk-copied bytes around the modified
field via `extend_from_slice`, which leaked input whitespace into
stdout under `-c`:

```
$ echo '{"x": 1, "y": 2}' | jq-jit-1.4.5 -c '.x += 1'
{"x": 2, "y": 2}    # BUG: leaked the spaces
$ echo '{"x": 1, "y": 2}' | jq-jit-1.5.0 -c '.x += 1'
{"x":2,"y":2}        # correct
```

The fix replaced bulk-copy with a per-byte walk
(`extend_compact_from_slice`) that strips whitespace inline. That walk
is the dominant cost on the regressed benchmarks. Three optimization
attempts (memchr2, memchr3+memchr2, inline+unchecked indexing) failed
to recover the original speed for the 30-50 byte slices the helpers
produce — see issue **#619** for the analysis and next directions
(SWAR, helper-side inlining, two-pass scan).

**Competitive context** (same `.x += 1` over 2M-line NDJSON):

| | time | vs jq-jit v1.5.0 |
|---|---|---|
| jq 1.8.1 | 6.76s | 50× slower |
| jaq 3.0.0 | 1.61s | 12× slower |
| **jq-jit v1.5.0** | **0.13s** | — |
| jq-jit v1.4.5 | 0.07s | 1.8× faster (with bug) |

Accepting the regression is the right call: v1.5.0 is correct, still
crushes both reference implementations, and the path to recovering
the lost speed is in #619.

### Top improvements

68 benchmarks improved > 5%, including:

| benchmark | v1.4.5 | v1.5.0 | ratio |
|---|---|---|---|
| `@csv (array)`       | 0.018 | 0.015 | 0.83× |
| `jaq: from`          | 0.006 | 0.005 | 0.83× |
| `remap+str chain`    | 0.178 | 0.151 | 0.85× |
| `dynkey {(.n)=.x*2}` | 0.132 | 0.112 | 0.85× |
| `jaq: try-catch`     | 0.090 | 0.077 | 0.86× |
| `array construct`    | 0.120 | 0.103 | 0.86× |
| `sel(len>5)\|remap`  | 0.233 | 0.200 | 0.86× |

## Test plan

- [x] `cargo build --release` — zero warnings.
- [x] `cargo test --release` — all pass.
- [x] `bench/comprehensive.sh` ran end-to-end (three captures total;
      one stale due to bisect leaving an old binary, two valid).
      237 benchmarks have v1.5.0 column.
- [x] `jaq: tree-update` correctness verified against `jq 1.8.1` (output `2`).
- [x] Write-path regression cluster bisected to `5426876` and tracked
      in #619 with three failed optimization attempts documented.
- [x] Competitive comparison vs `jq 1.8.1` and `jaq 3.0.0` confirms
      v1.5.0 is still 12-50× faster on the regressed benchmarks.

## Reproduction

```bash
python3 .claude/skills/release/scripts/update_history.py v1.5.0
# (idempotent if you strip existing v1.5.0 rows from TSV first)
```

Regression analysis is straight `csv.DictReader` over
`docs/benchmark-history.tsv`, comparing the v1.5.0 column to v1.4.5.

Note: if you bisect anything, **rebuild before re-benching** —
`git bisect reset` does not rebuild, and a stale binary will give
misleading numbers. (Lessons learned in this PR: see commits `67a28be`
→ `5d80c22`.)
