### PR TITLE
fix: drop subsecond component from todate/todateiso8601/date

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -3566,25 +3566,15 @@ fn rt_toisodate(v: &Value) -> Result<Value> {
         _ => unreachable!(),
     };
 
+    // jq's `def todate: strftime("%Y-%m-%dT%H:%M:%SZ")` floors the epoch to
+    // whole seconds before formatting (the broken-down-time `tm` produced by
+    // gmtime has no subsecond field), so any fractional input must be
+    // dropped to keep `todate | fromdateiso8601` round-tripping. See #613.
     let secs = epoch.floor() as i64;
-    let frac = epoch - epoch.floor();
-
-    if frac.abs() < 1e-9 {
-        // Integer epoch: no fractional part
-        let dt = DateTime::from_timestamp(secs, 0)
-            .ok_or_else(|| anyhow::anyhow!("toisodate: invalid epoch: {}", epoch))?;
-        let formatted = dt.format("%Y-%m-%dT%H:%M:%SZ").to_string();
-        Ok(Value::from_str(&formatted))
-    } else {
-        // Float epoch: include milliseconds
-        // Use round(frac * 1000) to get millis to avoid precision loss
-        let millis = (frac * 1000.0).round() as u32;
-        let nanos = millis * 1_000_000;
-        let dt = DateTime::from_timestamp(secs, nanos)
-            .ok_or_else(|| anyhow::anyhow!("toisodate: invalid epoch: {}", epoch))?;
-        let formatted = format!("{}.{:03}Z", dt.format("%Y-%m-%dT%H:%M:%S"), millis);
-        Ok(Value::from_str(&formatted))
-    }
+    let dt = DateTime::from_timestamp(secs, 0)
+        .ok_or_else(|| anyhow::anyhow!("toisodate: invalid epoch: {}", epoch))?;
+    let formatted = dt.format("%Y-%m-%dT%H:%M:%SZ").to_string();
+    Ok(Value::from_str(&formatted))
 }
 
 // -----------------------------------------------------------------------

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -9683,3 +9683,28 @@ length
 length
 "é"
 1
+
+# Issue #613: todate drops subsecond component to match jq round-trip
+todate
+1.5
+"1970-01-01T00:00:01Z"
+
+# Issue #613: todateiso8601 drops subsecond component
+todateiso8601
+0.001
+"1970-01-01T00:00:00Z"
+
+# Issue #613: todate on large fractional epoch drops subseconds
+todate
+1700000000.5
+"2023-11-14T22:13:20Z"
+
+# Issue #613: todate | fromdateiso8601 round-trips fractional epoch to integer
+todate | fromdateiso8601
+1.5
+1
+
+# Issue #613: date alias also drops subseconds
+date
+1.5
+"1970-01-01T00:00:01Z"


### PR DESCRIPTION
## Summary
- `rt_toisodate` was emitting `.NNN` milliseconds for fractional epochs, which jq 1.8.1 doesn't (its `def todate: strftime("%Y-%m-%dT%H:%M:%SZ")` operates on a broken-down-time `tm` with no subsecond field).
- Floor the epoch to whole seconds before formatting so `todate | fromdateiso8601` round-trips and matches jq.
- `todateiso8601/0` and the jqx `date/0` alias share this dispatch and are fixed at the same time.

## Test plan
- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (all green — official 509 + regression incl. 5 new cases for #613)
- [x] Manual repro against jq 1.8.1: `echo '1.5' | jq-jit -c 'todate'` → `"1970-01-01T00:00:01Z"`, `'todate | fromdateiso8601'` → `1`
- [x] `bench/comprehensive.sh` ran; numbers are noisy on this machine due to background processes (VSCode/etc.) but the changed code path (`rt_toisodate`) is not on any benchmark — no plausible regression vector.

Closes #613

🤖 Generated with [Claude Code](https://claude.com/claude-code)