### PR TITLE
fix: canonicalise subnormal-min repr in tostring/tojson interpreter path

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -5672,6 +5672,19 @@ fn push_value_tojson(v: &Value, out: &mut String, depth: usize) {
                 } else {
                     out.push_str(r);
                 }
+            } else if let Some(canonical) = repr
+                .as_ref()
+                .filter(|r| is_valid_json_number(r) && n.is_finite() && *n != 0.0)
+                .and_then(|r| normalize_jq_repr(r))
+                .filter(|c| fast_float::parse::<f64, _>(c.as_str()).ok() == Some(*n))
+            {
+                // Subnormal-edge case (#616): `repr_is_exact_for_f64` is too
+                // conservative for tiny exponents (< -323), but the literal
+                // can still round-trip through f64 — e.g. `5e-324` is the
+                // canonical form for the smallest positive subnormal. Prefer
+                // the normalised repr when it parses back to the same bits;
+                // otherwise fall through to the lossy f64 dtoa form.
+                out.push_str(&canonical);
             } else {
                 push_jq_number_str(out, *n);
             }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -9708,3 +9708,24 @@ todate | fromdateiso8601
 date
 1.5
 "1970-01-01T00:00:01Z"
+
+# Issue #616: tostring canonicalises subnormal min like tojson/identity
+tostring
+5e-324
+"5E-324"
+
+# Issue #616: tostring preserves a different subnormal literal that still
+# round-trips through f64 to the same bits as 5e-324
+tostring
+4.9e-324
+"4.9E-324"
+
+# Issue #616: tojson stays canonical at subnormal min
+tojson
+5e-324
+"5E-324"
+
+# Issue #616: identity still emits canonical subnormal
+.
+5e-324
+5E-324


### PR DESCRIPTION
## Summary
- The interpreter's `push_value_tojson` was falling back to the f64 dtoa form (`format_as_scientific_lowercase`, lowercase `e`) for any literal whose exponent fell outside `repr_is_exact_for_f64`'s `[-323, 308]` window — even when the repr round-trips through f64 cleanly. The smallest positive subnormal (`5e-324`) hit this case, so `tostring` and interpreter `tojson` printed `5e-324` while JIT raw-byte `tojson` and identity already produced the canonical `5E-324`.
- Add an `else-if` arm: when the repr is a valid JSON number, the value is finite and non-zero, and the normalised repr parses back to the same f64, prefer the canonical repr.
- Underflow (`1e-400` → `0.0`) and overflow (`1e1000` → ±∞) both fail the finite/non-zero gate, so the saturation behaviour documented in #415's `KNOWN_DIVERGENCES` list is unchanged.

## Test plan
- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (all green incl. official 509 + 1910-row regression suite + JIT/interp self-diff)
- [x] Manual repro:
  - `echo '5e-324' | jq-jit -c 'tostring'` → `"5E-324"` (was `"5e-324"`)
  - `echo '4.9e-324' | jq-jit -c 'tostring'` → `"4.9E-324"` (matches jq with decnum)
  - `echo '1e-400' | jq-jit -c 'tostring'` → `"0"` (unchanged, underflows to 0.0)
  - `echo '1e1000' | jq-jit -c 'tostring'` → `"1.7976931348623157e+308"` (unchanged, saturates per #415)

The new `else-if` arm only runs when the existing exact-match arm has already returned false, so common-path latency is unchanged.

Closes #616

🤖 Generated with [Claude Code](https://claude.com/claude-code)