### PR TITLE
feat: add get_jq_origin/0, get_prog_origin/0, get_search_list/0 builtins

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2785,6 +2785,7 @@ impl Parser {
             | "fromdateiso8601" | "todateiso8601" | "fromisodate" | "toisodate"
             | "todate" | "fromdate" | "date"
             | "input_line_number" | "input_filename"
+            | "get_jq_origin" | "get_prog_origin" | "get_search_list"
             | "combinations" | "modf"
             if !matches!(self.current(), Token::LParen) => {
                 self.compile_builtin_noargs(name)
@@ -3014,6 +3015,9 @@ impl Parser {
                 Ok(Expr::CallBuiltin { name: name.to_string(), args: vec![] })
             }
             "combinations" | "modf" => {
+                Ok(Expr::CallBuiltin { name: name.to_string(), args: vec![] })
+            }
+            "get_jq_origin" | "get_prog_origin" | "get_search_list" => {
                 Ok(Expr::CallBuiltin { name: name.to_string(), args: vec![] })
             }
             "input_filename" => {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -143,6 +143,9 @@ pub fn call_builtin(name: &str, args: &[Value]) -> Result<Value> {
         }),
         "env" | "$ENV" => Ok(rt_env()),
         "builtins" => Ok(rt_builtins()),
+        "get_jq_origin" => Ok(rt_get_jq_origin()),
+        "get_prog_origin" => Ok(rt_get_prog_origin()),
+        "get_search_list" => Ok(rt_get_search_list()),
         "debug" => unary_op(args, |v| {
             eprintln!("[\"DEBUG:\",{}]", crate::value::value_to_json_tojson(v));
             Ok(v.clone())
@@ -3589,6 +3592,38 @@ fn rt_env() -> Value {
     Value::object_from_map(env)
 }
 
+/// Directory containing the running interpreter binary (jq's
+/// `get_jq_origin/0`). Falls back to an empty string when
+/// `std::env::current_exe()` is unavailable.
+pub fn rt_get_jq_origin() -> Value {
+    let path = std::env::current_exe()
+        .ok()
+        .and_then(|p| p.parent().map(|p| p.to_string_lossy().into_owned()))
+        .unwrap_or_default();
+    Value::from_string(path)
+}
+
+/// Current working directory of the program (jq's
+/// `get_prog_origin/0`). Falls back to an empty string on error.
+pub fn rt_get_prog_origin() -> Value {
+    let path = std::env::current_dir()
+        .ok()
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    Value::from_string(path)
+}
+
+/// Module search path list. jq-jit doesn't implement `import`/`include`
+/// (see #614), so this returns jq 1.8.1's static defaults; feature-probing
+/// scripts that enumerate the search list still see a shape they recognise.
+pub fn rt_get_search_list() -> Value {
+    Value::Arr(Rc::new(vec![
+        Value::from_str("~/.jq"),
+        Value::from_str("$ORIGIN/../lib/jq"),
+        Value::from_str("$ORIGIN/../lib"),
+    ]))
+}
+
 pub fn rt_builtins() -> Value {
     // Source of truth for the `builtins/0` advertised list. Every spec
     // appears at most once (jq 1.8.1 emits each name+arity exactly once),
@@ -3660,6 +3695,7 @@ pub fn rt_builtins() -> Value {
         "todate/0", "fromdate/0", "date/0",
         "fromdateiso8601/0", "todateiso8601/0",
         "modulemeta/0", "builtins/0",
+        "get_jq_origin/0", "get_prog_origin/0", "get_search_list/0",
         "isempty/1",
         "del/1", "pick/1",
         "halt/0", "halt_error/0", "halt_error/1",

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -9729,3 +9729,23 @@ tojson
 .
 5e-324
 5E-324
+
+# Issue #614: get_search_list returns jq's static defaults
+get_search_list
+0
+["~/.jq","$ORIGIN/../lib/jq","$ORIGIN/../lib"]
+
+# Issue #614: get_jq_origin returns a string (the binary's directory)
+get_jq_origin | type
+0
+"string"
+
+# Issue #614: get_prog_origin returns a string (the cwd)
+get_prog_origin | type
+0
+"string"
+
+# Issue #614: builtins/0 advertises the new module-loading inspection trio
+builtins | contains(["get_jq_origin/0","get_prog_origin/0","get_search_list/0"])
+0
+true


### PR DESCRIPTION
## Summary
- Three module-loading inspection builtins that jq 1.8.1 advertises but jq-jit raised `unknown unary operation` for. Follow-up to #473.
  - `get_jq_origin/0` — directory of the running interpreter binary (`std::env::current_exe()` then parent).
  - `get_prog_origin/0` — process cwd (`std::env::current_dir()`).
  - `get_search_list/0` — module search path. jq-jit doesn't implement `import`/`include`, so this returns jq's static defaults (`["~/.jq", "$ORIGIN/../lib/jq", "$ORIGIN/../lib"]`); feature-probing scripts that enumerate the list still see a shape they recognise.
- Wired through the existing `Expr::CallBuiltin` 0-arg pathway used by `combinations`, `modf`, `fromcsv`, etc., so both interpreter and JIT route through `runtime::call_builtin`.
- `builtins/0` now advertises all three.

## Test plan
- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (all green incl. official 509 + regression suite + 4 new cases for #614)
- [x] Manual:
  - `echo 0 | jq-jit -c 'get_jq_origin'` → directory of `target/release/jq-jit`
  - `echo 0 | jq-jit -c 'get_prog_origin'` → cwd
  - `echo 0 | jq-jit -c 'get_search_list'` → `["~/.jq","$ORIGIN/../lib/jq","$ORIGIN/../lib"]`
  - `echo 0 | jq-jit -c 'builtins | map(select(test("^get_"))) | sort'` → `["get_jq_origin/0","get_prog_origin/0","get_search_list/0"]`

Closes #614

🤖 Generated with [Claude Code](https://claude.com/claude-code)