### PR TITLE
perf: speed up multi-path |= via in-place setpath_mut

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -2429,7 +2429,16 @@ pub fn eval(
                     Ok(false)
                 })?;
                 if has_output {
-                    result = crate::runtime::rt_setpath(&result, path, &new_val)?;
+                    // `rt_setpath_mut` mutates `result` via Rc::make_mut, so
+                    // each level is cloned at most once across the loop instead
+                    // of once per touched leaf. Heavy `|=` workloads such as
+                    // `(.. | scalars) |= .+1` over a deep tree drop from
+                    // O(N*D) to O(distinct internal nodes). See #551.
+                    let path_slice = match path {
+                        Value::Arr(a) => a.as_slice(),
+                        _ => bail!("Path must be specified as an array"),
+                    };
+                    crate::runtime::rt_setpath_mut(&mut result, path_slice, new_val)?;
                 } else {
                     // No output = delete this path
                     del_paths.push(path.clone());
@@ -2455,7 +2464,11 @@ pub fn eval(
                 }
                 let mut result = input.clone();
                 for path in &paths {
-                    result = crate::runtime::rt_setpath(&result, path, &new_val)?;
+                    let path_slice = match path {
+                        Value::Arr(a) => a.as_slice(),
+                        _ => bail!("Path must be specified as an array"),
+                    };
+                    crate::runtime::rt_setpath_mut(&mut result, path_slice, new_val.clone())?;
                 }
                 cb(result)
             })
@@ -5240,7 +5253,11 @@ fn eval_pick(f: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) -> 
     let mut result = Value::Null;
     for path in &paths {
         let val = crate::runtime::rt_getpath(&input, path)?;
-        result = crate::runtime::rt_setpath(&result, path, &val)?;
+        let path_slice = match path {
+            Value::Arr(a) => a.as_slice(),
+            _ => bail!("Path must be specified as an array"),
+        };
+        crate::runtime::rt_setpath_mut(&mut result, path_slice, val)?;
     }
     cb(result)
 }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -9799,3 +9799,28 @@ null
 [truncate_stream({a:[1,2]} | tostream)]
 2
 []
+
+# Issue #551: (.. | scalars) |= f preserves all leaves after switching Update
+# from rt_setpath to rt_setpath_mut (Rc::make_mut). Verifies every scalar
+# in a deep binary tree still gets updated, not just the last branch.
+nth(.; 0 | recurse([., .])) | (.. | scalars) |= .+1
+3
+[[[1,1],[1,1]],[[1,1],[1,1]]]
+
+# Issue #551: nested object/array updates compose under the new in-place
+# setpath path — every scalar gets +10, structure unchanged.
+(.. | scalars) |= .+10
+{"a":1,"b":{"c":2,"d":[3,4]}}
+{"a":11,"b":{"c":12,"d":[13,14]}}
+
+# Issue #551: multi-path assignment (no overlap) — each path mutates result
+# in place; Rc::make_mut on the inner objects keeps both writes.
+(.a, .b) = "x"
+{"a":1,"b":2}
+{"a":"x","b":"x"}
+
+# Issue #551: empty-output update deletes the path; the rest of the tree
+# still reflects prior in-place updates.
+.a |= empty | .b += 1
+{"a":1,"b":2}
+{"b":3}


### PR DESCRIPTION
## Summary

- `Expr::Update`'s loop did `result = rt_setpath(&result, path, &new_val)`, cloning each level along the path on every iteration. For `(.. | scalars) |= .+1` over a deep tree that's O(N*D) clones even though paths share internal nodes.
- Switch the loop to `rt_setpath_mut`. After the first visit the touched branch is uniquely owned by `result`, so `Rc::make_mut` skips the clone. Total clones collapse to O(distinct internal nodes touched).
- Apply the same change to `Expr::Assign` and `eval_pick` — both have the same multi-path accumulator shape.

## Why this is in the interpreter, not `eval_recurse_expr`

#551 hypothesised the regression came from the custom-step branch in `eval_recurse_expr`. Time-bisecting `nth(.; 0 | recurse([., .])) | (.. | scalars) |= .+1`:

| stage | user CPU |
|---|---|
| build the tree (`nth(...) | length`) | ~0.01s |
| build + walk + scalars (no update) | ~0.05s |
| full filter (`... |= .+1 | length`) | ~0.92s on main |

The dominant cost is in the `|=` itself, not the recurse, so the fix is in `Expr::Update`. The previous "phantom 14ms" baseline of pre-#497 was the early-exit case noted in 79080d1 — there's nothing to "restore."

## Benchmark

`nth(.; 0 | recurse([., .])) | (.. | scalars) |= .+1 | length` over input 17, best-of-5 user CPU on macOS arm64:

| condition | main | this PR |
|---|---|---|
| under load (Code helpers etc., load avg ~6) | 0.92s | 0.48s |
| v1.5.0 baseline (low load) | 0.222s | ~0.10s |

About 2× either way.

The full `bench/comprehensive.sh` was run earlier under heavy load — every entry was inflated proportionally vs the v1.5.0 column, so the absolute numbers aren't comparable. The relative comparison main vs this branch on tree-update specifically (controlled, same load) is the signal that matters.

## Test plan

- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` — official 509 + regression + diff_corpus + selfdiff_jit_interp + fuzz_restricted all pass
- [x] 4 new regression cases in `tests/regression.test`:
  - tree-update at depth 3 (`nth(.; 0 | recurse([., .])) | (.. | scalars) |= .+1`)
  - nested object/array updates (`(.. | scalars) |= .+10`)
  - multi-path assignment (`(.a, .b) = "x"`)
  - empty-output update + sibling += (deletes `.a`, increments `.b`)
- [x] Spot-checked `pick(.a, .b)` / `pick(.a.b, .c)` / `pick(.[1], .[3])` against jq 1.8.1 — identical output

Closes #551

🤖 Generated with [Claude Code](https://claude.com/claude-code)