### PR TITLE
release v1.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,7 +450,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jq-jit"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jq-jit"
-version = "1.5.0"
+version = "1.5.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A JIT-compiling implementation of jq using Cranelift"

--- a/docs/benchmark-history.md
+++ b/docs/benchmark-history.md
@@ -6,287 +6,287 @@ Recent slice (last 5 columns). Full history lives in
 
 ```text
 --- NDJSON workloads (2M objects) ---
-  Benchmark                v1.4.3  v1.4.4  3d440ca  v1.4.5  v1.5.0
-  ---                      ------  ------  -------  ------  ------
-  empty                    0.017s  0.017s  0.017s   0.017s  0.017s
-  identity -c              0.082s  0.082s  0.078s   0.081s  0.085s
-  identity (pretty)        0.108s  0.099s  0.101s   0.105s  0.103s
-  field access .name       0.080s  0.080s  0.087s   0.091s  0.093s
-  nested .x,.y,.name       0.111s  0.123s  0.144s   0.143s  0.145s
-  arithmetic .x + .y       0.064s  0.094s  0.082s   0.081s  0.082s
-  select .x > 1500000      0.066s  0.115s  0.069s   0.073s  0.080s
-  string concat            0.090s  0.089s  0.096s   0.096s  0.091s
-  object construct         0.087s  0.127s  0.112s   0.114s  0.111s
-  array construct          0.097s  0.102s  0.116s   0.120s  0.103s
-  .[]                      0.085s  0.098s  0.100s   0.099s  0.104s
-  to_entries               0.104s  0.112s  0.161s   0.156s  0.159s
-  keys                     0.088s  0.102s  0.098s   0.101s  0.101s
-  keys_unsorted            0.078s  0.091s  0.094s   0.093s  0.094s
-  length                   0.073s  0.085s  0.080s   0.083s  0.085s
-  has("x")                 0.030s  0.030s  0.029s   0.030s  0.038s
-  type                     0.019s  0.019s  0.022s   0.022s  0.022s
-  del(.name)               0.098s  0.095s  0.098s   0.099s  0.102s
-  @csv                     -       -       0.140s   0.137s  0.121s
-  split/join               -       -       0.093s   0.098s  0.090s
-  select|field             -       -       0.112s   0.112s  0.099s
-  select|remap             -       -       0.095s   0.096s  0.096s
-  computed remap           -       -       0.211s   0.214s  0.188s
-  [.x,.y]|add              -       -       0.082s   0.083s  0.085s
-  [.x,.y]|avg              -       -       0.110s   0.112s  0.108s
-  map(*2)|add              -       -       0.110s   0.113s  0.103s
-  keys|length              -       -       0.254s   0.254s  0.250s
-  .+{z=0}                  -       -       0.143s   0.147s  0.151s
-  split|first              -       -       0.092s   0.098s  0.087s
-  slice[0..5]              -       -       0.095s   0.100s  0.091s
-  dynkey {(.name)}         -       -       0.118s   0.121s  0.104s
-  .x += 1                  -       -       0.069s   0.070s  0.125s
-  {a}+{b} merge            -       -       0.143s   0.147s  0.130s
-  .x*2+1                   -       -       0.049s   0.050s  0.058s
-  .x+.y*2                  -       -       0.102s   0.105s  0.096s
-  .x > .y                  -       -       0.076s   0.077s  0.077s
-  to_entries|len           -       -       0.397s   0.395s  0.397s
-  .x|.+1 (pipe)            -       -       0.047s   0.048s  0.057s
-  .x|.*2|.+1               -       -       0.049s   0.050s  0.058s
-  .name|.+"_x"             -       -       0.098s   0.098s  0.092s
-  .x>N | not               -       -       0.040s   0.041s  0.049s
-  and (2 cmp)              -       -       0.080s   0.080s  0.081s
-  if-then-else             -       -       0.043s   0.043s  0.050s
-  sel(and)|field           -       -       0.076s   0.076s  0.076s
-  sel(and)|remap           -       -       0.074s   0.076s  0.077s
-  arith|cmp                -       -       0.044s   0.047s  0.052s
-  if cmp .field            -       -       0.102s   0.107s  0.111s
-  split|length             -       -       0.094s   0.099s  0.089s
-  [x,y]|min                -       -       0.090s   0.092s  0.090s
-  [x,y]|max                -       -       0.091s   0.095s  0.094s
-  [x,y]|sort|.[0]          -       -       0.087s   0.090s  0.088s
-  .name|len>5              -       -       0.096s   0.100s  0.089s
-  sel(len>5)|.x            -       -       0.125s   0.127s  0.110s
-  if .x>.y .name           -       -       0.087s   0.090s  0.089s
-  sel(.x>.y)|.name         -       -       0.071s   0.072s  0.072s
-  .x*2|tostring            -       -       0.047s   0.048s  0.055s
-  .x*.x+1                  -       -       0.056s   0.057s  0.064s
-  {k=.name,v=tostr}        -       -       0.160s   0.162s  0.149s
-  str add chain            -       -       0.386s   0.398s  0.382s
-  if>.y .name|empty        -       -       0.071s   0.073s  0.074s
-  if .x%2==0               -       -       0.045s   0.047s  0.053s
-  if .x*2+1>1M             -       -       0.045s   0.048s  0.053s
-  sel(.x%2==0)|.name       -       -       0.074s   0.076s  0.081s
-  sel(.x*2+1>1M)           -       -       0.142s   0.144s  0.156s
-  .x|@json                 -       -       0.045s   0.045s  0.047s
-  .x|@text                 -       -       0.045s   0.045s  0.047s
-  .name|@json              -       -       0.104s   0.107s  0.099s
-  sel|[arr]                -       -       0.148s   0.150s  0.144s
-  sel(and)|[arr]           -       -       0.076s   0.078s  0.077s
-  if>.y [arr]              -       -       0.199s   0.199s  0.177s
-  if sw then .f            -       -       0.135s   0.138s  0.137s
-  dynkey {(.n)=.x*2}       -       -       0.131s   0.132s  0.112s
-  sel(and)|.x*.y           -       -       0.075s   0.077s  0.078s
-  sel>N|str chain          -       -       0.158s   0.158s  0.153s
-  .f+"_"+arith_ts          -       -       0.145s   0.148s  0.134s
-  sel(sw)|str ch           -       -       0.317s   0.310s  0.298s
-  split|rev|join           -       -       0.123s   0.122s  0.114s
-  dynkey+static            -       -       0.324s   0.331s  0.334s
-  if>.y str chain          -       -       0.186s   0.189s  0.170s
-  remap+str chain          -       -       0.171s   0.178s  0.151s
-  sel(len>8)               -       -       0.163s   0.170s  0.162s
-  up|split|join            -       -       0.101s   0.104s  0.096s
-  .name|index              -       -       0.126s   0.128s  0.114s
-  .name|index+1            -       -       0.127s   0.133s  0.121s
-  .name|rindex             -       -       0.131s   0.134s  0.126s
-  .name|indices            -       -       0.153s   0.160s  0.154s
-  [x,y]|sort               -       -       0.154s   0.156s  0.152s
-  .name|scan               -       -       0.218s   0.219s  0.204s
-  .name|gsub               -       -       0.175s   0.178s  0.161s
-  walk(if num .+1)         -       -       0.140s   0.141s  0.137s
-  tojson                   -       -       0.106s   0.110s  0.107s
-  {name,x}                 -       -       0.144s   0.144s  0.132s
-  .z//.name                -       -       0.165s   0.164s  0.153s
-  .x|=test(re)             -       -       0.123s   0.124s  0.169s
-  ./sep|first              -       -       0.131s   0.132s  0.184s
-  .y=(.x*2)                -       -       0.112s   0.115s  0.178s
-  .y=(.x+.y)               -       -       0.161s   0.159s  0.228s
-  objects                  -       -       0.081s   0.085s  0.123s
-  .tag|=if..then N         -       -       0.613s   0.614s  0.607s
-  .x=(.x+1)                -       -       0.070s   0.072s  0.124s
-  sel>N|.y+=1              -       -       0.085s   0.087s  0.118s
-  sel(and)|.x+=1           -       -       0.100s   0.102s  0.109s
-  sel(sw)|.x+=1            -       -       0.132s   0.133s  0.160s
-  match(re)                -       -       0.369s   0.367s  0.359s
-  capture(re)              -       -       0.306s   0.303s  0.292s
-  first(.name,.x)          -       -       0.090s   0.093s  0.093s
-  if .x==null              -       -       0.043s   0.044s  0.046s
-  we(sw(.key))             -       -       0.111s   0.111s  0.107s
-  sel(sw or ew)            -       -       0.211s   0.214s  0.201s
-  path(.name,.x)           -       -       0.276s   0.277s  0.271s
-  sel(str+num+num)         -       -       0.142s   0.145s  0.151s
-  nested if|field          -       -       0.076s   0.077s  0.077s
-  .f|floor|.*2             -       -       0.050s   0.051s  0.059s
-  split|len>1              -       -       0.122s   0.124s  0.115s
-  .name|len|.*2            -       -       0.106s   0.107s  0.100s
-  if len>5 .x .y           -       -       0.137s   0.133s  0.115s
-  sel(len>5)|remap         -       -       0.230s   0.233s  0.200s
-  .x|tostr|len             -       -       0.056s   0.056s  0.059s
-  if .x>.y .x .y           -       -       0.093s   0.094s  0.094s
-  split|last|tonum         -       -       0.100s   0.104s  0.097s
-  split|rev|.[0]           -       -       0.097s   0.099s  0.095s
-  split|.[0]+.[1]          -       -       0.122s   0.123s  0.113s
-  .[]|strings              -       -       0.096s   0.095s  0.106s
-  .[]|numbers              -       -       0.107s   0.106s  0.129s
-  [x,y]|any(>1M)           -       -       0.082s   0.082s  0.082s
-  sel(dc|sw)               -       -       0.104s   0.107s  0.096s
-  [[x,y],[n]]|flat         -       -       0.475s   0.475s  0.452s
-  .x|floor|.*2             -       -       0.051s   0.051s  0.059s
-  tojson|fromjson          -       -       0.083s   0.081s  0.088s
-  [.x]|add                 -       -       0.048s   0.048s  0.059s
-  if>N {o}+.               -       -       0.123s   0.125s  0.133s
-  if>N .+{o}               -       -       0.124s   0.125s  0.135s
-  if .n=="s" .+{o}         -       -       0.167s   0.161s  0.161s
-  sel(.n>"s")              -       -       0.095s   0.094s  0.087s
-  [x,y,z]|min              -       -       0.311s   0.312s  0.306s
-  if .n|len>5 l s          -       -       0.107s   0.106s  0.100s
-  if .x|flr>N b s          -       -       0.047s   0.045s  0.054s
-  if .n|test l e           -       -       0.111s   0.112s  0.105s
-  if .n|sw l e             -       -       0.090s   0.091s  0.082s
-  if .n|ew l e             -       -       0.092s   0.091s  0.084s
-  .n|len|tostr             -       -       0.097s   0.099s  0.091s
+  Benchmark                v1.4.4  3d440ca  v1.4.5  v1.5.0  v1.5.1
+  ---                      ------  -------  ------  ------  ------
+  empty                    0.017s  0.017s   0.017s  0.017s  0.017s
+  identity -c              0.082s  0.078s   0.081s  0.085s  0.083s
+  identity (pretty)        0.099s  0.101s   0.105s  0.103s  0.103s
+  field access .name       0.080s  0.087s   0.091s  0.093s  0.090s
+  nested .x,.y,.name       0.123s  0.144s   0.143s  0.145s  0.146s
+  arithmetic .x + .y       0.094s  0.082s   0.081s  0.082s  0.081s
+  select .x > 1500000      0.115s  0.069s   0.073s  0.080s  0.081s
+  string concat            0.089s  0.096s   0.096s  0.091s  0.089s
+  object construct         0.127s  0.112s   0.114s  0.111s  0.109s
+  array construct          0.102s  0.116s   0.120s  0.103s  0.102s
+  .[]                      0.098s  0.100s   0.099s  0.104s  0.098s
+  to_entries               0.112s  0.161s   0.156s  0.159s  0.154s
+  keys                     0.102s  0.098s   0.101s  0.101s  0.101s
+  keys_unsorted            0.091s  0.094s   0.093s  0.094s  0.093s
+  length                   0.085s  0.080s   0.083s  0.085s  0.082s
+  has("x")                 0.030s  0.029s   0.030s  0.038s  0.035s
+  type                     0.019s  0.022s   0.022s  0.022s  0.023s
+  del(.name)               0.095s  0.098s   0.099s  0.102s  0.101s
+  @csv                     -       0.140s   0.137s  0.121s  0.119s
+  split/join               -       0.093s   0.098s  0.090s  0.088s
+  select|field             -       0.112s   0.112s  0.099s  0.093s
+  select|remap             -       0.095s   0.096s  0.096s  0.096s
+  computed remap           -       0.211s   0.214s  0.188s  0.186s
+  [.x,.y]|add              -       0.082s   0.083s  0.085s  0.084s
+  [.x,.y]|avg              -       0.110s   0.112s  0.108s  0.107s
+  map(*2)|add              -       0.110s   0.113s  0.103s  0.101s
+  keys|length              -       0.254s   0.254s  0.250s  0.251s
+  .+{z=0}                  -       0.143s   0.147s  0.151s  0.143s
+  split|first              -       0.092s   0.098s  0.087s  0.086s
+  slice[0..5]              -       0.095s   0.100s  0.091s  0.090s
+  dynkey {(.name)}         -       0.118s   0.121s  0.104s  0.101s
+  .x += 1                  -       0.069s   0.070s  0.125s  0.126s
+  {a}+{b} merge            -       0.143s   0.147s  0.130s  0.126s
+  .x*2+1                   -       0.049s   0.050s  0.058s  0.058s
+  .x+.y*2                  -       0.102s   0.105s  0.096s  0.095s
+  .x > .y                  -       0.076s   0.077s  0.077s  0.076s
+  to_entries|len           -       0.397s   0.395s  0.397s  0.394s
+  .x|.+1 (pipe)            -       0.047s   0.048s  0.057s  0.056s
+  .x|.*2|.+1               -       0.049s   0.050s  0.058s  0.058s
+  .name|.+"_x"             -       0.098s   0.098s  0.092s  0.092s
+  .x>N | not               -       0.040s   0.041s  0.049s  0.049s
+  and (2 cmp)              -       0.080s   0.080s  0.081s  0.080s
+  if-then-else             -       0.043s   0.043s  0.050s  0.051s
+  sel(and)|field           -       0.076s   0.076s  0.076s  0.076s
+  sel(and)|remap           -       0.074s   0.076s  0.077s  0.077s
+  arith|cmp                -       0.044s   0.047s  0.052s  0.053s
+  if cmp .field            -       0.102s   0.107s  0.111s  0.110s
+  split|length             -       0.094s   0.099s  0.089s  0.087s
+  [x,y]|min                -       0.090s   0.092s  0.090s  0.088s
+  [x,y]|max                -       0.091s   0.095s  0.094s  0.093s
+  [x,y]|sort|.[0]          -       0.087s   0.090s  0.088s  0.090s
+  .name|len>5              -       0.096s   0.100s  0.089s  0.089s
+  sel(len>5)|.x            -       0.125s   0.127s  0.110s  0.106s
+  if .x>.y .name           -       0.087s   0.090s  0.089s  0.089s
+  sel(.x>.y)|.name         -       0.071s   0.072s  0.072s  0.070s
+  .x*2|tostring            -       0.047s   0.048s  0.055s  0.055s
+  .x*.x+1                  -       0.056s   0.057s  0.064s  0.064s
+  {k=.name,v=tostr}        -       0.160s   0.162s  0.149s  0.143s
+  str add chain            -       0.386s   0.398s  0.382s  0.378s
+  if>.y .name|empty        -       0.071s   0.073s  0.074s  0.072s
+  if .x%2==0               -       0.045s   0.047s  0.053s  0.053s
+  if .x*2+1>1M             -       0.045s   0.048s  0.053s  0.054s
+  sel(.x%2==0)|.name       -       0.074s   0.076s  0.081s  0.081s
+  sel(.x*2+1>1M)           -       0.142s   0.144s  0.156s  0.154s
+  .x|@json                 -       0.045s   0.045s  0.047s  0.047s
+  .x|@text                 -       0.045s   0.045s  0.047s  0.047s
+  .name|@json              -       0.104s   0.107s  0.099s  0.099s
+  sel|[arr]                -       0.148s   0.150s  0.144s  0.144s
+  sel(and)|[arr]           -       0.076s   0.078s  0.077s  0.076s
+  if>.y [arr]              -       0.199s   0.199s  0.177s  0.172s
+  if sw then .f            -       0.135s   0.138s  0.137s  0.136s
+  dynkey {(.n)=.x*2}       -       0.131s   0.132s  0.112s  0.112s
+  sel(and)|.x*.y           -       0.075s   0.077s  0.078s  0.078s
+  sel>N|str chain          -       0.158s   0.158s  0.153s  0.151s
+  .f+"_"+arith_ts          -       0.145s   0.148s  0.134s  0.134s
+  sel(sw)|str ch           -       0.317s   0.310s  0.298s  0.300s
+  split|rev|join           -       0.123s   0.122s  0.114s  0.113s
+  dynkey+static            -       0.324s   0.331s  0.334s  0.336s
+  if>.y str chain          -       0.186s   0.189s  0.170s  0.168s
+  remap+str chain          -       0.171s   0.178s  0.151s  0.153s
+  sel(len>8)               -       0.163s   0.170s  0.162s  0.158s
+  up|split|join            -       0.101s   0.104s  0.096s  0.095s
+  .name|index              -       0.126s   0.128s  0.114s  0.117s
+  .name|index+1            -       0.127s   0.133s  0.121s  0.123s
+  .name|rindex             -       0.131s   0.134s  0.126s  0.129s
+  .name|indices            -       0.153s   0.160s  0.154s  0.149s
+  [x,y]|sort               -       0.154s   0.156s  0.152s  0.154s
+  .name|scan               -       0.218s   0.219s  0.204s  0.205s
+  .name|gsub               -       0.175s   0.178s  0.161s  0.165s
+  walk(if num .+1)         -       0.140s   0.141s  0.137s  0.140s
+  tojson                   -       0.106s   0.110s  0.107s  0.104s
+  {name,x}                 -       0.144s   0.144s  0.132s  0.125s
+  .z//.name                -       0.165s   0.164s  0.153s  0.152s
+  .x|=test(re)             -       0.123s   0.124s  0.169s  0.170s
+  ./sep|first              -       0.131s   0.132s  0.184s  0.182s
+  .y=(.x*2)                -       0.112s   0.115s  0.178s  0.177s
+  .y=(.x+.y)               -       0.161s   0.159s  0.228s  0.227s
+  objects                  -       0.081s   0.085s  0.123s  0.127s
+  .tag|=if..then N         -       0.613s   0.614s  0.607s  0.609s
+  .x=(.x+1)                -       0.070s   0.072s  0.124s  0.125s
+  sel>N|.y+=1              -       0.085s   0.087s  0.118s  0.122s
+  sel(and)|.x+=1           -       0.100s   0.102s  0.109s  0.107s
+  sel(sw)|.x+=1            -       0.132s   0.133s  0.160s  0.158s
+  match(re)                -       0.369s   0.367s  0.359s  0.365s
+  capture(re)              -       0.306s   0.303s  0.292s  0.304s
+  first(.name,.x)          -       0.090s   0.093s  0.093s  0.099s
+  if .x==null              -       0.043s   0.044s  0.046s  0.047s
+  we(sw(.key))             -       0.111s   0.111s  0.107s  0.106s
+  sel(sw or ew)            -       0.211s   0.214s  0.201s  0.212s
+  path(.name,.x)           -       0.276s   0.277s  0.271s  0.276s
+  sel(str+num+num)         -       0.142s   0.145s  0.151s  0.153s
+  nested if|field          -       0.076s   0.077s  0.077s  0.079s
+  .f|floor|.*2             -       0.050s   0.051s  0.059s  0.062s
+  split|len>1              -       0.122s   0.124s  0.115s  0.116s
+  .name|len|.*2            -       0.106s   0.107s  0.100s  0.101s
+  if len>5 .x .y           -       0.137s   0.133s  0.115s  0.118s
+  sel(len>5)|remap         -       0.230s   0.233s  0.200s  0.208s
+  .x|tostr|len             -       0.056s   0.056s  0.059s  0.061s
+  if .x>.y .x .y           -       0.093s   0.094s  0.094s  0.096s
+  split|last|tonum         -       0.100s   0.104s  0.097s  0.095s
+  split|rev|.[0]           -       0.097s   0.099s  0.095s  0.093s
+  split|.[0]+.[1]          -       0.122s   0.123s  0.113s  0.113s
+  .[]|strings              -       0.096s   0.095s  0.106s  0.108s
+  .[]|numbers              -       0.107s   0.106s  0.129s  0.126s
+  [x,y]|any(>1M)           -       0.082s   0.082s  0.082s  0.083s
+  sel(dc|sw)               -       0.104s   0.107s  0.096s  0.099s
+  [[x,y],[n]]|flat         -       0.475s   0.475s  0.452s  0.463s
+  .x|floor|.*2             -       0.051s   0.051s  0.059s  0.062s
+  tojson|fromjson          -       0.083s   0.081s  0.088s  0.087s
+  [.x]|add                 -       0.048s   0.048s  0.059s  0.060s
+  if>N {o}+.               -       0.123s   0.125s  0.133s  0.138s
+  if>N .+{o}               -       0.124s   0.125s  0.135s  0.135s
+  if .n=="s" .+{o}         -       0.167s   0.161s  0.161s  0.163s
+  sel(.n>"s")              -       0.095s   0.094s  0.087s  0.089s
+  [x,y,z]|min              -       0.311s   0.312s  0.306s  0.301s
+  if .n|len>5 l s          -       0.107s   0.106s  0.100s  0.099s
+  if .x|flr>N b s          -       0.047s   0.045s  0.054s  0.055s
+  if .n|test l e           -       0.111s   0.112s  0.105s  0.103s
+  if .n|sw l e             -       0.090s   0.091s  0.082s  0.083s
+  if .n|ew l e             -       0.092s   0.091s  0.084s  0.086s
+  .n|len|tostr             -       0.097s   0.099s  0.091s  0.090s
 
 --- String operations (2M objects) ---
-  Benchmark                v1.4.3  v1.4.4  3d440ca  v1.4.5  v1.5.0
-  ---                      ------  ------  -------  ------  ------
-  ascii_downcase           0.090s  0.088s  0.110s   0.112s  0.103s
-  ascii_upcase             0.090s  0.088s  0.108s   0.109s  0.102s
-  ltrimstr                 0.090s  0.090s  0.101s   0.102s  0.099s
-  rtrimstr                 0.089s  0.090s  0.105s   0.107s  0.099s
-  split                    0.150s  0.151s  0.169s   0.172s  0.165s
-  case+split               0.117s  0.116s  0.126s   0.128s  0.116s
-  join                     0.087s  0.092s  0.101s   0.104s  0.093s
-  startswith               0.084s  0.086s  0.101s   0.103s  0.095s
-  endswith                 0.085s  0.088s  0.103s   0.104s  0.095s
-  tostring                 0.043s  0.095s  0.052s   0.053s  0.061s
-  tonumber                 0.108s  0.104s  0.117s   0.117s  0.110s
-  string interpolation     0.104s  0.106s  0.135s   0.134s  0.122s
+  Benchmark                v1.4.4  3d440ca  v1.4.5  v1.5.0  v1.5.1
+  ---                      ------  -------  ------  ------  ------
+  ascii_downcase           0.088s  0.110s   0.112s  0.103s  0.105s
+  ascii_upcase             0.088s  0.108s   0.109s  0.102s  0.102s
+  ltrimstr                 0.090s  0.101s   0.102s  0.099s  0.096s
+  rtrimstr                 0.090s  0.105s   0.107s  0.099s  0.097s
+  split                    0.151s  0.169s   0.172s  0.165s  0.164s
+  case+split               0.116s  0.126s   0.128s  0.116s  0.117s
+  join                     0.092s  0.101s   0.104s  0.093s  0.092s
+  startswith               0.086s  0.101s   0.103s  0.095s  0.095s
+  endswith                 0.088s  0.103s   0.104s  0.095s  0.093s
+  tostring                 0.095s  0.052s   0.053s  0.061s  0.061s
+  tonumber                 0.104s  0.117s   0.117s  0.110s  0.110s
+  string interpolation     0.106s  0.135s   0.134s  0.122s  0.121s
 
 --- String ops (200K objects) ---
-  Benchmark                v1.4.3  v1.4.4  3d440ca  v1.4.5  v1.5.0
-  ---                      ------  ------  -------  ------  ------
-  test (regex)             0.013s  0.013s  0.014s   0.014s  0.014s
-  match (regex)            0.031s  0.032s  0.033s   0.033s  0.032s
-  @base64                  0.011s  0.011s  0.013s   0.012s  0.011s
-  @uri                     0.011s  0.011s  0.013s   0.013s  0.012s
-  @html                    0.012s  0.011s  0.013s   0.013s  0.012s
-  @csv (array)             0.013s  0.014s  0.020s   0.018s  0.015s
-  @tsv (array)             0.013s  0.014s  0.018s   0.017s  0.015s
-  gsub                     0.018s  0.018s  0.020s   0.020s  0.018s
-  case+gsub                0.181s  0.180s  0.193s   0.193s  0.178s
-  case+test                0.116s  0.115s  0.130s   0.130s  0.115s
-  ltrim+tonum+arith        0.107s  0.107s  0.118s   0.118s  0.108s
+  Benchmark                v1.4.4  3d440ca  v1.4.5  v1.5.0  v1.5.1
+  ---                      ------  -------  ------  ------  ------
+  test (regex)             0.013s  0.014s   0.014s  0.014s  0.014s
+  match (regex)            0.032s  0.033s   0.033s  0.032s  0.032s
+  @base64                  0.011s  0.013s   0.012s  0.011s  0.012s
+  @uri                     0.011s  0.013s   0.013s  0.012s  0.012s
+  @html                    0.011s  0.013s   0.013s  0.012s  0.013s
+  @csv (array)             0.014s  0.020s   0.018s  0.015s  0.016s
+  @tsv (array)             0.014s  0.018s   0.017s  0.015s  0.015s
+  gsub                     0.018s  0.020s   0.020s  0.018s  0.019s
+  case+gsub                0.180s  0.193s   0.193s  0.178s  0.181s
+  case+test                0.115s  0.130s   0.130s  0.115s  0.119s
+  ltrim+tonum+arith        0.107s  0.118s   0.118s  0.108s  0.110s
 
 --- Numeric & math (2M objects) ---
-  Benchmark                v1.4.3  v1.4.4  3d440ca  v1.4.5  v1.5.0
-  ---                      ------  ------  -------  ------  ------
-  floor                    0.042s  0.091s  0.048s   0.048s  0.056s
-  sqrt                     0.072s  0.115s  0.078s   0.078s  0.078s
-  modulo                   0.045s  0.095s  0.051s   0.051s  0.056s
-  if-elif-else             0.102s  0.134s  0.125s   0.124s  0.124s
-  select|del               0.073s  0.126s  0.079s   0.079s  0.090s
-  select|merge             0.105s  0.157s  0.110s   0.107s  0.118s
-  select(test)|merge       0.022s  0.021s  0.022s   0.022s  0.021s
+  Benchmark                v1.4.4  3d440ca  v1.4.5  v1.5.0  v1.5.1
+  ---                      ------  -------  ------  ------  ------
+  floor                    0.091s  0.048s   0.048s  0.056s  0.056s
+  sqrt                     0.115s  0.078s   0.078s  0.078s  0.079s
+  modulo                   0.095s  0.051s   0.051s  0.056s  0.058s
+  if-elif-else             0.134s  0.125s   0.124s  0.124s  0.125s
+  select|del               0.126s  0.079s   0.079s  0.090s  0.092s
+  select|merge             0.157s  0.110s   0.107s  0.118s  0.119s
+  select(test)|merge       0.021s  0.022s   0.022s  0.021s  0.021s
 
 --- Array generators ---
-  Benchmark                v1.4.3  v1.4.4  3d440ca  v1.4.5  v1.5.0
-  ---                      ------  ------  -------  ------  ------
-  range(2M) | length       0.011s  0.011s  0.011s   0.011s  0.011s
-  reverse(2M)              0.017s  0.017s  0.018s   0.017s  0.018s
-  sort(2M)                 0.022s  0.022s  0.023s   0.023s  0.025s
-  unique(1M)               0.028s  0.028s  0.029s   0.029s  0.030s
-  flatten(500K)            0.010s  0.010s  0.010s   0.010s  0.010s
-  min, max(2M)             0.017s  0.018s  0.017s   0.017s  0.018s
-  add numbers(2M)          0.012s  0.012s  0.012s   0.012s  0.013s
-  any/all(2M)              0.028s  0.027s  0.028s   0.027s  0.028s
-  limit(10; range(10M))    0.002s  0.002s  0.002s   0.002s  0.002s
-  first(range(10M))        0.002s  0.002s  0.002s   0.002s  0.002s
-  last(range(2M))          0.002s  0.002s  0.002s   0.002s  0.002s
-  indices(1M)              0.015s  0.015s  0.015s   0.015s  0.016s
+  Benchmark                v1.4.4  3d440ca  v1.4.5  v1.5.0  v1.5.1
+  ---                      ------  -------  ------  ------  ------
+  range(2M) | length       0.011s  0.011s   0.011s  0.011s  0.011s
+  reverse(2M)              0.017s  0.018s   0.017s  0.018s  0.018s
+  sort(2M)                 0.022s  0.023s   0.023s  0.025s  0.023s
+  unique(1M)               0.028s  0.029s   0.029s  0.030s  0.030s
+  flatten(500K)            0.010s  0.010s   0.010s  0.010s  0.010s
+  min, max(2M)             0.018s  0.017s   0.017s  0.018s  0.021s
+  add numbers(2M)          0.012s  0.012s   0.012s  0.013s  0.012s
+  any/all(2M)              0.027s  0.028s   0.027s  0.028s  0.028s
+  limit(10; range(10M))    0.002s  0.002s   0.002s  0.002s  0.002s
+  first(range(10M))        0.002s  0.002s   0.002s  0.002s  0.002s
+  last(range(2M))          0.002s  0.002s   0.002s  0.002s  0.002s
+  indices(1M)              0.015s  0.015s   0.015s  0.016s  0.016s
 
 --- Reduce & foreach ---
-  Benchmark                v1.4.3  v1.4.4  3d440ca  v1.4.5  v1.5.0
-  ---                      ------  ------  -------  ------  ------
-  reduce (sum)             0.009s  0.009s  0.009s   0.009s  0.009s
-  reduce (array build)     0.004s  0.004s  0.004s   0.004s  0.004s
-  reduce (obj build)       0.010s  0.010s  0.010s   0.009s  0.009s
-  reduce (setpath)         0.016s  0.016s  0.016s   0.017s  0.016s
-  foreach (running sum)    0.010s  0.010s  0.010s   0.010s  0.010s
-  foreach + emit           0.010s  0.010s  0.010s   0.010s  0.010s
-  reduce (sum-of-squares)  0.032s  0.032s  0.032s   0.032s  0.032s
-  reduce (conditional)     0.034s  0.034s  0.035s   0.035s  0.035s
-  reduce (product)         0.034s  0.034s  0.035s   0.034s  0.034s
-  foreach (conditional)    0.010s  0.010s  0.011s   0.010s  0.010s
-  until (100M)             0.295s  0.294s  0.297s   0.295s  0.300s
-  reduce (harmonic)        0.032s  0.032s  0.033s   0.033s  0.032s
-  reduce (floor pipe)      0.032s  0.032s  0.033s   0.033s  0.032s
-  reduce (sqrt pipe)       0.032s  0.032s  0.032s   0.032s  0.034s
-  reduce (sin+cos)         0.052s  0.052s  0.052s   0.052s  0.052s
+  Benchmark                v1.4.4  3d440ca  v1.4.5  v1.5.0  v1.5.1
+  ---                      ------  -------  ------  ------  ------
+  reduce (sum)             0.009s  0.009s   0.009s  0.009s  0.008s
+  reduce (array build)     0.004s  0.004s   0.004s  0.004s  0.004s
+  reduce (obj build)       0.010s  0.010s   0.009s  0.009s  0.009s
+  reduce (setpath)         0.016s  0.016s   0.017s  0.016s  0.016s
+  foreach (running sum)    0.010s  0.010s   0.010s  0.010s  0.010s
+  foreach + emit           0.010s  0.010s   0.010s  0.010s  0.010s
+  reduce (sum-of-squares)  0.032s  0.032s   0.032s  0.032s  0.032s
+  reduce (conditional)     0.034s  0.035s   0.035s  0.035s  0.035s
+  reduce (product)         0.034s  0.035s   0.034s  0.034s  0.034s
+  foreach (conditional)    0.010s  0.011s   0.010s  0.010s  0.010s
+  until (100M)             0.294s  0.297s   0.295s  0.300s  0.301s
+  reduce (harmonic)        0.032s  0.033s   0.033s  0.032s  0.032s
+  reduce (floor pipe)      0.032s  0.033s   0.033s  0.032s  0.032s
+  reduce (sqrt pipe)       0.032s  0.032s   0.032s  0.034s  0.032s
+  reduce (sin+cos)         0.052s  0.052s   0.052s  0.052s  0.052s
 
 --- Object operations ---
-  Benchmark                v1.4.3  v1.4.4  3d440ca  v1.4.5  v1.5.0
-  ---                      ------  ------  -------  ------  ------
-  large obj construct      0.004s  0.004s  0.004s   0.004s  0.004s
-  large obj keys           0.011s  0.010s  0.011s   0.011s  0.011s
-  large obj to_entries     0.011s  0.012s  0.012s   0.012s  0.012s
-  with_entries             0.009s  0.009s  0.009s   0.009s  0.009s
+  Benchmark                v1.4.4  3d440ca  v1.4.5  v1.5.0  v1.5.1
+  ---                      ------  -------  ------  ------  ------
+  large obj construct      0.004s  0.004s   0.004s  0.004s  0.004s
+  large obj keys           0.010s  0.011s   0.011s  0.011s  0.011s
+  large obj to_entries     0.012s  0.012s   0.012s  0.012s  0.012s
+  with_entries             0.009s  0.009s   0.009s  0.009s  0.009s
 
 --- Assignment operators ---
-  Benchmark                v1.4.3  v1.4.4  3d440ca  v1.4.5  v1.5.0
-  ---                      ------  ------  -------  ------  ------
-  .[] |= f (100K)          0.005s  0.005s  0.005s   0.005s  0.005s
-  .[] += 1 (100K)          0.005s  0.005s  0.005s   0.005s  0.005s
-  .[k] = v reduce(50K)     0.008s  0.008s  0.008s   0.008s  0.008s
+  Benchmark                v1.4.4  3d440ca  v1.4.5  v1.5.0  v1.5.1
+  ---                      ------  -------  ------  ------  ------
+  .[] |= f (100K)          0.005s  0.005s   0.005s  0.005s  0.005s
+  .[] += 1 (100K)          0.005s  0.005s   0.005s  0.005s  0.005s
+  .[k] = v reduce(50K)     0.008s  0.008s   0.008s  0.008s  0.008s
 
 --- String-heavy generators ---
-  Benchmark                v1.4.3  v1.4.4  3d440ca  v1.4.5  v1.5.0
-  ---                      ------  ------  -------  ------  ------
-  gsub(100K)               0.025s  0.025s  0.025s   0.025s  0.028s
-  join large(100K)         0.006s  0.005s  0.006s   0.005s  0.006s
-  explode/implode(100K)    0.029s  0.028s  0.029s   0.028s  0.028s
-  reduce str concat(100K)  0.008s  0.008s  0.008s   0.008s  0.008s
+  Benchmark                v1.4.4  3d440ca  v1.4.5  v1.5.0  v1.5.1
+  ---                      ------  -------  ------  ------  ------
+  gsub(100K)               0.025s  0.025s   0.025s  0.028s  0.026s
+  join large(100K)         0.005s  0.006s   0.005s  0.006s  0.005s
+  explode/implode(100K)    0.028s  0.029s   0.028s  0.028s  0.027s
+  reduce str concat(100K)  0.008s  0.008s   0.008s  0.008s  0.008s
 
 --- Try-catch & alternative ---
-  Benchmark                v1.4.3  v1.4.4  3d440ca  v1.4.5  v1.5.0
-  ---                      ------  ------  -------  ------  ------
-  alternative //           0.031s  0.031s  0.032s   0.032s  0.032s
-  try-catch                0.023s  0.023s  0.023s   0.023s  0.023s
-  label-break              0.004s  0.004s  0.004s   0.004s  0.004s
+  Benchmark                v1.4.4  3d440ca  v1.4.5  v1.5.0  v1.5.1
+  ---                      ------  -------  ------  ------  ------
+  alternative //           0.031s  0.032s   0.032s  0.032s  0.032s
+  try-catch                0.023s  0.023s   0.023s  0.023s  0.023s
+  label-break              0.004s  0.004s   0.004s  0.004s  0.004s
 
 --- Type conversion ---
-  Benchmark                v1.4.3  v1.4.4  3d440ca  v1.4.5  v1.5.0
-  ---                      ------  ------  -------  ------  ------
-  tojson/fromjson(100K)    0.021s  0.021s  0.022s   0.022s  0.022s
-  null propagation(2M)     0.089s  0.090s  0.088s   0.087s  0.089s
+  Benchmark                v1.4.4  3d440ca  v1.4.5  v1.5.0  v1.5.1
+  ---                      ------  -------  ------  ------  ------
+  tojson/fromjson(100K)    0.021s  0.022s   0.022s  0.022s  0.022s
+  null propagation(2M)     0.090s  0.088s   0.087s  0.089s  0.090s
 
 --- jaq-derived ---
-  Benchmark                v1.4.3  v1.4.4  3d440ca  v1.4.5  v1.5.0
-  ---                      ------  ------  -------  ------  ------
-  jaq: reverse             0.010s  0.011s  0.011s   0.010s  0.011s
-  jaq: sort                0.018s  0.018s  0.018s   0.017s  0.018s
-  jaq: group-by            0.034s  0.035s  0.037s   0.037s  0.037s
-  jaq: min-max             0.010s  0.010s  0.011s   0.010s  0.011s
-  jaq: ex-implode          0.019s  0.019s  0.019s   0.019s  0.019s
-  jaq: repeat              0.011s  0.011s  0.011s   0.011s  0.011s
-  jaq: from                0.006s  0.006s  0.006s   0.006s  0.005s
-  jaq: last                0.002s  0.002s  0.002s   0.002s  0.002s
-  jaq: cumsum              0.010s  0.012s  0.010s   0.010s  0.010s
-  jaq: cumsum-xy           0.016s  0.018s  0.017s   0.017s  0.017s
-  jaq: try-catch           0.084s  0.088s  0.083s   0.090s  0.077s
-  jaq: add                 0.039s  0.042s  0.040s   0.040s  0.041s
-  jaq: reduce              0.084s  0.094s  0.081s   0.086s  0.078s
-  jaq: reduce-update       0.005s  0.005s  0.005s   0.005s  0.005s
-  jaq: kv                  0.014s  0.014s  0.015s   0.014s  0.015s
-  jaq: kv-update           0.019s  0.018s  0.018s   0.018s  0.018s
-  jaq: kv-entries          0.056s  0.056s  0.055s   0.055s  0.056s
-  jaq: pyramid             0.016s  0.015s  0.016s   0.016s  0.016s
-  jaq: upto                0.007s  0.007s  0.007s   0.007s  0.007s
-  jaq: tree-flatten        0.003s  0.003s  0.003s   0.003s  0.003s
-  jaq: tree-update         0.007s  0.007s  0.007s   0.007s  0.222s
-  jaq: to-fromjson         0.005s  0.005s  0.005s   0.005s  0.005s
-  jaq: str-slice           0.014s  0.013s  0.014s   0.014s  0.014s
+  Benchmark                v1.4.4  3d440ca  v1.4.5  v1.5.0  v1.5.1
+  ---                      ------  -------  ------  ------  ------
+  jaq: reverse             0.011s  0.011s   0.010s  0.011s  -
+  jaq: sort                0.018s  0.018s   0.017s  0.018s  -
+  jaq: group-by            0.035s  0.037s   0.037s  0.037s  -
+  jaq: min-max             0.010s  0.011s   0.010s  0.011s  -
+  jaq: ex-implode          0.019s  0.019s   0.019s  0.019s  -
+  jaq: repeat              0.011s  0.011s   0.011s  0.011s  -
+  jaq: from                0.006s  0.006s   0.006s  0.005s  -
+  jaq: last                0.002s  0.002s   0.002s  0.002s  -
+  jaq: cumsum              0.012s  0.010s   0.010s  0.010s  -
+  jaq: cumsum-xy           0.018s  0.017s   0.017s  0.017s  -
+  jaq: try-catch           0.088s  0.083s   0.090s  0.077s  -
+  jaq: add                 0.042s  0.040s   0.040s  0.041s  -
+  jaq: reduce              0.094s  0.081s   0.086s  0.078s  -
+  jaq: reduce-update       0.005s  0.005s   0.005s  0.005s  -
+  jaq: kv                  0.014s  0.015s   0.014s  0.015s  -
+  jaq: kv-update           0.018s  0.018s   0.018s  0.018s  -
+  jaq: kv-entries          0.056s  0.055s   0.055s  0.056s  -
+  jaq: pyramid             0.015s  0.016s   0.016s  0.016s  -
+  jaq: upto                0.007s  0.007s   0.007s  0.007s  -
+  jaq: tree-flatten        0.003s  0.003s   0.003s  0.003s  -
+  jaq: tree-update         0.007s  0.007s   0.007s  0.222s  -
+  jaq: to-fromjson         0.005s  0.005s   0.005s  0.005s  -
+  jaq: str-slice           0.013s  0.014s   0.014s  0.014s  -
 ```

--- a/docs/benchmark-history.tsv
+++ b/docs/benchmark-history.tsv
@@ -2762,3 +2762,217 @@ jaq-derived	jaq: tree-flatten	v1.5.0	0.003
 jaq-derived	jaq: tree-update	v1.5.0	0.222
 jaq-derived	jaq: to-fromjson	v1.5.0	0.005
 jaq-derived	jaq: str-slice	v1.5.0	0.014
+NDJSON workloads (2M objects)	empty	v1.5.1	0.017
+NDJSON workloads (2M objects)	identity -c	v1.5.1	0.083
+NDJSON workloads (2M objects)	identity (pretty)	v1.5.1	0.103
+NDJSON workloads (2M objects)	field access .name	v1.5.1	0.090
+NDJSON workloads (2M objects)	nested .x,.y,.name	v1.5.1	0.146
+NDJSON workloads (2M objects)	arithmetic .x + .y	v1.5.1	0.081
+NDJSON workloads (2M objects)	select .x > 1500000	v1.5.1	0.081
+NDJSON workloads (2M objects)	string concat	v1.5.1	0.089
+NDJSON workloads (2M objects)	object construct	v1.5.1	0.109
+NDJSON workloads (2M objects)	array construct	v1.5.1	0.102
+NDJSON workloads (2M objects)	.[]	v1.5.1	0.098
+NDJSON workloads (2M objects)	to_entries	v1.5.1	0.154
+NDJSON workloads (2M objects)	keys	v1.5.1	0.101
+NDJSON workloads (2M objects)	keys_unsorted	v1.5.1	0.093
+NDJSON workloads (2M objects)	length	v1.5.1	0.082
+NDJSON workloads (2M objects)	has("x")	v1.5.1	0.035
+NDJSON workloads (2M objects)	type	v1.5.1	0.023
+NDJSON workloads (2M objects)	del(.name)	v1.5.1	0.101
+NDJSON workloads (2M objects)	@csv	v1.5.1	0.119
+NDJSON workloads (2M objects)	split/join	v1.5.1	0.088
+NDJSON workloads (2M objects)	select|field	v1.5.1	0.093
+NDJSON workloads (2M objects)	select|remap	v1.5.1	0.096
+NDJSON workloads (2M objects)	computed remap	v1.5.1	0.186
+NDJSON workloads (2M objects)	[.x,.y]|add	v1.5.1	0.084
+NDJSON workloads (2M objects)	[.x,.y]|avg	v1.5.1	0.107
+NDJSON workloads (2M objects)	map(*2)|add	v1.5.1	0.101
+NDJSON workloads (2M objects)	keys|length	v1.5.1	0.251
+NDJSON workloads (2M objects)	.+{z=0}	v1.5.1	0.143
+NDJSON workloads (2M objects)	split|first	v1.5.1	0.086
+NDJSON workloads (2M objects)	slice[0..5]	v1.5.1	0.090
+NDJSON workloads (2M objects)	dynkey {(.name)}	v1.5.1	0.101
+NDJSON workloads (2M objects)	.x += 1	v1.5.1	0.126
+NDJSON workloads (2M objects)	{a}+{b} merge	v1.5.1	0.126
+NDJSON workloads (2M objects)	.x*2+1	v1.5.1	0.058
+NDJSON workloads (2M objects)	.x+.y*2	v1.5.1	0.095
+NDJSON workloads (2M objects)	.x > .y	v1.5.1	0.076
+NDJSON workloads (2M objects)	to_entries|len	v1.5.1	0.394
+NDJSON workloads (2M objects)	.x|.+1 (pipe)	v1.5.1	0.056
+NDJSON workloads (2M objects)	.x|.*2|.+1	v1.5.1	0.058
+NDJSON workloads (2M objects)	.name|.+"_x"	v1.5.1	0.092
+NDJSON workloads (2M objects)	.x>N | not	v1.5.1	0.049
+NDJSON workloads (2M objects)	and (2 cmp)	v1.5.1	0.080
+NDJSON workloads (2M objects)	if-then-else	v1.5.1	0.051
+NDJSON workloads (2M objects)	sel(and)|field	v1.5.1	0.076
+NDJSON workloads (2M objects)	sel(and)|remap	v1.5.1	0.077
+NDJSON workloads (2M objects)	arith|cmp	v1.5.1	0.053
+NDJSON workloads (2M objects)	if cmp .field	v1.5.1	0.110
+NDJSON workloads (2M objects)	split|length	v1.5.1	0.087
+NDJSON workloads (2M objects)	[x,y]|min	v1.5.1	0.088
+NDJSON workloads (2M objects)	[x,y]|max	v1.5.1	0.093
+NDJSON workloads (2M objects)	[x,y]|sort|.[0]	v1.5.1	0.090
+NDJSON workloads (2M objects)	.name|len>5	v1.5.1	0.089
+NDJSON workloads (2M objects)	sel(len>5)|.x	v1.5.1	0.106
+NDJSON workloads (2M objects)	if .x>.y .name	v1.5.1	0.089
+NDJSON workloads (2M objects)	sel(.x>.y)|.name	v1.5.1	0.070
+NDJSON workloads (2M objects)	.x*2|tostring	v1.5.1	0.055
+NDJSON workloads (2M objects)	.x*.x+1	v1.5.1	0.064
+NDJSON workloads (2M objects)	{k=.name,v=tostr}	v1.5.1	0.143
+NDJSON workloads (2M objects)	str add chain	v1.5.1	0.378
+NDJSON workloads (2M objects)	if>.y .name|empty	v1.5.1	0.072
+NDJSON workloads (2M objects)	if .x%2==0	v1.5.1	0.053
+NDJSON workloads (2M objects)	if .x*2+1>1M	v1.5.1	0.054
+NDJSON workloads (2M objects)	sel(.x%2==0)|.name	v1.5.1	0.081
+NDJSON workloads (2M objects)	sel(.x*2+1>1M)	v1.5.1	0.154
+NDJSON workloads (2M objects)	.x|@json	v1.5.1	0.047
+NDJSON workloads (2M objects)	.x|@text	v1.5.1	0.047
+NDJSON workloads (2M objects)	.name|@json	v1.5.1	0.099
+NDJSON workloads (2M objects)	sel|[arr]	v1.5.1	0.144
+NDJSON workloads (2M objects)	sel(and)|[arr]	v1.5.1	0.076
+NDJSON workloads (2M objects)	if>.y [arr]	v1.5.1	0.172
+NDJSON workloads (2M objects)	if sw then .f	v1.5.1	0.136
+NDJSON workloads (2M objects)	dynkey {(.n)=.x*2}	v1.5.1	0.112
+NDJSON workloads (2M objects)	sel(and)|.x*.y	v1.5.1	0.078
+NDJSON workloads (2M objects)	sel>N|str chain	v1.5.1	0.151
+NDJSON workloads (2M objects)	.f+"_"+arith_ts	v1.5.1	0.134
+NDJSON workloads (2M objects)	sel(sw)|str ch	v1.5.1	0.300
+NDJSON workloads (2M objects)	split|rev|join	v1.5.1	0.113
+NDJSON workloads (2M objects)	dynkey+static	v1.5.1	0.336
+NDJSON workloads (2M objects)	if>.y str chain	v1.5.1	0.168
+NDJSON workloads (2M objects)	remap+str chain	v1.5.1	0.153
+NDJSON workloads (2M objects)	sel(len>8)	v1.5.1	0.158
+NDJSON workloads (2M objects)	up|split|join	v1.5.1	0.095
+NDJSON workloads (2M objects)	.name|index	v1.5.1	0.117
+NDJSON workloads (2M objects)	.name|index+1	v1.5.1	0.123
+NDJSON workloads (2M objects)	.name|rindex	v1.5.1	0.129
+NDJSON workloads (2M objects)	.name|indices	v1.5.1	0.149
+NDJSON workloads (2M objects)	[x,y]|sort	v1.5.1	0.154
+NDJSON workloads (2M objects)	.name|scan	v1.5.1	0.205
+NDJSON workloads (2M objects)	.name|gsub	v1.5.1	0.165
+NDJSON workloads (2M objects)	walk(if num .+1)	v1.5.1	0.140
+NDJSON workloads (2M objects)	tojson	v1.5.1	0.104
+NDJSON workloads (2M objects)	{name,x}	v1.5.1	0.125
+NDJSON workloads (2M objects)	.z//.name	v1.5.1	0.152
+NDJSON workloads (2M objects)	.x|=test(re)	v1.5.1	0.170
+NDJSON workloads (2M objects)	./sep|first	v1.5.1	0.182
+NDJSON workloads (2M objects)	.y=(.x*2)	v1.5.1	0.177
+NDJSON workloads (2M objects)	.y=(.x+.y)	v1.5.1	0.227
+NDJSON workloads (2M objects)	objects	v1.5.1	0.127
+NDJSON workloads (2M objects)	.tag|=if..then N	v1.5.1	0.609
+NDJSON workloads (2M objects)	.x=(.x+1)	v1.5.1	0.125
+NDJSON workloads (2M objects)	sel>N|.y+=1	v1.5.1	0.122
+NDJSON workloads (2M objects)	sel(and)|.x+=1	v1.5.1	0.107
+NDJSON workloads (2M objects)	sel(sw)|.x+=1	v1.5.1	0.158
+NDJSON workloads (2M objects)	match(re)	v1.5.1	0.365
+NDJSON workloads (2M objects)	capture(re)	v1.5.1	0.304
+NDJSON workloads (2M objects)	first(.name,.x)	v1.5.1	0.099
+NDJSON workloads (2M objects)	if .x==null	v1.5.1	0.047
+NDJSON workloads (2M objects)	we(sw(.key))	v1.5.1	0.106
+NDJSON workloads (2M objects)	sel(sw or ew)	v1.5.1	0.212
+NDJSON workloads (2M objects)	path(.name,.x)	v1.5.1	0.276
+NDJSON workloads (2M objects)	sel(str+num+num)	v1.5.1	0.153
+NDJSON workloads (2M objects)	nested if|field	v1.5.1	0.079
+NDJSON workloads (2M objects)	.f|floor|.*2	v1.5.1	0.062
+NDJSON workloads (2M objects)	split|len>1	v1.5.1	0.116
+NDJSON workloads (2M objects)	.name|len|.*2	v1.5.1	0.101
+NDJSON workloads (2M objects)	if len>5 .x .y	v1.5.1	0.118
+NDJSON workloads (2M objects)	sel(len>5)|remap	v1.5.1	0.208
+NDJSON workloads (2M objects)	.x|tostr|len	v1.5.1	0.061
+NDJSON workloads (2M objects)	if .x>.y .x .y	v1.5.1	0.096
+NDJSON workloads (2M objects)	split|last|tonum	v1.5.1	0.095
+NDJSON workloads (2M objects)	split|rev|.[0]	v1.5.1	0.093
+NDJSON workloads (2M objects)	split|.[0]+.[1]	v1.5.1	0.113
+NDJSON workloads (2M objects)	.[]|strings	v1.5.1	0.108
+NDJSON workloads (2M objects)	.[]|numbers	v1.5.1	0.126
+NDJSON workloads (2M objects)	[x,y]|any(>1M)	v1.5.1	0.083
+NDJSON workloads (2M objects)	sel(dc|sw)	v1.5.1	0.099
+NDJSON workloads (2M objects)	[[x,y],[n]]|flat	v1.5.1	0.463
+NDJSON workloads (2M objects)	.x|floor|.*2	v1.5.1	0.062
+NDJSON workloads (2M objects)	tojson|fromjson	v1.5.1	0.087
+NDJSON workloads (2M objects)	[.x]|add	v1.5.1	0.060
+NDJSON workloads (2M objects)	if>N {o}+.	v1.5.1	0.138
+NDJSON workloads (2M objects)	if>N .+{o}	v1.5.1	0.135
+NDJSON workloads (2M objects)	if .n=="s" .+{o}	v1.5.1	0.163
+NDJSON workloads (2M objects)	sel(.n>"s")	v1.5.1	0.089
+NDJSON workloads (2M objects)	[x,y,z]|min	v1.5.1	0.301
+NDJSON workloads (2M objects)	if .n|len>5 l s	v1.5.1	0.099
+NDJSON workloads (2M objects)	if .x|flr>N b s	v1.5.1	0.055
+NDJSON workloads (2M objects)	if .n|test l e	v1.5.1	0.103
+NDJSON workloads (2M objects)	if .n|sw l e	v1.5.1	0.083
+NDJSON workloads (2M objects)	if .n|ew l e	v1.5.1	0.086
+NDJSON workloads (2M objects)	.n|len|tostr	v1.5.1	0.090
+String operations (2M objects)	ascii_downcase	v1.5.1	0.105
+String operations (2M objects)	ascii_upcase	v1.5.1	0.102
+String operations (2M objects)	ltrimstr	v1.5.1	0.096
+String operations (2M objects)	rtrimstr	v1.5.1	0.097
+String operations (2M objects)	split	v1.5.1	0.164
+String operations (2M objects)	case+split	v1.5.1	0.117
+String operations (2M objects)	join	v1.5.1	0.092
+String operations (2M objects)	startswith	v1.5.1	0.095
+String operations (2M objects)	endswith	v1.5.1	0.093
+String operations (2M objects)	tostring	v1.5.1	0.061
+String operations (2M objects)	tonumber	v1.5.1	0.110
+String operations (2M objects)	string interpolation	v1.5.1	0.121
+String ops (200K objects)	test (regex)	v1.5.1	0.014
+String ops (200K objects)	match (regex)	v1.5.1	0.032
+String ops (200K objects)	@base64	v1.5.1	0.012
+String ops (200K objects)	@uri	v1.5.1	0.012
+String ops (200K objects)	@html	v1.5.1	0.013
+String ops (200K objects)	@csv (array)	v1.5.1	0.016
+String ops (200K objects)	@tsv (array)	v1.5.1	0.015
+String ops (200K objects)	gsub	v1.5.1	0.019
+String ops (200K objects)	case+gsub	v1.5.1	0.181
+String ops (200K objects)	case+test	v1.5.1	0.119
+String ops (200K objects)	ltrim+tonum+arith	v1.5.1	0.110
+Numeric & math (2M objects)	floor	v1.5.1	0.056
+Numeric & math (2M objects)	sqrt	v1.5.1	0.079
+Numeric & math (2M objects)	modulo	v1.5.1	0.058
+Numeric & math (2M objects)	if-elif-else	v1.5.1	0.125
+Numeric & math (2M objects)	select|del	v1.5.1	0.092
+Numeric & math (2M objects)	select|merge	v1.5.1	0.119
+Numeric & math (2M objects)	select(test)|merge	v1.5.1	0.021
+Array generators	range(2M) | length	v1.5.1	0.011
+Array generators	reverse(2M)	v1.5.1	0.018
+Array generators	sort(2M)	v1.5.1	0.023
+Array generators	unique(1M)	v1.5.1	0.030
+Array generators	flatten(500K)	v1.5.1	0.010
+Array generators	min, max(2M)	v1.5.1	0.021
+Array generators	add numbers(2M)	v1.5.1	0.012
+Array generators	any/all(2M)	v1.5.1	0.028
+Array generators	limit(10; range(10M))	v1.5.1	0.002
+Array generators	first(range(10M))	v1.5.1	0.002
+Array generators	last(range(2M))	v1.5.1	0.002
+Array generators	indices(1M)	v1.5.1	0.016
+Reduce & foreach	reduce (sum)	v1.5.1	0.008
+Reduce & foreach	reduce (array build)	v1.5.1	0.004
+Reduce & foreach	reduce (obj build)	v1.5.1	0.009
+Reduce & foreach	reduce (setpath)	v1.5.1	0.016
+Reduce & foreach	foreach (running sum)	v1.5.1	0.010
+Reduce & foreach	foreach + emit	v1.5.1	0.010
+Reduce & foreach	reduce (sum-of-squares)	v1.5.1	0.032
+Reduce & foreach	reduce (conditional)	v1.5.1	0.035
+Reduce & foreach	reduce (product)	v1.5.1	0.034
+Reduce & foreach	foreach (conditional)	v1.5.1	0.010
+Reduce & foreach	until (100M)	v1.5.1	0.301
+Reduce & foreach	reduce (harmonic)	v1.5.1	0.032
+Reduce & foreach	reduce (floor pipe)	v1.5.1	0.032
+Reduce & foreach	reduce (sqrt pipe)	v1.5.1	0.032
+Reduce & foreach	reduce (sin+cos)	v1.5.1	0.052
+Object operations	large obj construct	v1.5.1	0.004
+Object operations	large obj keys	v1.5.1	0.011
+Object operations	large obj to_entries	v1.5.1	0.012
+Object operations	with_entries	v1.5.1	0.009
+Assignment operators	.[] |= f (100K)	v1.5.1	0.005
+Assignment operators	.[] += 1 (100K)	v1.5.1	0.005
+Assignment operators	.[k] = v reduce(50K)	v1.5.1	0.008
+String-heavy generators	gsub(100K)	v1.5.1	0.026
+String-heavy generators	join large(100K)	v1.5.1	0.005
+String-heavy generators	explode/implode(100K)	v1.5.1	0.027
+String-heavy generators	reduce str concat(100K)	v1.5.1	0.008
+Try-catch & alternative	alternative //	v1.5.1	0.032
+Try-catch & alternative	try-catch	v1.5.1	0.023
+Try-catch & alternative	label-break	v1.5.1	0.004
+Type conversion	tojson/fromjson(100K)	v1.5.1	0.022
+Type conversion	null propagation(2M)	v1.5.1	0.090


### PR DESCRIPTION
## Summary

Patch release bundling fixes and additions since v1.5.0:

- perf: speed up multi-path `|=` via in-place `setpath_mut` (#625)
- feat: implement `tostream/0`, `fromstream/1`, `truncate_stream/1` (#624)
- feat: add `get_jq_origin/0`, `get_prog_origin/0`, `get_search_list/0` builtins (#623)
- fix: canonicalise subnormal-min repr in `tostring`/`tojson` interpreter path (#622)
- fix: drop subsecond component from `todate`/`todateiso8601`/`date` (#621)

## Bench

History columns appended for v1.5.1 in `docs/benchmark-history.{tsv,md}`.

No regression > 30%. Max ratio vs v1.5.0: **1.17x** on `min, max(2M)`
(0.018→0.021s — 3ms absolute on a sub-20ms benchmark, noise floor).
9 benchmarks > 5%, all on sub-100ms workloads with 1–11ms absolute
deltas; matched in the other direction by improvements down to 0.83x.

## Test plan

- [x] `cargo build --release` zero warnings
- [x] `cargo test --release` all passing
- [x] `bench/comprehensive.sh` — no regression > 30%