### PR TITLE
chore(deps): drop fast-float in favor of stdlib f64::from_str

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,12 +340,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "fast-float"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95765f67b4b18863968b4a1bd5bb576f732b29a4a28c7cd84c09fa3e2875f33c"
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,7 +455,6 @@ dependencies = [
  "cranelift-module",
  "cranelift-native",
  "csv",
- "fast-float",
  "itoa",
  "libc",
  "libm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ itoa = "1"
 compact_str = "0.9.0"
 memmap2 = "0.9"
 mimalloc = { version = "0.1", default-features = false }
-fast-float = "0.2"
 memchr = "2"
 ryu = "1"
 stacker = "0.1"

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -668,7 +668,7 @@ where
         content
     };
     let num_str = unsafe { std::str::from_utf8_unchecked(num_bytes) };
-    let mut n: f64 = match fast_float::parse(num_str) {
+    let mut n: f64 = match num_str.parse::<f64>() {
         Ok(n) => n,
         Err(_) => return RawApplyOutcome::Bail,
     };
@@ -3079,7 +3079,7 @@ where
     } else if json_object_get_fields_raw_buf(raw, 0, fields, ranges_buf) {
         let mut all_ok = true;
         for (i, &(s, e)) in ranges_buf[..nf].iter().enumerate() {
-            match fast_float::parse::<f64, _>(unsafe { std::str::from_utf8_unchecked(&raw[s..e]) }) {
+            match unsafe { std::str::from_utf8_unchecked(&raw[s..e]) }.parse::<f64>() {
                 Ok(n) => vals_buf[i] = n,
                 Err(_) => { all_ok = false; break; }
             }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1554,7 +1554,7 @@ fn rt_tonumber(v: &Value) -> Result<Value> {
             }
             // Strip leading '+' for compatibility with jq
             let parse_str = s_ref.strip_prefix('+').unwrap_or(s_ref);
-            match fast_float::parse(parse_str) {
+            match parse_str.parse::<f64>() {
                 Ok(n) => {
                     // Mirror parse_json_number: preserve repr when the canonical
                     // decnum-style form differs from the f64 default. Without

--- a/src/value.rs
+++ b/src/value.rs
@@ -920,7 +920,7 @@ pub fn json_object_get_num(b: &[u8], pos: usize, field: &str) -> Option<f64> {
                             e
                         };
                         let num_str = unsafe { std::str::from_utf8_unchecked(&b[i..end]) };
-                        value = fast_float::parse::<f64, _>(num_str).ok();
+                        value = num_str.parse::<f64>().ok();
                     } else if (k - start) <= 15 {
                         value = Some(if neg { -(n as f64) } else { n as f64 });
                     }
@@ -1039,7 +1039,7 @@ pub fn parse_json_num(b: &[u8]) -> Option<f64> {
     }
     if k < b.len() && (b[k] == b'.' || b[k] == b'e' || b[k] == b'E') {
         let num_str = unsafe { std::str::from_utf8_unchecked(b) };
-        return fast_float::parse::<f64, _>(num_str).ok();
+        return num_str.parse::<f64>().ok();
     }
     if k != b.len() { return None; } // trailing garbage
     if (k - start) > 15 { return None; }
@@ -3476,7 +3476,7 @@ pub fn json_object_get_two_nums(b: &[u8], pos: usize, field1: &str, field2: &str
                 };
                 let num_str = unsafe { std::str::from_utf8_unchecked(&b[i..end]) };
                 i = end;
-                fast_float::parse::<f64, _>(num_str).ok()?
+                num_str.parse::<f64>().ok()?
             } else {
                 if (k - start) > 15 { return None; }
                 i = k;
@@ -3770,7 +3770,7 @@ fn walk_json_nums_inner(buf: &mut Vec<u8>, b: &[u8], pos: &mut usize, op: u8, op
                 while *pos < b.len() && b[*pos].is_ascii_digit() { *pos += 1; }
             }
             let num_str = unsafe { std::str::from_utf8_unchecked(&b[start..*pos]) };
-            if let Ok(n) = fast_float::parse::<f64, _>(num_str) {
+            if let Ok(n) = num_str.parse::<f64>() {
                 let result = match op {
                     b'+' => n + operand,
                     b'-' => n - operand,
@@ -4718,7 +4718,7 @@ fn parse_json_number(b: &[u8], pos: usize) -> Result<(Value, usize)> {
     // before stashing the repr (issue #143).
     let num_str = unsafe { std::str::from_utf8_unchecked(&b[pos..i]) };
     let canonical_in = if num_str.starts_with('+') { &num_str[1..] } else { num_str };
-    let n: f64 = fast_float::parse(num_str).unwrap_or(0.0);
+    let n: f64 = num_str.parse::<f64>().unwrap_or(0.0);
     // Fast path: for simple decimals (no exponent, no trailing zeros after dot, ≤15 sig digits),
     // Rust's Display roundtrips identically — skip format_jq_number to avoid String allocation.
     if !has_exp && has_dot && (i - digits_start) <= 16 {
@@ -5676,7 +5676,7 @@ fn push_value_tojson(v: &Value, out: &mut String, depth: usize) {
                 .as_ref()
                 .filter(|r| is_valid_json_number(r) && n.is_finite() && *n != 0.0)
                 .and_then(|r| normalize_jq_repr(r))
-                .filter(|c| fast_float::parse::<f64, _>(c.as_str()).ok() == Some(*n))
+                .filter(|c| c.as_str().parse::<f64>().ok() == Some(*n))
             {
                 // Subnormal-edge case (#616): `repr_is_exact_for_f64` is too
                 // conservative for tiny exponents (< -323), but the literal


### PR DESCRIPTION
## Summary

- Replaces all 9 `fast_float::parse(...)` call sites with `s.parse::<f64>()` and removes the `fast-float` dependency.
- Resolves two Dependabot advisories on the unmaintained `fast-float` crate: GHSA-8655-xgh5-5vvq (RUSTSEC-2025-0003) and GHSA-x8jh-xj3x-gx3c (RUSTSEC-2024-0379).
- The fast-float algorithm was upstreamed into libcore in Rust 1.55 (rust-lang/rust#86761), so `<f64 as FromStr>` is performance-equivalent. All inputs were already `&str` (often via `from_utf8_unchecked` from a validated JSON-number byte slice), so the rewrite is a mechanical 1:1; `parse_partial` is not used anywhere.

## Test plan

- [x] `cargo build --release` — zero warnings
- [x] `cargo test --release` — official 509 + regression suites all pass
- [x] `fast-float` no longer appears in `Cargo.lock`
- [x] `./bench/comprehensive.sh` — geomean ratio vs v1.5.1 = **1.0078x** across 181 benchmarks (>0.02s). Numeric-parse-heavy cases are within noise:
  - `tonumber`: 0.110s → 0.109s
  - `ltrim+tonum+arith`: 0.110s → 0.112s
  - `split|last|tonum`: 0.095s → 0.098s
  - `@csv`: 0.119s → 0.122s
  - `tojson|fromjson`: 0.087s → 0.083s
- [ ] After merge: confirm Dependabot alerts auto-resolve.

Closes #627

🤖 Generated with [Claude Code](https://claude.com/claude-code)