### PR TITLE
build(release): publish windows-x86_64 zip alongside the existing tarballs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,28 +13,36 @@ env:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest
             target: linux-x86_64
           - os: macos-latest
             target: macos-arm64
+          - os: windows-latest
+            target: windows-x86_64
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
 
       - name: Install jq 1.8.1 (for differential tests)
+        shell: bash
         run: |
           case "${{ runner.os }}-${{ runner.arch }}" in
-            Linux-X64)   asset=jq-linux-amd64 ;;
-            Linux-ARM64) asset=jq-linux-arm64 ;;
-            macOS-X64)   asset=jq-macos-amd64 ;;
-            macOS-ARM64) asset=jq-macos-arm64 ;;
+            Linux-X64)    asset=jq-linux-amd64;       binary=jq     ;;
+            Linux-ARM64)  asset=jq-linux-arm64;       binary=jq     ;;
+            macOS-X64)    asset=jq-macos-amd64;       binary=jq     ;;
+            macOS-ARM64)  asset=jq-macos-arm64;       binary=jq     ;;
+            Windows-X64)  asset=jq-windows-amd64.exe; binary=jq.exe ;;
             *) echo "unsupported runner: ${{ runner.os }}-${{ runner.arch }}"; exit 1 ;;
           esac
-          curl -L -o /tmp/jq "https://github.com/jqlang/jq/releases/download/jq-1.8.1/${asset}"
-          sudo install -m 0755 /tmp/jq /usr/local/bin/jq
-          jq --version | grep -q '^jq-1\.8\.'
+          dest="$RUNNER_TEMP/jq181"
+          mkdir -p "$dest"
+          curl -L -o "$dest/$binary" "https://github.com/jqlang/jq/releases/download/jq-1.8.1/${asset}"
+          chmod +x "$dest/$binary"
+          "$dest/$binary" --version | grep -q '^jq-1\.8\.'
+          echo "JQ_BIN=$dest/$binary" >> "$GITHUB_ENV"
 
       - name: Build
         run: cargo build --release
@@ -42,7 +50,9 @@ jobs:
       - name: Run tests
         run: cargo test --release
 
-      - name: Package
+      - name: Package (tar.gz)
+        if: matrix.os != 'windows-latest'
+        shell: bash
         run: |
           staging="jq-jit-${{ matrix.target }}"
           mkdir -p "$staging"
@@ -50,11 +60,24 @@ jobs:
           cp LICENSE-MIT LICENSE-APACHE THIRD-PARTY-LICENSES.md README.md "$staging/"
           tar czf "${staging}.tar.gz" -C "$staging" .
 
+      - name: Package (zip)
+        if: matrix.os == 'windows-latest'
+        shell: bash
+        run: |
+          staging="jq-jit-${{ matrix.target }}"
+          mkdir -p "$staging"
+          cp target/release/jq-jit.exe "$staging/"
+          cp LICENSE-MIT LICENSE-APACHE THIRD-PARTY-LICENSES.md README.md "$staging/"
+          7z a "${staging}.zip" "./${staging}/*" >/dev/null
+
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
           name: jq-jit-${{ matrix.target }}
-          path: jq-jit-${{ matrix.target }}.tar.gz
+          path: |
+            jq-jit-${{ matrix.target }}.tar.gz
+            jq-jit-${{ matrix.target }}.zip
+          if-no-files-found: ignore
 
   release:
     needs: build
@@ -68,7 +91,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
-        run: gh release create "${{ github.ref_name }}" --generate-notes jq-jit-*.tar.gz
+        run: gh release create "${{ github.ref_name }}" --generate-notes jq-jit-*.tar.gz jq-jit-*.zip
 
       - name: Checkout homebrew-tap
         uses: actions/checkout@v6

--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ Pre-built binaries from the [latest release](https://github.com/m5d215/jq-jit/re
 brew install m5d215/tap/jq-jit
 ```
 
-Only macOS arm64 and Linux x86_64 binaries are currently published. For other platforms, build from source (see below).
+The Homebrew tap covers macOS arm64 and Linux x86_64. Windows x86_64 ships as a `.zip` on the releases page (see below); for any other platform, build from source.
 
 ### Prebuilt binaries (manual)
 
-Download the tarball for your platform from the [releases page](https://github.com/m5d215/jq-jit/releases/latest) and extract `jq-jit` onto your `PATH`.
+Download the archive for your platform from the [releases page](https://github.com/m5d215/jq-jit/releases/latest) and extract the binary onto your `PATH`. macOS / Linux ship as `.tar.gz`, Windows as `.zip` (`jq-jit.exe`).
 
 ## Building
 


### PR DESCRIPTION
## Summary

- `release.yml`: add `windows-latest` to the build matrix and ship `jq-jit-windows-x86_64.zip` from every tag push.
- `README.md`: drop the "Linux/macOS only" caveat in the Installation section.

## Why

`ci.yml` now exercises `windows-latest` on every PR (`#631`), so the Windows port is stable enough to publish. This is the second half of #600.

## Implementation notes

- The jq-1.8.1 install step is reused verbatim from `ci.yml`'s green Windows job (`JQ_BIN` env var, `$RUNNER_TEMP/jq181/`).
- Packaging is split: tar.gz on Linux/macOS, `7z a` zip on Windows. `actions/upload-artifact` collects both archive names with `if-no-files-found: ignore` so each runner uploads only its own.
- The homebrew-tap formula bump still iterates over `macos-arm64` / `linux-x86_64` only — Windows zips are correctly skipped.
- `gh release create` globs both `.tar.gz` and `.zip`.

## Caveat

The release workflow only runs on tag push, so this PR is **not** exercised by PR CI. The YAML parses cleanly (`ruby -ryaml`), and every cross-platform step except `7z a` is byte-identical to the green Windows job in `ci.yml`. If the zip step trips at the next tag push it's a `release.yml` patch, not a code regression.

## Test plan

- [x] `ruby -ryaml` parses both workflow files
- [x] CI matrix in `ci.yml` already passes on `windows-latest` (PR #631)
- [ ] Next release tag push attaches `jq-jit-windows-x86_64.zip` to the GitHub release

Closes #600

🤖 Generated with [Claude Code](https://claude.com/claude-code)