### PR TITLE
fix(jit): .f OP .f and {a:.f, b:.f} dropped second slot to null (#634)

### DIFF
--- a/src/jit.rs
+++ b/src/jit.rs
@@ -5541,12 +5541,17 @@ extern "C" fn jit_rt_field_binop_field(
         };
         let ka = std::slice::from_raw_parts(ka_ptr, ka_len);
         let kb = std::slice::from_raw_parts(kb_ptr, kb_len);
-        // Single-pass scan for both fields
+        // Single-pass scan for both fields. When ka == kb (e.g. `.n + .n`) a
+        // matching entry must populate both slots — the else-if branch alone
+        // would leave vb empty and silently read the second operand as null.
+        let same_key = ka == kb;
         let mut va: Option<&Value> = None;
         let mut vb: Option<&Value> = None;
         for (k, v) in obj.iter() {
             let kb_entry = k.as_bytes();
-            if va.is_none() && kb_entry == ka { va = Some(v); if vb.is_some() { break; } }
+            if same_key {
+                if kb_entry == ka { va = Some(v); vb = Some(v); break; }
+            } else if va.is_none() && kb_entry == ka { va = Some(v); if vb.is_some() { break; } }
             else if vb.is_none() && kb_entry == kb { vb = Some(v); if va.is_some() { break; } }
         }
         // Fast path: both fields are Num (most common case for arithmetic)
@@ -6792,12 +6797,14 @@ extern "C" fn jit_rt_obj_from_fields(
             for (k, v) in src_obj.iter() {
                 if found == all_found { break; }
                 let k_bytes = k.as_bytes();
+                // Do NOT break after the first matching pair — multiple pairs
+                // may reference the same source field (e.g. `{a: .n, b: .n}`),
+                // and each must receive a copy of the value.
                 for (fi, &(_, _, sfp, sfl)) in pairs.iter().enumerate() {
                     if fi < 64 && (found & (1u64 << fi)) != 0 { continue; }
                     if k_bytes.len() == sfl && k_bytes == std::slice::from_raw_parts(sfp, sfl) {
                         val_buf[fi].write(v.clone());
                         found |= 1u64 << fi;
-                        break;
                     }
                 }
             }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -9824,3 +9824,54 @@ nth(.; 0 | recurse([., .])) | (.. | scalars) |= .+1
 .a |= empty | .b += 1
 {"a":1,"b":2}
 {"b":3}
+
+# Issue #634: `.f OP .f` (same field on both sides) — the FieldBinopField
+# JIT fast path used a single-pass `if/else if` scan that filled only the
+# first slot when both keys matched, so the second operand silently read
+# as null. Verify all five arithmetic ops on a piped object input.
+{n: 5} | .n + .n
+null
+10
+
+{n: 5} | .n - .n
+null
+0
+
+{n: 5} | .n * .n
+null
+25
+
+{n: 6} | .n / .n
+null
+1
+
+{n: 7} | .n % .n
+null
+0
+
+# Issue #634: the same single-pass scan is used by the comparison ops.
+# Pre-fix `.n == .n` returned `false` because the second projection read null.
+{n: 5} | .n == .n
+null
+true
+
+{n: 5} | .n > .n
+null
+false
+
+# Issue #634: the original surfacing was a quadratic until-condition that
+# read the loop variable on both sides of `*`.
+def f: {n: 0} | until(.n * .n > 100; .n += 1) | .n; f
+null
+11
+
+# Issue #634: ObjFromFields fusion (introduced earlier) had the same shape
+# bug — multiple output fields sharing one source field only filled the
+# first pair and left the rest as null.
+{n: 5} | {a: .n, b: .n, c: .n}
+null
+{"a":5,"b":5,"c":5}
+
+{n: 5, m: 7} | {a: .n, b: .m, c: .n}
+null
+{"a":5,"b":7,"c":5}


### PR DESCRIPTION
## Summary

Two single-pass JIT scans were silently dropping all but the first matching slot when multiple operands referenced the same field name:

- `jit_rt_field_binop_field` — `.n + .n`, `.n == .n`, etc. read the second operand as null because the loop's `if/else if` filled only the LHS slot when both keys matched. From #634.
- `jit_rt_obj_from_fields` — `{a: .n, b: .n}` filled only the first pair because the inner loop broke after the first match.

## Root cause

`jit_rt_field_binop_field`'s single-pass rewrite (7615b7a, shipped from **v0.4.0**, ~2 months / through every 1.x release) lost the equal-keys case because the original code did two independent `obj.get` calls. The raw-bytes counterpart (`json_object_get_two_nums`) special-cases `field1 == field2` and was correct, so stdin-fed expressions worked while pipe-fed ones broke — exactly matching the issue's repro.

`jit_rt_obj_from_fields` (6314599, shipped from **v0.3.0**) had the analogous shape: the inner loop broke after writing the first pair, so any duplicate source-field references yielded null for the rest.

## Test plan

- [x] `cargo build --release` — zero warnings
- [x] `cargo test --release` — all suites pass (incl. new regression cases for both bugs and the original `until` repro)
- [x] `./bench/comprehensive.sh` — `arithmetic .x + .y` 0.084s, `object construct` 0.113s, `computed remap` 0.191s vs v1.5.2 baselines (0.084 / 0.115 / 0.190); no regression
- [x] Manual repro from the issue (all five arith ops, comparisons, `until` loop, `{a:.n, b:.n, c:.n}`)

Closes #634