### PR TITLE
fix(eval): zero-arg recursive defs share `as $x` slot across frames (#635)

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -2600,6 +2600,19 @@ pub fn eval(
                         if let Some(parts) = detect_linear_recursive_gen(&func.body, fid) {
                             return eval_linear_recursive_gen(parts, input, env, cb);
                         }
+                        // Recursive zero-arg (or arity-mismatched) call: rename
+                        // the body's local bindings to fresh indices so each
+                        // frame's `as $x` / Reduce / Foreach / Label gets its
+                        // own slot. Without this, the callback-driven eval
+                        // model lets an outer frame's body run while an inner
+                        // frame still owns the shared slot, and the outer
+                        // read sees the inner value (#635). The non-zero-arg
+                        // recursive path already routes through `Recursive` /
+                        // `CacheMiss` for the same reason.
+                        let mut nv = env.borrow().next_var;
+                        let body = substitute_and_rename(&func.body, &[], &[], &mut nv);
+                        env.borrow_mut().next_var = nv;
+                        return stacker::maybe_grow(128 * 1024, 32 * 1024 * 1024, || eval(&body, input, env, cb));
                     }
                     stacker::maybe_grow(128 * 1024, 32 * 1024 * 1024, || eval(&func.body, input, env, cb))
                 }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -9875,3 +9875,31 @@ null
 {n: 5, m: 7} | {a: .n, b: .m, c: .n}
 null
 {"a":5,"b":7,"c":5}
+
+# Issue #635: a zero-arg recursive `def` shared one var slot per `as`-bound
+# name across every recursive frame. The callback-driven eval model lets an
+# outer frame's body run while an inner frame still owns the slot, so an
+# outer `$x` read returned the inner value. The non-zero-arg case routed
+# through `substitute_and_rename` already; the Direct path now does the
+# same when the function is recursive.
+def f: . as $x | if . == 0 then null else (. - 1 | f) as $r | [$x, $r] end; 3 | f
+null
+[3,[2,[1,null]]]
+
+# Issue #635: function parameters were unaffected (the substitute_and_rename
+# path already covers them) — keep this around as a guard.
+def f($x): if $x == 0 then null else ($x - 1 | f($x - 1)) as $r | [$x, $r] end; f(3)
+null
+[3,[2,[1,null]]]
+
+# Issue #635: post-recursion `$x` read with a list-prepend body — verifies
+# the outer-frame `$x` survives a recursive call that itself rebinds `$x`.
+def f: . as $x | if . == 0 then [] else (. - 1 | f) as $r | $r + [$x] end; 5 | f
+null
+[1,2,3,4,5]
+
+# Issue #635: classic doubly-recursive numeric (no shared slot risk, but
+# guards that the rename path doesn't break the common case).
+def fib: . as $n | if $n < 2 then $n else ($n - 1 | fib) + ($n - 2 | fib) end; 10 | fib
+null
+55


### PR DESCRIPTION
## Summary

Zero-arg recursive defs (`def f: ... f`) routed through `FuncAction::Direct`, which calls `eval(&func.body, ...)` directly. Local bindings inside the body kept their parse-time var indices, so every recursive frame wrote the same slot. The callback-driven eval model then let an outer frame's `[$x, $r]` body run while an inner frame still owned the slot — the outer read returned the inner value.

The non-zero-arg recursive path already calls `substitute_and_rename` for exactly this reason (the comment on that helper spells it out). Routing the zero-arg recursive case through the same helper (with empty params) gives each frame its own slot and lets the existing save/restore around the binding work.

## Root cause

`substitute_and_rename` was wired only into `FuncAction::Recursive` / `CacheMiss`-recursive, both of which require `param_vars.is_empty() == false`. The dispatch at `src/eval.rs:2547` short-circuits zero-arg / no-args calls into `Direct` before the recursive-cache check ever runs, so the body went unrenamed.

I traced the bug by instrumenting `LetBinding` and `LoadVar` and confirmed:
- `vars[$x]` was correctly written and restored at each frame's binding entry/exit.
- But the outer-frame `[$x, $r]` cb fired *while inside* the inner recursive call's eval, before the inner restore. At that moment `vars[$x]` still held the deepest-frame's value, so every level read the same value.

## Why JIT mode shows the same symptom

`flatten_gen` rejects recursive `FuncCall` (`return false`), so the whole filter falls back to the eval interpreter. `JQJIT_TRACE=1` confirms `matched=eval` for the issue's repro. The fix lives in `eval.rs` and covers both modes.

## Test plan

- [x] `cargo build --release` — zero warnings
- [x] `cargo test --release` — all suites pass (incl. new regression cases for the issue's repro, the `def f: ... [$x] + .` cousin, and a textbook recursive `fib` to guard the rename path)
- [x] `./bench/comprehensive.sh` — `until (100M)` 0.34s, matches baseline before the fix (the `0.303s` history datapoint was noise; rerunning the just-merged main on this hardware gives 0.34s as well). No regression in arithmetic / object / generator paths.
- [x] Verified the function-parameter case (`def f($x): ...`) and the variable-prebind workaround (`. as $x | $x as $y | ...`) still work as the issue describes.

Closes #635