### PR TITLE
fix(parser): module nested defs missing from compiled_funcs map (#638)

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -56,6 +56,21 @@ impl Scope {
         func_id
     }
 
+    /// Push a function body to `compiled_funcs` only, without registering it
+    /// in the name-lookup table. Used by module loading for nested defs that
+    /// must keep a slot for runtime FuncCall dispatch but should not be
+    /// callable by name from outside their parent.
+    fn define_anon_func(&mut self, nargs: usize, body: Expr, param_vars: Vec<u16>) -> usize {
+        let func_id = self.compiled_funcs.len();
+        self.compiled_funcs.push(CompiledFunc {
+            name: None,
+            nargs,
+            body,
+            param_vars,
+        });
+        func_id
+    }
+
     fn update_func_body(&mut self, func_id: usize, body: Expr, param_vars: Vec<u16>) {
         if let Some(f) = self.compiled_funcs.get_mut(func_id) {
             f.body = body;
@@ -1110,18 +1125,28 @@ impl Parser {
         // Register module's functions into our scope with namespace prefix.
         // Build a func_id mapping (module-internal → main scope) so that
         // intra-module FuncCall references get remapped correctly.
+        //
+        // Top-level defs go through `define_func` so the namespaced name is
+        // looked up by callers in the main script. Inner defs (nested inside
+        // an outer def) are listed in `compiled_funcs` but not in
+        // `scope.funcs` — they still need a slot in the main scope's
+        // `compiled_funcs` so their `FuncCall` references resolve at runtime,
+        // but they must not be reachable by name from outside their parent
+        // (#638). Without this, a nested recursive `def g` inside a module's
+        // exported `def f` triggered "undefined function id" at the recursive
+        // self-call site.
         let mut func_id_map: Vec<(usize, usize)> = Vec::new(); // (old, new)
-
-        // First pass: register all functions with placeholder bodies to get new func_ids
-        for (name, mod_func_id, nargs) in &mod_parser.scope.funcs {
-            let func = &mod_parser.scope.compiled_funcs[*mod_func_id];
-            let new_name = if namespace.is_empty() {
-                name.clone()
+        for (mod_func_id, mod_func) in mod_parser.scope.compiled_funcs.iter().enumerate() {
+            let top_level_name = mod_parser.scope.funcs.iter()
+                .find(|(_, fid, _)| *fid == mod_func_id)
+                .map(|(name, _, _)| name.clone());
+            let new_id = if let Some(name) = top_level_name {
+                let new_name = if namespace.is_empty() { name } else { format!("{}::{}", namespace, name) };
+                self.scope.define_func(&new_name, mod_func.nargs, Expr::Empty, mod_func.param_vars.clone())
             } else {
-                format!("{}::{}", namespace, name)
+                self.scope.define_anon_func(mod_func.nargs, Expr::Empty, mod_func.param_vars.clone())
             };
-            let new_id = self.scope.define_func(&new_name, *nargs, Expr::Empty, func.param_vars.clone());
-            func_id_map.push((*mod_func_id, new_id));
+            func_id_map.push((mod_func_id, new_id));
         }
 
         // Second pass: remap func_ids in bodies and install them

--- a/tests/modules/issue_638.jq
+++ b/tests/modules/issue_638.jq
@@ -1,0 +1,15 @@
+def f:
+    def g:
+        if . == 0 then empty
+        else ., (. - 1 | g) end
+    ;
+    [g]
+;
+def to_multiprecision:
+    def loop:
+        if . == 0 then empty
+        else . % 10, ((./10) | floor | loop)
+        end
+    ;
+    [loop]
+;

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -9903,3 +9903,20 @@ null
 def fib: . as $n | if $n < 2 then $n else ($n - 1 | fib) + ($n - 2 | fib) end; 10 | fib
 null
 55
+
+# Issue #638: a `def` exported from an imported module with a nested
+# recursive helper (`def g:` inside `def f:`) failed with
+# "undefined function id" because module loading only re-registered the
+# top-level `scope.funcs` entries; nested defs sat in `compiled_funcs`
+# without a remapping, so the FuncCall self-reference couldn't resolve.
+# Fixture lives at `tests/modules/issue_638.jq`.
+import "issue_638" as M; M::f
+3
+[3,2,1]
+
+# Issue #638: same root cause, distinct surface — a nested generator
+# that integer-divides until it hits 0. Pre-fix this collapsed to `[[]]`
+# (no error, just a silently-broken inner generator).
+import "issue_638" as M; M::to_multiprecision
+196
+[6,9,1]


### PR DESCRIPTION
## Summary

A `def f: def g: ... g; ...` exported from an imported module triggered "undefined function id" at the recursive `g` call. The same shape inlined in the main script worked fine. A nearby case (`to_multiprecision`-style nested generator) silently collapsed to `[[]]` instead of erroring — same root cause, different broken codegen path.

## Root cause

`load_code_module` walked `mod_parser.scope.funcs` (top-level visible defs) to assign new IDs in the main scope's `compiled_funcs`. Inner defs nested inside an outer def live in `compiled_funcs` but get pruned from `scope.funcs` once the parent body finishes parsing — so the remap loop skipped them. The outer body's `FuncCall` kept the module-internal `g` ID, which either pointed past the main scope's `compiled_funcs` (the "undefined function id" case) or aliased some unrelated entry (the silent miscompile).

## Fix

Iterate `mod_parser.scope.compiled_funcs` instead. For each entry:
- if it appears in `scope.funcs` (top-level), call `define_func` with the namespaced name so the main script can resolve it by name;
- otherwise (nested), push it via a new `define_anon_func` that only adds to `compiled_funcs`, keeping it out of the name-lookup table so it's not callable from outside its parent.

The existing second pass (`remap_func_ids` + `update_func_body`) now patches every nested FuncCall too because the map is complete.

## Test plan

- [x] `cargo build --release` — zero warnings
- [x] Manual: issue's exact repro (`mod.jq` + `main.jq`) returns `[3,2,1]` under both default and `JQJIT_FORCE_INTERPRETER=1`
- [x] Manual: the `to_multiprecision`-style nested generator (`196 | L::to_multiprecision`) returns `[6,9,1]`
- [x] Manual: `include` directive (no namespace) works the same way
- [x] Manual: inline (no module) is unchanged
- [x] Regression suite gains two new cases backed by `tests/modules/issue_638.jq`
- [x] Full `cargo test --release` running in CI; the parser change is confined to `load_code_module` (only invoked on `import`/`include`) so non-module filters are untouched

Closes #638