### PR TITLE
release v1.5.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jq-jit"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jq-jit"
-version = "1.5.2"
+version = "1.5.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A JIT-compiling implementation of jq using Cranelift"

--- a/docs/benchmark-history.md
+++ b/docs/benchmark-history.md
@@ -6,287 +6,287 @@ Recent slice (last 5 columns). Full history lives in
 
 ```text
 --- NDJSON workloads (2M objects) ---
-  Benchmark                3d440ca  v1.4.5  v1.5.0  v1.5.1  v1.5.2
-  ---                      -------  ------  ------  ------  ------
-  empty                    0.017s   0.017s  0.017s  0.018s  0.017s
-  identity -c              0.078s   0.081s  0.085s  0.089s  0.086s
-  identity (pretty)        0.101s   0.105s  0.103s  0.108s  0.108s
-  field access .name       0.087s   0.091s  0.093s  0.095s  0.092s
-  nested .x,.y,.name       0.144s   0.143s  0.145s  0.154s  0.154s
-  arithmetic .x + .y       0.082s   0.081s  0.082s  0.086s  0.084s
-  select .x > 1500000      0.069s   0.073s  0.080s  0.084s  0.085s
-  string concat            0.096s   0.096s  0.091s  0.093s  0.096s
-  object construct         0.112s   0.114s  0.111s  0.112s  0.115s
-  array construct          0.116s   0.120s  0.103s  0.109s  0.103s
-  .[]                      0.100s   0.099s  0.104s  0.106s  0.107s
-  to_entries               0.161s   0.156s  0.159s  0.159s  0.158s
-  keys                     0.098s   0.101s  0.101s  0.105s  0.106s
-  keys_unsorted            0.094s   0.093s  0.094s  0.096s  0.095s
-  length                   0.080s   0.083s  0.085s  0.086s  0.084s
-  has("x")                 0.029s   0.030s  0.038s  0.036s  0.036s
-  type                     0.022s   0.022s  0.022s  0.023s  0.023s
-  del(.name)               0.098s   0.099s  0.102s  0.104s  0.107s
-  @csv                     0.140s   0.137s  0.121s  0.119s  0.122s
-  split/join               0.093s   0.098s  0.090s  0.088s  0.091s
-  select|field             0.112s   0.112s  0.099s  0.095s  0.099s
-  select|remap             0.095s   0.096s  0.096s  0.099s  0.101s
-  computed remap           0.211s   0.214s  0.188s  0.187s  0.190s
-  [.x,.y]|add              0.082s   0.083s  0.085s  0.084s  0.083s
-  [.x,.y]|avg              0.110s   0.112s  0.108s  0.111s  0.106s
-  map(*2)|add              0.110s   0.113s  0.103s  0.105s  0.104s
-  keys|length              0.254s   0.254s  0.250s  0.253s  0.253s
-  .+{z=0}                  0.143s   0.147s  0.151s  0.148s  0.149s
-  split|first              0.092s   0.098s  0.087s  0.089s  0.091s
-  slice[0..5]              0.095s   0.100s  0.091s  0.093s  0.093s
-  dynkey {(.name)}         0.118s   0.121s  0.104s  0.104s  0.104s
-  .x += 1                  0.069s   0.070s  0.125s  0.128s  0.128s
-  {a}+{b} merge            0.143s   0.147s  0.130s  0.127s  0.131s
-  .x*2+1                   0.049s   0.050s  0.058s  0.060s  0.060s
-  .x+.y*2                  0.102s   0.105s  0.096s  0.096s  0.097s
-  .x > .y                  0.076s   0.077s  0.077s  0.078s  0.078s
-  to_entries|len           0.397s   0.395s  0.397s  0.403s  0.396s
-  .x|.+1 (pipe)            0.047s   0.048s  0.057s  0.058s  0.058s
-  .x|.*2|.+1               0.049s   0.050s  0.058s  0.061s  0.059s
-  .name|.+"_x"             0.098s   0.098s  0.092s  0.092s  0.095s
-  .x>N | not               0.040s   0.041s  0.049s  0.050s  0.049s
-  and (2 cmp)              0.080s   0.080s  0.081s  0.082s  0.082s
-  if-then-else             0.043s   0.043s  0.050s  0.052s  0.052s
-  sel(and)|field           0.076s   0.076s  0.076s  0.080s  0.079s
-  sel(and)|remap           0.074s   0.076s  0.077s  0.081s  0.077s
-  arith|cmp                0.044s   0.047s  0.052s  0.055s  0.055s
-  if cmp .field            0.102s   0.107s  0.111s  0.115s  0.115s
-  split|length             0.094s   0.099s  0.089s  0.089s  0.092s
-  [x,y]|min                0.090s   0.092s  0.090s  0.092s  0.090s
-  [x,y]|max                0.091s   0.095s  0.094s  0.097s  0.095s
-  [x,y]|sort|.[0]          0.087s   0.090s  0.088s  0.093s  0.091s
-  .name|len>5              0.096s   0.100s  0.089s  0.093s  0.091s
-  sel(len>5)|.x            0.125s   0.127s  0.110s  0.113s  0.108s
-  if .x>.y .name           0.087s   0.090s  0.089s  0.092s  0.090s
-  sel(.x>.y)|.name         0.071s   0.072s  0.072s  0.072s  0.071s
-  .x*2|tostring            0.047s   0.048s  0.055s  0.057s  0.057s
-  .x*.x+1                  0.056s   0.057s  0.064s  0.066s  0.066s
-  {k=.name,v=tostr}        0.160s   0.162s  0.149s  0.150s  0.144s
-  str add chain            0.386s   0.398s  0.382s  0.386s  0.384s
-  if>.y .name|empty        0.071s   0.073s  0.074s  0.076s  0.073s
-  if .x%2==0               0.045s   0.047s  0.053s  0.054s  0.054s
-  if .x*2+1>1M             0.045s   0.048s  0.053s  0.056s  0.056s
-  sel(.x%2==0)|.name       0.074s   0.076s  0.081s  0.083s  0.083s
-  sel(.x*2+1>1M)           0.142s   0.144s  0.156s  0.157s  0.159s
-  .x|@json                 0.045s   0.045s  0.047s  0.047s  0.048s
-  .x|@text                 0.045s   0.045s  0.047s  0.048s  0.048s
-  .name|@json              0.104s   0.107s  0.099s  0.100s  0.100s
-  sel|[arr]                0.148s   0.150s  0.144s  0.145s  0.148s
-  sel(and)|[arr]           0.076s   0.078s  0.077s  0.078s  0.077s
-  if>.y [arr]              0.199s   0.199s  0.177s  0.177s  0.173s
-  if sw then .f            0.135s   0.138s  0.137s  0.138s  0.140s
-  dynkey {(.n)=.x*2}       0.131s   0.132s  0.112s  0.116s  0.114s
-  sel(and)|.x*.y           0.075s   0.077s  0.078s  0.078s  0.076s
-  sel>N|str chain          0.158s   0.158s  0.153s  0.156s  0.152s
-  .f+"_"+arith_ts          0.145s   0.148s  0.134s  0.130s  0.131s
-  sel(sw)|str ch           0.317s   0.310s  0.298s  0.307s  0.309s
-  split|rev|join           0.123s   0.122s  0.114s  0.111s  0.115s
-  dynkey+static            0.324s   0.331s  0.334s  0.339s  0.329s
-  if>.y str chain          0.186s   0.189s  0.170s  0.163s  0.165s
-  remap+str chain          0.171s   0.178s  0.151s  0.150s  0.151s
-  sel(len>8)               0.163s   0.170s  0.162s  0.164s  0.161s
-  up|split|join            0.101s   0.104s  0.096s  0.096s  0.095s
-  .name|index              0.126s   0.128s  0.114s  0.123s  0.122s
-  .name|index+1            0.127s   0.133s  0.121s  0.123s  0.124s
-  .name|rindex             0.131s   0.134s  0.126s  0.127s  0.129s
-  .name|indices            0.153s   0.160s  0.154s  0.155s  0.155s
-  [x,y]|sort               0.154s   0.156s  0.152s  0.152s  0.155s
-  .name|scan               0.218s   0.219s  0.204s  0.208s  0.211s
-  .name|gsub               0.175s   0.178s  0.161s  0.172s  0.167s
-  walk(if num .+1)         0.140s   0.141s  0.137s  0.137s  0.139s
-  tojson                   0.106s   0.110s  0.107s  0.105s  0.113s
-  {name,x}                 0.144s   0.144s  0.132s  0.127s  0.125s
-  .z//.name                0.165s   0.164s  0.153s  0.159s  0.154s
-  .x|=test(re)             0.123s   0.124s  0.169s  0.179s  0.171s
-  ./sep|first              0.131s   0.132s  0.184s  0.183s  0.185s
-  .y=(.x*2)                0.112s   0.115s  0.178s  0.176s  0.180s
-  .y=(.x+.y)               0.161s   0.159s  0.228s  0.230s  0.230s
-  objects                  0.081s   0.085s  0.123s  0.137s  0.130s
-  .tag|=if..then N         0.613s   0.614s  0.607s  0.602s  0.615s
-  .x=(.x+1)                0.070s   0.072s  0.124s  0.128s  0.128s
-  sel>N|.y+=1              0.085s   0.087s  0.118s  0.123s  0.121s
-  sel(and)|.x+=1           0.100s   0.102s  0.109s  0.109s  0.108s
-  sel(sw)|.x+=1            0.132s   0.133s  0.160s  0.159s  0.161s
-  match(re)                0.369s   0.367s  0.359s  0.360s  0.364s
-  capture(re)              0.306s   0.303s  0.292s  0.291s  0.297s
-  first(.name,.x)          0.090s   0.093s  0.093s  0.095s  0.096s
-  if .x==null              0.043s   0.044s  0.046s  0.048s  0.047s
-  we(sw(.key))             0.111s   0.111s  0.107s  0.106s  0.105s
-  sel(sw or ew)            0.211s   0.214s  0.201s  0.206s  0.205s
-  path(.name,.x)           0.276s   0.277s  0.271s  0.276s  0.274s
-  sel(str+num+num)         0.142s   0.145s  0.151s  0.151s  0.153s
-  nested if|field          0.076s   0.077s  0.077s  0.077s  0.078s
-  .f|floor|.*2             0.050s   0.051s  0.059s  0.061s  0.061s
-  split|len>1              0.122s   0.124s  0.115s  0.117s  0.117s
-  .name|len|.*2            0.106s   0.107s  0.100s  0.101s  0.103s
-  if len>5 .x .y           0.137s   0.133s  0.115s  0.113s  0.111s
-  sel(len>5)|remap         0.230s   0.233s  0.200s  0.202s  0.204s
-  .x|tostr|len             0.056s   0.056s  0.059s  0.059s  0.059s
-  if .x>.y .x .y           0.093s   0.094s  0.094s  0.096s  0.095s
-  split|last|tonum         0.100s   0.104s  0.097s  0.095s  0.093s
-  split|rev|.[0]           0.097s   0.099s  0.095s  0.090s  0.091s
-  split|.[0]+.[1]          0.122s   0.123s  0.113s  0.113s  0.113s
-  .[]|strings              0.096s   0.095s  0.106s  0.106s  0.109s
-  .[]|numbers              0.107s   0.106s  0.129s  0.125s  0.128s
-  [x,y]|any(>1M)           0.082s   0.082s  0.082s  0.082s  0.082s
-  sel(dc|sw)               0.104s   0.107s  0.096s  0.097s  0.100s
-  [[x,y],[n]]|flat         0.475s   0.475s  0.452s  0.457s  0.459s
-  .x|floor|.*2             0.051s   0.051s  0.059s  0.062s  0.061s
-  tojson|fromjson          0.083s   0.081s  0.088s  0.087s  0.087s
-  [.x]|add                 0.048s   0.048s  0.059s  0.059s  0.063s
-  if>N {o}+.               0.123s   0.125s  0.133s  0.135s  0.136s
-  if>N .+{o}               0.124s   0.125s  0.135s  0.136s  0.139s
-  if .n=="s" .+{o}         0.167s   0.161s  0.161s  0.161s  0.157s
-  sel(.n>"s")              0.095s   0.094s  0.087s  0.088s  0.087s
-  [x,y,z]|min              0.311s   0.312s  0.306s  0.309s  0.311s
-  if .n|len>5 l s          0.107s   0.106s  0.100s  0.100s  0.100s
-  if .x|flr>N b s          0.047s   0.045s  0.054s  0.054s  0.055s
-  if .n|test l e           0.111s   0.112s  0.105s  0.102s  0.104s
-  if .n|sw l e             0.090s   0.091s  0.082s  0.083s  0.083s
-  if .n|ew l e             0.092s   0.091s  0.084s  0.083s  0.084s
-  .n|len|tostr             0.097s   0.099s  0.091s  0.091s  0.088s
+  Benchmark                v1.4.5  v1.5.0  v1.5.1  v1.5.2  v1.5.3
+  ---                      ------  ------  ------  ------  ------
+  empty                    0.017s  0.017s  0.018s  0.017s  0.017s
+  identity -c              0.081s  0.085s  0.089s  0.086s  0.092s
+  identity (pretty)        0.105s  0.103s  0.108s  0.108s  0.109s
+  field access .name       0.091s  0.093s  0.095s  0.092s  0.097s
+  nested .x,.y,.name       0.143s  0.145s  0.154s  0.154s  0.155s
+  arithmetic .x + .y       0.081s  0.082s  0.086s  0.084s  0.084s
+  select .x > 1500000      0.073s  0.080s  0.084s  0.085s  0.083s
+  string concat            0.096s  0.091s  0.093s  0.096s  0.099s
+  object construct         0.114s  0.111s  0.112s  0.115s  0.113s
+  array construct          0.120s  0.103s  0.109s  0.103s  0.105s
+  .[]                      0.099s  0.104s  0.106s  0.107s  0.104s
+  to_entries               0.156s  0.159s  0.159s  0.158s  0.158s
+  keys                     0.101s  0.101s  0.105s  0.106s  0.104s
+  keys_unsorted            0.093s  0.094s  0.096s  0.095s  0.095s
+  length                   0.083s  0.085s  0.086s  0.084s  0.084s
+  has("x")                 0.030s  0.038s  0.036s  0.036s  0.035s
+  type                     0.022s  0.022s  0.023s  0.023s  0.023s
+  del(.name)               0.099s  0.102s  0.104s  0.107s  0.104s
+  @csv                     0.137s  0.121s  0.119s  0.122s  0.124s
+  split/join               0.098s  0.090s  0.088s  0.091s  0.093s
+  select|field             0.112s  0.099s  0.095s  0.099s  0.096s
+  select|remap             0.096s  0.096s  0.099s  0.101s  0.101s
+  computed remap           0.214s  0.188s  0.187s  0.190s  0.187s
+  [.x,.y]|add              0.083s  0.085s  0.084s  0.083s  0.086s
+  [.x,.y]|avg              0.112s  0.108s  0.111s  0.106s  0.108s
+  map(*2)|add              0.113s  0.103s  0.105s  0.104s  0.105s
+  keys|length              0.254s  0.250s  0.253s  0.253s  0.253s
+  .+{z=0}                  0.147s  0.151s  0.148s  0.149s  0.151s
+  split|first              0.098s  0.087s  0.089s  0.091s  0.093s
+  slice[0..5]              0.100s  0.091s  0.093s  0.093s  0.099s
+  dynkey {(.name)}         0.121s  0.104s  0.104s  0.104s  0.108s
+  .x += 1                  0.070s  0.125s  0.128s  0.128s  0.130s
+  {a}+{b} merge            0.147s  0.130s  0.127s  0.131s  0.132s
+  .x*2+1                   0.050s  0.058s  0.060s  0.060s  0.060s
+  .x+.y*2                  0.105s  0.096s  0.096s  0.097s  0.097s
+  .x > .y                  0.077s  0.077s  0.078s  0.078s  0.077s
+  to_entries|len           0.395s  0.397s  0.403s  0.396s  0.399s
+  .x|.+1 (pipe)            0.048s  0.057s  0.058s  0.058s  0.058s
+  .x|.*2|.+1               0.050s  0.058s  0.061s  0.059s  0.060s
+  .name|.+"_x"             0.098s  0.092s  0.092s  0.095s  0.096s
+  .x>N | not               0.041s  0.049s  0.050s  0.049s  0.048s
+  and (2 cmp)              0.080s  0.081s  0.082s  0.082s  0.081s
+  if-then-else             0.043s  0.050s  0.052s  0.052s  0.052s
+  sel(and)|field           0.076s  0.076s  0.080s  0.079s  0.078s
+  sel(and)|remap           0.076s  0.077s  0.081s  0.077s  0.078s
+  arith|cmp                0.047s  0.052s  0.055s  0.055s  0.054s
+  if cmp .field            0.107s  0.111s  0.115s  0.115s  0.115s
+  split|length             0.099s  0.089s  0.089s  0.092s  0.091s
+  [x,y]|min                0.092s  0.090s  0.092s  0.090s  0.091s
+  [x,y]|max                0.095s  0.094s  0.097s  0.095s  0.094s
+  [x,y]|sort|.[0]          0.090s  0.088s  0.093s  0.091s  0.091s
+  .name|len>5              0.100s  0.089s  0.093s  0.091s  0.093s
+  sel(len>5)|.x            0.127s  0.110s  0.113s  0.108s  0.109s
+  if .x>.y .name           0.090s  0.089s  0.092s  0.090s  0.088s
+  sel(.x>.y)|.name         0.072s  0.072s  0.072s  0.071s  0.073s
+  .x*2|tostring            0.048s  0.055s  0.057s  0.057s  0.056s
+  .x*.x+1                  0.057s  0.064s  0.066s  0.066s  0.065s
+  {k=.name,v=tostr}        0.162s  0.149s  0.150s  0.144s  0.145s
+  str add chain            0.398s  0.382s  0.386s  0.384s  0.389s
+  if>.y .name|empty        0.073s  0.074s  0.076s  0.073s  0.071s
+  if .x%2==0               0.047s  0.053s  0.054s  0.054s  0.055s
+  if .x*2+1>1M             0.048s  0.053s  0.056s  0.056s  0.055s
+  sel(.x%2==0)|.name       0.076s  0.081s  0.083s  0.083s  0.087s
+  sel(.x*2+1>1M)           0.144s  0.156s  0.157s  0.159s  0.161s
+  .x|@json                 0.045s  0.047s  0.047s  0.048s  0.049s
+  .x|@text                 0.045s  0.047s  0.048s  0.048s  0.048s
+  .name|@json              0.107s  0.099s  0.100s  0.100s  0.103s
+  sel|[arr]                0.150s  0.144s  0.145s  0.148s  0.146s
+  sel(and)|[arr]           0.078s  0.077s  0.078s  0.077s  0.079s
+  if>.y [arr]              0.199s  0.177s  0.177s  0.173s  0.175s
+  if sw then .f            0.138s  0.137s  0.138s  0.140s  0.144s
+  dynkey {(.n)=.x*2}       0.132s  0.112s  0.116s  0.114s  0.116s
+  sel(and)|.x*.y           0.077s  0.078s  0.078s  0.076s  0.079s
+  sel>N|str chain          0.158s  0.153s  0.156s  0.152s  0.155s
+  .f+"_"+arith_ts          0.148s  0.134s  0.130s  0.131s  0.132s
+  sel(sw)|str ch           0.310s  0.298s  0.307s  0.309s  0.307s
+  split|rev|join           0.122s  0.114s  0.111s  0.115s  0.114s
+  dynkey+static            0.331s  0.334s  0.339s  0.329s  0.337s
+  if>.y str chain          0.189s  0.170s  0.163s  0.165s  0.168s
+  remap+str chain          0.178s  0.151s  0.150s  0.151s  0.157s
+  sel(len>8)               0.170s  0.162s  0.164s  0.161s  0.166s
+  up|split|join            0.104s  0.096s  0.096s  0.095s  0.098s
+  .name|index              0.128s  0.114s  0.123s  0.122s  0.124s
+  .name|index+1            0.133s  0.121s  0.123s  0.124s  0.127s
+  .name|rindex             0.134s  0.126s  0.127s  0.129s  0.133s
+  .name|indices            0.160s  0.154s  0.155s  0.155s  0.155s
+  [x,y]|sort               0.156s  0.152s  0.152s  0.155s  0.155s
+  .name|scan               0.219s  0.204s  0.208s  0.211s  0.209s
+  .name|gsub               0.178s  0.161s  0.172s  0.167s  0.169s
+  walk(if num .+1)         0.141s  0.137s  0.137s  0.139s  0.139s
+  tojson                   0.110s  0.107s  0.105s  0.113s  0.109s
+  {name,x}                 0.144s  0.132s  0.127s  0.125s  0.124s
+  .z//.name                0.164s  0.153s  0.159s  0.154s  0.159s
+  .x|=test(re)             0.124s  0.169s  0.179s  0.171s  0.173s
+  ./sep|first              0.132s  0.184s  0.183s  0.185s  0.188s
+  .y=(.x*2)                0.115s  0.178s  0.176s  0.180s  0.184s
+  .y=(.x+.y)               0.159s  0.228s  0.230s  0.230s  0.239s
+  objects                  0.085s  0.123s  0.137s  0.130s  0.137s
+  .tag|=if..then N         0.614s  0.607s  0.602s  0.615s  0.611s
+  .x=(.x+1)                0.072s  0.124s  0.128s  0.128s  0.127s
+  sel>N|.y+=1              0.087s  0.118s  0.123s  0.121s  0.124s
+  sel(and)|.x+=1           0.102s  0.109s  0.109s  0.108s  0.114s
+  sel(sw)|.x+=1            0.133s  0.160s  0.159s  0.161s  0.165s
+  match(re)                0.367s  0.359s  0.360s  0.364s  0.374s
+  capture(re)              0.303s  0.292s  0.291s  0.297s  0.299s
+  first(.name,.x)          0.093s  0.093s  0.095s  0.096s  0.098s
+  if .x==null              0.044s  0.046s  0.048s  0.047s  0.047s
+  we(sw(.key))             0.111s  0.107s  0.106s  0.105s  0.110s
+  sel(sw or ew)            0.214s  0.201s  0.206s  0.205s  0.211s
+  path(.name,.x)           0.277s  0.271s  0.276s  0.274s  0.277s
+  sel(str+num+num)         0.145s  0.151s  0.151s  0.153s  0.155s
+  nested if|field          0.077s  0.077s  0.077s  0.078s  0.078s
+  .f|floor|.*2             0.051s  0.059s  0.061s  0.061s  0.061s
+  split|len>1              0.124s  0.115s  0.117s  0.117s  0.120s
+  .name|len|.*2            0.107s  0.100s  0.101s  0.103s  0.105s
+  if len>5 .x .y           0.133s  0.115s  0.113s  0.111s  0.113s
+  sel(len>5)|remap         0.233s  0.200s  0.202s  0.204s  0.204s
+  .x|tostr|len             0.056s  0.059s  0.059s  0.059s  0.060s
+  if .x>.y .x .y           0.094s  0.094s  0.096s  0.095s  0.094s
+  split|last|tonum         0.104s  0.097s  0.095s  0.093s  0.099s
+  split|rev|.[0]           0.099s  0.095s  0.090s  0.091s  0.096s
+  split|.[0]+.[1]          0.123s  0.113s  0.113s  0.113s  0.119s
+  .[]|strings              0.095s  0.106s  0.106s  0.109s  0.104s
+  .[]|numbers              0.106s  0.129s  0.125s  0.128s  0.125s
+  [x,y]|any(>1M)           0.082s  0.082s  0.082s  0.082s  0.082s
+  sel(dc|sw)               0.107s  0.096s  0.097s  0.100s  0.100s
+  [[x,y],[n]]|flat         0.475s  0.452s  0.457s  0.459s  0.454s
+  .x|floor|.*2             0.051s  0.059s  0.062s  0.061s  0.061s
+  tojson|fromjson          0.081s  0.088s  0.087s  0.087s  0.089s
+  [.x]|add                 0.048s  0.059s  0.059s  0.063s  0.060s
+  if>N {o}+.               0.125s  0.133s  0.135s  0.136s  0.140s
+  if>N .+{o}               0.125s  0.135s  0.136s  0.139s  0.135s
+  if .n=="s" .+{o}         0.161s  0.161s  0.161s  0.157s  0.163s
+  sel(.n>"s")              0.094s  0.087s  0.088s  0.087s  0.091s
+  [x,y,z]|min              0.312s  0.306s  0.309s  0.311s  0.309s
+  if .n|len>5 l s          0.106s  0.100s  0.100s  0.100s  0.104s
+  if .x|flr>N b s          0.045s  0.054s  0.054s  0.055s  0.056s
+  if .n|test l e           0.112s  0.105s  0.102s  0.104s  0.108s
+  if .n|sw l e             0.091s  0.082s  0.083s  0.083s  0.086s
+  if .n|ew l e             0.091s  0.084s  0.083s  0.084s  0.087s
+  .n|len|tostr             0.099s  0.091s  0.091s  0.088s  0.090s
 
 --- String operations (2M objects) ---
-  Benchmark                3d440ca  v1.4.5  v1.5.0  v1.5.1  v1.5.2
-  ---                      -------  ------  ------  ------  ------
-  ascii_downcase           0.110s   0.112s  0.103s  0.104s  0.105s
-  ascii_upcase             0.108s   0.109s  0.102s  0.105s  0.102s
-  ltrimstr                 0.101s   0.102s  0.099s  0.097s  0.098s
-  rtrimstr                 0.105s   0.107s  0.099s  0.099s  0.096s
-  split                    0.169s   0.172s  0.165s  0.165s  0.166s
-  case+split               0.126s   0.128s  0.116s  0.114s  0.117s
-  join                     0.101s   0.104s  0.093s  0.091s  0.094s
-  startswith               0.101s   0.103s  0.095s  0.096s  0.093s
-  endswith                 0.103s   0.104s  0.095s  0.097s  0.095s
-  tostring                 0.052s   0.053s  0.061s  0.063s  0.063s
-  tonumber                 0.117s   0.117s  0.110s  0.109s  0.109s
-  string interpolation     0.135s   0.134s  0.122s  0.117s  0.119s
+  Benchmark                v1.4.5  v1.5.0  v1.5.1  v1.5.2  v1.5.3
+  ---                      ------  ------  ------  ------  ------
+  ascii_downcase           0.112s  0.103s  0.104s  0.105s  0.106s
+  ascii_upcase             0.109s  0.102s  0.105s  0.102s  0.105s
+  ltrimstr                 0.102s  0.099s  0.097s  0.098s  0.099s
+  rtrimstr                 0.107s  0.099s  0.099s  0.096s  0.104s
+  split                    0.172s  0.165s  0.165s  0.166s  0.169s
+  case+split               0.128s  0.116s  0.114s  0.117s  0.119s
+  join                     0.104s  0.093s  0.091s  0.094s  0.094s
+  startswith               0.103s  0.095s  0.096s  0.093s  0.099s
+  endswith                 0.104s  0.095s  0.097s  0.095s  0.101s
+  tostring                 0.053s  0.061s  0.063s  0.063s  0.063s
+  tonumber                 0.117s  0.110s  0.109s  0.109s  0.113s
+  string interpolation     0.134s  0.122s  0.117s  0.119s  0.118s
 
 --- String ops (200K objects) ---
-  Benchmark                3d440ca  v1.4.5  v1.5.0  v1.5.1  v1.5.2
-  ---                      -------  ------  ------  ------  ------
-  test (regex)             0.014s   0.014s  0.014s  0.014s  0.015s
-  match (regex)            0.033s   0.033s  0.032s  0.032s  0.032s
-  @base64                  0.013s   0.012s  0.011s  0.012s  0.012s
-  @uri                     0.013s   0.013s  0.012s  0.011s  0.012s
-  @html                    0.013s   0.013s  0.012s  0.012s  0.013s
-  @csv (array)             0.020s   0.018s  0.015s  0.016s  0.016s
-  @tsv (array)             0.018s   0.017s  0.015s  0.015s  0.015s
-  gsub                     0.020s   0.020s  0.018s  0.019s  0.019s
-  case+gsub                0.193s   0.193s  0.178s  0.176s  0.179s
-  case+test                0.130s   0.130s  0.115s  0.116s  0.119s
-  ltrim+tonum+arith        0.118s   0.118s  0.108s  0.113s  0.112s
+  Benchmark                v1.4.5  v1.5.0  v1.5.1  v1.5.2  v1.5.3
+  ---                      ------  ------  ------  ------  ------
+  test (regex)             0.014s  0.014s  0.014s  0.015s  0.014s
+  match (regex)            0.033s  0.032s  0.032s  0.032s  0.032s
+  @base64                  0.012s  0.011s  0.012s  0.012s  0.012s
+  @uri                     0.013s  0.012s  0.011s  0.012s  0.012s
+  @html                    0.013s  0.012s  0.012s  0.013s  0.013s
+  @csv (array)             0.018s  0.015s  0.016s  0.016s  0.016s
+  @tsv (array)             0.017s  0.015s  0.015s  0.015s  0.015s
+  gsub                     0.020s  0.018s  0.019s  0.019s  0.019s
+  case+gsub                0.193s  0.178s  0.176s  0.179s  0.179s
+  case+test                0.130s  0.115s  0.116s  0.119s  0.121s
+  ltrim+tonum+arith        0.118s  0.108s  0.113s  0.112s  0.114s
 
 --- Numeric & math (2M objects) ---
-  Benchmark                3d440ca  v1.4.5  v1.5.0  v1.5.1  v1.5.2
-  ---                      -------  ------  ------  ------  ------
-  floor                    0.048s   0.048s  0.056s  0.057s  0.056s
-  sqrt                     0.078s   0.078s  0.078s  0.079s  0.078s
-  modulo                   0.051s   0.051s  0.056s  0.057s  0.058s
-  if-elif-else             0.125s   0.124s  0.124s  0.124s  0.125s
-  select|del               0.079s   0.079s  0.090s  0.091s  0.094s
-  select|merge             0.110s   0.107s  0.118s  0.117s  0.121s
-  select(test)|merge       0.022s   0.022s  0.021s  0.021s  0.021s
+  Benchmark                v1.4.5  v1.5.0  v1.5.1  v1.5.2  v1.5.3
+  ---                      ------  ------  ------  ------  ------
+  floor                    0.048s  0.056s  0.057s  0.056s  0.056s
+  sqrt                     0.078s  0.078s  0.079s  0.078s  0.078s
+  modulo                   0.051s  0.056s  0.057s  0.058s  0.057s
+  if-elif-else             0.124s  0.124s  0.124s  0.125s  0.123s
+  select|del               0.079s  0.090s  0.091s  0.094s  0.092s
+  select|merge             0.107s  0.118s  0.117s  0.121s  0.120s
+  select(test)|merge       0.022s  0.021s  0.021s  0.021s  0.021s
 
 --- Array generators ---
-  Benchmark                3d440ca  v1.4.5  v1.5.0  v1.5.1  v1.5.2
-  ---                      -------  ------  ------  ------  ------
-  range(2M) | length       0.011s   0.011s  0.011s  0.012s  0.012s
-  reverse(2M)              0.018s   0.017s  0.018s  0.018s  0.018s
-  sort(2M)                 0.023s   0.023s  0.025s  0.023s  0.023s
-  unique(1M)               0.029s   0.029s  0.030s  0.030s  0.031s
-  flatten(500K)            0.010s   0.010s  0.010s  0.011s  0.011s
-  min, max(2M)             0.017s   0.017s  0.018s  0.018s  0.022s
-  add numbers(2M)          0.012s   0.012s  0.013s  0.013s  0.013s
-  any/all(2M)              0.028s   0.027s  0.028s  0.028s  0.029s
-  limit(10; range(10M))    0.002s   0.002s  0.002s  0.002s  0.002s
-  first(range(10M))        0.002s   0.002s  0.002s  0.002s  0.003s
-  last(range(2M))          0.002s   0.002s  0.002s  0.002s  0.002s
-  indices(1M)              0.015s   0.015s  0.016s  0.016s  0.016s
+  Benchmark                v1.4.5  v1.5.0  v1.5.1  v1.5.2  v1.5.3
+  ---                      ------  ------  ------  ------  ------
+  range(2M) | length       0.011s  0.011s  0.012s  0.012s  0.011s
+  reverse(2M)              0.017s  0.018s  0.018s  0.018s  0.018s
+  sort(2M)                 0.023s  0.025s  0.023s  0.023s  0.023s
+  unique(1M)               0.029s  0.030s  0.030s  0.031s  0.030s
+  flatten(500K)            0.010s  0.010s  0.011s  0.011s  0.011s
+  min, max(2M)             0.017s  0.018s  0.018s  0.022s  0.022s
+  add numbers(2M)          0.012s  0.013s  0.013s  0.013s  0.013s
+  any/all(2M)              0.027s  0.028s  0.028s  0.029s  0.028s
+  limit(10; range(10M))    0.002s  0.002s  0.002s  0.002s  0.002s
+  first(range(10M))        0.002s  0.002s  0.002s  0.003s  0.002s
+  last(range(2M))          0.002s  0.002s  0.002s  0.002s  0.002s
+  indices(1M)              0.015s  0.016s  0.016s  0.016s  0.016s
 
 --- Reduce & foreach ---
-  Benchmark                3d440ca  v1.4.5  v1.5.0  v1.5.1  v1.5.2
-  ---                      -------  ------  ------  ------  ------
-  reduce (sum)             0.009s   0.009s  0.009s  0.009s  0.009s
-  reduce (array build)     0.004s   0.004s  0.004s  0.004s  0.004s
-  reduce (obj build)       0.010s   0.009s  0.009s  0.010s  0.010s
-  reduce (setpath)         0.016s   0.017s  0.016s  0.016s  0.016s
-  foreach (running sum)    0.010s   0.010s  0.010s  0.010s  0.010s
-  foreach + emit           0.010s   0.010s  0.010s  0.010s  0.010s
-  reduce (sum-of-squares)  0.032s   0.032s  0.032s  0.034s  0.034s
-  reduce (conditional)     0.035s   0.035s  0.035s  0.036s  0.036s
-  reduce (product)         0.035s   0.034s  0.034s  0.034s  0.035s
-  foreach (conditional)    0.011s   0.010s  0.010s  0.011s  0.011s
-  until (100M)             0.297s   0.295s  0.300s  0.303s  0.303s
-  reduce (harmonic)        0.033s   0.033s  0.032s  0.033s  0.034s
-  reduce (floor pipe)      0.033s   0.033s  0.032s  0.033s  0.034s
-  reduce (sqrt pipe)       0.032s   0.032s  0.034s  0.033s  0.033s
-  reduce (sin+cos)         0.052s   0.052s  0.052s  0.052s  0.052s
+  Benchmark                v1.4.5  v1.5.0  v1.5.1  v1.5.2  v1.5.3
+  ---                      ------  ------  ------  ------  ------
+  reduce (sum)             0.009s  0.009s  0.009s  0.009s  0.009s
+  reduce (array build)     0.004s  0.004s  0.004s  0.004s  0.004s
+  reduce (obj build)       0.009s  0.009s  0.010s  0.010s  0.010s
+  reduce (setpath)         0.017s  0.016s  0.016s  0.016s  0.016s
+  foreach (running sum)    0.010s  0.010s  0.010s  0.010s  0.010s
+  foreach + emit           0.010s  0.010s  0.010s  0.010s  0.010s
+  reduce (sum-of-squares)  0.032s  0.032s  0.034s  0.034s  0.033s
+  reduce (conditional)     0.035s  0.035s  0.036s  0.036s  0.035s
+  reduce (product)         0.034s  0.034s  0.034s  0.035s  0.034s
+  foreach (conditional)    0.010s  0.010s  0.011s  0.011s  0.010s
+  until (100M)             0.295s  0.300s  0.303s  0.303s  0.302s
+  reduce (harmonic)        0.033s  0.032s  0.033s  0.034s  0.036s
+  reduce (floor pipe)      0.033s  0.032s  0.033s  0.034s  0.034s
+  reduce (sqrt pipe)       0.032s  0.034s  0.033s  0.033s  0.034s
+  reduce (sin+cos)         0.052s  0.052s  0.052s  0.052s  0.052s
 
 --- Object operations ---
-  Benchmark                3d440ca  v1.4.5  v1.5.0  v1.5.1  v1.5.2
-  ---                      -------  ------  ------  ------  ------
-  large obj construct      0.004s   0.004s  0.004s  0.004s  0.004s
-  large obj keys           0.011s   0.011s  0.011s  0.011s  0.011s
-  large obj to_entries     0.012s   0.012s  0.012s  0.012s  0.012s
-  with_entries             0.009s   0.009s  0.009s  0.009s  0.009s
+  Benchmark                v1.4.5  v1.5.0  v1.5.1  v1.5.2  v1.5.3
+  ---                      ------  ------  ------  ------  ------
+  large obj construct      0.004s  0.004s  0.004s  0.004s  0.004s
+  large obj keys           0.011s  0.011s  0.011s  0.011s  0.011s
+  large obj to_entries     0.012s  0.012s  0.012s  0.012s  0.012s
+  with_entries             0.009s  0.009s  0.009s  0.009s  0.009s
 
 --- Assignment operators ---
-  Benchmark                3d440ca  v1.4.5  v1.5.0  v1.5.1  v1.5.2
-  ---                      -------  ------  ------  ------  ------
-  .[] |= f (100K)          0.005s   0.005s  0.005s  0.005s  0.005s
-  .[] += 1 (100K)          0.005s   0.005s  0.005s  0.006s  0.005s
-  .[k] = v reduce(50K)     0.008s   0.008s  0.008s  0.008s  0.008s
+  Benchmark                v1.4.5  v1.5.0  v1.5.1  v1.5.2  v1.5.3
+  ---                      ------  ------  ------  ------  ------
+  .[] |= f (100K)          0.005s  0.005s  0.005s  0.005s  0.005s
+  .[] += 1 (100K)          0.005s  0.005s  0.006s  0.005s  0.005s
+  .[k] = v reduce(50K)     0.008s  0.008s  0.008s  0.008s  0.008s
 
 --- String-heavy generators ---
-  Benchmark                3d440ca  v1.4.5  v1.5.0  v1.5.1  v1.5.2
-  ---                      -------  ------  ------  ------  ------
-  gsub(100K)               0.025s   0.025s  0.028s  0.027s  0.027s
-  join large(100K)         0.006s   0.005s  0.006s  0.005s  0.006s
-  explode/implode(100K)    0.029s   0.028s  0.028s  0.027s  0.027s
-  reduce str concat(100K)  0.008s   0.008s  0.008s  0.008s  0.008s
+  Benchmark                v1.4.5  v1.5.0  v1.5.1  v1.5.2  v1.5.3
+  ---                      ------  ------  ------  ------  ------
+  gsub(100K)               0.025s  0.028s  0.027s  0.027s  0.026s
+  join large(100K)         0.005s  0.006s  0.005s  0.006s  0.005s
+  explode/implode(100K)    0.028s  0.028s  0.027s  0.027s  0.027s
+  reduce str concat(100K)  0.008s  0.008s  0.008s  0.008s  0.008s
 
 --- Try-catch & alternative ---
-  Benchmark                3d440ca  v1.4.5  v1.5.0  v1.5.1  v1.5.2
-  ---                      -------  ------  ------  ------  ------
-  alternative //           0.032s   0.032s  0.032s  0.033s  0.033s
-  try-catch                0.023s   0.023s  0.023s  0.023s  0.023s
-  label-break              0.004s   0.004s  0.004s  0.004s  0.004s
+  Benchmark                v1.4.5  v1.5.0  v1.5.1  v1.5.2  v1.5.3
+  ---                      ------  ------  ------  ------  ------
+  alternative //           0.032s  0.032s  0.033s  0.033s  0.032s
+  try-catch                0.023s  0.023s  0.023s  0.023s  0.023s
+  label-break              0.004s  0.004s  0.004s  0.004s  0.004s
 
 --- Type conversion ---
-  Benchmark                3d440ca  v1.4.5  v1.5.0  v1.5.1  v1.5.2
-  ---                      -------  ------  ------  ------  ------
-  tojson/fromjson(100K)    0.022s   0.022s  0.022s  0.022s  0.022s
-  null propagation(2M)     0.088s   0.087s  0.089s  0.090s  0.090s
+  Benchmark                v1.4.5  v1.5.0  v1.5.1  v1.5.2  v1.5.3
+  ---                      ------  ------  ------  ------  ------
+  tojson/fromjson(100K)    0.022s  0.022s  0.022s  0.022s  0.022s
+  null propagation(2M)     0.087s  0.089s  0.090s  0.090s  0.090s
 
 --- jaq-derived ---
-  Benchmark                3d440ca  v1.4.5  v1.5.0  v1.5.1  v1.5.2
-  ---                      -------  ------  ------  ------  ------
-  jaq: reverse             0.011s   0.010s  0.011s  -       -
-  jaq: sort                0.018s   0.017s  0.018s  -       -
-  jaq: group-by            0.037s   0.037s  0.037s  -       -
-  jaq: min-max             0.011s   0.010s  0.011s  -       -
-  jaq: ex-implode          0.019s   0.019s  0.019s  -       -
-  jaq: repeat              0.011s   0.011s  0.011s  -       -
-  jaq: from                0.006s   0.006s  0.005s  -       -
-  jaq: last                0.002s   0.002s  0.002s  -       -
-  jaq: cumsum              0.010s   0.010s  0.010s  -       -
-  jaq: cumsum-xy           0.017s   0.017s  0.017s  -       -
-  jaq: try-catch           0.083s   0.090s  0.077s  -       -
-  jaq: add                 0.040s   0.040s  0.041s  -       -
-  jaq: reduce              0.081s   0.086s  0.078s  -       -
-  jaq: reduce-update       0.005s   0.005s  0.005s  -       -
-  jaq: kv                  0.015s   0.014s  0.015s  -       -
-  jaq: kv-update           0.018s   0.018s  0.018s  -       -
-  jaq: kv-entries          0.055s   0.055s  0.056s  -       -
-  jaq: pyramid             0.016s   0.016s  0.016s  -       -
-  jaq: upto                0.007s   0.007s  0.007s  -       -
-  jaq: tree-flatten        0.003s   0.003s  0.003s  -       -
-  jaq: tree-update         0.007s   0.007s  0.222s  -       -
-  jaq: to-fromjson         0.005s   0.005s  0.005s  -       -
-  jaq: str-slice           0.014s   0.014s  0.014s  -       -
+  Benchmark                v1.4.5  v1.5.0  v1.5.1  v1.5.2  v1.5.3
+  ---                      ------  ------  ------  ------  ------
+  jaq: reverse             0.010s  0.011s  -       -       -
+  jaq: sort                0.017s  0.018s  -       -       -
+  jaq: group-by            0.037s  0.037s  -       -       -
+  jaq: min-max             0.010s  0.011s  -       -       -
+  jaq: ex-implode          0.019s  0.019s  -       -       -
+  jaq: repeat              0.011s  0.011s  -       -       -
+  jaq: from                0.006s  0.005s  -       -       -
+  jaq: last                0.002s  0.002s  -       -       -
+  jaq: cumsum              0.010s  0.010s  -       -       -
+  jaq: cumsum-xy           0.017s  0.017s  -       -       -
+  jaq: try-catch           0.090s  0.077s  -       -       -
+  jaq: add                 0.040s  0.041s  -       -       -
+  jaq: reduce              0.086s  0.078s  -       -       -
+  jaq: reduce-update       0.005s  0.005s  -       -       -
+  jaq: kv                  0.014s  0.015s  -       -       -
+  jaq: kv-update           0.018s  0.018s  -       -       -
+  jaq: kv-entries          0.055s  0.056s  -       -       -
+  jaq: pyramid             0.016s  0.016s  -       -       -
+  jaq: upto                0.007s  0.007s  -       -       -
+  jaq: tree-flatten        0.003s  0.003s  -       -       -
+  jaq: tree-update         0.007s  0.222s  -       -       -
+  jaq: to-fromjson         0.005s  0.005s  -       -       -
+  jaq: str-slice           0.014s  0.014s  -       -       -
 ```

--- a/docs/benchmark-history.tsv
+++ b/docs/benchmark-history.tsv
@@ -3190,3 +3190,217 @@ Try-catch & alternative	try-catch	v1.5.2	0.023
 Try-catch & alternative	label-break	v1.5.2	0.004
 Type conversion	tojson/fromjson(100K)	v1.5.2	0.022
 Type conversion	null propagation(2M)	v1.5.2	0.090
+NDJSON workloads (2M objects)	empty	v1.5.3	0.017
+NDJSON workloads (2M objects)	identity -c	v1.5.3	0.092
+NDJSON workloads (2M objects)	identity (pretty)	v1.5.3	0.109
+NDJSON workloads (2M objects)	field access .name	v1.5.3	0.097
+NDJSON workloads (2M objects)	nested .x,.y,.name	v1.5.3	0.155
+NDJSON workloads (2M objects)	arithmetic .x + .y	v1.5.3	0.084
+NDJSON workloads (2M objects)	select .x > 1500000	v1.5.3	0.083
+NDJSON workloads (2M objects)	string concat	v1.5.3	0.099
+NDJSON workloads (2M objects)	object construct	v1.5.3	0.113
+NDJSON workloads (2M objects)	array construct	v1.5.3	0.105
+NDJSON workloads (2M objects)	.[]	v1.5.3	0.104
+NDJSON workloads (2M objects)	to_entries	v1.5.3	0.158
+NDJSON workloads (2M objects)	keys	v1.5.3	0.104
+NDJSON workloads (2M objects)	keys_unsorted	v1.5.3	0.095
+NDJSON workloads (2M objects)	length	v1.5.3	0.084
+NDJSON workloads (2M objects)	has("x")	v1.5.3	0.035
+NDJSON workloads (2M objects)	type	v1.5.3	0.023
+NDJSON workloads (2M objects)	del(.name)	v1.5.3	0.104
+NDJSON workloads (2M objects)	@csv	v1.5.3	0.124
+NDJSON workloads (2M objects)	split/join	v1.5.3	0.093
+NDJSON workloads (2M objects)	select|field	v1.5.3	0.096
+NDJSON workloads (2M objects)	select|remap	v1.5.3	0.101
+NDJSON workloads (2M objects)	computed remap	v1.5.3	0.187
+NDJSON workloads (2M objects)	[.x,.y]|add	v1.5.3	0.086
+NDJSON workloads (2M objects)	[.x,.y]|avg	v1.5.3	0.108
+NDJSON workloads (2M objects)	map(*2)|add	v1.5.3	0.105
+NDJSON workloads (2M objects)	keys|length	v1.5.3	0.253
+NDJSON workloads (2M objects)	.+{z=0}	v1.5.3	0.151
+NDJSON workloads (2M objects)	split|first	v1.5.3	0.093
+NDJSON workloads (2M objects)	slice[0..5]	v1.5.3	0.099
+NDJSON workloads (2M objects)	dynkey {(.name)}	v1.5.3	0.108
+NDJSON workloads (2M objects)	.x += 1	v1.5.3	0.130
+NDJSON workloads (2M objects)	{a}+{b} merge	v1.5.3	0.132
+NDJSON workloads (2M objects)	.x*2+1	v1.5.3	0.060
+NDJSON workloads (2M objects)	.x+.y*2	v1.5.3	0.097
+NDJSON workloads (2M objects)	.x > .y	v1.5.3	0.077
+NDJSON workloads (2M objects)	to_entries|len	v1.5.3	0.399
+NDJSON workloads (2M objects)	.x|.+1 (pipe)	v1.5.3	0.058
+NDJSON workloads (2M objects)	.x|.*2|.+1	v1.5.3	0.060
+NDJSON workloads (2M objects)	.name|.+"_x"	v1.5.3	0.096
+NDJSON workloads (2M objects)	.x>N | not	v1.5.3	0.048
+NDJSON workloads (2M objects)	and (2 cmp)	v1.5.3	0.081
+NDJSON workloads (2M objects)	if-then-else	v1.5.3	0.052
+NDJSON workloads (2M objects)	sel(and)|field	v1.5.3	0.078
+NDJSON workloads (2M objects)	sel(and)|remap	v1.5.3	0.078
+NDJSON workloads (2M objects)	arith|cmp	v1.5.3	0.054
+NDJSON workloads (2M objects)	if cmp .field	v1.5.3	0.115
+NDJSON workloads (2M objects)	split|length	v1.5.3	0.091
+NDJSON workloads (2M objects)	[x,y]|min	v1.5.3	0.091
+NDJSON workloads (2M objects)	[x,y]|max	v1.5.3	0.094
+NDJSON workloads (2M objects)	[x,y]|sort|.[0]	v1.5.3	0.091
+NDJSON workloads (2M objects)	.name|len>5	v1.5.3	0.093
+NDJSON workloads (2M objects)	sel(len>5)|.x	v1.5.3	0.109
+NDJSON workloads (2M objects)	if .x>.y .name	v1.5.3	0.088
+NDJSON workloads (2M objects)	sel(.x>.y)|.name	v1.5.3	0.073
+NDJSON workloads (2M objects)	.x*2|tostring	v1.5.3	0.056
+NDJSON workloads (2M objects)	.x*.x+1	v1.5.3	0.065
+NDJSON workloads (2M objects)	{k=.name,v=tostr}	v1.5.3	0.145
+NDJSON workloads (2M objects)	str add chain	v1.5.3	0.389
+NDJSON workloads (2M objects)	if>.y .name|empty	v1.5.3	0.071
+NDJSON workloads (2M objects)	if .x%2==0	v1.5.3	0.055
+NDJSON workloads (2M objects)	if .x*2+1>1M	v1.5.3	0.055
+NDJSON workloads (2M objects)	sel(.x%2==0)|.name	v1.5.3	0.087
+NDJSON workloads (2M objects)	sel(.x*2+1>1M)	v1.5.3	0.161
+NDJSON workloads (2M objects)	.x|@json	v1.5.3	0.049
+NDJSON workloads (2M objects)	.x|@text	v1.5.3	0.048
+NDJSON workloads (2M objects)	.name|@json	v1.5.3	0.103
+NDJSON workloads (2M objects)	sel|[arr]	v1.5.3	0.146
+NDJSON workloads (2M objects)	sel(and)|[arr]	v1.5.3	0.079
+NDJSON workloads (2M objects)	if>.y [arr]	v1.5.3	0.175
+NDJSON workloads (2M objects)	if sw then .f	v1.5.3	0.144
+NDJSON workloads (2M objects)	dynkey {(.n)=.x*2}	v1.5.3	0.116
+NDJSON workloads (2M objects)	sel(and)|.x*.y	v1.5.3	0.079
+NDJSON workloads (2M objects)	sel>N|str chain	v1.5.3	0.155
+NDJSON workloads (2M objects)	.f+"_"+arith_ts	v1.5.3	0.132
+NDJSON workloads (2M objects)	sel(sw)|str ch	v1.5.3	0.307
+NDJSON workloads (2M objects)	split|rev|join	v1.5.3	0.114
+NDJSON workloads (2M objects)	dynkey+static	v1.5.3	0.337
+NDJSON workloads (2M objects)	if>.y str chain	v1.5.3	0.168
+NDJSON workloads (2M objects)	remap+str chain	v1.5.3	0.157
+NDJSON workloads (2M objects)	sel(len>8)	v1.5.3	0.166
+NDJSON workloads (2M objects)	up|split|join	v1.5.3	0.098
+NDJSON workloads (2M objects)	.name|index	v1.5.3	0.124
+NDJSON workloads (2M objects)	.name|index+1	v1.5.3	0.127
+NDJSON workloads (2M objects)	.name|rindex	v1.5.3	0.133
+NDJSON workloads (2M objects)	.name|indices	v1.5.3	0.155
+NDJSON workloads (2M objects)	[x,y]|sort	v1.5.3	0.155
+NDJSON workloads (2M objects)	.name|scan	v1.5.3	0.209
+NDJSON workloads (2M objects)	.name|gsub	v1.5.3	0.169
+NDJSON workloads (2M objects)	walk(if num .+1)	v1.5.3	0.139
+NDJSON workloads (2M objects)	tojson	v1.5.3	0.109
+NDJSON workloads (2M objects)	{name,x}	v1.5.3	0.124
+NDJSON workloads (2M objects)	.z//.name	v1.5.3	0.159
+NDJSON workloads (2M objects)	.x|=test(re)	v1.5.3	0.173
+NDJSON workloads (2M objects)	./sep|first	v1.5.3	0.188
+NDJSON workloads (2M objects)	.y=(.x*2)	v1.5.3	0.184
+NDJSON workloads (2M objects)	.y=(.x+.y)	v1.5.3	0.239
+NDJSON workloads (2M objects)	objects	v1.5.3	0.137
+NDJSON workloads (2M objects)	.tag|=if..then N	v1.5.3	0.611
+NDJSON workloads (2M objects)	.x=(.x+1)	v1.5.3	0.127
+NDJSON workloads (2M objects)	sel>N|.y+=1	v1.5.3	0.124
+NDJSON workloads (2M objects)	sel(and)|.x+=1	v1.5.3	0.114
+NDJSON workloads (2M objects)	sel(sw)|.x+=1	v1.5.3	0.165
+NDJSON workloads (2M objects)	match(re)	v1.5.3	0.374
+NDJSON workloads (2M objects)	capture(re)	v1.5.3	0.299
+NDJSON workloads (2M objects)	first(.name,.x)	v1.5.3	0.098
+NDJSON workloads (2M objects)	if .x==null	v1.5.3	0.047
+NDJSON workloads (2M objects)	we(sw(.key))	v1.5.3	0.110
+NDJSON workloads (2M objects)	sel(sw or ew)	v1.5.3	0.211
+NDJSON workloads (2M objects)	path(.name,.x)	v1.5.3	0.277
+NDJSON workloads (2M objects)	sel(str+num+num)	v1.5.3	0.155
+NDJSON workloads (2M objects)	nested if|field	v1.5.3	0.078
+NDJSON workloads (2M objects)	.f|floor|.*2	v1.5.3	0.061
+NDJSON workloads (2M objects)	split|len>1	v1.5.3	0.120
+NDJSON workloads (2M objects)	.name|len|.*2	v1.5.3	0.105
+NDJSON workloads (2M objects)	if len>5 .x .y	v1.5.3	0.113
+NDJSON workloads (2M objects)	sel(len>5)|remap	v1.5.3	0.204
+NDJSON workloads (2M objects)	.x|tostr|len	v1.5.3	0.060
+NDJSON workloads (2M objects)	if .x>.y .x .y	v1.5.3	0.094
+NDJSON workloads (2M objects)	split|last|tonum	v1.5.3	0.099
+NDJSON workloads (2M objects)	split|rev|.[0]	v1.5.3	0.096
+NDJSON workloads (2M objects)	split|.[0]+.[1]	v1.5.3	0.119
+NDJSON workloads (2M objects)	.[]|strings	v1.5.3	0.104
+NDJSON workloads (2M objects)	.[]|numbers	v1.5.3	0.125
+NDJSON workloads (2M objects)	[x,y]|any(>1M)	v1.5.3	0.082
+NDJSON workloads (2M objects)	sel(dc|sw)	v1.5.3	0.100
+NDJSON workloads (2M objects)	[[x,y],[n]]|flat	v1.5.3	0.454
+NDJSON workloads (2M objects)	.x|floor|.*2	v1.5.3	0.061
+NDJSON workloads (2M objects)	tojson|fromjson	v1.5.3	0.089
+NDJSON workloads (2M objects)	[.x]|add	v1.5.3	0.060
+NDJSON workloads (2M objects)	if>N {o}+.	v1.5.3	0.140
+NDJSON workloads (2M objects)	if>N .+{o}	v1.5.3	0.135
+NDJSON workloads (2M objects)	if .n=="s" .+{o}	v1.5.3	0.163
+NDJSON workloads (2M objects)	sel(.n>"s")	v1.5.3	0.091
+NDJSON workloads (2M objects)	[x,y,z]|min	v1.5.3	0.309
+NDJSON workloads (2M objects)	if .n|len>5 l s	v1.5.3	0.104
+NDJSON workloads (2M objects)	if .x|flr>N b s	v1.5.3	0.056
+NDJSON workloads (2M objects)	if .n|test l e	v1.5.3	0.108
+NDJSON workloads (2M objects)	if .n|sw l e	v1.5.3	0.086
+NDJSON workloads (2M objects)	if .n|ew l e	v1.5.3	0.087
+NDJSON workloads (2M objects)	.n|len|tostr	v1.5.3	0.090
+String operations (2M objects)	ascii_downcase	v1.5.3	0.106
+String operations (2M objects)	ascii_upcase	v1.5.3	0.105
+String operations (2M objects)	ltrimstr	v1.5.3	0.099
+String operations (2M objects)	rtrimstr	v1.5.3	0.104
+String operations (2M objects)	split	v1.5.3	0.169
+String operations (2M objects)	case+split	v1.5.3	0.119
+String operations (2M objects)	join	v1.5.3	0.094
+String operations (2M objects)	startswith	v1.5.3	0.099
+String operations (2M objects)	endswith	v1.5.3	0.101
+String operations (2M objects)	tostring	v1.5.3	0.063
+String operations (2M objects)	tonumber	v1.5.3	0.113
+String operations (2M objects)	string interpolation	v1.5.3	0.118
+String ops (200K objects)	test (regex)	v1.5.3	0.014
+String ops (200K objects)	match (regex)	v1.5.3	0.032
+String ops (200K objects)	@base64	v1.5.3	0.012
+String ops (200K objects)	@uri	v1.5.3	0.012
+String ops (200K objects)	@html	v1.5.3	0.013
+String ops (200K objects)	@csv (array)	v1.5.3	0.016
+String ops (200K objects)	@tsv (array)	v1.5.3	0.015
+String ops (200K objects)	gsub	v1.5.3	0.019
+String ops (200K objects)	case+gsub	v1.5.3	0.179
+String ops (200K objects)	case+test	v1.5.3	0.121
+String ops (200K objects)	ltrim+tonum+arith	v1.5.3	0.114
+Numeric & math (2M objects)	floor	v1.5.3	0.056
+Numeric & math (2M objects)	sqrt	v1.5.3	0.078
+Numeric & math (2M objects)	modulo	v1.5.3	0.057
+Numeric & math (2M objects)	if-elif-else	v1.5.3	0.123
+Numeric & math (2M objects)	select|del	v1.5.3	0.092
+Numeric & math (2M objects)	select|merge	v1.5.3	0.120
+Numeric & math (2M objects)	select(test)|merge	v1.5.3	0.021
+Array generators	range(2M) | length	v1.5.3	0.011
+Array generators	reverse(2M)	v1.5.3	0.018
+Array generators	sort(2M)	v1.5.3	0.023
+Array generators	unique(1M)	v1.5.3	0.030
+Array generators	flatten(500K)	v1.5.3	0.011
+Array generators	min, max(2M)	v1.5.3	0.022
+Array generators	add numbers(2M)	v1.5.3	0.013
+Array generators	any/all(2M)	v1.5.3	0.028
+Array generators	limit(10; range(10M))	v1.5.3	0.002
+Array generators	first(range(10M))	v1.5.3	0.002
+Array generators	last(range(2M))	v1.5.3	0.002
+Array generators	indices(1M)	v1.5.3	0.016
+Reduce & foreach	reduce (sum)	v1.5.3	0.009
+Reduce & foreach	reduce (array build)	v1.5.3	0.004
+Reduce & foreach	reduce (obj build)	v1.5.3	0.010
+Reduce & foreach	reduce (setpath)	v1.5.3	0.016
+Reduce & foreach	foreach (running sum)	v1.5.3	0.010
+Reduce & foreach	foreach + emit	v1.5.3	0.010
+Reduce & foreach	reduce (sum-of-squares)	v1.5.3	0.033
+Reduce & foreach	reduce (conditional)	v1.5.3	0.035
+Reduce & foreach	reduce (product)	v1.5.3	0.034
+Reduce & foreach	foreach (conditional)	v1.5.3	0.010
+Reduce & foreach	until (100M)	v1.5.3	0.302
+Reduce & foreach	reduce (harmonic)	v1.5.3	0.036
+Reduce & foreach	reduce (floor pipe)	v1.5.3	0.034
+Reduce & foreach	reduce (sqrt pipe)	v1.5.3	0.034
+Reduce & foreach	reduce (sin+cos)	v1.5.3	0.052
+Object operations	large obj construct	v1.5.3	0.004
+Object operations	large obj keys	v1.5.3	0.011
+Object operations	large obj to_entries	v1.5.3	0.012
+Object operations	with_entries	v1.5.3	0.009
+Assignment operators	.[] |= f (100K)	v1.5.3	0.005
+Assignment operators	.[] += 1 (100K)	v1.5.3	0.005
+Assignment operators	.[k] = v reduce(50K)	v1.5.3	0.008
+String-heavy generators	gsub(100K)	v1.5.3	0.026
+String-heavy generators	join large(100K)	v1.5.3	0.005
+String-heavy generators	explode/implode(100K)	v1.5.3	0.027
+String-heavy generators	reduce str concat(100K)	v1.5.3	0.008
+Try-catch & alternative	alternative //	v1.5.3	0.032
+Try-catch & alternative	try-catch	v1.5.3	0.023
+Try-catch & alternative	label-break	v1.5.3	0.004
+Type conversion	tojson/fromjson(100K)	v1.5.3	0.022
+Type conversion	null propagation(2M)	v1.5.3	0.090


### PR DESCRIPTION
## Summary

Bug-fix patch release covering three regression hunts that surfaced via the same callback-driven generator model.

- **#634** — same-field arithmetic (`.n + .n`, `.n == .n`, `{a: .n, b: .n}`) silently read the second slot as null. The JIT `FieldBinopField` / `ObjFromFields` single-pass scans (introduced in v0.4.0 / v0.3.0 for a 5% gain) didn't handle equal keys.
- **#635** — zero-arg recursive `def f: ... f` shared one var slot per `as $x` name across frames. The non-zero-arg path already routed through `substitute_and_rename`; the Direct path now does the same when the function is recursive.
- **#638** — nested `def g` inside an exported module's outer def failed with "undefined function id". `load_code_module` only re-registered top-level entries; nested defs sat in `compiled_funcs` without a remapping.

## Bench

`docs/benchmark-history.{tsv,md}` got a `v1.5.3` column (214 rows). No benchmark regressed >5% vs v1.5.2. 12 borderline entries (1.05–1.08×) confirmed to be measurement noise — direct re-timing of the worst (`rtrimstr`) lands on 0.10s user, matching v1.5.2 exactly. The first bench run was contaminated by a Steam game using ~75% CPU and was discarded.

## Release plumbing

After auto-merge, `v1.5.3` is tagged on main and pushed; `.github/workflows/release.yml` builds binaries (`linux-x86_64`, `macos-arm64`, `windows-x86_64`), creates the GitHub Release with auto-generated notes, and bumps the homebrew-tap formula.