### PR TITLE
fix(eval): drop unsafe LoadVar+Add+Collect env-clear fast path (#642)

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1394,42 +1394,23 @@ pub fn eval(
                 BinOp::Add if matches!(rhs.as_ref(), Expr::Collect { .. }) => {
                     // Optimize `arr + [elems]`: push directly instead of creating intermediate array
                     let gen = match rhs.as_ref() { Expr::Collect { generator } => generator, _ => unreachable!() };
-                    // When lhs is LoadVar and gen doesn't use that var, temporarily clear env
-                    // to reduce refcount and enable Rc::try_unwrap for in-place push.
-                    let loadvar_idx = if let Expr::LoadVar { var_index } = lhs.as_ref() {
-                        if !expr_uses_var(gen, *var_index) { Some(*var_index) } else { None }
-                    } else { None };
                     eval(lhs, input.clone(), env, &mut |lval| {
                         match lval {
                             Value::Arr(arr_rc) => {
-                                // First try direct try_unwrap
+                                // Try direct try_unwrap; on failure, deep-clone the Vec.
+                                // We previously had a "drop env's copy" fast path for
+                                // `LoadVar(vi) + [gen]`, but that mutated `vars[vi]` to
+                                // Null and left a hole that subsequent generator
+                                // iterations / sibling reads observed (#642).
                                 match Rc::try_unwrap(arr_rc) {
                                     Ok(mut vec) => {
                                         eval(gen, input.clone(), env, &mut |elem| { vec.push(elem); Ok(true) })?;
                                         cb(Value::Arr(Rc::new(vec)))
                                     }
                                     Err(arr_rc) => {
-                                        // If lhs was LoadVar, DROP env's copy to reduce refcount.
-                                        // Safe: the surrounding LetBinding will restore env[vi] anyway.
-                                        if let Some(vi) = loadvar_idx {
-                                            drop(std::mem::replace(&mut env.borrow_mut().vars[vi as usize], Value::Null));
-                                            match Rc::try_unwrap(arr_rc) {
-                                                Ok(mut vec) => {
-                                                    eval(gen, input.clone(), env, &mut |elem| { vec.push(elem); Ok(true) })?;
-                                                    cb(Value::Arr(Rc::new(vec)))
-                                                }
-                                                Err(arr_rc) => {
-                                                    // Other references exist, fall back to clone
-                                                    let mut vec = (*arr_rc).clone();
-                                                    eval(gen, input.clone(), env, &mut |elem| { vec.push(elem); Ok(true) })?;
-                                                    cb(Value::Arr(Rc::new(vec)))
-                                                }
-                                            }
-                                        } else {
-                                            let mut vec = (*arr_rc).clone();
-                                            eval(gen, input.clone(), env, &mut |elem| { vec.push(elem); Ok(true) })?;
-                                            cb(Value::Arr(Rc::new(vec)))
-                                        }
+                                        let mut vec = (*arr_rc).clone();
+                                        eval(gen, input.clone(), env, &mut |elem| { vec.push(elem); Ok(true) })?;
+                                        cb(Value::Arr(Rc::new(vec)))
                                     }
                                 }
                             }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -9931,3 +9931,28 @@ import "issue_638" as M; M::to_multiprecision
 [ range(0; 10) as $a | range(0; 10) as $b | select($b != $a) | range(0; 10) as $c | select($c != $a and $c != $b) | range(0; 10) as $d | select($d != $a and $d != $b and $d != $c) | select(($a*100+$b*10+$c) % 7 == 0) | [$a,$b,$c,$d] ] | length
 null
 728
+
+# Issue #642: a recursive `def f($chain)` whose body iterates a generator
+# and recurses with `f($chain + [$n])` looped forever (1-arg form) or
+# emitted broken chains (multi-arg form). The eval-side
+# `BinOp.Add + Collect` "drop env's copy" fast path cleared
+# `vars[$chain]` to Null so Rc::try_unwrap could consume the array
+# in-place, but the outer `as $n` iteration re-read `$chain` on the next
+# step and saw the cleared slot. Removing that fast path (always
+# deep-clone when refcount > 1) restores correctness.
+def f($chain): if ($chain | length) >= 2 then $chain else [10, 20][] as $n | f($chain + [$n]) end; [f([])]
+null
+[[10,10],[10,20],[20,10],[20,20]]
+
+# Issue #642: 3-arg form. Pre-fix produced [[10,30],[40],[20,30],[40]] —
+# the second iteration of the inner `as $n` lost `$chain`'s prior element.
+{a: [10, 20], b: [30, 40]} as $by | def f($y; $rem; $chain): if ($rem | length) == 0 then $chain else $rem[] as $t | $by[$t][] as $n | select($n > $y) | f($n; ($rem - [$t]); ($chain + [$n])) end; [f(5; ["a", "b"]; [])]
+null
+[[10,30],[10,40],[20,30],[20,40]]
+
+# Issue #642: same root cause in a non-recursive form — `$arr` bound by
+# the outer `as`, then read across an iteration that also computes
+# `$arr + [$i]`. Pre-fix the second iteration saw `$arr` as null.
+[[1,2,3] as $arr | range(2) as $i | ($arr + [$i] | length)]
+null
+[4,4]


### PR DESCRIPTION
## Summary
- Removes the `BinOp.Add + Collect` evaluator's "drop env's copy" fast path that cleared `vars[vi]` to Null to enable an in-place `Rc::try_unwrap`. The optimization claimed safety on the surrounding LetBinding's restore, but generators iterating *within* that LetBinding's scope re-read `vi` between iterations and saw the cleared slot.
- The `def f($chain): ... [10,20][] as $n | f($chain + [$n]) end` shape from #642 hits this exactly: each step of the inner `as $n` loop re-evaluates the recursive call, whose substituted body's `LetBinding(_) = LoadVar($chain) + [...]` cleared `$chain`. Result: infinite loop in the 1-arg form, broken chains in multi-arg forms.
- Always deep-clone when `Rc::try_unwrap` fails (matches the pre-existing fallback for non-LoadVar lhs). Costs ~30% on a 1000-element recursive accumulator (`f($n; $acc): f($n-1; $acc + [$n])` — 7ms → 10ms); a smarter safe-position detector can restore the fast path later.

## Test plan
- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` (all suites pass, including the 3 new regression cases — 1-arg recursion, 3-arg P61-style, and the same-scope `[$arr,iteration,$arr+[i]]` minimal repro)
- [x] `bench/comprehensive.sh` (no >5% regression on tracked benchmarks; only sub-millisecond noise on unrelated items)
- [x] Manual verification: both repros from the issue now match `jq 1.8.1` output

Closes #642