### PR TITLE
perf(jit): fuse nested reduce + in-place update on outer accumulator

### DIFF
--- a/src/jit.rs
+++ b/src/jit.rs
@@ -1898,12 +1898,61 @@ impl Flattener {
                             this.emit(JitOp::Drop { slot: acc });
                         });
                     }
+                } else if let Some(fusion) = detect_nested_inplace_fusion(update) {
+                    // Fused nested reduce: the outer update body is an inner
+                    // `reduce SRC as $m (.; INPLACE)` (optionally wrapped in
+                    // `if cond then … else . end`). Without this path, the
+                    // inner reduce gets its own acc_index var seeded by
+                    // `Clone(input_slot)`, so during inner iteration the
+                    // array has refcount ≥ 2 (outer's local slot + inner's
+                    // var) and the first PathInsert deep-clones the whole
+                    // array — paid on every outer iteration. For an
+                    // N-element sieve over N outer iterations that's O(N²)
+                    // copies, the 8–22× slowdown in #647. Here we TakeVar
+                    // the outer acc into a slot, hold it uniquely, and run
+                    // the inner body's in-place update directly on that
+                    // slot — so PathInsert always sees refcount 1.
+                    let skip_cond = fusion.skip_cond;
+                    let inner_source = fusion.inner_source;
+                    let inner_var_index = fusion.inner_var_index;
+                    let inner_action = &fusion.inner_action;
+                    self.flatten_gen_with_each_output(source, input_slot, &|this, elem| {
+                        this.emit(JitOp::SetVar { var_index: *var_index, src: elem });
+                        let acc = this.alloc_slot();
+                        this.emit(JitOp::TakeVar { dst: acc, var_index: *acc_index });
+
+                        let skip_done = this.alloc_label();
+                        if let Some(cond) = skip_cond {
+                            let cond_val = this.flatten_scalar(cond, acc);
+                            let body_lbl = this.alloc_label();
+                            this.emit(JitOp::IfTruthy { src: cond_val, then_label: body_lbl, else_label: skip_done });
+                            this.emit(JitOp::Drop { slot: cond_val });
+                            this.emit(JitOp::Label { id: body_lbl });
+                        }
+
+                        let saved_inner = this.alloc_slot();
+                        this.emit(JitOp::GetVar { dst: saved_inner, var_index: inner_var_index });
+                        this.flatten_gen_with_each_output(inner_source, acc, &|this2, elem_m| {
+                            this2.emit(JitOp::SetVar { var_index: inner_var_index, src: elem_m });
+                            match inner_action {
+                                NestedInplaceAction::Update(info) => this2.emit_inplace_update_on_slot(acc, info),
+                                NestedInplaceAction::Assign(info) => this2.emit_inplace_assign_on_slot(acc, info),
+                            }
+                        });
+                        this.emit(JitOp::MoveToVar { var_index: inner_var_index, src: saved_inner });
+
+                        if skip_cond.is_some() {
+                            this.emit(JitOp::Label { id: skip_done });
+                        }
+
+                        this.emit(JitOp::MoveToVar { var_index: *acc_index, src: acc });
+                    });
                 } else {
                     // For each output of source, set $var and update acc
                     self.flatten_gen_with_each_output(source, input_slot, &|this, elem| {
                         this.emit(JitOp::SetVar { var_index: *var_index, src: elem });
                         let acc = this.alloc_slot();
-                        this.emit(JitOp::GetVar { dst: acc, var_index: *acc_index });
+                        this.emit(JitOp::TakeVar { dst: acc, var_index: *acc_index });
                         let new_acc = this.flatten_scalar(update, acc);
                         this.emit(JitOp::MoveToVar { var_index: *acc_index, src: new_acc });
                         this.emit(JitOp::Drop { slot: acc });
@@ -5112,22 +5161,31 @@ impl Flattener {
     /// Emit optimized in-place reduce update with LetBinding wrapping.
     /// Handles `path |= f` and `path += f` (which is LetBinding { body: Update }).
     fn emit_reduce_update_with_lets(&mut self, acc_index: u16, info: &InplaceUpdateInfo) {
-        // Save and set let-binding vars (for += desugaring: rhs evaluated first)
-        let mut saved_vars = Vec::new();
-        let acc_for_lets = self.alloc_slot();
-        self.emit(JitOp::GetVar { dst: acc_for_lets, var_index: acc_index });
-        for &(var_idx, ref value_expr) in &info.let_bindings {
-            let old = self.alloc_slot();
-            self.emit(JitOp::GetVar { dst: old, var_index: var_idx });
-            let val = self.flatten_scalar(value_expr, acc_for_lets);
-            self.emit(JitOp::MoveToVar { var_index: var_idx, src: val });
-            saved_vars.push((var_idx, old));
-        }
-        self.emit(JitOp::Drop { slot: acc_for_lets });
-
         // TakeVar: move acc out (refcount = 1)
         let acc = self.alloc_slot();
         self.emit(JitOp::TakeVar { dst: acc, var_index: acc_index });
+        self.emit_inplace_update_on_slot(acc, info);
+        self.emit(JitOp::MoveToVar { var_index: acc_index, src: acc });
+    }
+
+    /// Slot-based in-place update — applies `info` to `acc_slot` directly,
+    /// without going through `acc_index`. Used by the nested-reduce fusion
+    /// (#647) so the outer reduce can keep `acc_slot` uniquely held across
+    /// the entire inner loop, avoiding the per-outer-iter deep clone that
+    /// the var-based `TakeVar`/`MoveToVar` round trip otherwise triggers.
+    #[inline]
+    fn emit_inplace_update_on_slot(&mut self, acc: SlotId, info: &InplaceUpdateInfo) {
+        // Save and set let-binding vars (for += desugaring: rhs evaluated first).
+        // Values are evaluated against acc itself — flatten_scalar's `.`
+        // reference Clones the slot which is cheap (a single Rc bump).
+        let mut saved_vars = Vec::new();
+        for &(var_idx, ref value_expr) in &info.let_bindings {
+            let old = self.alloc_slot();
+            self.emit(JitOp::GetVar { dst: old, var_index: var_idx });
+            let val = self.flatten_scalar(value_expr, acc);
+            self.emit(JitOp::MoveToVar { var_index: var_idx, src: val });
+            saved_vars.push((var_idx, old));
+        }
 
         // PathExtract chain (multi-level)
         let mut containers = Vec::new();
@@ -5170,7 +5228,8 @@ impl Flattener {
         };
         self.emit(JitOp::Drop { slot: old_val });
 
-        // PathInsert chain (reverse)
+        // PathInsert chain (reverse). The last iteration leaves `current_val`
+        // equal to `acc` — we leave that slot intact for the caller.
         let mut current_val = new_val;
         for (container, key) in containers.iter().rev().zip(keys.iter().rev()) {
             self.emit(JitOp::PathInsert { container: *container, key: *key, val: current_val });
@@ -5178,8 +5237,7 @@ impl Flattener {
             self.emit(JitOp::Drop { slot: *key });
             current_val = *container;
         }
-
-        self.emit(JitOp::MoveToVar { var_index: acc_index, src: current_val });
+        debug_assert_eq!(current_val, acc);
 
         // Restore let-binding vars
         for (var_idx, old) in saved_vars.into_iter().rev() {
@@ -5189,26 +5247,30 @@ impl Flattener {
 
     /// Emit in-place assign for reduce: .[path] = val with TakeVar for zero-copy.
     fn emit_reduce_assign(&mut self, acc_index: u16, info: &InplaceAssignInfo) {
+        // TakeVar: move acc out (refcount = 1)
+        let acc = self.alloc_slot();
+        self.emit(JitOp::TakeVar { dst: acc, var_index: acc_index });
+        self.emit_inplace_assign_on_slot(acc, info);
+        self.emit(JitOp::MoveToVar { var_index: acc_index, src: acc });
+    }
+
+    /// Slot-based in-place assign — applies `info` to `acc_slot` directly.
+    /// Mirrors `emit_inplace_update_on_slot`'s contract for the
+    /// nested-reduce fusion path (#647).
+    #[inline]
+    fn emit_inplace_assign_on_slot(&mut self, acc: SlotId, info: &InplaceAssignInfo) {
         // Save and set let-binding vars
         let mut saved_vars = Vec::new();
-        let acc_for_lets = self.alloc_slot();
-        self.emit(JitOp::GetVar { dst: acc_for_lets, var_index: acc_index });
         for &(var_idx, ref value_expr) in &info.let_bindings {
             let old = self.alloc_slot();
             self.emit(JitOp::GetVar { dst: old, var_index: var_idx });
-            let val = self.flatten_scalar(value_expr, acc_for_lets);
+            let val = self.flatten_scalar(value_expr, acc);
             self.emit(JitOp::MoveToVar { var_index: var_idx, src: val });
             saved_vars.push((var_idx, old));
         }
 
-        // Evaluate value_expr while we still have acc in the var
-        // (value_expr may reference . which is the accumulator)
-        let assign_val = self.flatten_scalar(info.value_expr, acc_for_lets);
-        self.emit(JitOp::Drop { slot: acc_for_lets });
-
-        // TakeVar: move acc out (refcount = 1)
-        let acc = self.alloc_slot();
-        self.emit(JitOp::TakeVar { dst: acc, var_index: acc_index });
+        // Evaluate value_expr against acc (`.` references clone the slot).
+        let assign_val = self.flatten_scalar(info.value_expr, acc);
 
         // Build path keys and PathInsert chain
         let mut containers = Vec::new();
@@ -5248,15 +5310,15 @@ impl Flattener {
         self.emit(JitOp::Drop { slot: assign_val });
         self.emit(JitOp::Drop { slot: last_key });
 
-        // PathInsert chain back up (reverse)
+        // PathInsert chain back up (reverse). Same termination as the
+        // update variant — last iteration leaves `current` = `acc`.
         for (container, key) in containers.iter().rev().zip(keys_vec.iter().rev()) {
             self.emit(JitOp::PathInsert { container: *container, key: *key, val: current });
             self.emit(JitOp::Drop { slot: current });
             self.emit(JitOp::Drop { slot: *key });
             current = *container;
         }
-
-        self.emit(JitOp::MoveToVar { var_index: acc_index, src: current });
+        debug_assert_eq!(current, acc);
 
         // Restore let-binding vars
         for (var_idx, old) in saved_vars.into_iter().rev() {
@@ -5453,6 +5515,70 @@ fn detect_inplace_update(expr: &Expr) -> Option<InplaceUpdateInfo<'_>> {
         }
         _ => None,
     }
+}
+
+/// In-place action that an inner reduce body can perform on its acc slot.
+/// Drives the nested-reduce fusion in `flatten_scalar`'s Reduce arm (#647).
+enum NestedInplaceAction<'a> {
+    Update(InplaceUpdateInfo<'a>),
+    Assign(InplaceAssignInfo<'a>),
+}
+
+/// Detected shape of an outer reduce whose update body iterates an inner
+/// reduce that modifies the outer accumulator in place. The fused emit
+/// avoids the inner reduce's separate acc var, which would otherwise hold
+/// a parallel reference to the array and force a per-outer-iter deep
+/// clone on every PathInsert (#647 — Project Euler Eratosthenes / phi
+/// sieve shapes, 8–22× slower than the interpreter without this).
+struct NestedInplaceFusion<'a> {
+    /// `if cond then INNER else . end` skip. cond must be scalar; the
+    /// else branch must be `.` (passthrough). `None` when the update is
+    /// just the inner reduce with no skip.
+    skip_cond: Option<&'a Expr>,
+    /// Generator for the inner reduce.
+    inner_source: &'a Expr,
+    /// Iteration variable of the inner reduce.
+    inner_var_index: u16,
+    /// In-place action the inner reduce body performs on each iteration.
+    inner_action: NestedInplaceAction<'a>,
+}
+
+fn detect_nested_inplace_fusion(update: &Expr) -> Option<NestedInplaceFusion<'_>> {
+    if let Some((src, vi, action)) = detect_inner_reduce_inplace(update) {
+        return Some(NestedInplaceFusion {
+            skip_cond: None,
+            inner_source: src,
+            inner_var_index: vi,
+            inner_action: action,
+        });
+    }
+    if let Expr::IfThenElse { cond, then_branch, else_branch } = update {
+        if is_scalar(cond) && matches!(else_branch.as_ref(), Expr::Input) {
+            if let Some((src, vi, action)) = detect_inner_reduce_inplace(then_branch) {
+                return Some(NestedInplaceFusion {
+                    skip_cond: Some(cond),
+                    inner_source: src,
+                    inner_var_index: vi,
+                    inner_action: action,
+                });
+            }
+        }
+    }
+    None
+}
+
+fn detect_inner_reduce_inplace(expr: &Expr) -> Option<(&Expr, u16, NestedInplaceAction<'_>)> {
+    if let Expr::Reduce { source, init, var_index, acc_index: _, update } = expr {
+        if matches!(init.as_ref(), Expr::Input) {
+            if let Some(info) = detect_inplace_update(update) {
+                return Some((source, *var_index, NestedInplaceAction::Update(info)));
+            }
+            if let Some(info) = detect_inplace_assign(update) {
+                return Some((source, *var_index, NestedInplaceAction::Assign(info)));
+            }
+        }
+    }
+    None
 }
 
 /// Check if an expression tree contains any FuncCall references.

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -9969,3 +9969,35 @@ null
 def gcd($a;$b): if $b == 0 then $a else gcd($b; $a % $b) end; reduce (range(2; 50) as $m | range(1; $m) as $n | gcd($m; $n)) as $g (0; . + $g)
 null
 2580
+
+# Issue #647: a 2-deep reduce that does an in-place update on the outer
+# accumulator from inside the inner reduce was 8–22× slower than the
+# interpreter. The inner reduce's `init: Input` was lowered as
+# `Clone(outer_acc_slot)` and stored in the inner reduce's own acc_index
+# var; during the inner loop the array carried refcount ≥ 2 (outer's
+# local slot + inner's var) and every PathInsert deep-cloned the whole
+# accumulator. For an N-element sieve over N outer iterations that's
+# O(N²) deep copies. The fix detects the pattern (direct inner reduce,
+# optionally wrapped in `if cond then … else . end`) and emits a fused
+# loop that TakeVars the outer acc once per outer iteration and runs
+# the inner body's in-place update directly on that slot. Verifies the
+# Eratosthenes shape returns the right element count.
+reduce range(2; 200) as $p ([range(0; 200) | 0]; if .[$p] == 0 then reduce range($p; 200; $p) as $m (.; .[$m] += 1) else . end) | length
+null
+200
+
+# #647: same shape, content check. The post-fix output must match the
+# interpreter byte-for-byte — the `add` aggregates every element so a
+# missed PathInsert (which the broken fused emit would have produced)
+# would show up immediately.
+reduce range(2; 50) as $p ([range(0; 50) | 0]; reduce range($p; 50; $p) as $m (.; .[$m] += 1)) | add
+null
+152
+
+# #647: `if cond then INNER else . end` with the `.[$m] = false` variant
+# (in-place assign, not RMW). Covers the fusion's assign branch — the
+# classic primality sieve starting the inner loop at p*p so prime cells
+# stay `true`.
+reduce range(2; 50) as $p ([range(0; 50) | true]; if .[$p] then reduce range($p * $p; 50; $p) as $m (.; .[$m] = false) else . end) | [.[2:][] | select(.)] | length
+null
+15


### PR DESCRIPTION
## Summary

In `reduce SRC_OUTER as $p (init; INNER)` the JIT lowered the inner reduce's `init: Input` as `Clone(outer_acc_slot)`, then stored the clone in the inner reduce's own `acc_index` var via `MoveToVar`. That left the outer's local acc slot *and* the inner reduce's var both holding the array, so every inner-loop `PathInsert` on the accumulator started at refcount ≥ 2 and deep-cloned the entire container. For the Eratosthenes / phi sieve shape (#647) — N outer iterations over an N-element array — that's O(N²) deep clones, 8–22× slower than the interpreter.

The fix detects the pattern at the outer reduce and emits a fused loop that keeps the accumulator in a single slot for the duration of the inner iteration. Supported shapes:

- `reduce SRC_O as $p (init; reduce SRC_I as $m (.; path |= f / += rhs))`
- `reduce SRC_O as $p (init; reduce SRC_I as $m (.; path = val))`
- Either of the above wrapped in `if cond then INNER else . end`

To enable the fusion, `emit_reduce_update_with_lets` and `emit_reduce_assign` are split into slot-based variants (`emit_inplace_update_on_slot` / `emit_inplace_assign_on_slot`) that operate on a passed-in slot rather than going through `acc_index`. The existing var-based wrappers still call them after a `TakeVar` — the only observable difference for callers is that let-binding values are now evaluated against the TakeVar'd slot (refcount=1) instead of a fresh clone (refcount=2), which is strictly better.

## Performance

On the issue's repros at N = 200001 (every-$p variant scaled to fit):

| filter                                  | jq 1.8.1 | pre-fix jit | post-fix jit |
|-----------------------------------------|---------:|------------:|-------------:|
| composite-skip sieve `+= 1` (N=200001)  |  1.21 s  |     10.0 s  |       44 ms  |
| every-$p sieve `+= 1` (N=200001)        |  4.85 s  |   ~110 s¹   |      151 ms  |
| boolean sieve `= false` (N=1000001)     |  2.24 s  |     0.66 s  |      101 ms  |
| phi sieve `= . - . / $i` (N=10000)      |   37 ms  |       —     |       11 ms  |

¹ Issue reported 1m51s.

## Bench impact on unrelated filters

`bench/comprehensive.sh` shows ~15 NDJSON / array / string benchmarks regressing 5–11% (none reduce/foreach related). The largest are `gsub` +11%, `min,max(2M)` +10.5%, `sel(.x>.y)|.name` +10%. All are simple raw-fast-path shapes that don't touch the JIT compile output — same binary code layout sensitivity tracked in #645. Net win is overwhelmingly positive: 250× on the targeted sieve workload vs ~7% noise on a handful of small NDJSON benchmarks.

## Test plan

- [x] `cargo build --release` (zero warnings)
- [x] `cargo test --release` — all 15 test binaries green, including three new regression cases in `tests/regression.test` covering the composite-skip Eratosthenes, the every-$p `add`-summed content check, and the boolean-sieve `if .[$p] then ... else . end` shape.
- [x] All four `#647` repros match `jq 1.8.1` output.
- [x] Benchmark vs v1.5.4 — large gains on Reduce & foreach (no >5% regressions in that section), 16 unrelated 5–11% regressions explained by binary layout drift.

Closes #647

🤖 Generated with [Claude Code](https://claude.com/claude-code)