### PR TITLE
fix(eval): move input into Update result so reduce RMW stays in-place

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -2392,7 +2392,15 @@ pub fn eval(
                 }
                 return Err(e);
             }
-            let mut result = input.clone();
+            // Move `input` into `result` so `rt_setpath_mut`'s `Rc::make_mut`
+            // can mutate in place when the caller exclusively owns the value.
+            // The previous `input.clone()` bumped the refcount and forced a
+            // full container clone per iteration, defeating the in-place
+            // `reduce gen as $x (acc; .[$x] += 1)` shape whenever the source
+            // generator made the reduce fall off the JIT's fast path (#652).
+            // `eval_path`'s clone above is dropped before this point, so the
+            // move is safe as long as `input` itself was exclusively held.
+            let mut result = input;
             let mut del_paths = Vec::new();
             for path in &paths {
                 let old_val = crate::runtime::rt_getpath(&result, path).unwrap_or(Value::Null);

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -10013,3 +10013,23 @@ null
 def valid_at($board; $r; $c; $v): (($r / 3 | floor) * 3) as $br | (($c / 3 | floor) * 3) as $bc | reduce range(0; 9) as $k (true; . and $board[$r * 9 + $k] != $v and $board[$k * 9 + $c] != $v and $board[($br + ($k / 3 | floor)) * 9 + $bc + ($k % 3)] != $v); def first_empty: . as $board | reduce range(0; 81) as $i (null; if . != null then . elif $board[$i] == 0 then $i else . end); def solve: . as $board | if all($board[]; . != 0) then $board else first_empty as $idx | ($idx / 9 | floor) as $r | ($idx % 9) as $c | range(1; 10) as $v | select(valid_at($board; $r; $c; $v)) | ($board | .[$idx] = $v) | solve end; first(solve)
 [0,0,0,0,0,0,9,0,7,0,0,0,4,2,0,1,8,0,0,0,0,7,0,5,0,2,6,1,0,0,9,0,4,0,0,0,0,5,0,0,0,0,0,4,0,0,0,0,5,0,7,0,0,9,9,2,0,1,0,8,0,0,0,0,3,4,0,5,9,0,0,0,5,0,7,0,0,0,0,0,0]
 [4,6,2,8,3,1,9,5,7,7,9,5,4,2,6,1,8,3,3,8,1,7,9,5,4,2,6,1,7,3,9,8,4,2,6,5,6,5,9,3,1,2,7,4,8,2,4,8,5,6,7,3,1,9,9,2,6,1,7,8,5,3,4,8,3,4,2,5,9,6,7,1,5,1,7,6,4,3,8,9,2]
+
+# Issue #652: `reduce gen as $x (acc; .[$x] += 1)` couldn't mutate `acc` in
+# place when the generator forced the reduce off the JIT's RMW fast path,
+# because eval's `Update` evaluator cloned its `input` into `result` and
+# kept the original alive — `Rc::make_mut` then saw refcount > 1 every
+# iteration and deep-copied the whole array. Moving `input` into `result`
+# (after `eval_path` drops its borrowed clone) lets `make_mut` short-circuit.
+# This regression test exercises the same shape — recursive def call in the
+# generator chain forcing the eval fallback — with sizes small enough to be
+# verifiable but representative of the original Project Euler P75 trigger.
+def rec($x): if $x <= 0 then 0 else rec($x - 1) end; 100 as $N | reduce (range(0; 500) | rec(0) + (. % $N)) as $i ([range(0; $N) | 0]; .[$i] += 1) | add
+null
+500
+
+# Issue #652: project-euler P75 shape (gcd helper + reduce-on-array-index).
+# Stock jq runs this in ~0.1s; pre-fix jq-jit took ~4s on size 50_000.
+# Sized down here to fit the regression suite's quick-pass budget.
+def gcd($a; $b): if $b == 0 then $a else gcd($b; $a % $b) end; 100 as $LIMIT | ($LIMIT | sqrt | floor) as $MMAX | reduce (range(2; $MMAX + 1) as $m | range(1; $m) as $n | select(($m - $n) % 2 == 1 and gcd($m; $n) == 1) | (2 * $m * ($m + $n)) as $Lp | select($Lp <= $LIMIT) | range($Lp; $LIMIT + 1; $Lp)) as $L ([range(0; $LIMIT + 1) | 0]; .[$L] += 1) | [.[] | select(. == 1)] | length
+null
+11


### PR DESCRIPTION
## Summary

- `Expr::Update` in the eval interpreter cloned `input` into `result`, leaving the original `Rc` alive and forcing `rt_setpath_mut`'s `Rc::make_mut` to deep-clone the whole container every iteration of `reduce gen as \$x (acc; .[\$x] += 1)`.
- The JIT has its own in-place reduce fast path, so the bug only surfaced when a construct (e.g. a recursive def call in the generator chain) knocked the reduce back into the eval interpreter. Project Euler P75 with `LIMIT = 1_500_000` then went from ~0.1s in stock jq to a >120s timeout.
- Move `input` into `result`. `eval_path` only borrows it and drops its clone before this point, so the refcount stays at 1 and `make_mut` short-circuits to in-place mutation.

## Test plan

- [x] `cargo build --release` — zero warnings
- [x] `cargo test --release` — 509 official + 1955 regression + 1110 differential + 12 corpus, all pass
- [x] Two new regression tests in `tests/regression.test`: minimal `rec(\$x)` driver and sized-down P75
- [x] `./bench/comprehensive.sh` — within noise of locally rebenched v1.5.5 (one +5.7% outlier on `.[]`, several -10% wins)
- [x] Project Euler P75 (LIMIT=1.5M): >120s timeout → 0.94s after fix

Closes #652

🤖 Generated with [Claude Code](https://claude.com/claude-code)