### PR TITLE
perf(cli): skip JIT for null-input filters with big ASTs (#658)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -2599,11 +2599,23 @@ fn real_main() {
     // since their runtime dominates regardless of input size.
     // Must be done before process_input closure captures &filter.
     const JIT_THRESHOLD: usize = 4096;
+    // For null_input, there is no input to amortize JIT compile cost against.
+    // The original heuristic ("always JIT for -n") assumed runtime work would
+    // dominate, but for filter ASTs in the few-hundred-node range with no loop
+    // constructs the Cranelift codegen pass alone runs ~30 ms — far more than
+    // the interpreter takes for the same workload (#658). Cap the AST size
+    // beyond which a null-input filter without loops falls back to the
+    // interpreter.
+    const NULL_INPUT_JIT_AST_LIMIT: usize = 100;
     if force_interp {
         // Self-diff mode (#323) — leave jit_fn empty and let
         // execute / execute_cb take the eval path.
-    } else if filter.has_loop_constructs() || null_input {
+    } else if filter.has_loop_constructs() {
         filter.compile_jit();
+    } else if null_input {
+        if filter.ast_node_count() <= NULL_INPUT_JIT_AST_LIMIT {
+            filter.compile_jit();
+        }
     } else if !null_input {
         if files.is_empty() {
             if raw_input && !slurp {

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -2543,6 +2543,68 @@ impl Filter {
         walk(&self.parsed.0)
     }
 
+    /// Counts AST nodes in the parsed filter. Proxies JIT compile cost: each
+    /// node turns into one or more Cranelift IR instructions during codegen.
+    /// Used by the binary's null-input heuristic — see `src/bin/jq-jit.rs`.
+    pub fn ast_node_count(&self) -> usize {
+        use crate::ir::{Expr, StringPart};
+        fn count(e: &Expr) -> usize {
+            1 + match e {
+                Expr::Pipe { left, right } | Expr::Comma { left, right }
+                | Expr::BinOp { lhs: left, rhs: right, .. }
+                | Expr::Alternative { primary: left, fallback: right } => count(left) + count(right),
+                Expr::UnaryOp { operand, .. } | Expr::Negate { operand }
+                | Expr::Collect { generator: operand } | Expr::Each { input_expr: operand }
+                | Expr::EachOpt { input_expr: operand } | Expr::Recurse { input_expr: operand } => count(operand),
+                Expr::Index { expr, key } | Expr::IndexOpt { expr, key } => count(expr) + count(key),
+                Expr::IfThenElse { cond, then_branch, else_branch } => count(cond) + count(then_branch) + count(else_branch),
+                Expr::TryCatch { try_expr, catch_expr } => count(try_expr) + count(catch_expr),
+                Expr::Reduce { source, init, update, .. } => count(source) + count(init) + count(update),
+                Expr::Foreach { source, init, update, extract, .. } => {
+                    count(source) + count(init) + count(update)
+                        + extract.as_ref().map_or(0, |e| count(e))
+                }
+                Expr::Slice { expr, from, to } => {
+                    count(expr) + from.as_ref().map_or(0, |e| count(e)) + to.as_ref().map_or(0, |e| count(e))
+                }
+                Expr::ObjectConstruct { pairs } => pairs.iter().map(|(k, v)| count(k) + count(v)).sum(),
+                Expr::LetBinding { value, body, .. } => count(value) + count(body),
+                Expr::Label { body, .. } => count(body),
+                Expr::Break { value, .. } => count(value),
+                Expr::CallBuiltin { args, .. } | Expr::FuncCall { args, .. } => args.iter().map(count).sum(),
+                Expr::Update { path_expr, update_expr } | Expr::Assign { path_expr, value_expr: update_expr } => {
+                    count(path_expr) + count(update_expr)
+                }
+                Expr::ClosureOp { input_expr, key_expr, .. } => count(input_expr) + count(key_expr),
+                Expr::Format { expr, .. } | Expr::PathExpr { expr } | Expr::Debug { expr } | Expr::Stderr { expr } => count(expr),
+                Expr::Limit { count: c, generator } => count(c) + count(generator),
+                Expr::While { cond, update, .. } | Expr::Until { cond, update } => count(cond) + count(update),
+                Expr::Repeat { update, .. } => count(update),
+                Expr::AllShort { generator, predicate } | Expr::AnyShort { generator, predicate } => count(generator) + count(predicate),
+                Expr::Range { from, to, step } => {
+                    count(from) + count(to) + step.as_ref().map_or(0, |s| count(s))
+                }
+                Expr::SetPath { path, value } => count(path) + count(value),
+                Expr::GetPath { path } => count(path),
+                Expr::DelPaths { paths } => count(paths),
+                Expr::StringInterpolation { parts } => parts.iter().map(|p| match p {
+                    StringPart::Literal(_) => 0,
+                    StringPart::Expr(e) => count(e),
+                }).sum(),
+                Expr::Error { msg } => msg.as_ref().map_or(0, |e| count(e)),
+                Expr::AlternativeDestructure { alternatives } => alternatives.iter().map(count).sum(),
+                Expr::RegexTest { input_expr, re, flags, .. }
+                | Expr::RegexMatch { input_expr, re, flags, .. }
+                | Expr::RegexCapture { input_expr, re, flags, .. }
+                | Expr::RegexScan { input_expr, re, flags, .. } => count(input_expr) + count(re) + count(flags),
+                Expr::RegexSub { input_expr, re, tostr, flags }
+                | Expr::RegexGsub { input_expr, re, tostr, flags } => count(input_expr) + count(re) + count(tostr) + count(flags),
+                _ => 0,
+            }
+        }
+        count(&self.parsed.0)
+    }
+
     /// Returns true if this filter is a simple identity (`.`) that passes through input unchanged.
     /// Also recognizes semantic equivalences like `to_entries | from_entries`.
     pub fn is_identity(&self) -> bool {

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -10045,3 +10045,13 @@ null
 200 as $LIMIT | ([range(0; $LIMIT + 1) | true] | .[0] = false | .[1] = false | reduce range(2; ($LIMIT | sqrt | floor) + 1) as $p (.; if .[$p] then reduce range($p * $p; $LIMIT + 1; $p) as $m (.; .[$m] = false) else . end ) | . as $sv | [range(2; $LIMIT + 1) | select($sv[.])]) as $primes | ($primes - [2, 5]) as $cand | def mulmod($a; $b; $n): ($a / 16384 | floor) as $ah | ($a % 16384) as $al | (($ah * $b) % $n * 16384 + $al * $b) % $n; def powmod($base; $e; $n): if $n <= 1 then 0 else {b: ($base % $n), e: $e, r: 1} | until(.e == 0; (if .e % 2 == 1 then mulmod(.r; .b; $n) else .r end) as $nr | {b: mulmod(.b; .b; $n), e: (.e / 2 | floor), r: $nr} ) | .r end; def is_prime($n): if $n < 2 then false elif $n == 2 or $n == 3 then true elif $n % 2 == 0 then false else ({s: 0, d: ($n - 1)} | until(.d % 2 == 1; {s: (.s + 1), d: (.d / 2 | floor)})) as $sd | $sd.s as $s | $sd.d as $d | reduce [2, 7, 61][] as $a (true; . and ( if $a >= $n then true else powmod($a; $d; $n) as $x | if $x == 1 or $x == $n - 1 then true else ({x: $x, found: false} | reduce range(0; $s - 1) as $_ (.; if .found then . else mulmod(.x; .x; $n) as $nx | if $nx == $n - 1 then {x: $nx, found: true} else {x: $nx, found: false} end end )) | .found end end)) end; def concat($a; $b): $a * pow(10; ($b | tostring | length)) + $b; def compat($p; $q): is_prime(concat($p; $q)) and is_prime(concat($q; $p)); def dfs($chosen; $sum; $startIdx; $best): if ($chosen | length) == 5 then if $best == null or $sum < $best then $sum else $best end else ($chosen | length) as $L | reduce range($startIdx; $cand | length) as $i ($best; . as $cur | $cand[$i] as $p | if $cur != null and ($sum + $p * (5 - $L)) >= $cur then $cur elif ($chosen | reduce .[] as $c (true; . and compat($c; $p))) then dfs($chosen + [$p]; $sum + $p; $i + 1; $cur) else $cur end ) end; dfs([]; 0; 0; null)
 null
 null
+
+# Issue #658: deep nested range × select cascade compiled JIT for null_input
+# even though there is no input to amortize compile cost against. With ~380
+# AST nodes and no loop construct, Cranelift's codegen pass took ~30 ms while
+# the interpreter ran the same workload in <2 ms — a ~9x slowdown vs stock jq.
+# Sized down here so the test runs quickly while preserving the cascading
+# `range × select × select` shape that overwhelms the JIT compile heuristic.
+[range(0; 100) as $v | select($v % 17 == 0) | ($v / 10 | floor) as $d2 | ($v % 10) as $d1 | select($d2 != $d1) | range(0; 10) as $d0 | select($d0 != $d1 and $d0 != $d2) | select(($d0 * 100 + $d1 * 10 + $d2) % 7 == 0) | $d2 * 100 + $d1 * 10 + $d0] | add
+null
+1542


### PR DESCRIPTION
## Summary

- For `-n` (null_input) runs, JIT was unconditionally compiled on the rationale that "there is no input to amortize compile cost against, so JIT is always worth it." That breaks down once the filter AST grows: Cranelift's codegen pass scales with IR size, and a few-hundred-node filter with no loop construct (e.g. cascading `range × select`) spends ~30 ms compiling while the interpreter runs the same workload in 2-7 ms.
- Add `Filter::ast_node_count()` and gate the null-input JIT path on a 100-node cap. Loop-bearing filters (Reduce/Foreach with input source, Update, While/Until/Repeat) still JIT via `has_loop_constructs()`; small null-input filters still JIT below the cap; only big null-input filters with no loop construct fall back to the interpreter.
- On the issue repro this drops null-input run time from ~40 ms to ~7 ms (stock jq is ~5 ms).

## Test plan

- [x] `cargo build --release` — zero warnings
- [x] `cargo test --release` — jq official 509/509, regression 1957/1957, selfdiff + differential + fuzz all green
- [x] Issue #658 repro: 40ms → 7ms vs jq's 5ms
- [x] Heavy null-input loop filters (`reduce range(1M) ...`, `[range(1M)] | add`, `[range(1M) | select(...)] | add`) still JIT and keep their existing perf
- [x] `bench/comprehensive.sh` — variations within noise (no >5% regression on any benchmark that the heuristic actually touches; NDJSON / stdin-driven benches do not use the null_input path)
- [x] Regression case added to `tests/regression.test`

Closes #658

🤖 Generated with [Claude Code](https://claude.com/claude-code)