### PR TITLE
perf(cli): null-input JIT gate walks def bodies; add --force-jit/--force-interp

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -2220,10 +2220,8 @@ fn main() {
 }
 
 fn real_main() {
-    let force_interp = force_interpreter_enabled();
-    if force_interp {
-        jq_jit::interpreter::set_force_interpreter(true);
-    }
+    let mut force_interp = force_interpreter_enabled();
+    let mut force_jit = false;
     let args: Vec<String> = std::env::args().collect();
 
     let mut filter_str = None;
@@ -2277,6 +2275,8 @@ fn real_main() {
             "-M" | "--monochrome-output" => color_output = false,
             "--unbuffered" => unbuffered = true,
             "--seq" => seq = true,
+            "--force-jit" => { force_jit = true; force_interp = false; }
+            "--force-interp" | "--force-interpreter" => { force_interp = true; force_jit = false; }
             "-a" | "--ascii-output" => {
                 // Recognised but not yet implemented (#126). Emit a
                 // clear error instead of falling through to the filter
@@ -2457,6 +2457,12 @@ fn real_main() {
         i += 1;
     }
 
+    // CLI flag --force-interp / --force-jit (and JQJIT_FORCE_INTERPRETER) — apply
+    // after arg parsing so a CLI flag overrides the env var either way.
+    if force_interp {
+        jq_jit::interpreter::set_force_interpreter(true);
+    }
+
     let filter_str = match filter_str {
         Some(f) => f,
         None => {
@@ -2608,12 +2614,20 @@ fn real_main() {
     // interpreter.
     const NULL_INPUT_JIT_AST_LIMIT: usize = 100;
     if force_interp {
-        // Self-diff mode (#323) — leave jit_fn empty and let
-        // execute / execute_cb take the eval path.
+        // Self-diff mode (#323) / --force-interp — leave jit_fn empty and
+        // let execute / execute_cb take the eval path.
+    } else if force_jit {
+        // --force-jit bypasses the heuristics entirely.
+        filter.compile_jit();
     } else if filter.has_loop_constructs() {
         filter.compile_jit();
     } else if null_input {
-        if filter.ast_node_count() <= NULL_INPUT_JIT_AST_LIMIT {
+        // For null_input, eval.rs's "constant-range reduce on small input"
+        // exception (which makes `has_loop_constructs` gate on
+        // input-referencing source) does not apply — any Reduce/Foreach is
+        // a real runtime loop, and the AST-size cap only kicks in when the
+        // filter has no loop construct at all (the #658 shape).
+        if filter.has_any_runtime_loop_construct() || filter.ast_node_count() <= NULL_INPUT_JIT_AST_LIMIT {
             filter.compile_jit();
         }
     } else if !null_input {

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -2543,6 +2543,68 @@ impl Filter {
         walk(&self.parsed.0)
     }
 
+    /// Returns true if the AST contains any runtime loop construct (Reduce,
+    /// Foreach, Recurse, Update, While, Until, Repeat) anywhere — including
+    /// inside `def` bodies. Used by the binary's null-input JIT gate: with no
+    /// input to amortize against, eval.rs's "small input + constant-range
+    /// reduce" exception (which makes `has_loop_constructs` gate on
+    /// input-referencing source and walk only the top-level expression) no
+    /// longer applies — any loop is a real runtime loop the JIT can usually
+    /// speed up enough to cover compile cost.
+    pub fn has_any_runtime_loop_construct(&self) -> bool {
+        use crate::ir::Expr;
+        fn walk(e: &Expr) -> bool {
+            match e {
+                Expr::Reduce { .. } | Expr::Foreach { .. } | Expr::Recurse { .. }
+                | Expr::Update { .. } | Expr::While { .. } | Expr::Until { .. }
+                | Expr::Repeat { .. } => true,
+                Expr::Pipe { left, right } | Expr::Comma { left, right }
+                | Expr::BinOp { lhs: left, rhs: right, .. }
+                | Expr::Alternative { primary: left, fallback: right } => walk(left) || walk(right),
+                Expr::UnaryOp { operand, .. } | Expr::Negate { operand }
+                | Expr::Collect { generator: operand } | Expr::Each { input_expr: operand }
+                | Expr::EachOpt { input_expr: operand } => walk(operand),
+                Expr::Index { expr, key } | Expr::IndexOpt { expr, key } => walk(expr) || walk(key),
+                Expr::IfThenElse { cond, then_branch, else_branch } =>
+                    walk(cond) || walk(then_branch) || walk(else_branch),
+                Expr::TryCatch { try_expr, catch_expr } => walk(try_expr) || walk(catch_expr),
+                Expr::Slice { expr, from, to } => walk(expr)
+                    || from.as_ref().map_or(false, |e| walk(e))
+                    || to.as_ref().map_or(false, |e| walk(e)),
+                Expr::ObjectConstruct { pairs } => pairs.iter().any(|(k, v)| walk(k) || walk(v)),
+                Expr::LetBinding { value, body, .. } => walk(value) || walk(body),
+                Expr::Label { body, .. } => walk(body),
+                Expr::Break { value, .. } => walk(value),
+                Expr::CallBuiltin { args, .. } | Expr::FuncCall { args, .. } => args.iter().any(walk),
+                Expr::Assign { path_expr, value_expr } => walk(path_expr) || walk(value_expr),
+                Expr::ClosureOp { input_expr, key_expr, .. } => walk(input_expr) || walk(key_expr),
+                Expr::Format { expr: e, .. } | Expr::PathExpr { expr: e } | Expr::Debug { expr: e } | Expr::Stderr { expr: e } => walk(e),
+                Expr::Limit { count, generator } => walk(count) || walk(generator),
+                Expr::AllShort { generator, predicate } | Expr::AnyShort { generator, predicate } => walk(generator) || walk(predicate),
+                Expr::Range { from, to, step } => walk(from) || walk(to) || step.as_ref().map_or(false, |s| walk(s)),
+                Expr::SetPath { path, value } => walk(path) || walk(value),
+                Expr::GetPath { path } => walk(path),
+                Expr::DelPaths { paths } => walk(paths),
+                Expr::StringInterpolation { parts } => parts.iter().any(|p| match p {
+                    crate::ir::StringPart::Expr(e) => walk(e),
+                    crate::ir::StringPart::Literal(_) => false,
+                }),
+                Expr::Error { msg } => msg.as_ref().map_or(false, |e| walk(e)),
+                Expr::AlternativeDestructure { alternatives } => alternatives.iter().any(walk),
+                Expr::RegexTest { input_expr, re, flags, .. }
+                | Expr::RegexMatch { input_expr, re, flags, .. }
+                | Expr::RegexCapture { input_expr, re, flags, .. }
+                | Expr::RegexScan { input_expr, re, flags, .. } => walk(input_expr) || walk(re) || walk(flags),
+                Expr::RegexSub { input_expr, re, tostr, flags }
+                | Expr::RegexGsub { input_expr, re, tostr, flags } => walk(input_expr) || walk(re) || walk(tostr) || walk(flags),
+                _ => false,
+            }
+        }
+        // Also walk def bodies — a reduce buried inside `def f: reduce ...; f`
+        // is just as much a runtime loop as a top-level one (#658 follow-up).
+        walk(&self.parsed.0) || self.parsed.1.iter().any(|f| walk(&f.body))
+    }
+
     /// Counts AST nodes in the parsed filter. Proxies JIT compile cost: each
     /// node turns into one or more Cranelift IR instructions during codegen.
     /// Used by the binary's null-input heuristic — see `src/bin/jq-jit.rs`.
@@ -2602,7 +2664,9 @@ impl Filter {
                 _ => 0,
             }
         }
-        count(&self.parsed.0)
+        // Include def bodies — the JIT inlines them, so they contribute to
+        // codegen size as much as the top-level expression (#658 follow-up).
+        count(&self.parsed.0) + self.parsed.1.iter().map(|f| count(&f.body)).sum::<usize>()
     }
 
     /// Returns true if this filter is a simple identity (`.`) that passes through input unchanged.

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -10055,3 +10055,15 @@ null
 [range(0; 100) as $v | select($v % 17 == 0) | ($v / 10 | floor) as $d2 | ($v % 10) as $d1 | select($d2 != $d1) | range(0; 10) as $d0 | select($d0 != $d1 and $d0 != $d2) | select(($d0 * 100 + $d1 * 10 + $d2) % 7 == 0) | $d2 * 100 + $d1 * 10 + $d0] | add
 null
 1542
+
+# Issue #658 follow-up: the null-input JIT gate only walked the top-level
+# expression, so loop constructs hidden in `def` bodies were invisible. A
+# filter like `def steps: ...until(...)...; steps(N)` whose AST exceeds the
+# size cap was sent to the interpreter even though the inner until() makes
+# it a clear JIT win. The fix walks def bodies in both the loop-construct
+# detector and the AST-node counter. Output is unchanged either way; this
+# case exists only to pin the cross-version correctness contract while the
+# gate decision shifts.
+def steps($n): {n: $n, c: 0} | until(.n == 1; if .n % 2 == 0 then .n /= 2 else .n = .n*3 + 1 end | .c += 1) | .c; [range(1; 100) | steps(.)] | max
+null
+118


### PR DESCRIPTION
## Summary

- #660's AST-size gate for null-input filters only walked the top-level expression, so loop constructs hidden inside `def` bodies were invisible. Real filters like Project Euler #49 (def with reduce-based prime sieve) and #64 (def with until-driven continued fraction) had AST sizes just over the 100-node cap and were sent to the interpreter — running 2–15× slower than the JIT path #660 was supposed to preserve.
- Adds `Filter::has_any_runtime_loop_construct()` which catches Reduce/Foreach/Recurse/Update/While/Until/Repeat anywhere (including in `def` bodies). The null-input gate JITs whenever this predicate is true OR the AST is small enough.
- Extends `Filter::ast_node_count()` to walk def bodies too — the JIT inlines them, so they count toward the codegen budget.
- Adds `--force-jit` and `--force-interp` CLI flags. Useful for benchmarking and bug isolation. The existing `JQJIT_FORCE_INTERPRETER` env var still works; CLI overrides it either way.

## Bench

Curated 91-problem Project Euler corpus (real-world `-n` filters with mixed AST sizes and loop shapes), comparing v1.5.5 (pre #660) vs this branch:

| metric | value |
|---|---|
| median post/pre ratio | 1.00 |
| max regression | 1.12× (#70, AST=146) |
| #43 (#658 shape, 385 nodes) | 17 ms vs 65 ms (3.8× faster) |
| #49 / #64 (def-body loops, ~110 nodes) | parity with v1.5.5 (was 2–15× slower with #660 only) |

`bench/comprehensive.sh` runs only filters with real (not null) input, so it isn't affected by this gate; variations vs v1.5.5 are all in the 1–2 ms machine-noise range.

## Test plan

- [x] `cargo build --release` — zero warnings
- [x] `cargo test --release` — jq official 509/509, regression 1958/1958 (+1 case), selfdiff + differential + fuzz + corpus all green
- [x] Project Euler corpus diff vs `jq 1.8.1` — no DIFF rows
- [x] Smoke: `--force-jit` and `--force-interp` produce matching outputs for the #658 repro and PE #49

Follow-up to #660 / #658.

🤖 Generated with [Claude Code](https://claude.com/claude-code)