### PR TITLE
release v1.5.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jq-jit"
-version = "1.5.5"
+version = "1.5.6"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jq-jit"
-version = "1.5.5"
+version = "1.5.6"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A JIT-compiling implementation of jq using Cranelift"

--- a/docs/benchmark-history.md
+++ b/docs/benchmark-history.md
@@ -6,229 +6,229 @@ Recent slice (last 5 columns). Full history lives in
 
 ```text
 --- NDJSON workloads (2M objects) ---
-  Benchmark                v1.5.1  v1.5.2  v1.5.3  v1.5.4  v1.5.5
+  Benchmark                v1.5.2  v1.5.3  v1.5.4  v1.5.5  v1.5.6
   ---                      ------  ------  ------  ------  ------
-  empty                    0.018s  0.017s  0.017s  0.017s  0.017s
-  identity -c              0.089s  0.086s  0.092s  0.088s  0.087s
-  identity (pretty)        0.108s  0.108s  0.109s  0.103s  0.102s
-  field access .name       0.095s  0.092s  0.097s  0.096s  0.094s
-  nested .x,.y,.name       0.154s  0.154s  0.155s  0.151s  0.150s
-  arithmetic .x + .y       0.086s  0.084s  0.084s  0.085s  0.086s
-  select .x > 1500000      0.084s  0.085s  0.083s  0.083s  0.083s
-  string concat            0.093s  0.096s  0.099s  0.094s  0.093s
-  object construct         0.112s  0.115s  0.113s  0.115s  0.115s
-  array construct          0.109s  0.103s  0.105s  0.107s  0.106s
-  .[]                      0.106s  0.107s  0.104s  0.105s  0.106s
-  to_entries               0.159s  0.158s  0.158s  0.157s  0.162s
-  keys                     0.105s  0.106s  0.104s  0.107s  0.106s
-  keys_unsorted            0.096s  0.095s  0.095s  0.094s  0.095s
-  length                   0.086s  0.084s  0.084s  0.085s  0.086s
-  has("x")                 0.036s  0.036s  0.035s  0.037s  0.037s
-  type                     0.023s  0.023s  0.023s  0.022s  0.023s
-  del(.name)               0.104s  0.107s  0.104s  0.103s  0.102s
-  @csv                     0.119s  0.122s  0.124s  0.127s  0.124s
-  split/join               0.088s  0.091s  0.093s  0.091s  0.091s
-  select|field             0.095s  0.099s  0.096s  0.103s  0.097s
-  select|remap             0.099s  0.101s  0.101s  0.100s  0.100s
-  computed remap           0.187s  0.190s  0.187s  0.194s  0.192s
-  [.x,.y]|add              0.084s  0.083s  0.086s  0.084s  0.086s
-  [.x,.y]|avg              0.111s  0.106s  0.108s  0.107s  0.112s
-  map(*2)|add              0.105s  0.104s  0.105s  0.105s  0.106s
-  keys|length              0.253s  0.253s  0.253s  0.254s  0.252s
-  .+{z=0}                  0.148s  0.149s  0.151s  0.152s  0.147s
-  split|first              0.089s  0.091s  0.093s  0.090s  0.090s
-  slice[0..5]              0.093s  0.093s  0.099s  0.093s  0.092s
-  dynkey {(.name)}         0.104s  0.104s  0.108s  0.109s  0.104s
-  .x += 1                  0.128s  0.128s  0.130s  0.128s  0.125s
-  {a}+{b} merge            0.127s  0.131s  0.132s  0.136s  0.130s
+  empty                    0.017s  0.017s  0.017s  0.017s  0.017s
+  identity -c              0.086s  0.092s  0.088s  0.087s  0.087s
+  identity (pretty)        0.108s  0.109s  0.103s  0.102s  0.105s
+  field access .name       0.092s  0.097s  0.096s  0.094s  0.095s
+  nested .x,.y,.name       0.154s  0.155s  0.151s  0.150s  0.150s
+  arithmetic .x + .y       0.084s  0.084s  0.085s  0.086s  0.083s
+  select .x > 1500000      0.085s  0.083s  0.083s  0.083s  0.082s
+  string concat            0.096s  0.099s  0.094s  0.093s  0.093s
+  object construct         0.115s  0.113s  0.115s  0.115s  0.111s
+  array construct          0.103s  0.105s  0.107s  0.106s  0.103s
+  .[]                      0.107s  0.104s  0.105s  0.106s  0.101s
+  to_entries               0.158s  0.158s  0.157s  0.162s  0.159s
+  keys                     0.106s  0.104s  0.107s  0.106s  0.109s
+  keys_unsorted            0.095s  0.095s  0.094s  0.095s  0.095s
+  length                   0.084s  0.084s  0.085s  0.086s  0.085s
+  has("x")                 0.036s  0.035s  0.037s  0.037s  0.034s
+  type                     0.023s  0.023s  0.022s  0.023s  0.022s
+  del(.name)               0.107s  0.104s  0.103s  0.102s  0.104s
+  @csv                     0.122s  0.124s  0.127s  0.124s  0.123s
+  split/join               0.091s  0.093s  0.091s  0.091s  0.089s
+  select|field             0.099s  0.096s  0.103s  0.097s  0.095s
+  select|remap             0.101s  0.101s  0.100s  0.100s  0.095s
+  computed remap           0.190s  0.187s  0.194s  0.192s  0.191s
+  [.x,.y]|add              0.083s  0.086s  0.084s  0.086s  0.082s
+  [.x,.y]|avg              0.106s  0.108s  0.107s  0.112s  0.106s
+  map(*2)|add              0.104s  0.105s  0.105s  0.106s  0.103s
+  keys|length              0.253s  0.253s  0.254s  0.252s  0.251s
+  .+{z=0}                  0.149s  0.151s  0.152s  0.147s  0.146s
+  split|first              0.091s  0.093s  0.090s  0.090s  0.090s
+  slice[0..5]              0.093s  0.099s  0.093s  0.092s  0.092s
+  dynkey {(.name)}         0.104s  0.108s  0.109s  0.104s  0.102s
+  .x += 1                  0.128s  0.130s  0.128s  0.125s  0.125s
+  {a}+{b} merge            0.131s  0.132s  0.136s  0.130s  0.135s
   .x*2+1                   0.060s  0.060s  0.060s  0.060s  0.060s
-  .x+.y*2                  0.096s  0.097s  0.097s  0.098s  0.100s
-  .x > .y                  0.078s  0.078s  0.077s  0.078s  0.081s
-  to_entries|len           0.403s  0.396s  0.399s  0.397s  0.394s
+  .x+.y*2                  0.097s  0.097s  0.098s  0.100s  0.096s
+  .x > .y                  0.078s  0.077s  0.078s  0.081s  0.077s
+  to_entries|len           0.396s  0.399s  0.397s  0.394s  0.400s
   .x|.+1 (pipe)            0.058s  0.058s  0.058s  0.058s  0.058s
-  .x|.*2|.+1               0.061s  0.059s  0.060s  0.059s  0.060s
-  .name|.+"_x"             0.092s  0.095s  0.096s  0.094s  0.092s
-  .x>N | not               0.050s  0.049s  0.048s  0.051s  0.050s
-  and (2 cmp)              0.082s  0.082s  0.081s  0.081s  0.085s
-  if-then-else             0.052s  0.052s  0.052s  0.051s  0.052s
-  sel(and)|field           0.080s  0.079s  0.078s  0.078s  0.083s
-  sel(and)|remap           0.081s  0.077s  0.078s  0.077s  0.083s
-  arith|cmp                0.055s  0.055s  0.054s  0.055s  0.055s
-  if cmp .field            0.115s  0.115s  0.115s  0.115s  0.114s
-  split|length             0.089s  0.092s  0.091s  0.089s  0.088s
-  [x,y]|min                0.092s  0.090s  0.091s  0.089s  0.095s
-  [x,y]|max                0.097s  0.095s  0.094s  0.094s  0.097s
-  [x,y]|sort|.[0]          0.093s  0.091s  0.091s  0.091s  0.094s
-  .name|len>5              0.093s  0.091s  0.093s  0.094s  0.092s
-  sel(len>5)|.x            0.113s  0.108s  0.109s  0.111s  0.110s
-  if .x>.y .name           0.092s  0.090s  0.088s  0.091s  0.092s
-  sel(.x>.y)|.name         0.072s  0.071s  0.073s  0.070s  0.076s
-  .x*2|tostring            0.057s  0.057s  0.056s  0.057s  0.057s
-  .x*.x+1                  0.066s  0.066s  0.065s  0.066s  0.066s
-  {k=.name,v=tostr}        0.150s  0.144s  0.145s  0.154s  0.146s
-  str add chain            0.386s  0.384s  0.389s  0.393s  0.378s
-  if>.y .name|empty        0.076s  0.073s  0.071s  0.073s  0.080s
-  if .x%2==0               0.054s  0.054s  0.055s  0.054s  0.056s
-  if .x*2+1>1M             0.056s  0.056s  0.055s  0.056s  0.056s
-  sel(.x%2==0)|.name       0.083s  0.083s  0.087s  0.084s  0.083s
-  sel(.x*2+1>1M)           0.157s  0.159s  0.161s  0.158s  0.159s
-  .x|@json                 0.047s  0.048s  0.049s  0.048s  0.047s
-  .x|@text                 0.048s  0.048s  0.048s  0.048s  0.048s
-  .name|@json              0.100s  0.100s  0.103s  0.108s  0.104s
-  sel|[arr]                0.145s  0.148s  0.146s  0.147s  0.146s
-  sel(and)|[arr]           0.078s  0.077s  0.079s  0.078s  0.082s
-  if>.y [arr]              0.177s  0.173s  0.175s  0.183s  0.176s
-  if sw then .f            0.138s  0.140s  0.144s  0.139s  0.138s
-  dynkey {(.n)=.x*2}       0.116s  0.114s  0.116s  0.113s  0.113s
-  sel(and)|.x*.y           0.078s  0.076s  0.079s  0.077s  0.082s
-  sel>N|str chain          0.156s  0.152s  0.155s  0.159s  0.154s
-  .f+"_"+arith_ts          0.130s  0.131s  0.132s  0.140s  0.133s
-  sel(sw)|str ch           0.307s  0.309s  0.307s  0.310s  0.303s
-  split|rev|join           0.111s  0.115s  0.114s  0.117s  0.114s
-  dynkey+static            0.339s  0.329s  0.337s  0.339s  0.344s
-  if>.y str chain          0.163s  0.165s  0.168s  0.174s  0.167s
-  remap+str chain          0.150s  0.151s  0.157s  0.160s  0.153s
-  sel(len>8)               0.164s  0.161s  0.166s  0.161s  0.160s
-  up|split|join            0.096s  0.095s  0.098s  0.095s  0.099s
-  .name|index              0.123s  0.122s  0.124s  0.123s  0.121s
-  .name|index+1            0.123s  0.124s  0.127s  0.126s  0.125s
-  .name|rindex             0.127s  0.129s  0.133s  0.129s  0.129s
-  .name|indices            0.155s  0.155s  0.155s  0.155s  0.157s
-  [x,y]|sort               0.152s  0.155s  0.155s  0.156s  0.153s
-  .name|scan               0.208s  0.211s  0.209s  0.211s  0.209s
-  .name|gsub               0.172s  0.167s  0.169s  0.166s  0.163s
-  walk(if num .+1)         0.137s  0.139s  0.139s  0.142s  0.145s
-  tojson                   0.105s  0.113s  0.109s  0.108s  0.106s
-  {name,x}                 0.127s  0.125s  0.124s  0.134s  0.129s
-  .z//.name                0.159s  0.154s  0.159s  0.155s  0.157s
-  .x|=test(re)             0.179s  0.171s  0.173s  0.172s  0.173s
-  ./sep|first              0.183s  0.185s  0.188s  0.187s  0.184s
-  .y=(.x*2)                0.176s  0.180s  0.184s  0.179s  0.179s
-  .y=(.x+.y)               0.230s  0.230s  0.239s  0.229s  0.229s
-  objects                  0.137s  0.130s  0.137s  0.137s  0.128s
-  .tag|=if..then N         0.602s  0.615s  0.611s  0.618s  0.607s
-  .x=(.x+1)                0.128s  0.128s  0.127s  0.128s  0.122s
-  sel>N|.y+=1              0.123s  0.121s  0.124s  0.122s  0.123s
-  sel(and)|.x+=1           0.109s  0.108s  0.114s  0.110s  0.109s
-  sel(sw)|.x+=1            0.159s  0.161s  0.165s  0.165s  0.163s
-  match(re)                0.360s  0.364s  0.374s  0.375s  0.361s
-  capture(re)              0.291s  0.297s  0.299s  0.306s  0.298s
-  first(.name,.x)          0.095s  0.096s  0.098s  0.097s  0.096s
-  if .x==null              0.048s  0.047s  0.047s  0.047s  0.047s
-  we(sw(.key))             0.106s  0.105s  0.110s  0.108s  0.107s
-  sel(sw or ew)            0.206s  0.205s  0.211s  0.214s  0.207s
-  path(.name,.x)           0.276s  0.274s  0.277s  0.278s  0.274s
-  sel(str+num+num)         0.151s  0.153s  0.155s  0.150s  0.151s
-  nested if|field          0.077s  0.078s  0.078s  0.077s  0.082s
+  .x|.*2|.+1               0.059s  0.060s  0.059s  0.060s  0.059s
+  .name|.+"_x"             0.095s  0.096s  0.094s  0.092s  0.092s
+  .x>N | not               0.049s  0.048s  0.051s  0.050s  0.049s
+  and (2 cmp)              0.082s  0.081s  0.081s  0.085s  0.080s
+  if-then-else             0.052s  0.052s  0.051s  0.052s  0.052s
+  sel(and)|field           0.079s  0.078s  0.078s  0.083s  0.077s
+  sel(and)|remap           0.077s  0.078s  0.077s  0.083s  0.077s
+  arith|cmp                0.055s  0.054s  0.055s  0.055s  0.053s
+  if cmp .field            0.115s  0.115s  0.115s  0.114s  0.114s
+  split|length             0.092s  0.091s  0.089s  0.088s  0.090s
+  [x,y]|min                0.090s  0.091s  0.089s  0.095s  0.090s
+  [x,y]|max                0.095s  0.094s  0.094s  0.097s  0.092s
+  [x,y]|sort|.[0]          0.091s  0.091s  0.091s  0.094s  0.090s
+  .name|len>5              0.091s  0.093s  0.094s  0.092s  0.092s
+  sel(len>5)|.x            0.108s  0.109s  0.111s  0.110s  0.111s
+  if .x>.y .name           0.090s  0.088s  0.091s  0.092s  0.089s
+  sel(.x>.y)|.name         0.071s  0.073s  0.070s  0.076s  0.072s
+  .x*2|tostring            0.057s  0.056s  0.057s  0.057s  0.056s
+  .x*.x+1                  0.066s  0.065s  0.066s  0.066s  0.066s
+  {k=.name,v=tostr}        0.144s  0.145s  0.154s  0.146s  0.144s
+  str add chain            0.384s  0.389s  0.393s  0.378s  0.385s
+  if>.y .name|empty        0.073s  0.071s  0.073s  0.080s  0.073s
+  if .x%2==0               0.054s  0.055s  0.054s  0.056s  0.054s
+  if .x*2+1>1M             0.056s  0.055s  0.056s  0.056s  0.054s
+  sel(.x%2==0)|.name       0.083s  0.087s  0.084s  0.083s  0.083s
+  sel(.x*2+1>1M)           0.159s  0.161s  0.158s  0.159s  0.159s
+  .x|@json                 0.048s  0.049s  0.048s  0.047s  0.048s
+  .x|@text                 0.048s  0.048s  0.048s  0.048s  0.047s
+  .name|@json              0.100s  0.103s  0.108s  0.104s  0.103s
+  sel|[arr]                0.148s  0.146s  0.147s  0.146s  0.143s
+  sel(and)|[arr]           0.077s  0.079s  0.078s  0.082s  0.077s
+  if>.y [arr]              0.173s  0.175s  0.183s  0.176s  0.173s
+  if sw then .f            0.140s  0.144s  0.139s  0.138s  0.139s
+  dynkey {(.n)=.x*2}       0.114s  0.116s  0.113s  0.113s  0.114s
+  sel(and)|.x*.y           0.076s  0.079s  0.077s  0.082s  0.076s
+  sel>N|str chain          0.152s  0.155s  0.159s  0.154s  0.151s
+  .f+"_"+arith_ts          0.131s  0.132s  0.140s  0.133s  0.132s
+  sel(sw)|str ch           0.309s  0.307s  0.310s  0.303s  0.307s
+  split|rev|join           0.115s  0.114s  0.117s  0.114s  0.114s
+  dynkey+static            0.329s  0.337s  0.339s  0.344s  0.331s
+  if>.y str chain          0.165s  0.168s  0.174s  0.167s  0.165s
+  remap+str chain          0.151s  0.157s  0.160s  0.153s  0.148s
+  sel(len>8)               0.161s  0.166s  0.161s  0.160s  0.165s
+  up|split|join            0.095s  0.098s  0.095s  0.099s  0.097s
+  .name|index              0.122s  0.124s  0.123s  0.121s  0.121s
+  .name|index+1            0.124s  0.127s  0.126s  0.125s  0.123s
+  .name|rindex             0.129s  0.133s  0.129s  0.129s  0.127s
+  .name|indices            0.155s  0.155s  0.155s  0.157s  0.146s
+  [x,y]|sort               0.155s  0.155s  0.156s  0.153s  0.152s
+  .name|scan               0.211s  0.209s  0.211s  0.209s  0.208s
+  .name|gsub               0.167s  0.169s  0.166s  0.163s  0.168s
+  walk(if num .+1)         0.139s  0.139s  0.142s  0.145s  0.143s
+  tojson                   0.113s  0.109s  0.108s  0.106s  0.104s
+  {name,x}                 0.125s  0.124s  0.134s  0.129s  0.133s
+  .z//.name                0.154s  0.159s  0.155s  0.157s  0.157s
+  .x|=test(re)             0.171s  0.173s  0.172s  0.173s  0.180s
+  ./sep|first              0.185s  0.188s  0.187s  0.184s  0.182s
+  .y=(.x*2)                0.180s  0.184s  0.179s  0.179s  0.178s
+  .y=(.x+.y)               0.230s  0.239s  0.229s  0.229s  0.233s
+  objects                  0.130s  0.137s  0.137s  0.128s  0.138s
+  .tag|=if..then N         0.615s  0.611s  0.618s  0.607s  0.614s
+  .x=(.x+1)                0.128s  0.127s  0.128s  0.122s  0.128s
+  sel>N|.y+=1              0.121s  0.124s  0.122s  0.123s  0.121s
+  sel(and)|.x+=1           0.108s  0.114s  0.110s  0.109s  0.111s
+  sel(sw)|.x+=1            0.161s  0.165s  0.165s  0.163s  0.164s
+  match(re)                0.364s  0.374s  0.375s  0.361s  0.369s
+  capture(re)              0.297s  0.299s  0.306s  0.298s  0.296s
+  first(.name,.x)          0.096s  0.098s  0.097s  0.096s  0.097s
+  if .x==null              0.047s  0.047s  0.047s  0.047s  0.046s
+  we(sw(.key))             0.105s  0.110s  0.108s  0.107s  0.110s
+  sel(sw or ew)            0.205s  0.211s  0.214s  0.207s  0.205s
+  path(.name,.x)           0.274s  0.277s  0.278s  0.274s  0.274s
+  sel(str+num+num)         0.153s  0.155s  0.150s  0.151s  0.152s
+  nested if|field          0.078s  0.078s  0.077s  0.082s  0.076s
   .f|floor|.*2             0.061s  0.061s  0.061s  0.061s  0.061s
-  split|len>1              0.117s  0.117s  0.120s  0.120s  0.118s
-  .name|len|.*2            0.101s  0.103s  0.105s  0.104s  0.102s
-  if len>5 .x .y           0.113s  0.111s  0.113s  0.116s  0.115s
-  sel(len>5)|remap         0.202s  0.204s  0.204s  0.209s  0.206s
-  .x|tostr|len             0.059s  0.059s  0.060s  0.060s  0.058s
-  if .x>.y .x .y           0.096s  0.095s  0.094s  0.094s  0.098s
-  split|last|tonum         0.095s  0.093s  0.099s  0.095s  0.095s
-  split|rev|.[0]           0.090s  0.091s  0.096s  0.091s  0.094s
-  split|.[0]+.[1]          0.113s  0.113s  0.119s  0.113s  0.115s
-  .[]|strings              0.106s  0.109s  0.104s  0.105s  0.106s
-  .[]|numbers              0.125s  0.128s  0.125s  0.124s  0.124s
-  [x,y]|any(>1M)           0.082s  0.082s  0.082s  0.082s  0.087s
-  sel(dc|sw)               0.097s  0.100s  0.100s  0.099s  0.102s
-  [[x,y],[n]]|flat         0.457s  0.459s  0.454s  0.464s  0.456s
-  .x|floor|.*2             0.062s  0.061s  0.061s  0.061s  0.061s
-  tojson|fromjson          0.087s  0.087s  0.089s  0.087s  0.087s
-  [.x]|add                 0.059s  0.063s  0.060s  0.058s  0.060s
-  if>N {o}+.               0.135s  0.136s  0.140s  0.138s  0.134s
-  if>N .+{o}               0.136s  0.139s  0.135s  0.137s  0.134s
-  if .n=="s" .+{o}         0.161s  0.157s  0.163s  0.168s  0.161s
-  sel(.n>"s")              0.088s  0.087s  0.091s  0.090s  0.089s
-  [x,y,z]|min              0.309s  0.311s  0.309s  0.314s  0.309s
-  if .n|len>5 l s          0.100s  0.100s  0.104s  0.102s  0.102s
-  if .x|flr>N b s          0.054s  0.055s  0.056s  0.054s  0.056s
-  if .n|test l e           0.102s  0.104s  0.108s  0.108s  0.103s
-  if .n|sw l e             0.083s  0.083s  0.086s  0.083s  0.083s
-  if .n|ew l e             0.083s  0.084s  0.087s  0.085s  0.084s
-  .n|len|tostr             0.091s  0.088s  0.090s  0.090s  0.091s
+  split|len>1              0.117s  0.120s  0.120s  0.118s  0.114s
+  .name|len|.*2            0.103s  0.105s  0.104s  0.102s  0.103s
+  if len>5 .x .y           0.111s  0.113s  0.116s  0.115s  0.113s
+  sel(len>5)|remap         0.204s  0.204s  0.209s  0.206s  0.207s
+  .x|tostr|len             0.059s  0.060s  0.060s  0.058s  0.059s
+  if .x>.y .x .y           0.095s  0.094s  0.094s  0.098s  0.093s
+  split|last|tonum         0.093s  0.099s  0.095s  0.095s  0.096s
+  split|rev|.[0]           0.091s  0.096s  0.091s  0.094s  0.090s
+  split|.[0]+.[1]          0.113s  0.119s  0.113s  0.115s  0.114s
+  .[]|strings              0.109s  0.104s  0.105s  0.106s  0.104s
+  .[]|numbers              0.128s  0.125s  0.124s  0.124s  0.124s
+  [x,y]|any(>1M)           0.082s  0.082s  0.082s  0.087s  0.082s
+  sel(dc|sw)               0.100s  0.100s  0.099s  0.102s  0.097s
+  [[x,y],[n]]|flat         0.459s  0.454s  0.464s  0.456s  0.460s
+  .x|floor|.*2             0.061s  0.061s  0.061s  0.061s  0.061s
+  tojson|fromjson          0.087s  0.089s  0.087s  0.087s  0.085s
+  [.x]|add                 0.063s  0.060s  0.058s  0.060s  0.060s
+  if>N {o}+.               0.136s  0.140s  0.138s  0.134s  0.135s
+  if>N .+{o}               0.139s  0.135s  0.137s  0.134s  0.138s
+  if .n=="s" .+{o}         0.157s  0.163s  0.168s  0.161s  0.161s
+  sel(.n>"s")              0.087s  0.091s  0.090s  0.089s  0.089s
+  [x,y,z]|min              0.311s  0.309s  0.314s  0.309s  0.309s
+  if .n|len>5 l s          0.100s  0.104s  0.102s  0.102s  0.100s
+  if .x|flr>N b s          0.055s  0.056s  0.054s  0.056s  0.056s
+  if .n|test l e           0.104s  0.108s  0.108s  0.103s  0.106s
+  if .n|sw l e             0.083s  0.086s  0.083s  0.083s  0.084s
+  if .n|ew l e             0.084s  0.087s  0.085s  0.084s  0.084s
+  .n|len|tostr             0.088s  0.090s  0.090s  0.091s  0.092s
 
 --- String operations (2M objects) ---
-  Benchmark                v1.5.1  v1.5.2  v1.5.3  v1.5.4  v1.5.5
+  Benchmark                v1.5.2  v1.5.3  v1.5.4  v1.5.5  v1.5.6
   ---                      ------  ------  ------  ------  ------
-  ascii_downcase           0.104s  0.105s  0.106s  0.107s  0.108s
-  ascii_upcase             0.105s  0.102s  0.105s  0.104s  0.108s
-  ltrimstr                 0.097s  0.098s  0.099s  0.099s  0.096s
-  rtrimstr                 0.099s  0.096s  0.104s  0.101s  0.099s
-  split                    0.165s  0.166s  0.169s  0.168s  0.168s
-  case+split               0.114s  0.117s  0.119s  0.116s  0.113s
-  join                     0.091s  0.094s  0.094s  0.095s  0.090s
-  startswith               0.096s  0.093s  0.099s  0.096s  0.095s
-  endswith                 0.097s  0.095s  0.101s  0.099s  0.097s
-  tostring                 0.063s  0.063s  0.063s  0.063s  0.062s
-  tonumber                 0.109s  0.109s  0.113s  0.113s  0.114s
-  string interpolation     0.117s  0.119s  0.118s  0.121s  0.115s
+  ascii_downcase           0.105s  0.106s  0.107s  0.108s  0.105s
+  ascii_upcase             0.102s  0.105s  0.104s  0.108s  0.103s
+  ltrimstr                 0.098s  0.099s  0.099s  0.096s  0.095s
+  rtrimstr                 0.096s  0.104s  0.101s  0.099s  0.098s
+  split                    0.166s  0.169s  0.168s  0.168s  0.162s
+  case+split               0.117s  0.119s  0.116s  0.113s  0.115s
+  join                     0.094s  0.094s  0.095s  0.090s  0.091s
+  startswith               0.093s  0.099s  0.096s  0.095s  0.095s
+  endswith                 0.095s  0.101s  0.099s  0.097s  0.096s
+  tostring                 0.063s  0.063s  0.063s  0.062s  0.063s
+  tonumber                 0.109s  0.113s  0.113s  0.114s  0.110s
+  string interpolation     0.119s  0.118s  0.121s  0.115s  0.118s
 
 --- String ops (200K objects) ---
-  Benchmark                v1.5.1  v1.5.2  v1.5.3  v1.5.4  v1.5.5
+  Benchmark                v1.5.2  v1.5.3  v1.5.4  v1.5.5  v1.5.6
   ---                      ------  ------  ------  ------  ------
-  test (regex)             0.014s  0.015s  0.014s  0.014s  0.014s
-  match (regex)            0.032s  0.032s  0.032s  0.032s  0.032s
+  test (regex)             0.015s  0.014s  0.014s  0.014s  0.015s
+  match (regex)            0.032s  0.032s  0.032s  0.032s  0.033s
   @base64                  0.012s  0.012s  0.012s  0.012s  0.012s
-  @uri                     0.011s  0.012s  0.012s  0.012s  0.013s
-  @html                    0.012s  0.013s  0.013s  0.012s  0.013s
-  @csv (array)             0.016s  0.016s  0.016s  0.016s  0.015s
-  @tsv (array)             0.015s  0.015s  0.015s  0.015s  0.014s
-  gsub                     0.019s  0.019s  0.019s  0.018s  0.018s
-  case+gsub                0.176s  0.179s  0.179s  0.177s  0.176s
-  case+test                0.116s  0.119s  0.121s  0.118s  0.118s
-  ltrim+tonum+arith        0.113s  0.112s  0.114s  0.115s  0.112s
+  @uri                     0.012s  0.012s  0.012s  0.013s  0.012s
+  @html                    0.013s  0.013s  0.012s  0.013s  0.012s
+  @csv (array)             0.016s  0.016s  0.016s  0.015s  0.015s
+  @tsv (array)             0.015s  0.015s  0.015s  0.014s  0.015s
+  gsub                     0.019s  0.019s  0.018s  0.018s  0.019s
+  case+gsub                0.179s  0.179s  0.177s  0.176s  0.181s
+  case+test                0.119s  0.121s  0.118s  0.118s  0.119s
+  ltrim+tonum+arith        0.112s  0.114s  0.115s  0.112s  0.111s
 
 --- Numeric & math (2M objects) ---
-  Benchmark                v1.5.1  v1.5.2  v1.5.3  v1.5.4  v1.5.5
+  Benchmark                v1.5.2  v1.5.3  v1.5.4  v1.5.5  v1.5.6
   ---                      ------  ------  ------  ------  ------
-  floor                    0.057s  0.056s  0.056s  0.056s  0.057s
-  sqrt                     0.079s  0.078s  0.078s  0.078s  0.079s
-  modulo                   0.057s  0.058s  0.057s  0.058s  0.058s
-  if-elif-else             0.124s  0.125s  0.123s  0.124s  0.124s
-  select|del               0.091s  0.094s  0.092s  0.092s  0.090s
-  select|merge             0.117s  0.121s  0.120s  0.118s  0.119s
-  select(test)|merge       0.021s  0.021s  0.021s  0.022s  0.021s
+  floor                    0.056s  0.056s  0.056s  0.057s  0.057s
+  sqrt                     0.078s  0.078s  0.078s  0.079s  0.079s
+  modulo                   0.058s  0.057s  0.058s  0.058s  0.057s
+  if-elif-else             0.125s  0.123s  0.124s  0.124s  0.121s
+  select|del               0.094s  0.092s  0.092s  0.090s  0.092s
+  select|merge             0.121s  0.120s  0.118s  0.119s  0.120s
+  select(test)|merge       0.021s  0.021s  0.022s  0.021s  0.022s
 
 --- Array generators ---
-  Benchmark                v1.5.1  v1.5.2  v1.5.3  v1.5.4  v1.5.5
+  Benchmark                v1.5.2  v1.5.3  v1.5.4  v1.5.5  v1.5.6
   ---                      ------  ------  ------  ------  ------
-  range(2M) | length       0.012s  0.012s  0.011s  0.012s  0.011s
+  range(2M) | length       0.012s  0.011s  0.012s  0.011s  0.011s
   reverse(2M)              0.018s  0.018s  0.018s  0.018s  0.018s
   sort(2M)                 0.023s  0.023s  0.023s  0.023s  0.023s
-  unique(1M)               0.030s  0.031s  0.030s  0.030s  0.030s
-  flatten(500K)            0.011s  0.011s  0.011s  0.011s  0.010s
-  min, max(2M)             0.018s  0.022s  0.022s  0.019s  0.021s
+  unique(1M)               0.031s  0.030s  0.030s  0.030s  0.030s
+  flatten(500K)            0.011s  0.011s  0.011s  0.010s  0.010s
+  min, max(2M)             0.022s  0.022s  0.019s  0.021s  0.018s
   add numbers(2M)          0.013s  0.013s  0.013s  0.013s  0.013s
-  any/all(2M)              0.028s  0.029s  0.028s  0.028s  0.028s
+  any/all(2M)              0.029s  0.028s  0.028s  0.028s  0.028s
   limit(10; range(10M))    0.002s  0.002s  0.002s  0.002s  0.002s
-  first(range(10M))        0.002s  0.003s  0.002s  0.002s  0.002s
+  first(range(10M))        0.003s  0.002s  0.002s  0.002s  0.002s
   last(range(2M))          0.002s  0.002s  0.002s  0.002s  0.002s
   indices(1M)              0.016s  0.016s  0.016s  0.016s  0.016s
 
 --- Reduce & foreach ---
-  Benchmark                v1.5.1  v1.5.2  v1.5.3  v1.5.4  v1.5.5
+  Benchmark                v1.5.2  v1.5.3  v1.5.4  v1.5.5  v1.5.6
   ---                      ------  ------  ------  ------  ------
   reduce (sum)             0.009s  0.009s  0.009s  0.009s  0.009s
   reduce (array build)     0.004s  0.004s  0.004s  0.004s  0.004s
-  reduce (obj build)       0.010s  0.010s  0.010s  0.010s  0.009s
-  reduce (setpath)         0.016s  0.016s  0.016s  0.017s  0.016s
+  reduce (obj build)       0.010s  0.010s  0.010s  0.009s  0.009s
+  reduce (setpath)         0.016s  0.016s  0.017s  0.016s  0.016s
   foreach (running sum)    0.010s  0.010s  0.010s  0.010s  0.010s
   foreach + emit           0.010s  0.010s  0.010s  0.010s  0.010s
-  reduce (sum-of-squares)  0.034s  0.034s  0.033s  0.034s  0.033s
-  reduce (conditional)     0.036s  0.036s  0.035s  0.036s  0.036s
-  reduce (product)         0.034s  0.035s  0.034s  0.034s  0.034s
-  foreach (conditional)    0.011s  0.011s  0.010s  0.010s  0.010s
-  until (100M)             0.303s  0.303s  0.302s  0.302s  0.300s
-  reduce (harmonic)        0.033s  0.034s  0.036s  0.033s  0.033s
-  reduce (floor pipe)      0.033s  0.034s  0.034s  0.034s  0.033s
-  reduce (sqrt pipe)       0.033s  0.033s  0.034s  0.033s  0.033s
+  reduce (sum-of-squares)  0.034s  0.033s  0.034s  0.033s  0.033s
+  reduce (conditional)     0.036s  0.035s  0.036s  0.036s  0.035s
+  reduce (product)         0.035s  0.034s  0.034s  0.034s  0.034s
+  foreach (conditional)    0.011s  0.010s  0.010s  0.010s  0.010s
+  until (100M)             0.303s  0.302s  0.302s  0.300s  0.301s
+  reduce (harmonic)        0.034s  0.036s  0.033s  0.033s  0.033s
+  reduce (floor pipe)      0.034s  0.034s  0.034s  0.033s  0.032s
+  reduce (sqrt pipe)       0.033s  0.034s  0.033s  0.033s  0.032s
   reduce (sin+cos)         0.052s  0.052s  0.052s  0.052s  0.052s
 
 --- Object operations ---
-  Benchmark                v1.5.1  v1.5.2  v1.5.3  v1.5.4  v1.5.5
+  Benchmark                v1.5.2  v1.5.3  v1.5.4  v1.5.5  v1.5.6
   ---                      ------  ------  ------  ------  ------
   large obj construct      0.004s  0.004s  0.004s  0.004s  0.004s
   large obj keys           0.011s  0.011s  0.011s  0.011s  0.011s
@@ -236,35 +236,35 @@ Recent slice (last 5 columns). Full history lives in
   with_entries             0.009s  0.009s  0.009s  0.009s  0.009s
 
 --- Assignment operators ---
-  Benchmark                v1.5.1  v1.5.2  v1.5.3  v1.5.4  v1.5.5
+  Benchmark                v1.5.2  v1.5.3  v1.5.4  v1.5.5  v1.5.6
   ---                      ------  ------  ------  ------  ------
   .[] |= f (100K)          0.005s  0.005s  0.005s  0.005s  0.005s
-  .[] += 1 (100K)          0.006s  0.005s  0.005s  0.005s  0.005s
+  .[] += 1 (100K)          0.005s  0.005s  0.005s  0.005s  0.005s
   .[k] = v reduce(50K)     0.008s  0.008s  0.008s  0.008s  0.008s
 
 --- String-heavy generators ---
-  Benchmark                v1.5.1  v1.5.2  v1.5.3  v1.5.4  v1.5.5
+  Benchmark                v1.5.2  v1.5.3  v1.5.4  v1.5.5  v1.5.6
   ---                      ------  ------  ------  ------  ------
-  gsub(100K)               0.027s  0.027s  0.026s  0.027s  0.026s
-  join large(100K)         0.005s  0.006s  0.005s  0.005s  0.005s
-  explode/implode(100K)    0.027s  0.027s  0.027s  0.028s  0.027s
+  gsub(100K)               0.027s  0.026s  0.027s  0.026s  0.027s
+  join large(100K)         0.006s  0.005s  0.005s  0.005s  0.006s
+  explode/implode(100K)    0.027s  0.027s  0.028s  0.027s  0.028s
   reduce str concat(100K)  0.008s  0.008s  0.008s  0.008s  0.008s
 
 --- Try-catch & alternative ---
-  Benchmark                v1.5.1  v1.5.2  v1.5.3  v1.5.4  v1.5.5
+  Benchmark                v1.5.2  v1.5.3  v1.5.4  v1.5.5  v1.5.6
   ---                      ------  ------  ------  ------  ------
-  alternative //           0.033s  0.033s  0.032s  0.033s  0.032s
+  alternative //           0.033s  0.032s  0.033s  0.032s  0.032s
   try-catch                0.023s  0.023s  0.023s  0.023s  0.023s
   label-break              0.004s  0.004s  0.004s  0.004s  0.004s
 
 --- Type conversion ---
-  Benchmark                v1.5.1  v1.5.2  v1.5.3  v1.5.4  v1.5.5
+  Benchmark                v1.5.2  v1.5.3  v1.5.4  v1.5.5  v1.5.6
   ---                      ------  ------  ------  ------  ------
   tojson/fromjson(100K)    0.022s  0.022s  0.022s  0.022s  0.022s
-  null propagation(2M)     0.090s  0.090s  0.090s  0.090s  0.089s
+  null propagation(2M)     0.090s  0.090s  0.090s  0.089s  0.090s
 
 --- jaq-derived ---
-  Benchmark                v1.5.1  v1.5.2  v1.5.3  v1.5.4  v1.5.5
+  Benchmark                v1.5.2  v1.5.3  v1.5.4  v1.5.5  v1.5.6
   ---                      ------  ------  ------  ------  ------
   jaq: reverse             -       -       -       -       -
   jaq: sort                -       -       -       -       -

--- a/docs/benchmark-history.tsv
+++ b/docs/benchmark-history.tsv
@@ -3832,3 +3832,217 @@ Try-catch & alternative	try-catch	v1.5.5	0.023
 Try-catch & alternative	label-break	v1.5.5	0.004
 Type conversion	tojson/fromjson(100K)	v1.5.5	0.022
 Type conversion	null propagation(2M)	v1.5.5	0.089
+NDJSON workloads (2M objects)	empty	v1.5.6	0.017
+NDJSON workloads (2M objects)	identity -c	v1.5.6	0.087
+NDJSON workloads (2M objects)	identity (pretty)	v1.5.6	0.105
+NDJSON workloads (2M objects)	field access .name	v1.5.6	0.095
+NDJSON workloads (2M objects)	nested .x,.y,.name	v1.5.6	0.150
+NDJSON workloads (2M objects)	arithmetic .x + .y	v1.5.6	0.083
+NDJSON workloads (2M objects)	select .x > 1500000	v1.5.6	0.082
+NDJSON workloads (2M objects)	string concat	v1.5.6	0.093
+NDJSON workloads (2M objects)	object construct	v1.5.6	0.111
+NDJSON workloads (2M objects)	array construct	v1.5.6	0.103
+NDJSON workloads (2M objects)	.[]	v1.5.6	0.101
+NDJSON workloads (2M objects)	to_entries	v1.5.6	0.159
+NDJSON workloads (2M objects)	keys	v1.5.6	0.109
+NDJSON workloads (2M objects)	keys_unsorted	v1.5.6	0.095
+NDJSON workloads (2M objects)	length	v1.5.6	0.085
+NDJSON workloads (2M objects)	has("x")	v1.5.6	0.034
+NDJSON workloads (2M objects)	type	v1.5.6	0.022
+NDJSON workloads (2M objects)	del(.name)	v1.5.6	0.104
+NDJSON workloads (2M objects)	@csv	v1.5.6	0.123
+NDJSON workloads (2M objects)	split/join	v1.5.6	0.089
+NDJSON workloads (2M objects)	select|field	v1.5.6	0.095
+NDJSON workloads (2M objects)	select|remap	v1.5.6	0.095
+NDJSON workloads (2M objects)	computed remap	v1.5.6	0.191
+NDJSON workloads (2M objects)	[.x,.y]|add	v1.5.6	0.082
+NDJSON workloads (2M objects)	[.x,.y]|avg	v1.5.6	0.106
+NDJSON workloads (2M objects)	map(*2)|add	v1.5.6	0.103
+NDJSON workloads (2M objects)	keys|length	v1.5.6	0.251
+NDJSON workloads (2M objects)	.+{z=0}	v1.5.6	0.146
+NDJSON workloads (2M objects)	split|first	v1.5.6	0.090
+NDJSON workloads (2M objects)	slice[0..5]	v1.5.6	0.092
+NDJSON workloads (2M objects)	dynkey {(.name)}	v1.5.6	0.102
+NDJSON workloads (2M objects)	.x += 1	v1.5.6	0.125
+NDJSON workloads (2M objects)	{a}+{b} merge	v1.5.6	0.135
+NDJSON workloads (2M objects)	.x*2+1	v1.5.6	0.060
+NDJSON workloads (2M objects)	.x+.y*2	v1.5.6	0.096
+NDJSON workloads (2M objects)	.x > .y	v1.5.6	0.077
+NDJSON workloads (2M objects)	to_entries|len	v1.5.6	0.400
+NDJSON workloads (2M objects)	.x|.+1 (pipe)	v1.5.6	0.058
+NDJSON workloads (2M objects)	.x|.*2|.+1	v1.5.6	0.059
+NDJSON workloads (2M objects)	.name|.+"_x"	v1.5.6	0.092
+NDJSON workloads (2M objects)	.x>N | not	v1.5.6	0.049
+NDJSON workloads (2M objects)	and (2 cmp)	v1.5.6	0.080
+NDJSON workloads (2M objects)	if-then-else	v1.5.6	0.052
+NDJSON workloads (2M objects)	sel(and)|field	v1.5.6	0.077
+NDJSON workloads (2M objects)	sel(and)|remap	v1.5.6	0.077
+NDJSON workloads (2M objects)	arith|cmp	v1.5.6	0.053
+NDJSON workloads (2M objects)	if cmp .field	v1.5.6	0.114
+NDJSON workloads (2M objects)	split|length	v1.5.6	0.090
+NDJSON workloads (2M objects)	[x,y]|min	v1.5.6	0.090
+NDJSON workloads (2M objects)	[x,y]|max	v1.5.6	0.092
+NDJSON workloads (2M objects)	[x,y]|sort|.[0]	v1.5.6	0.090
+NDJSON workloads (2M objects)	.name|len>5	v1.5.6	0.092
+NDJSON workloads (2M objects)	sel(len>5)|.x	v1.5.6	0.111
+NDJSON workloads (2M objects)	if .x>.y .name	v1.5.6	0.089
+NDJSON workloads (2M objects)	sel(.x>.y)|.name	v1.5.6	0.072
+NDJSON workloads (2M objects)	.x*2|tostring	v1.5.6	0.056
+NDJSON workloads (2M objects)	.x*.x+1	v1.5.6	0.066
+NDJSON workloads (2M objects)	{k=.name,v=tostr}	v1.5.6	0.144
+NDJSON workloads (2M objects)	str add chain	v1.5.6	0.385
+NDJSON workloads (2M objects)	if>.y .name|empty	v1.5.6	0.073
+NDJSON workloads (2M objects)	if .x%2==0	v1.5.6	0.054
+NDJSON workloads (2M objects)	if .x*2+1>1M	v1.5.6	0.054
+NDJSON workloads (2M objects)	sel(.x%2==0)|.name	v1.5.6	0.083
+NDJSON workloads (2M objects)	sel(.x*2+1>1M)	v1.5.6	0.159
+NDJSON workloads (2M objects)	.x|@json	v1.5.6	0.048
+NDJSON workloads (2M objects)	.x|@text	v1.5.6	0.047
+NDJSON workloads (2M objects)	.name|@json	v1.5.6	0.103
+NDJSON workloads (2M objects)	sel|[arr]	v1.5.6	0.143
+NDJSON workloads (2M objects)	sel(and)|[arr]	v1.5.6	0.077
+NDJSON workloads (2M objects)	if>.y [arr]	v1.5.6	0.173
+NDJSON workloads (2M objects)	if sw then .f	v1.5.6	0.139
+NDJSON workloads (2M objects)	dynkey {(.n)=.x*2}	v1.5.6	0.114
+NDJSON workloads (2M objects)	sel(and)|.x*.y	v1.5.6	0.076
+NDJSON workloads (2M objects)	sel>N|str chain	v1.5.6	0.151
+NDJSON workloads (2M objects)	.f+"_"+arith_ts	v1.5.6	0.132
+NDJSON workloads (2M objects)	sel(sw)|str ch	v1.5.6	0.307
+NDJSON workloads (2M objects)	split|rev|join	v1.5.6	0.114
+NDJSON workloads (2M objects)	dynkey+static	v1.5.6	0.331
+NDJSON workloads (2M objects)	if>.y str chain	v1.5.6	0.165
+NDJSON workloads (2M objects)	remap+str chain	v1.5.6	0.148
+NDJSON workloads (2M objects)	sel(len>8)	v1.5.6	0.165
+NDJSON workloads (2M objects)	up|split|join	v1.5.6	0.097
+NDJSON workloads (2M objects)	.name|index	v1.5.6	0.121
+NDJSON workloads (2M objects)	.name|index+1	v1.5.6	0.123
+NDJSON workloads (2M objects)	.name|rindex	v1.5.6	0.127
+NDJSON workloads (2M objects)	.name|indices	v1.5.6	0.146
+NDJSON workloads (2M objects)	[x,y]|sort	v1.5.6	0.152
+NDJSON workloads (2M objects)	.name|scan	v1.5.6	0.208
+NDJSON workloads (2M objects)	.name|gsub	v1.5.6	0.168
+NDJSON workloads (2M objects)	walk(if num .+1)	v1.5.6	0.143
+NDJSON workloads (2M objects)	tojson	v1.5.6	0.104
+NDJSON workloads (2M objects)	{name,x}	v1.5.6	0.133
+NDJSON workloads (2M objects)	.z//.name	v1.5.6	0.157
+NDJSON workloads (2M objects)	.x|=test(re)	v1.5.6	0.180
+NDJSON workloads (2M objects)	./sep|first	v1.5.6	0.182
+NDJSON workloads (2M objects)	.y=(.x*2)	v1.5.6	0.178
+NDJSON workloads (2M objects)	.y=(.x+.y)	v1.5.6	0.233
+NDJSON workloads (2M objects)	objects	v1.5.6	0.138
+NDJSON workloads (2M objects)	.tag|=if..then N	v1.5.6	0.614
+NDJSON workloads (2M objects)	.x=(.x+1)	v1.5.6	0.128
+NDJSON workloads (2M objects)	sel>N|.y+=1	v1.5.6	0.121
+NDJSON workloads (2M objects)	sel(and)|.x+=1	v1.5.6	0.111
+NDJSON workloads (2M objects)	sel(sw)|.x+=1	v1.5.6	0.164
+NDJSON workloads (2M objects)	match(re)	v1.5.6	0.369
+NDJSON workloads (2M objects)	capture(re)	v1.5.6	0.296
+NDJSON workloads (2M objects)	first(.name,.x)	v1.5.6	0.097
+NDJSON workloads (2M objects)	if .x==null	v1.5.6	0.046
+NDJSON workloads (2M objects)	we(sw(.key))	v1.5.6	0.110
+NDJSON workloads (2M objects)	sel(sw or ew)	v1.5.6	0.205
+NDJSON workloads (2M objects)	path(.name,.x)	v1.5.6	0.274
+NDJSON workloads (2M objects)	sel(str+num+num)	v1.5.6	0.152
+NDJSON workloads (2M objects)	nested if|field	v1.5.6	0.076
+NDJSON workloads (2M objects)	.f|floor|.*2	v1.5.6	0.061
+NDJSON workloads (2M objects)	split|len>1	v1.5.6	0.114
+NDJSON workloads (2M objects)	.name|len|.*2	v1.5.6	0.103
+NDJSON workloads (2M objects)	if len>5 .x .y	v1.5.6	0.113
+NDJSON workloads (2M objects)	sel(len>5)|remap	v1.5.6	0.207
+NDJSON workloads (2M objects)	.x|tostr|len	v1.5.6	0.059
+NDJSON workloads (2M objects)	if .x>.y .x .y	v1.5.6	0.093
+NDJSON workloads (2M objects)	split|last|tonum	v1.5.6	0.096
+NDJSON workloads (2M objects)	split|rev|.[0]	v1.5.6	0.090
+NDJSON workloads (2M objects)	split|.[0]+.[1]	v1.5.6	0.114
+NDJSON workloads (2M objects)	.[]|strings	v1.5.6	0.104
+NDJSON workloads (2M objects)	.[]|numbers	v1.5.6	0.124
+NDJSON workloads (2M objects)	[x,y]|any(>1M)	v1.5.6	0.082
+NDJSON workloads (2M objects)	sel(dc|sw)	v1.5.6	0.097
+NDJSON workloads (2M objects)	[[x,y],[n]]|flat	v1.5.6	0.460
+NDJSON workloads (2M objects)	.x|floor|.*2	v1.5.6	0.061
+NDJSON workloads (2M objects)	tojson|fromjson	v1.5.6	0.085
+NDJSON workloads (2M objects)	[.x]|add	v1.5.6	0.060
+NDJSON workloads (2M objects)	if>N {o}+.	v1.5.6	0.135
+NDJSON workloads (2M objects)	if>N .+{o}	v1.5.6	0.138
+NDJSON workloads (2M objects)	if .n=="s" .+{o}	v1.5.6	0.161
+NDJSON workloads (2M objects)	sel(.n>"s")	v1.5.6	0.089
+NDJSON workloads (2M objects)	[x,y,z]|min	v1.5.6	0.309
+NDJSON workloads (2M objects)	if .n|len>5 l s	v1.5.6	0.100
+NDJSON workloads (2M objects)	if .x|flr>N b s	v1.5.6	0.056
+NDJSON workloads (2M objects)	if .n|test l e	v1.5.6	0.106
+NDJSON workloads (2M objects)	if .n|sw l e	v1.5.6	0.084
+NDJSON workloads (2M objects)	if .n|ew l e	v1.5.6	0.084
+NDJSON workloads (2M objects)	.n|len|tostr	v1.5.6	0.092
+String operations (2M objects)	ascii_downcase	v1.5.6	0.105
+String operations (2M objects)	ascii_upcase	v1.5.6	0.103
+String operations (2M objects)	ltrimstr	v1.5.6	0.095
+String operations (2M objects)	rtrimstr	v1.5.6	0.098
+String operations (2M objects)	split	v1.5.6	0.162
+String operations (2M objects)	case+split	v1.5.6	0.115
+String operations (2M objects)	join	v1.5.6	0.091
+String operations (2M objects)	startswith	v1.5.6	0.095
+String operations (2M objects)	endswith	v1.5.6	0.096
+String operations (2M objects)	tostring	v1.5.6	0.063
+String operations (2M objects)	tonumber	v1.5.6	0.110
+String operations (2M objects)	string interpolation	v1.5.6	0.118
+String ops (200K objects)	test (regex)	v1.5.6	0.015
+String ops (200K objects)	match (regex)	v1.5.6	0.033
+String ops (200K objects)	@base64	v1.5.6	0.012
+String ops (200K objects)	@uri	v1.5.6	0.012
+String ops (200K objects)	@html	v1.5.6	0.012
+String ops (200K objects)	@csv (array)	v1.5.6	0.015
+String ops (200K objects)	@tsv (array)	v1.5.6	0.015
+String ops (200K objects)	gsub	v1.5.6	0.019
+String ops (200K objects)	case+gsub	v1.5.6	0.181
+String ops (200K objects)	case+test	v1.5.6	0.119
+String ops (200K objects)	ltrim+tonum+arith	v1.5.6	0.111
+Numeric & math (2M objects)	floor	v1.5.6	0.057
+Numeric & math (2M objects)	sqrt	v1.5.6	0.079
+Numeric & math (2M objects)	modulo	v1.5.6	0.057
+Numeric & math (2M objects)	if-elif-else	v1.5.6	0.121
+Numeric & math (2M objects)	select|del	v1.5.6	0.092
+Numeric & math (2M objects)	select|merge	v1.5.6	0.120
+Numeric & math (2M objects)	select(test)|merge	v1.5.6	0.022
+Array generators	range(2M) | length	v1.5.6	0.011
+Array generators	reverse(2M)	v1.5.6	0.018
+Array generators	sort(2M)	v1.5.6	0.023
+Array generators	unique(1M)	v1.5.6	0.030
+Array generators	flatten(500K)	v1.5.6	0.010
+Array generators	min, max(2M)	v1.5.6	0.018
+Array generators	add numbers(2M)	v1.5.6	0.013
+Array generators	any/all(2M)	v1.5.6	0.028
+Array generators	limit(10; range(10M))	v1.5.6	0.002
+Array generators	first(range(10M))	v1.5.6	0.002
+Array generators	last(range(2M))	v1.5.6	0.002
+Array generators	indices(1M)	v1.5.6	0.016
+Reduce & foreach	reduce (sum)	v1.5.6	0.009
+Reduce & foreach	reduce (array build)	v1.5.6	0.004
+Reduce & foreach	reduce (obj build)	v1.5.6	0.009
+Reduce & foreach	reduce (setpath)	v1.5.6	0.016
+Reduce & foreach	foreach (running sum)	v1.5.6	0.010
+Reduce & foreach	foreach + emit	v1.5.6	0.010
+Reduce & foreach	reduce (sum-of-squares)	v1.5.6	0.033
+Reduce & foreach	reduce (conditional)	v1.5.6	0.035
+Reduce & foreach	reduce (product)	v1.5.6	0.034
+Reduce & foreach	foreach (conditional)	v1.5.6	0.010
+Reduce & foreach	until (100M)	v1.5.6	0.301
+Reduce & foreach	reduce (harmonic)	v1.5.6	0.033
+Reduce & foreach	reduce (floor pipe)	v1.5.6	0.032
+Reduce & foreach	reduce (sqrt pipe)	v1.5.6	0.032
+Reduce & foreach	reduce (sin+cos)	v1.5.6	0.052
+Object operations	large obj construct	v1.5.6	0.004
+Object operations	large obj keys	v1.5.6	0.011
+Object operations	large obj to_entries	v1.5.6	0.012
+Object operations	with_entries	v1.5.6	0.009
+Assignment operators	.[] |= f (100K)	v1.5.6	0.005
+Assignment operators	.[] += 1 (100K)	v1.5.6	0.005
+Assignment operators	.[k] = v reduce(50K)	v1.5.6	0.008
+String-heavy generators	gsub(100K)	v1.5.6	0.027
+String-heavy generators	join large(100K)	v1.5.6	0.006
+String-heavy generators	explode/implode(100K)	v1.5.6	0.028
+String-heavy generators	reduce str concat(100K)	v1.5.6	0.008
+Try-catch & alternative	alternative //	v1.5.6	0.032
+Try-catch & alternative	try-catch	v1.5.6	0.023
+Try-catch & alternative	label-break	v1.5.6	0.004
+Type conversion	tojson/fromjson(100K)	v1.5.6	0.022
+Type conversion	null propagation(2M)	v1.5.6	0.090


### PR DESCRIPTION
## Summary

Patch release bundling recent reduce/eval correctness fixes and the null-input JIT gate tuning.

Changes since v1.5.5:
- `fix(eval): roll back next_var after recursive def frame returns` (#654)
- `fix(eval): move input into Update result so reduce RMW stays in-place` (#656)
- `test(regression): add Project Euler P60 case for #655` (#657)
- `perf(cli): skip JIT for null-input filters whose AST exceeds the compile threshold` (#660)
- `perf(cli): make null-input JIT gate walk def bodies, add --force-jit/--force-interp` (#661)

## Benchmarks

Appended v1.5.6 column to `docs/benchmark-history.{tsv,md}`. Aggregate sum vs v1.5.5: **0.994x** (slight overall improvement, 214 benchmarks).

No regression > 5% on any benchmark ≥10ms after re-run. Worst remaining ratios are all within historical noise bands (NDJSON `objects` 0.128→0.138 vs v1.5.1-v1.5.5 range 0.128-0.137; small string-ops at 1ms granularity).