### PR TITLE
feat(jqx): memoize/1 and memoize/2 for function-result caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,17 @@ cap, new inserts are silently dropped (the program continues, just without
 caching new entries). Body errors do not poison the cache — the next call
 re-evaluates.
 
+Run with `--debug-memo` to print per-slot cache stats (hits / misses / entries)
+to stderr at program exit. Useful for confirming a `memoize(...)` is actually
+hitting:
+
+```bash
+jq-jit --debug-memo -n 'def fib: memoize(if . < 2 then . else ((. - 1) | fib) + ((. - 2) | fib) end); 30 | fib'
+# memoize stats: 1 slot(s)
+#   slot          hits        misses       entries
+#      0            28            31            31
+```
+
 The 1-arg form keys only by the current input. If your body closes over a
 `$var` that varies between calls, results will be stale — pull the var into
 the key explicitly with the 2-arg form: `memoize(. + $x; [., $x])`.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Passes 100% of the official jq test suite (509/509) while being **8x-180x faster
 - **Streaming JSON parser** for memory-efficient NDJSON processing
 - **Memory-mapped file I/O** — mmap-based file reading with no upfront allocation
 - **Optimized value representation** with compact strings, mimalloc, and inline Cranelift codegen
-- **jqx extensions** — shell command execution (`exec`/`execv`) and CSV/TSV parsing (`fromcsv`/`fromcsvh`/`fromtsv`/`fromtsvh`)
+- **jqx extensions** — shell command execution (`exec`/`execv`), CSV/TSV parsing (`fromcsv`/`fromcsvh`/`fromtsv`/`fromtsvh`), and function-result memoization (`memoize`)
 
 ## Performance
 
@@ -187,6 +187,39 @@ jq-jit -Rsc 'fromcsvh(["name","age"])' < no-header.csv
 # Combine with exec
 jq-jit -n 'exec("cat data.csv") | fromcsvh | select(.age | tonumber > 25)'
 ```
+
+### Memoization
+
+| Function | Description |
+|----------|-------------|
+| `memoize(f)` | Cache the output sequence of `f` keyed by the current input value. |
+
+Each lexical occurrence of `memoize(...)` gets its own cache; entries persist
+for the lifetime of the program (across NDJSON input records). Keys compare by
+structural equality, matching jq's `==` semantics (objects are order-independent,
+arrays element-wise). The body is run to completion on first call — multi-output
+generators are materialized so subsequent calls re-yield the same sequence.
+
+Self-recursive memoization Just Works: jq's `def` binds the same name inside
+the body, so recursive calls go through the memoized wrapper:
+
+```bash
+# Fibonacci — exponential without memo, linear with it
+jq-jit -n 'def fib: memoize(if . < 2 then . else ((. - 1) | fib) + ((. - 2) | fib) end); 80 | fib'
+
+# Collatz chain length — subgraph revisits become O(1)
+jq-jit -n 'def collatz: memoize(if . == 1 then 0 else (if . % 2 == 0 then ./2 else 3*. + 1 end | collatz) + 1 end); 27 | collatz'
+```
+
+Eviction defaults to "unbounded for program lifetime" up to a per-slot cap of
+1,000,000 entries; control it with `--memo-max-entries N` on the CLI. Past the
+cap, new inserts are silently dropped (the program continues, just without
+caching new entries). Body errors do not poison the cache — the next call
+re-evaluates.
+
+Do not close over mutable state inside `memoize(...)`: only the input value is
+part of the cache key. A body that reads a `$var` set elsewhere in the program
+will return stale results if that var changes between calls.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ jq-jit -n 'exec("cat data.csv") | fromcsvh | select(.age | tonumber > 25)'
 | Function | Description |
 |----------|-------------|
 | `memoize(f)` | Cache the output sequence of `f` keyed by the current input value. |
+| `memoize(f; key)` | Same, but use `key` (evaluated against the input) as the cache key instead of the input itself. |
 
 Each lexical occurrence of `memoize(...)` gets its own cache; entries persist
 for the lifetime of the program (across NDJSON input records). Keys compare by
@@ -209,6 +210,9 @@ jq-jit -n 'def fib: memoize(if . < 2 then . else ((. - 1) | fib) + ((. - 2) | fi
 
 # Collatz chain length — subgraph revisits become O(1)
 jq-jit -n 'def collatz: memoize(if . == 1 then 0 else (if . % 2 == 0 then ./2 else 3*. + 1 end | collatz) + 1 end); 27 | collatz'
+
+# 2-arg form: memoize a transformation by record id, ignoring the rest
+jq-jit -c 'memoize(.value * 2; .id)' <<< '{"id":1,"value":10}'
 ```
 
 Eviction defaults to "unbounded for program lifetime" up to a per-slot cap of
@@ -217,9 +221,9 @@ cap, new inserts are silently dropped (the program continues, just without
 caching new entries). Body errors do not poison the cache — the next call
 re-evaluates.
 
-Do not close over mutable state inside `memoize(...)`: only the input value is
-part of the cache key. A body that reads a `$var` set elsewhere in the program
-will return stale results if that var changes between calls.
+The 1-arg form keys only by the current input. If your body closes over a
+`$var` that varies between calls, results will be stale — pull the var into
+the key explicitly with the 2-arg form: `memoize(. + $x; [., $x])`.
 
 ## Testing
 

--- a/bench/comprehensive.sh
+++ b/bench/comprehensive.sh
@@ -350,6 +350,22 @@ bench_gen "tojson/fromjson(100K)"       100000    '[range(.) | {a: ., b: "x"}] |
 bench_gen "null propagation(2M)"        2000000   '[range(.) | null] | map(.a.b.c?) | length'
 
 echo ""
+echo "--- Memoization (jqx) ---"
+header
+# fib via self-recursive memoize. Without memo, fib(N) is exponential — N=40
+# already takes minutes. With memo each value computed once, so this scales
+# linearly. Drives the "is memoize working" regression anchor.
+bench_gen "memo fib (1K)"               1000     'def fib: memoize(if . < 2 then . else ((. - 1) | fib) + ((. - 2) | fib) end); [range(.) | fib] | last'
+# Collatz chain length, summed. Exercises the "subgraph revisit" pattern
+# where memo collapses overlapping tails of the chains.
+bench_gen "memo collatz sum (10K)"      10000    'def c: memoize(if . == 1 then 0 else (if . % 2 == 0 then ./2 else 3*.+1 end | c) + 1 end); [range(1; .) | c] | add'
+# 2-arg memoize: body computes from the full record but cache is keyed by
+# .id. 100K inputs deduplicate onto 1K unique keys; the expensive body runs
+# only ~1K times. The outer record is bound to `$rec` so the `reduce`
+# update can reach `.v` past the accumulator.
+bench_gen "memo by .id (100K, 1K keys)" 100000   '[range(.) | {id: (. % 1000), v: .}] | map(. as $rec | memoize(reduce range(0; 100) as $i (0; . + $i * $rec.v); .id)) | length'
+
+echo ""
 echo "--- jaq-derived ---"
 header
 BENCH_DIR="$HOME/src/github.com/01mf02/jaq/examples/benches"

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -173,6 +173,14 @@ $ JQJIT_TRACE=1 jq-jit '{a:.x, a:.x+1}' <<< '{"x":1}'
 
 JIT にまで降りる filter はここ。`flatten_scalar` / `flatten_gen` の match 群。複雑 path の Update/Assign は `__update__:idx:idx` closure op で eval にバックアウトする。
 
+### `memoize/1` は interpreter 専用
+
+`Expr::Memoize` は cache lookup が cold path なので JIT 化メリットがなく、
+`flatten_gen` の catch-all (`_ => false`) で reject。同じ理由で fast path
+（`detect_*` 群 / `simplify_expr` の rewrite）にも乗らない — `memoize` を
+含む filter は interpreter で評価される前提。値レベル cache のキーは
+`value::ValueKey`（`runtime::values_equal` 準拠 + NaN reflexive）で持つ。
+
 ---
 
 ## 3. 守るべき invariant

--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -2222,6 +2222,7 @@ fn main() {
 fn real_main() {
     let mut force_interp = force_interpreter_enabled();
     let mut force_jit = false;
+    let mut memo_max_entries: Option<usize> = None;
     let args: Vec<String> = std::env::args().collect();
 
     let mut filter_str = None;
@@ -2277,6 +2278,21 @@ fn real_main() {
             "--seq" => seq = true,
             "--force-jit" => { force_jit = true; force_interp = false; }
             "--force-interp" | "--force-interpreter" => { force_interp = true; force_jit = false; }
+            "--memo-max-entries" => {
+                i += 1;
+                if i < expanded_args.len() {
+                    match expanded_args[i].parse::<usize>() {
+                        Ok(n) => memo_max_entries = Some(n),
+                        Err(_) => {
+                            eprintln!("jq: --memo-max-entries expects a non-negative integer");
+                            process::exit(2);
+                        }
+                    }
+                } else {
+                    eprintln!("jq: --memo-max-entries expects a value");
+                    process::exit(2);
+                }
+            }
             "-a" | "--ascii-output" => {
                 // Recognised but not yet implemented (#126). Emit a
                 // clear error instead of falling through to the filter
@@ -2532,6 +2548,9 @@ fn real_main() {
             process::exit(3);
         }
     };
+    if let Some(n) = memo_max_entries {
+        filter.set_memo_max_entries(n);
+    }
 
     // projection_fields is set below after all pattern detections
 
@@ -21309,6 +21328,7 @@ fn print_usage() {
     eprintln!("  -M, --monochrome-output  Disable color output (default)");
     eprintln!("  --args                   Remaining args are string $ARGS.positional");
     eprintln!("  --jsonargs               Remaining args are JSON $ARGS.positional");
+    eprintln!("  --memo-max-entries N     Per-slot cap for memoize/1 cache (jqx; default 1000000)");
     eprintln!("  --version                Show version");
     eprintln!("  -h, --help               Show this help");
 }

--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -2223,6 +2223,7 @@ fn real_main() {
     let mut force_interp = force_interpreter_enabled();
     let mut force_jit = false;
     let mut memo_max_entries: Option<usize> = None;
+    let mut debug_memo = false;
     let args: Vec<String> = std::env::args().collect();
 
     let mut filter_str = None;
@@ -2293,6 +2294,7 @@ fn real_main() {
                     process::exit(2);
                 }
             }
+            "--debug-memo" => debug_memo = true,
             "-a" | "--ascii-output" => {
                 // Recognised but not yet implemented (#126). Emit a
                 // clear error instead of falling through to the filter
@@ -21292,6 +21294,11 @@ fn real_main() {
     }
     let _ = out.flush();
 
+    if debug_memo {
+        let mut stderr = io::stderr().lock();
+        let _ = filter.dump_memo_stats(&mut stderr);
+    }
+
     if had_error {
         process::exit(5);
     }
@@ -21329,6 +21336,7 @@ fn print_usage() {
     eprintln!("  --args                   Remaining args are string $ARGS.positional");
     eprintln!("  --jsonargs               Remaining args are JSON $ARGS.positional");
     eprintln!("  --memo-max-entries N     Per-slot cap for memoize/1 cache (jqx; default 1000000)");
+    eprintln!("  --debug-memo             Print per-slot memoize cache stats to stderr on exit (jqx)");
     eprintln!("  --version                Show version");
     eprintln!("  -h, --help               Show this help");
 }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -93,7 +93,22 @@ pub enum MemoEntry {
     Many(Rc<Vec<Value>>),
 }
 
-pub type MemoSlot = Rc<RefCell<HashMap<ValueKey, MemoEntry>>>;
+/// Per-slot cache state: the entries themselves plus diagnostic counters.
+/// `hits` / `misses` are populated unconditionally — the branch is cheap and
+/// reading them is the whole point of `--debug-memo`.
+pub struct SlotState {
+    pub entries: HashMap<ValueKey, MemoEntry>,
+    pub hits: u64,
+    pub misses: u64,
+}
+
+impl SlotState {
+    fn new() -> Self {
+        SlotState { entries: HashMap::new(), hits: 0, misses: 0 }
+    }
+}
+
+pub type MemoSlot = Rc<RefCell<SlotState>>;
 
 pub struct Env {
     vars: Vec<Value>,
@@ -130,7 +145,7 @@ pub fn default_memo_max_entries() -> usize {
 }
 
 fn fresh_memo_slots(n: u32) -> Vec<MemoSlot> {
-    (0..n).map(|_| Rc::new(RefCell::new(HashMap::new()))).collect()
+    (0..n).map(|_| Rc::new(RefCell::new(SlotState::new()))).collect()
 }
 
 impl Env {
@@ -3272,7 +3287,12 @@ fn memo_lookup_or_run(
     env: &EnvRef,
     cb: &mut dyn FnMut(Value) -> GenResult,
 ) -> GenResult {
-    let cached = slot.borrow().get(&cache_key).cloned();
+    let cached = {
+        let mut state = slot.borrow_mut();
+        let hit = state.entries.get(&cache_key).cloned();
+        if hit.is_some() { state.hits += 1; } else { state.misses += 1; }
+        hit
+    };
     if let Some(entry) = cached {
         return match entry {
             MemoEntry::Single(v) => cb(v),
@@ -3298,10 +3318,10 @@ fn memo_lookup_or_run(
         MemoEntry::Many(Rc::new(outputs))
     };
     {
-        let mut slot_mut = slot.borrow_mut();
+        let mut state = slot.borrow_mut();
         let cap = env.borrow().memo_max_entries;
-        if slot_mut.len() < cap {
-            slot_mut.insert(cache_key, entry.clone());
+        if state.entries.len() < cap {
+            state.entries.insert(cache_key, entry.clone());
         }
     }
     match entry {

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -12,7 +12,7 @@ use std::rc::Rc;
 use anyhow::{Result, bail};
 
 use crate::ir::*;
-use crate::value::{Value, ObjInner, NumRepr, KeyStr};
+use crate::value::{Value, ObjInner, NumRepr, KeyStr, ValueKey};
 
 type GenResult = Result<bool>;
 pub type EnvRef = Rc<RefCell<Env>>;
@@ -82,6 +82,8 @@ impl std::fmt::Display for BreakError {
 }
 impl std::error::Error for BreakError {}
 
+pub type MemoSlot = Rc<RefCell<HashMap<ValueKey, Rc<Vec<Value>>>>>;
+
 pub struct Env {
     vars: Vec<Value>,
     funcs: Vec<Rc<CompiledFunc>>,
@@ -99,14 +101,41 @@ pub struct Env {
     /// Pointer-based substitution cache: func_id → (args_ptr, substituted_body).
     /// For non-LoadVar args from stable (cached) call sites.
     subst_ptr_cache: Vec<(usize, usize, Rc<Expr>)>,
+    /// One cache map per lexical `memoize(...)` occurrence in the program.
+    /// Lifetime is the whole program execution (persists across NDJSON inputs).
+    /// `Rc` so the eval path can clone a handle and drop the `Env` borrow
+    /// before invoking the memoized body (which may itself borrow `Env`).
+    pub memo_slots: Vec<MemoSlot>,
+    /// Per-slot upper bound on cache entries. New inserts past this cap are
+    /// silently dropped (the program continues, just without caching that
+    /// entry). Controlled by `--memo-max-entries` on the CLI.
+    pub memo_max_entries: usize,
+}
+
+const DEFAULT_MEMO_MAX_ENTRIES: usize = 1_000_000;
+
+pub fn default_memo_max_entries() -> usize {
+    DEFAULT_MEMO_MAX_ENTRIES
+}
+
+fn fresh_memo_slots(n: u32) -> Vec<MemoSlot> {
+    (0..n).map(|_| Rc::new(RefCell::new(HashMap::new()))).collect()
 }
 
 impl Env {
     pub fn new(funcs: Vec<CompiledFunc>) -> Self {
-        Env { vars: vec![Value::Null; 65536], funcs: funcs.into_iter().map(Rc::new).collect(), next_label: 0, next_var: 256, lib_dirs: Vec::new(), closures: Vec::new(), recursive_cache: Vec::new(), subst_cache: Vec::new(), subst_ptr_cache: Vec::new() }
+        Env { vars: vec![Value::Null; 65536], funcs: funcs.into_iter().map(Rc::new).collect(), next_label: 0, next_var: 256, lib_dirs: Vec::new(), closures: Vec::new(), recursive_cache: Vec::new(), subst_cache: Vec::new(), subst_ptr_cache: Vec::new(), memo_slots: Vec::new(), memo_max_entries: DEFAULT_MEMO_MAX_ENTRIES }
     }
     pub fn with_lib_dirs(funcs: Vec<CompiledFunc>, lib_dirs: Vec<String>) -> Self {
-        Env { vars: vec![Value::Null; 65536], funcs: funcs.into_iter().map(Rc::new).collect(), next_label: 0, next_var: 256, lib_dirs, closures: Vec::new(), recursive_cache: Vec::new(), subst_cache: Vec::new(), subst_ptr_cache: Vec::new() }
+        Env { vars: vec![Value::Null; 65536], funcs: funcs.into_iter().map(Rc::new).collect(), next_label: 0, next_var: 256, lib_dirs, closures: Vec::new(), recursive_cache: Vec::new(), subst_cache: Vec::new(), subst_ptr_cache: Vec::new(), memo_slots: Vec::new(), memo_max_entries: DEFAULT_MEMO_MAX_ENTRIES }
+    }
+    /// Allocate `n` memo cache slots. Called once per program after parsing,
+    /// using `ParseResult::memo_slots`.
+    pub fn set_memo_slots(&mut self, n: u32) {
+        self.memo_slots = fresh_memo_slots(n);
+    }
+    pub fn set_memo_max_entries(&mut self, n: usize) {
+        self.memo_max_entries = n;
     }
     /// Reset env state for reuse across multiple inputs.
     /// Keeps allocated buffers (vars, caches) but resets mutable state.
@@ -119,7 +148,9 @@ impl Env {
         self.next_label = 0;
         self.next_var = 256;
         self.closures.clear();
-        // Keep recursive_cache, subst_cache, subst_ptr_cache — they stay valid across inputs
+        // Keep recursive_cache, subst_cache, subst_ptr_cache, memo_slots —
+        // they stay valid across inputs (memo cache spans the whole program
+        // lifetime per #671 design).
     }
     #[inline(always)]
     fn get_var(&self, idx: u16) -> Value {
@@ -279,6 +310,7 @@ fn subst_inner(
         Expr::AlternativeDestructure { alternatives } => Expr::AlternativeDestructure {
             alternatives: alternatives.iter().map(|a| s!(a)).collect(),
         },
+        Expr::Memoize { slot_id, body } => Expr::Memoize { slot_id: *slot_id, body: sb!(body) },
         Expr::Input | Expr::Empty | Expr::Not | Expr::Env | Expr::Builtins
         | Expr::ReadInput | Expr::ReadInputs | Expr::ModuleMeta | Expr::GenLabel
         | Expr::Literal(_) | Expr::Loc { .. } => expr.clone(),
@@ -610,6 +642,7 @@ fn subst_cow(expr: &Expr, pv: &[u16], args: &[Expr]) -> Option<Expr> {
                 alternatives: alternatives.iter().zip(results).map(|(a, r)| r.unwrap_or_else(|| a.clone())).collect(),
             })
         }
+        Expr::Memoize { slot_id, body } => s!(body).map(|b| Expr::Memoize { slot_id: *slot_id, body: Box::new(b) }),
         // Leaf nodes never contain param var references
         Expr::Input | Expr::Empty | Expr::Not | Expr::Env | Expr::Builtins
         | Expr::ReadInput | Expr::ReadInputs | Expr::ModuleMeta | Expr::GenLabel
@@ -660,6 +693,7 @@ fn contains_func_call(expr: &Expr, target: usize) -> bool {
             c!(input_expr) || c!(re) || c!(tostr) || c!(flags)
         }
         Expr::AlternativeDestructure { alternatives } => alternatives.iter().any(|a| c!(a)),
+        Expr::Memoize { body, .. } => c!(body),
         Expr::Input | Expr::Empty | Expr::Not | Expr::Env | Expr::Builtins
         | Expr::ReadInput | Expr::ReadInputs | Expr::ModuleMeta | Expr::GenLabel
         | Expr::Literal(_) | Expr::Loc { .. } | Expr::LoadVar { .. } | Expr::Error { msg: None } => false,
@@ -741,6 +775,8 @@ fn expr_uses_outer_input(expr: &Expr) -> bool {
         | Expr::RegexTest { .. } | Expr::RegexMatch { .. } | Expr::RegexCapture { .. }
         | Expr::RegexScan { .. } | Expr::RegexSub { .. } | Expr::RegexGsub { .. }
         | Expr::AlternativeDestructure { .. } => true,
+        // Memoize keys cache by current input → always uses input
+        Expr::Memoize { .. } => true,
     }
 }
 
@@ -810,6 +846,7 @@ fn expr_uses_var(expr: &Expr, target: u16) -> bool {
             expr_uses_var(input_expr, target) || expr_uses_var(re, target) || expr_uses_var(tostr, target) || expr_uses_var(flags, target)
         }
         Expr::AlternativeDestructure { alternatives } => alternatives.iter().any(|a| expr_uses_var(a, target)),
+        Expr::Memoize { body, .. } => expr_uses_var(body, target),
     }
 }
 
@@ -3163,6 +3200,47 @@ pub fn eval(
 
         Expr::CallBuiltin { name, args } => {
             eval_call_builtin(name, args, input, env, cb)
+        }
+
+        Expr::Memoize { slot_id, body } => {
+            let slot = {
+                let env_ref = env.borrow();
+                match env_ref.memo_slots.get(*slot_id as usize) {
+                    Some(s) => s.clone(),
+                    None => bail!("memoize slot {} not allocated", slot_id),
+                }
+            };
+            let key = ValueKey(input.clone());
+            // Cache hit: re-yield the materialized output sequence.
+            let cached = slot.borrow().get(&key).cloned();
+            if let Some(outputs) = cached {
+                for v in outputs.iter() {
+                    if !cb(v.clone())? { return Ok(false); }
+                }
+                return Ok(true);
+            }
+            // Miss: run the body to completion, collecting every output.
+            // We do not pass the consumer's `cb` directly — `memoize` must
+            // observe the full output sequence to cache it, even if the
+            // consumer wants to stop after the first value. This means
+            // `memoize` forces the body to fully evaluate; for the typical
+            // single-output pure body that is the natural case, but it is
+            // a documented difference for generator/side-effecting bodies.
+            let mut outputs: Vec<Value> = Vec::new();
+            eval(body, input, env, &mut |v| { outputs.push(v); Ok(true) })?;
+            let outputs_rc = Rc::new(outputs);
+            // Cache subject to per-slot cap.
+            {
+                let mut slot_mut = slot.borrow_mut();
+                let cap = env.borrow().memo_max_entries;
+                if slot_mut.len() < cap {
+                    slot_mut.insert(key, outputs_rc.clone());
+                }
+            }
+            for v in outputs_rc.iter() {
+                if !cb(v.clone())? { return Ok(false); }
+            }
+            Ok(true)
         }
     }
 }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -82,7 +82,18 @@ impl std::fmt::Display for BreakError {
 }
 impl std::error::Error for BreakError {}
 
-pub type MemoSlot = Rc<RefCell<HashMap<ValueKey, Rc<Vec<Value>>>>>;
+/// Cached output sequence for a single memoize call site.
+///
+/// The vast majority of memoize use cases — fib, Collatz, totient, etc. —
+/// have single-output bodies, so we special-case that to skip an
+/// `Rc<Vec<Value>>` allocation and a 1-element iteration on every cache hit.
+#[derive(Clone)]
+pub enum MemoEntry {
+    Single(Value),
+    Many(Rc<Vec<Value>>),
+}
+
+pub type MemoSlot = Rc<RefCell<HashMap<ValueKey, MemoEntry>>>;
 
 pub struct Env {
     vars: Vec<Value>,
@@ -310,7 +321,11 @@ fn subst_inner(
         Expr::AlternativeDestructure { alternatives } => Expr::AlternativeDestructure {
             alternatives: alternatives.iter().map(|a| s!(a)).collect(),
         },
-        Expr::Memoize { slot_id, body } => Expr::Memoize { slot_id: *slot_id, body: sb!(body) },
+        Expr::Memoize { slot_id, key, body } => Expr::Memoize {
+            slot_id: *slot_id,
+            key: key.as_ref().map(|k| sb!(k)),
+            body: sb!(body),
+        },
         Expr::Input | Expr::Empty | Expr::Not | Expr::Env | Expr::Builtins
         | Expr::ReadInput | Expr::ReadInputs | Expr::ModuleMeta | Expr::GenLabel
         | Expr::Literal(_) | Expr::Loc { .. } => expr.clone(),
@@ -642,7 +657,16 @@ fn subst_cow(expr: &Expr, pv: &[u16], args: &[Expr]) -> Option<Expr> {
                 alternatives: alternatives.iter().zip(results).map(|(a, r)| r.unwrap_or_else(|| a.clone())).collect(),
             })
         }
-        Expr::Memoize { slot_id, body } => s!(body).map(|b| Expr::Memoize { slot_id: *slot_id, body: Box::new(b) }),
+        Expr::Memoize { slot_id, key, body } => {
+            let k = key.as_ref().and_then(|k2| s!(k2));
+            let b = s!(body);
+            if k.is_none() && b.is_none() { return None; }
+            Some(Expr::Memoize {
+                slot_id: *slot_id,
+                key: if k.is_some() { k.map(Box::new) } else { key.clone() },
+                body: Box::new(b.unwrap_or_else(|| body.as_ref().clone())),
+            })
+        }
         // Leaf nodes never contain param var references
         Expr::Input | Expr::Empty | Expr::Not | Expr::Env | Expr::Builtins
         | Expr::ReadInput | Expr::ReadInputs | Expr::ModuleMeta | Expr::GenLabel
@@ -693,7 +717,9 @@ fn contains_func_call(expr: &Expr, target: usize) -> bool {
             c!(input_expr) || c!(re) || c!(tostr) || c!(flags)
         }
         Expr::AlternativeDestructure { alternatives } => alternatives.iter().any(|a| c!(a)),
-        Expr::Memoize { body, .. } => c!(body),
+        Expr::Memoize { key, body, .. } => {
+            key.as_ref().is_some_and(|k| c!(k)) || c!(body)
+        }
         Expr::Input | Expr::Empty | Expr::Not | Expr::Env | Expr::Builtins
         | Expr::ReadInput | Expr::ReadInputs | Expr::ModuleMeta | Expr::GenLabel
         | Expr::Literal(_) | Expr::Loc { .. } | Expr::LoadVar { .. } | Expr::Error { msg: None } => false,
@@ -846,7 +872,10 @@ fn expr_uses_var(expr: &Expr, target: u16) -> bool {
             expr_uses_var(input_expr, target) || expr_uses_var(re, target) || expr_uses_var(tostr, target) || expr_uses_var(flags, target)
         }
         Expr::AlternativeDestructure { alternatives } => alternatives.iter().any(|a| expr_uses_var(a, target)),
-        Expr::Memoize { body, .. } => expr_uses_var(body, target),
+        Expr::Memoize { key, body, .. } => {
+            key.as_ref().is_some_and(|k| expr_uses_var(k, target))
+                || expr_uses_var(body, target)
+        }
     }
 }
 
@@ -3202,7 +3231,7 @@ pub fn eval(
             eval_call_builtin(name, args, input, env, cb)
         }
 
-        Expr::Memoize { slot_id, body } => {
+        Expr::Memoize { slot_id, key, body } => {
             let slot = {
                 let env_ref = env.borrow();
                 match env_ref.memo_slots.get(*slot_id as usize) {
@@ -3210,34 +3239,75 @@ pub fn eval(
                     None => bail!("memoize slot {} not allocated", slot_id),
                 }
             };
-            let key = ValueKey(input.clone());
-            // Cache hit: re-yield the materialized output sequence.
-            let cached = slot.borrow().get(&key).cloned();
-            if let Some(outputs) = cached {
-                for v in outputs.iter() {
+            match key {
+                None => {
+                    // 1-arg form: cache key IS the current input.
+                    memo_lookup_or_run(&slot, ValueKey(input.clone()), body, input, env, cb)
+                }
+                Some(key_expr) => {
+                    // 2-arg form: each value yielded by `key` drives a separate
+                    // cache lookup; the body runs against the original input.
+                    eval(key_expr, input.clone(), env, &mut |k| {
+                        memo_lookup_or_run(&slot, ValueKey(k), body, input.clone(), env, cb)
+                    })
+                }
+            }
+        }
+    }
+}
+
+/// Shared cache-lookup-or-compute path for both arities of `memoize`.
+///
+/// On hit, re-yields the cached output sequence. On miss, runs `body`
+/// against `body_input` to completion (collecting every output), inserts
+/// the result subject to the per-slot cap, and yields it.
+///
+/// Body errors are propagated without poisoning the cache — the next call
+/// re-evaluates.
+fn memo_lookup_or_run(
+    slot: &MemoSlot,
+    cache_key: ValueKey,
+    body: &Expr,
+    body_input: Value,
+    env: &EnvRef,
+    cb: &mut dyn FnMut(Value) -> GenResult,
+) -> GenResult {
+    let cached = slot.borrow().get(&cache_key).cloned();
+    if let Some(entry) = cached {
+        return match entry {
+            MemoEntry::Single(v) => cb(v),
+            MemoEntry::Many(rc) => {
+                for v in rc.iter() {
                     if !cb(v.clone())? { return Ok(false); }
                 }
-                return Ok(true);
+                Ok(true)
             }
-            // Miss: run the body to completion, collecting every output.
-            // We do not pass the consumer's `cb` directly — `memoize` must
-            // observe the full output sequence to cache it, even if the
-            // consumer wants to stop after the first value. This means
-            // `memoize` forces the body to fully evaluate; for the typical
-            // single-output pure body that is the natural case, but it is
-            // a documented difference for generator/side-effecting bodies.
-            let mut outputs: Vec<Value> = Vec::new();
-            eval(body, input, env, &mut |v| { outputs.push(v); Ok(true) })?;
-            let outputs_rc = Rc::new(outputs);
-            // Cache subject to per-slot cap.
-            {
-                let mut slot_mut = slot.borrow_mut();
-                let cap = env.borrow().memo_max_entries;
-                if slot_mut.len() < cap {
-                    slot_mut.insert(key, outputs_rc.clone());
-                }
-            }
-            for v in outputs_rc.iter() {
+        };
+    }
+    // Miss: run the body to completion. We do not pass the consumer's `cb`
+    // directly — `memoize` must observe the full output sequence to cache
+    // it, even if the consumer wants to stop after the first value. This
+    // means `memoize` forces the body to fully evaluate; for the typical
+    // single-output pure body that is the natural case, but it is a
+    // documented difference for generator/side-effecting bodies.
+    let mut outputs: Vec<Value> = Vec::new();
+    eval(body, body_input, env, &mut |v| { outputs.push(v); Ok(true) })?;
+    let entry = if outputs.len() == 1 {
+        MemoEntry::Single(outputs[0].clone())
+    } else {
+        MemoEntry::Many(Rc::new(outputs))
+    };
+    {
+        let mut slot_mut = slot.borrow_mut();
+        let cap = env.borrow().memo_max_entries;
+        if slot_mut.len() < cap {
+            slot_mut.insert(cache_key, entry.clone());
+        }
+    }
+    match entry {
+        MemoEntry::Single(v) => cb(v),
+        MemoEntry::Many(rc) => {
+            for v in rc.iter() {
                 if !cb(v.clone())? { return Ok(false); }
             }
             Ok(true)

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -310,6 +310,11 @@ pub struct Filter {
     lib_dirs: Vec<String>,
     /// Cached eval environment to avoid re-allocating per call.
     cached_env: std::cell::RefCell<Option<crate::eval::EnvRef>>,
+    /// Number of `memoize(...)` slots the program needs. Used to size the
+    /// per-program memo cache when the Env is materialized.
+    memo_slots: u32,
+    /// Per-slot upper bound on cache entries (CLI `--memo-max-entries`).
+    memo_max_entries: usize,
 }
 
 /// Extract string function condition from an expression (test/startswith/endswith/contains on Input).
@@ -2112,6 +2117,7 @@ fn contains_input(expr: &crate::ir::Expr) -> bool {
         Expr::FuncCall { args, .. } => args.iter().any(contains_input),
         Expr::ClosureOp { .. } | Expr::AnyShort { .. } | Expr::AllShort { .. }
         | Expr::AlternativeDestructure { .. } => true, // conservative
+        Expr::Memoize { body, .. } => contains_input(body),
     }
 }
 
@@ -2379,6 +2385,7 @@ impl Filter {
 
     pub fn with_options(program: &str, lib_dirs: &[String], use_jit: bool) -> Result<Self> {
         let result = crate::parser::Parser::parse_with_libs(program, lib_dirs)?;
+        let memo_slots = result.memo_slots;
         let parsed = (result.expr, result.funcs);
 
         // Try JIT compilation for the parsed expression.
@@ -2406,7 +2413,18 @@ impl Filter {
             _jit_compiler: jit_compiler,
             lib_dirs: lib_dirs.to_vec(),
             cached_env: std::cell::RefCell::new(None),
+            memo_slots,
+            memo_max_entries: crate::eval::default_memo_max_entries(),
         })
+    }
+
+    /// Set the per-slot memoize cache cap. Honoured by the eval Env when
+    /// it is first materialized; subsequent calls reuse the same cap.
+    pub fn set_memo_max_entries(&mut self, n: usize) {
+        self.memo_max_entries = n;
+        if let Some(ref env) = *self.cached_env.borrow() {
+            env.borrow_mut().set_memo_max_entries(n);
+        }
     }
 
     /// Try to JIT-compile this filter if not already JIT'd.
@@ -11343,7 +11361,26 @@ impl Filter {
         }
 
         let (ref expr, ref funcs) = self.parsed;
-        crate::eval::execute_ir_with_libs(expr, input.clone(), funcs.clone(), self.lib_dirs.clone())
+        // Mirror execute_cb's env setup so memoize slots are wired up.
+        let env = {
+            let mut cached = self.cached_env.borrow_mut();
+            if let Some(ref env) = *cached {
+                env.clone()
+            } else {
+                let mut e = crate::eval::Env::with_lib_dirs(funcs.clone(), self.lib_dirs.clone());
+                e.set_memo_slots(self.memo_slots);
+                e.set_memo_max_entries(self.memo_max_entries);
+                let env = std::rc::Rc::new(std::cell::RefCell::new(e));
+                *cached = Some(env.clone());
+                env
+            }
+        };
+        let mut outputs = Vec::new();
+        crate::eval::execute_ir_with_env_cb(expr, input.clone(), &env, &mut |v| {
+            match &v { Value::Error(e) => { eprintln!("jq: error: {}", e); }, _ => { outputs.push(v); } }
+            Ok(true)
+        })?;
+        Ok(outputs)
     }
 
     /// Execute the filter with a callback for each result (avoids Vec allocation).
@@ -11374,9 +11411,10 @@ impl Filter {
             if let Some(ref env) = *cached {
                 env.clone()
             } else {
-                let env = std::rc::Rc::new(std::cell::RefCell::new(
-                    crate::eval::Env::with_lib_dirs(funcs.clone(), self.lib_dirs.clone())
-                ));
+                let mut e = crate::eval::Env::with_lib_dirs(funcs.clone(), self.lib_dirs.clone());
+                e.set_memo_slots(self.memo_slots);
+                e.set_memo_max_entries(self.memo_max_entries);
+                let env = std::rc::Rc::new(std::cell::RefCell::new(e));
                 *cached = Some(env.clone());
                 env
             }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -2117,7 +2117,9 @@ fn contains_input(expr: &crate::ir::Expr) -> bool {
         Expr::FuncCall { args, .. } => args.iter().any(contains_input),
         Expr::ClosureOp { .. } | Expr::AnyShort { .. } | Expr::AllShort { .. }
         | Expr::AlternativeDestructure { .. } => true, // conservative
-        Expr::Memoize { body, .. } => contains_input(body),
+        Expr::Memoize { key, body, .. } => {
+            key.as_ref().is_some_and(|k| contains_input(k)) || contains_input(body)
+        }
     }
 }
 

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -2429,6 +2429,31 @@ impl Filter {
         }
     }
 
+    /// Number of `memoize(...)` call sites in the parsed program.
+    pub fn memo_slot_count(&self) -> u32 {
+        self.memo_slots
+    }
+
+    /// Dump per-slot memoize cache stats (hits / misses / size) to the
+    /// given writer. Used by `--debug-memo`. No-op if the program contains
+    /// no `memoize` calls or if the Env was never materialized.
+    pub fn dump_memo_stats(&self, w: &mut dyn std::io::Write) -> std::io::Result<()> {
+        if self.memo_slots == 0 { return Ok(()); }
+        let cached = self.cached_env.borrow();
+        let env = match cached.as_ref() {
+            Some(e) => e,
+            None => return Ok(()),
+        };
+        let env_ref = env.borrow();
+        writeln!(w, "memoize stats: {} slot(s)", env_ref.memo_slots.len())?;
+        writeln!(w, "  {:>4}  {:>12}  {:>12}  {:>12}", "slot", "hits", "misses", "entries")?;
+        for (i, slot) in env_ref.memo_slots.iter().enumerate() {
+            let s = slot.borrow();
+            writeln!(w, "  {:>4}  {:>12}  {:>12}  {:>12}", i, s.hits, s.misses, s.entries.len())?;
+        }
+        Ok(())
+    }
+
     /// Try to JIT-compile this filter if not already JIT'd.
     /// Call this after determining the input is large enough to justify compilation.
     pub fn compile_jit(&mut self) {

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -338,12 +338,18 @@ pub enum Expr {
         args: Vec<Expr>,
     },
 
-    /// `memoize(body)` — jqx extension. Caches the body's output sequence
-    /// keyed by the input value. Each lexical occurrence in the program
-    /// gets a unique `slot_id` assigned during the compile pass; the cache
-    /// itself lives on the runtime `Env`.
+    /// `memoize(body)` / `memoize(body; key)` — jqx extension.
+    ///
+    /// Caches the body's output sequence per cache key. Each lexical
+    /// occurrence gets a unique `slot_id` assigned during the compile pass.
+    ///
+    /// With no `key` (1-arg form), the cache key is the current input value.
+    /// With an explicit `key` (2-arg form), the key expression is evaluated
+    /// against the current input — each value it yields drives one cache
+    /// lookup, and the body runs against the original input on miss.
     Memoize {
         slot_id: u32,
+        key: Option<Box<Expr>>,
         body: Box<Expr>,
     },
 }

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -337,6 +337,15 @@ pub enum Expr {
         name: String,
         args: Vec<Expr>,
     },
+
+    /// `memoize(body)` — jqx extension. Caches the body's output sequence
+    /// keyed by the input value. Each lexical occurrence in the program
+    /// gets a unique `slot_id` assigned during the compile pass; the cache
+    /// itself lives on the runtime `Env`.
+    Memoize {
+        slot_id: u32,
+        body: Box<Expr>,
+    },
 }
 
 /// String interpolation part.
@@ -585,6 +594,8 @@ impl Expr {
             Expr::Recurse { .. } | Expr::Range { .. } | Expr::PathExpr { .. }
             | Expr::SetPath { .. } | Expr::GetPath { .. } | Expr::DelPaths { .. }
             | Expr::Break { .. } | Expr::FuncCall { .. } => false,
+            // Memoize body always reads input (the cache key)
+            Expr::Memoize { .. } => false,
         }
     }
 

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -4689,7 +4689,10 @@ impl Flattener {
             Expr::CallBuiltin { args, .. } => {
                 for a in args { Self::collect_loadvar_indices(a, out); }
             }
-            Expr::Memoize { body, .. } => Self::collect_loadvar_indices(body, out),
+            Expr::Memoize { key, body, .. } => {
+                if let Some(k) = key { Self::collect_loadvar_indices(k, out); }
+                Self::collect_loadvar_indices(body, out);
+            }
         }
     }
 

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -4689,6 +4689,7 @@ impl Flattener {
             Expr::CallBuiltin { args, .. } => {
                 for a in args { Self::collect_loadvar_indices(a, out); }
             }
+            Expr::Memoize { body, .. } => Self::collect_loadvar_indices(body, out),
         }
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -19,6 +19,9 @@ struct Scope {
     next_var: u16,
     /// Compiled function bodies.
     compiled_funcs: Vec<CompiledFunc>,
+    /// Next available memoize slot id. Each lexical occurrence of `memoize(...)`
+    /// gets a unique slot; the Env allocates one cache map per slot.
+    next_memo_slot: u32,
 }
 
 impl Scope {
@@ -28,7 +31,14 @@ impl Scope {
             funcs: Vec::new(),
             next_var: 0,
             compiled_funcs: Vec::new(),
+            next_memo_slot: 0,
         }
+    }
+
+    fn alloc_memo_slot(&mut self) -> u32 {
+        let id = self.next_memo_slot;
+        self.next_memo_slot += 1;
+        id
     }
 
     fn alloc_var(&mut self, name: &str) -> u16 {
@@ -719,6 +729,9 @@ pub struct Parser {
 pub struct ParseResult {
     pub expr: Expr,
     pub funcs: Vec<CompiledFunc>,
+    /// Total number of `memoize(...)` slots required by the program. The
+    /// runtime `Env` allocates one cache map per slot.
+    pub memo_slots: u32,
 }
 
 impl Parser {
@@ -746,6 +759,7 @@ impl Parser {
         Ok(ParseResult {
             expr,
             funcs: parser.scope.compiled_funcs,
+            memo_slots: parser.scope.next_memo_slot,
         })
     }
 
@@ -3303,6 +3317,11 @@ impl Parser {
                 // This is a recursive pattern - use Recurse node
                 Ok(Expr::Recurse { input_expr: Box::new(f) })
             }
+            ("memoize", 1) => {
+                let body = args.into_iter().next().unwrap();
+                let slot_id = self.scope.alloc_memo_slot();
+                Ok(Expr::Memoize { slot_id, body: Box::new(body) })
+            }
             ("recurse", 2) => {
                 let mut args = args.into_iter();
                 let f = args.next().unwrap();
@@ -4204,6 +4223,9 @@ fn remap_func_ids(expr: Expr, map: &[(usize, usize)]) -> Expr {
         },
         Expr::CallBuiltin { name, args } => Expr::CallBuiltin {
             name, args: args.into_iter().map(|a| remap_func_ids(a, map)).collect(),
+        },
+        Expr::Memoize { slot_id, body } => Expr::Memoize {
+            slot_id, body: Box::new(remap_func_ids(*body, map)),
         },
         // Leaf nodes: no remapping needed
         Expr::Input | Expr::Literal(_) | Expr::LoadVar { .. } | Expr::Empty

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3320,7 +3320,14 @@ impl Parser {
             ("memoize", 1) => {
                 let body = args.into_iter().next().unwrap();
                 let slot_id = self.scope.alloc_memo_slot();
-                Ok(Expr::Memoize { slot_id, body: Box::new(body) })
+                Ok(Expr::Memoize { slot_id, key: None, body: Box::new(body) })
+            }
+            ("memoize", 2) => {
+                let mut it = args.into_iter();
+                let body = it.next().unwrap();
+                let key = it.next().unwrap();
+                let slot_id = self.scope.alloc_memo_slot();
+                Ok(Expr::Memoize { slot_id, key: Some(Box::new(key)), body: Box::new(body) })
             }
             ("recurse", 2) => {
                 let mut args = args.into_iter();
@@ -4224,8 +4231,10 @@ fn remap_func_ids(expr: Expr, map: &[(usize, usize)]) -> Expr {
         Expr::CallBuiltin { name, args } => Expr::CallBuiltin {
             name, args: args.into_iter().map(|a| remap_func_ids(a, map)).collect(),
         },
-        Expr::Memoize { slot_id, body } => Expr::Memoize {
-            slot_id, body: Box::new(remap_func_ids(*body, map)),
+        Expr::Memoize { slot_id, key, body } => Expr::Memoize {
+            slot_id,
+            key: key.map(|k| Box::new(remap_func_ids(*k, map))),
+            body: Box::new(remap_func_ids(*body, map)),
         },
         // Leaf nodes: no remapping needed
         Expr::Input | Expr::Literal(_) | Expr::LoadVar { .. } | Expr::Empty

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -3747,6 +3747,7 @@ pub fn rt_builtins() -> Value {
         "have_decnum/0", "have_literal_numbers/0",
         "exec/1", "exec/2", "execv/1",
         "fromcsv/0", "fromtsv/0", "fromcsvh/0", "fromcsvh/1", "fromtsvh/0", "fromtsvh/1",
+        "memoize/1",
         "tostream/0", "fromstream/1", "truncate_stream/1",
         "toboolean/0",
         "format/1",

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -3747,7 +3747,7 @@ pub fn rt_builtins() -> Value {
         "have_decnum/0", "have_literal_numbers/0",
         "exec/1", "exec/2", "execv/1",
         "fromcsv/0", "fromtsv/0", "fromcsvh/0", "fromcsvh/1", "fromtsvh/0", "fromtsvh/1",
-        "memoize/1",
+        "memoize/1", "memoize/2",
         "tostream/0", "fromstream/1", "truncate_stream/1",
         "toboolean/0",
         "format/1",

--- a/src/value.rs
+++ b/src/value.rs
@@ -4,6 +4,7 @@
 
 use std::cell::{RefCell, UnsafeCell};
 use std::fmt;
+use std::hash::{Hash, Hasher};
 use std::rc::Rc;
 
 use anyhow::{Result, bail};
@@ -462,6 +463,114 @@ impl PartialEq for Value {
             (Value::Obj(ObjInner(a)), Value::Obj(ObjInner(b))) => a == b,
             _ => false,
         }
+    }
+}
+
+/// `Value` wrapper usable as a `HashMap` / `HashSet` key.
+///
+/// Required because:
+/// - `Value::PartialEq` keeps IEEE 754 semantics (`NaN != NaN`), so `Value`
+///   cannot implement `Eq` directly without violating reflexivity.
+/// - `==` on `Rc<ObjMap>` compares the derived `ObjMap::PartialEq`, which is
+///   order-sensitive over `entries: Vec`, but jq object equality is
+///   order-independent (see `runtime::values_equal`).
+///
+/// `ValueKey` provides an `Eq` + `Hash` pair consistent with
+/// `runtime::values_equal` plus NaN reflexivity (NaN as a cache key matches
+/// itself). Used as the key type for memoization caches and future hash-map
+/// values.
+#[derive(Debug, Clone)]
+pub struct ValueKey(pub Value);
+
+impl ValueKey {
+    fn key_eq(a: &Value, b: &Value) -> bool {
+        match (a, b) {
+            (Value::Null, Value::Null) => true,
+            (Value::True, Value::True) => true,
+            (Value::False, Value::False) => true,
+            (Value::Num(x, _), Value::Num(y, _)) => {
+                if x.is_nan() && y.is_nan() {
+                    true
+                } else {
+                    x == y
+                }
+            }
+            (Value::Str(x), Value::Str(y)) => x == y,
+            (Value::Arr(x), Value::Arr(y)) => {
+                x.len() == y.len()
+                    && x.iter().zip(y.iter()).all(|(a, b)| Self::key_eq(a, b))
+            }
+            (Value::Obj(ObjInner(x)), Value::Obj(ObjInner(y))) => {
+                x.len() == y.len()
+                    && x.iter().all(|(k, v)| {
+                        y.get(k.as_str()).is_some_and(|yv| Self::key_eq(v, yv))
+                    })
+            }
+            (Value::Error(x), Value::Error(y)) => x == y,
+            _ => false,
+        }
+    }
+
+    fn hash_value<H: Hasher>(v: &Value, state: &mut H) {
+        match v {
+            Value::Null => 0u8.hash(state),
+            Value::False => 1u8.hash(state),
+            Value::True => 2u8.hash(state),
+            Value::Num(n, _) => {
+                3u8.hash(state);
+                let bits = if n.is_nan() {
+                    f64::NAN.to_bits()
+                } else if *n == 0.0 {
+                    0u64
+                } else {
+                    n.to_bits()
+                };
+                bits.hash(state);
+            }
+            Value::Str(s) => {
+                4u8.hash(state);
+                s.as_str().hash(state);
+            }
+            Value::Arr(a) => {
+                5u8.hash(state);
+                a.len().hash(state);
+                for elem in a.iter() {
+                    Self::hash_value(elem, state);
+                }
+            }
+            Value::Obj(ObjInner(o)) => {
+                6u8.hash(state);
+                o.len().hash(state);
+                let mut combined: u64 = 0;
+                for (k, val) in o.iter() {
+                    let mut h = std::collections::hash_map::DefaultHasher::new();
+                    k.as_str().hash(&mut h);
+                    Self::hash_value(val, &mut h);
+                    combined ^= h.finish();
+                }
+                combined.hash(state);
+            }
+            Value::Error(e) => {
+                7u8.hash(state);
+                e.as_str().hash(state);
+            }
+        }
+    }
+}
+
+impl PartialEq for ValueKey {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        Self::key_eq(&self.0, &other.0)
+    }
+}
+
+impl Eq for ValueKey {}
+
+impl Hash for ValueKey {
+    #[inline]
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        Self::hash_value(&self.0, state);
     }
 }
 

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -10067,3 +10067,28 @@ null
 def steps($n): {n: $n, c: 0} | until(.n == 1; if .n % 2 == 0 then .n /= 2 else .n = .n*3 + 1 end | .c += 1) | .c; [range(1; 100) | steps(.)] | max
 null
 118
+
+# Issue #671: memoize/1 jqx extension — fib via self-recursive memo
+def fib: memoize(if . < 2 then . else ((. - 1) | fib) + ((. - 2) | fib) end); 30 | fib
+null
+832040
+
+# Issue #671: memoize/1 — Collatz length, exercises subgraph revisits
+def collatz_len: memoize(if . == 1 then 0 else (if . % 2 == 0 then ./2 else 3*. + 1 end | collatz_len) + 1 end); 27 | collatz_len
+null
+111
+
+# Issue #671: memoize/1 — distinct inputs each cached independently
+def sq: memoize(. * .); [1, 2, 3, 2, 1] | map(sq)
+null
+[1,4,9,4,1]
+
+# Issue #671: memoize/1 — body that yields multiple values is re-yielded on hit
+def two: memoize(., . + 1); [1, 1, 2] | map([two]) | add
+null
+[1,2,1,2,2,3]
+
+# Issue #671: memoize/1 — object-valued input keys hit by structural equality
+def tag: memoize(.a + .b); [{a: 1, b: 2}, {b: 2, a: 1}, {a: 3, b: 4}] | map(tag)
+null
+[3,3,7]

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -10092,3 +10092,27 @@ null
 def tag: memoize(.a + .b); [{a: 1, b: 2}, {b: 2, a: 1}, {a: 3, b: 4}] | map(tag)
 null
 [3,3,7]
+
+# Issue #671: memoize/1 — closed-over $vars are NOT part of the cache key.
+# Pins the documented contract: `memoize` keys by current input only, so a
+# body that closes over a $var that differs between calls will return stale
+# results from the first call. Users who need this should pull the $var
+# into the input (e.g. `[., $x] | memoize(...)`) or use the 2-arg
+# `memoize(f; key)` form.
+def f($x): memoize(. + $x); 10 | [f(1), f(2)]
+null
+[11,11]
+
+# Issue #671: memoize/2 — explicit key includes $var so cache discriminates.
+# Same body as the staleness test above; adding `[., $x]` as the key keeps
+# each (input, $x) pair in its own cache entry.
+def f($x): memoize(. + $x; [., $x]); 10 | [f(1), f(2), f(1)]
+null
+[11,12,11]
+
+# Issue #671: memoize/2 — large input keyed by a small discriminator.
+# Body computes from full input; cache identity is just `.id`. Demonstrates
+# the documented pattern for "memoize a transformation by record id".
+def by_id: memoize(.value * 2; .id); [{id: 1, value: 10}, {id: 2, value: 20}, {id: 1, value: 999}] | map(by_id)
+null
+[20,40,20]


### PR DESCRIPTION
Closes #671.

Adds a `memoize` jqx extension that caches a filter's output sequence keyed by either the current input (`memoize(f)`) or a user-supplied key expression (`memoize(f; key)`). Each lexical occurrence of `memoize(...)` gets its own per-program cache; entries persist across NDJSON inputs.

## Summary

- `memoize(f)` — cache `f`'s output sequence by current input value.
- `memoize(f; key)` — same, but `key` (evaluated against the input) is the cache identity instead of the whole input. Each value yielded by `key` drives a separate cache lookup.
- `Value: Hash + Eq` lands via a new `ValueKey` newtype that matches `runtime::values_equal` plus NaN reflexivity. Shared infra with #667 when it picks up a native `map` type.
- `--memo-max-entries N` caps each slot (default 1,000,000). Past the cap, new inserts are silently dropped and the program continues without caching new entries.
- `--debug-memo` dumps per-slot hit / miss / entries counts to stderr at exit.
- Single-output bodies (the typical pure-DP case: fib, Collatz, totient) skip a `Rc<Vec<Value>>` allocation on every hit via `MemoEntry::{Single | Many}`.
- Body errors do not poison the cache — next call re-evaluates.

## Why a builtin and not jq sugar

Even if a native hash-map type lands (#667), `memoize` still has to be a runtime primitive: jq has no mutable refs, so a cache that propagates updates across a recursive subtree can only live runtime-side. So this is independent of #667; the shared piece is `ValueKey`.

## Implementation path

- `Expr::Memoize { slot_id, key, body }` is a new IR variant. Parser assigns `slot_id` per lexical occurrence; the eval pass owns the cache on `Env`.
- `flatten_gen`'s catch-all already rejects `Memoize`, so the JIT falls back to interpreter automatically. `memoize` is intentionally interpreter-only: the cache lookup is cold-path and JIT-ing it would buy nothing.
- `Env` keeps `Vec<Rc<RefCell<SlotState>>>` — `Rc` so the eval path can drop the Env borrow before re-entering eval for the body.

## Tests

- 8 new regression cases in `tests/regression.test`: self-recursive fib / Collatz, distinct-input caching, multi-output re-yield, object-key structural equality, 1-arg `$var`-closure staleness pin, 2-arg form rescuing the staleness case, by-`.id` discriminator.
- Official 509 + full regression / proptest / diff / corpus / selfdiff suites all pass.
- 3 cases added to `bench/comprehensive.sh` under a new "Memoization (jqx)" section as a regression anchor: linearized fib, Collatz sum, 100K calls deduplicated to 1K keys via 2-arg memoize.

## Test plan

- [x] `cargo build --release` — zero warnings
- [x] `cargo test --release` — 509 official + all regression + proptest + corpus + selfdiff
- [x] Local smoke: `def fib: memoize(...); 80 | fib` instant; `--debug-memo` dumps stats; `--memo-max-entries 5` still produces correct output
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)