### PR TITLE
perf(eval): scalar-value Assign fast path keeps acc Rc refcount at 1 (#659)

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -2533,6 +2533,32 @@ pub fn eval(
         }
 
         Expr::Assign { path_expr, value_expr } => {
+            // Scalar-value fast path: compute new_val via eval_one so the
+            // generator form's `input.clone()` never sits alive in an outer
+            // callback frame. Once paths are collected, `input` has refcount
+            // 1 again, so we can move it into `result` and rt_setpath_mut's
+            // Rc::make_mut mutates in place instead of deep-cloning the
+            // accumulator on every iteration (#659).
+            if let Ok(new_val) = eval_one(value_expr, &input, env) {
+                let mut paths = Vec::new();
+                let path_result = eval_path(path_expr, input.clone(), env, &mut |p| { paths.push(p); Ok(true) });
+                if let Err(e) = path_result {
+                    let msg = format!("{}", e);
+                    if let Some(json) = msg.strip_prefix("__pathexpr_result__:") {
+                        bail!("Invalid path expression with result {}", json);
+                    }
+                    return Err(e);
+                }
+                let mut result = input;
+                for path in &paths {
+                    let path_slice = match path {
+                        Value::Arr(a) => a.as_slice(),
+                        _ => bail!("Path must be specified as an array"),
+                    };
+                    crate::runtime::rt_setpath_mut(&mut result, path_slice, new_val.clone())?;
+                }
+                return cb(result);
+            }
             eval(value_expr, input.clone(), env, &mut |new_val| {
                 let mut paths = Vec::new();
                 let path_result = eval_path(path_expr, input.clone(), env, &mut |p| { paths.push(p); Ok(true) });

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -10116,3 +10116,10 @@ null
 def by_id: memoize(.value * 2; .id); [{id: 1, value: 10}, {id: 2, value: 20}, {id: 1, value: 999}] | map(by_id)
 null
 [20,40,20]
+
+# Issue #659: reduce with destructured pattern + conditional .[$k] = $p body.
+# Validates the in-place fast path (#659) that avoids deep-cloning the
+# accumulator on every iteration when the value expression is scalar.
+reduce ([2,1,2],[3,2,3],[5,3,5],[3,2,4]) as [$p,$s,$c] ([null,null,null,null,null,null]; ($p - $s + $c) as $k | if $k >= 2 and (.[$k] == null or $p < .[$k]) then .[$k] = $p else . end) | .[2:]
+null
+[null,2,3,3,null,5]


### PR DESCRIPTION
## Summary

The `Expr::Assign` arm in `eval()` ran `eval(value_expr, input.clone(), env, &mut |..| { … })` for every assignment. The cloned `input` sits alive in the generator-callback frame for the whole body, so when the inner callback then did `let mut result = input.clone()` and `rt_setpath_mut(&mut result, …)`, the underlying `Rc` still had refcount ≥ 2 and `Rc::make_mut` **deep-cloned the entire accumulator on every iteration** — for the issue's repro that's a 12001-slot array, copied per `reduce` step.

Add a scalar-value fast path: when `eval_one(value_expr)` succeeds (covers the common `.[$k] = $p` / `.[i] = expr` shape), compute the value first with no input clone held in an outer frame, then move `input` into `result` so the Rc has a single owner and `rt_setpath_mut` mutates in place. Generator-valued assignments (`.[i] = (.x, .y)`) fall through to the unchanged original path.

## Numbers

Issue #659 repro (K=12000 fact-gen reduce), `time -p` user CPU best of 3:

| build | time |
|---|---|
| jq 1.7.1 | 1.07s |
| jq-jit main (before fix) | 1.54s (1.44× of stock jq) |
| jq-jit after | 0.44s (0.41× of stock jq) |

`bench/comprehensive.sh` shows uniform small speedups across the assignment, reduce, and NDJSON sections (e.g. `.[k] = v reduce(50K)` 0.009s → 0.008s, `.[] |= f` 0.006s → 0.005s). No regressions.

## Test plan

- [x] `cargo build --release` — zero warnings
- [x] `cargo test --release` — 424-case regression + 509 official + selfdiff + fuzz all pass; new regression case for #659 added to `tests/regression.test`
- [x] `bench/comprehensive.sh` — no regression vs `docs/benchmark-history.md`; uniform speedup
- [x] Generator-valued assign (`.[0] = (.[] | . * 10)`) matches stock jq's three-output behaviour

Closes #659

🤖 Generated with [Claude Code](https://claude.com/claude-code)