### PR TITLE
perf(eval): reduce avoids cloning input when source doesn't reference it

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -2080,12 +2080,34 @@ pub fn eval(
                     if matches!(path_expr.as_ref(), Expr::Input) => value_expr.as_ref(),
                 _ => update.as_ref(),
             };
-            let mut acc = if let Ok(v) = eval_one(init, &input, env) {
-                v
+            // For init = `.`, move input directly into the accumulator (no clone).
+            // For sources that don't reference outer input (e.g. range), pass
+            // Value::Null and drop our own input ref — without this the outer
+            // reduce's input.clone() pins the Rc at refcount ≥ 2 across every
+            // iteration, so nested `.[$i] = .[$i] + 1` bodies fall off the
+            // in-place fast path and deep-copy the array on each step (#664).
+            let init_is_input = matches!(init.as_ref(), Expr::Input);
+            let source_needs_input = expr_uses_outer_input(source);
+            let (mut acc, source_input) = if init_is_input {
+                if source_needs_input {
+                    (input.clone(), input)
+                } else {
+                    (input, Value::Null)
+                }
             } else {
-                let mut a = Value::Null;
-                eval(init, input.clone(), env, &mut |v| { a = v; Ok(true) })?;
-                a
+                let acc_val = if let Ok(v) = eval_one(init, &input, env) {
+                    v
+                } else {
+                    let mut a = Value::Null;
+                    eval(init, input.clone(), env, &mut |v| { a = v; Ok(true) })?;
+                    a
+                };
+                if source_needs_input {
+                    (acc_val, input)
+                } else {
+                    drop(input);
+                    (acc_val, Value::Null)
+                }
             };
             let vi = *var_index;
             let ai = *acc_index;
@@ -2121,7 +2143,7 @@ pub fn eval(
             } else { None };
             if let Some((tmp_vi, ref bindings, inner_body)) = fused {
                 // Fused Reduce+destructure: batch $var store + array destructure into 2 borrow_muts
-                eval(source, input.clone(), env, &mut |val| {
+                eval(source, source_input, env, &mut |val| {
                     let acc_val = std::mem::replace(&mut acc, Value::Null);
                     // Setup: store $var, destructure acc, null tmp (1 borrow_mut)
                     let (old_var, old_tmp, destructured) = {
@@ -2182,7 +2204,7 @@ pub fn eval(
                     } else { None }
                 } else { None };
                 if let Some((add_rhs, _temp_var)) = add_inplace {
-                    eval(source, input.clone(), env, &mut |val| {
+                    eval(source, source_input, env, &mut |val| {
                         let old_var = std::mem::replace(&mut env.borrow_mut().vars[vi as usize], val);
                         let rhs_val = {
                             let mut r = Value::Null;
@@ -2213,7 +2235,7 @@ pub fn eval(
                     })?;
                     cb(acc)
                 } else {
-                    eval(source, input.clone(), env, &mut |val| {
+                    eval(source, source_input, env, &mut |val| {
                         let acc_val = std::mem::replace(&mut acc, Value::Null);
                         let old_var = std::mem::replace(&mut env.borrow_mut().vars[vi as usize], val);
                         eval(update, acc_val, env, &mut |new_acc| { acc = new_acc; Ok(true) })?;
@@ -2223,7 +2245,7 @@ pub fn eval(
                     cb(acc)
                 }
             } else {
-                eval(source, input.clone(), env, &mut |val| {
+                eval(source, source_input, env, &mut |val| {
                     let acc_val = std::mem::replace(&mut acc, Value::Null);
                     let (old_var, old_acc) = {
                         let mut e = env.borrow_mut();

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -10123,3 +10123,11 @@ null
 reduce ([2,1,2],[3,2,3],[5,3,5],[3,2,4]) as [$p,$s,$c] ([null,null,null,null,null,null]; ($p - $s + $c) as $k | if $k >= 2 and (.[$k] == null or $p < .[$k]) then .[$k] = $p else . end) | .[2:]
 null
 [null,2,3,3,null,5]
+
+# Issue #664: nested reduce with .[$k] = .[$k] + 1 body stays on the in-place
+# path. Each outer-reduce level now drops its own input ref before iterating,
+# so the accumulator's Rc refcount stays 1 and the inner Assign mutates the
+# array in place instead of deep-cloning every step.
+[range(0; 5) | 0] | reduce range(0; 3) as $a (.; reduce range(0; $a + 1) as $b (.; if $a + $b >= 5 then . else .[$a + $b] = .[$a + $b] + 1 end))
+null
+[1,1,2,1,1]


### PR DESCRIPTION
## Summary

- Move `input` directly into the accumulator when `init = .`, instead of `eval_one(Input, &input)` which clones unnecessarily.
- Pass `Value::Null` to source eval (and drop our outer-input ref) when source doesn't reference `.`. The previous `input.clone()` kept the Rc alive across every iteration, so for nested reduce the inner accumulator's refcount stayed ≥ 2 and `Rc::make_mut` deep-copied the array on every in-place body.

## Impact

Related to #664. The 4-level small repro under `--force-interp`:

| build | time |
|---|---|
| main (interp) | 193s |
| this PR (interp) | ~1s |

The default JIT path is unaffected here. The same Rc-aliasing pattern in JIT comes from `Clone`-based slot semantics for `IfThenElse` + `Assign` inside a reduce-update body, which is a different fix (multi-level fusion / slot uniqueness propagation) and not in scope for this PR. Filing as a related improvement rather than `Closes #664`.

## Test plan
- [x] cargo build --release (zero warnings)
- [x] cargo test --release (full suite + new regression case for nested reduce in-place)
- [x] bench/comprehensive.sh — within noise vs v1.6.0 baseline across reduce / foreach / assignment / NDJSON sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)