### PR TITLE
fix(eval): rename param slots when args call the same def (#679)

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -2667,6 +2667,15 @@ pub fn eval(
                 CacheHit(Rc<Expr>),
                 CacheMiss(Rc<CompiledFunc>),
             }
+            // An arg that itself calls the same def re-enters with the
+            // same parser-allocated parameter slots. In the CPS eval model
+            // the inner frame's writes leak through the outer's
+            // continuation: the outer LetBinding for $y fires its cb while
+            // $x is still bound to the inner's value, so the outer body
+            // reads the inner's $x. Route through the rename path so the
+            // outer frame gets its own slots — same fix the recursive-body
+            // arms already apply (#679).
+            let arg_recursive = args.iter().any(|a| contains_func_call(a, *func_id));
             let action = {
                 let e = env.borrow();
                 let func = match e.funcs.get(*func_id) {
@@ -2679,7 +2688,7 @@ pub fn eval(
                     let is_recursive = e.recursive_cache.iter()
                         .find(|(k, _)| *k == *func_id)
                         .map(|&(_, r)| r);
-                    if is_recursive == Some(true) {
+                    if is_recursive == Some(true) || arg_recursive {
                         FuncAction::Recursive(func)
                     } else if is_recursive == Some(false) {
                         // Known non-recursive: try cache lookup in same borrow

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -10143,3 +10143,26 @@ null
 [range(0; 5) | 0] | reduce range(0; 3) as $a (.; reduce range(0; $a + 1) as $b (.; if $a + $b >= 5 then . else .[$a + $b] |= . + 1 end))
 null
 [1,1,2,1,1]
+
+# Issue #679: nested user-def call as the 2nd arg of the same def. Both calls
+# share parser-allocated $x / $y slots; without the arg-recursion rename
+# guard the outer's $x reads the inner's [4,4] instead of [3,3], producing
+# [10,10]. Expected sum: 3+4+2 = 9.
+def big_add($x; $y): [$x[0] + $y[0], $x[1] + $y[1]]; big_add([3,3]; big_add([4,4]; [2,2]))
+null
+[9,9]
+
+# Issue #679: same hazard with the outer's first arg supplied by piped input
+# (`.` as $x). The arg-recursion check must look at every arg, not just the
+# raw call's positional ones, since the inner call is still the 2nd arg.
+def big_add($x; $y): [$x[0] + $y[0], $x[1] + $y[1]]; [3,3] | big_add(.; big_add([4,4]; [2,2]))
+null
+[9,9]
+
+# Issue #679: inner call in 1st arg position must still produce the correct
+# answer — this shape was never buggy (the inner restores before the outer
+# let-x's cb fires) but the rename path is what triggers now, so guard
+# against regressions in the rename code itself.
+def big_add($x; $y): [$x[0] + $y[0], $x[1] + $y[1]]; big_add(big_add([3,3]; [4,4]); [2,2])
+null
+[9,9]


### PR DESCRIPTION
## Summary
- `f(A; f(B; C))` re-enters `f` with the same parser-allocated `\$x` / `\$y` slots. In CPS eval the inner LetBinding's writes are still live when its result propagates up: the cb it calls is the outer LetBinding's cb, which fires its body-eval before the inner's restore. The outer body then reads the inner's `\$x` instead of its own argument.
- Treat this shape the same as a recursive body — route through `substitute_and_rename` so the outer frame gets fresh slots and the inner's writes can no longer leak through.
- Added 3 regression cases covering the two repro shapes (literal-arg and piped-input-as-outer-x) plus the inner-in-first-arg shape (was already correct, guards against renaming itself regressing).

## Test plan
- [x] `cargo build --release` zero warnings
- [x] `cargo test --release` all suites pass (official 509 + regression + fuzz_restricted + selfdiff)
- [x] All five repro variants from the issue probe match stock jq
- [x] P162 (`projecteuler-jq`) still produces the correct hex digest at the same speed
- [x] `bench/comprehensive.sh` — none of the bench shapes use user-defined functions, so the fix's added per-FuncCall arg walk doesn't touch them; observed deltas in the reduce section are within the established noise floor of this script on this hardware (best-of-3 / 10 ms granularity)

Closes #679

🤖 Generated with [Claude Code](https://claude.com/claude-code)