### PR TITLE
docs(release-skill): slim down SKILL.md, drop Invocation section

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -5,131 +5,82 @@ description: Cut a new jq-jit release — pre-flight, bench, version bump, tag, 
 
 # release — jq-jit release workflow
 
-Cut a new release from the current branch. Bundles benchmark capture,
-`Cargo.toml` bump, and `docs/benchmark-history.{tsv,md}` updates into a
-single PR; tags & pushes after auto-merge so the existing release
-workflow (`.github/workflows/release.yml`) builds binaries, creates the
-GitHub Release, and bumps the Homebrew tap formula.
+Cut a release from the current branch in **one PR**: benchmark capture +
+`Cargo.toml` bump + `docs/benchmark-history.{tsv,md}`. Tag & push after
+auto-merge; `.github/workflows/release.yml` then builds binaries, creates
+the GitHub Release, and bumps the Homebrew tap.
 
-Run **autonomously** end-to-end. Do not pause for confirmation unless
-the regression gate triggers (see step 4).
+Run **autonomously** end-to-end. Only pause if the regression gate
+(step 4) exceeds 1.30.
 
-## Invocation
+## Version
 
-This skill is **not bound to a slash command** — `/release` resolves to
-the user-global aeonnext release skill at `~/.claude/skills/release/`,
-not this one. Invoke it via the `Skill` tool (the description above
-matches user intent like "リリースして" / "release" / "release v1.5.0"
-in the jq-jit repo).
-
-## Determining the version
-
-Extract from user input:
+Extract the target from user input:
 
 | User says | Behavior |
 |---|---|
-| "release" / "リリース" (no other arg) | Auto-detect bump type from commits since last tag |
-| "release patch" / "patch でリリース" | Force patch bump (e.g. v1.4.4 → v1.4.5) |
-| "release minor" / "minor リリース" | Force minor bump (v1.4.4 → v1.5.0) |
-| "release major" / "major リリース" | Force major bump (v1.4.4 → v2.0.0) |
-| "release v1.5.0" / "v1.5.0 でリリース" | Explicit version |
+| "release" / "リリース" (no arg) | Auto-detect bump from commits since last tag |
+| "release patch/minor/major" | Force that bump |
+| "release v1.5.0" | Explicit version |
 
-Auto-detection scans `git log v<latest>..HEAD --pretty=%s` for
-Conventional Commits prefixes:
-
-- Any `feat!:`, `fix!:`, `<type>!:` or `BREAKING CHANGE:` body → **major**
-- Any `feat:` → **minor**
-- Otherwise → **patch**
+Auto-detect scans `git log v<latest>..HEAD --pretty=%s`:
+`feat!:` / `<type>!:` / `BREAKING CHANGE:` → **major**; `feat:` →
+**minor**; otherwise → **patch**.
 
 ## Workflow
 
-### 1. Pre-flight
+**1. Pre-flight.** cwd = repo root (`git rev-parse --show-toplevel`).
+`cargo build --release` → **zero warnings** (hard project rule; fix or
+stop, never suppress). `cargo test --release` → pass.
 
-- Confirm cwd is repo root (`git rev-parse --show-toplevel`).
-- `cargo build --release` — must succeed with **zero warnings**. If
-  warnings appear, fix them (or stop and surface to user) before
-  continuing. Zero warnings is a hard project rule (see CLAUDE.md).
-- `cargo test --release` — must pass.
+**2. Version + branch.** Compute `vX.Y.Z`; ensure `git tag -l vX.Y.Z`
+is empty. On `main` → `git checkout -b release/vX.Y.Z`. On any other
+branch → stay (release bundles with current WIP, which is intentional);
+commit/stash unrelated dirty edits first (ask if intent is unclear).
 
-### 2. Determine version
-
-Apply the rule from the Args table to compute target `vX.Y.Z`. Then:
-
-- Verify no tag named `vX.Y.Z` already exists: `git tag -l vX.Y.Z`.
-- Branch handling:
-  - On `main` → create `git checkout -b release/vX.Y.Z`.
-  - On any other branch → stay (release will bundle with current WIP).
-    Note any uncommitted changes; if working tree is dirty with edits
-    unrelated to the release, prefer to commit/stash them first
-    (ask the user if intent is unclear).
-
-### 3. Benchmark + history update
+**3. Benchmark.** Run in the **background** (`run_in_background: true`):
 
 ```
 python3 .claude/skills/release/scripts/update_history.py vX.Y.Z
 ```
 
-Run it in the **background** (`run_in_background: true`). The script
-runs `bench/comprehensive.sh` (~10 min), parses output, appends rows to
-`docs/benchmark-history.tsv`, and regenerates the slim
-`docs/benchmark-history.md` (last 5 columns).
+It runs `bench/comprehensive.sh` (~10 min), appends to
+`docs/benchmark-history.tsv`, and regenerates the slim `.md` (last 5
+columns). Never poll — wait for the completion notification.
 
-Do not poll — wait for the completion notification.
-
-### 4. Regression gate
-
-After the bench step, compare the new `vX.Y.Z` column against the
-previous version's column in `docs/benchmark-history.tsv`. Compute
-`ratio = new / previous` per benchmark (skip rows where the previous
-column is empty — they're new patterns with no baseline).
+**4. Regression gate.** Per benchmark, `ratio = new / previous` (skip
+rows with an empty previous column — new patterns, no baseline).
 
 | Max ratio | Action |
 |---|---|
-| ≤ 1.05 | Continue to step 5. |
-| 1.05–1.30 | **Re-run** the bench once (`update_history.py` again — note this appends a *second* `vX.Y.Z` column; remove duplicates from TSV before re-running, or run with a temp version label and replace). If still in this range, treat as confirmed regression: investigate the cause (`git log v<previous>..HEAD --oneline` for suspects, code-level inspection of the regressed benchmarks). Apply the fix and re-run bench. If the fix is too involved, open a GitHub issue with `gh issue create` describing the regressed benchmarks + suspected cause, then continue the release with the regression on record. |
-| > 1.30 | **Stop.** Show the user which benchmarks regressed and by how much, and ask how to proceed. Do not bump or PR. |
+| ≤ 1.05 | Continue. |
+| 1.05–1.30 | Re-run bench once (this appends a *second* `vX.Y.Z` column — dedup the TSV or use a temp label first). Still in range → confirmed regression: investigate (`git log v<prev>..HEAD --oneline`, inspect the regressed benchmarks), fix + re-bench. Too involved → `gh issue create` for the regression, then continue the release on record. |
+| > 1.30 | **Stop.** Show the user which benchmarks regressed and by how much; don't bump or PR. |
 
-If the bench produced any `FAIL/TIMEOUT` entries, suspect bench-data
-drift before code regression — historically this has been the cause
-(e.g. #316: `ltrim+tonum+arith` failing because the data prefix didn't
-match the filter expectation).
+`FAIL/TIMEOUT` entries → suspect bench-data drift before code regression
+(e.g. #316: `ltrim+tonum+arith` failed because the data prefix didn't
+match the filter).
 
-### 5. Cargo.toml bump
+**5. Bump.** `sed -i '' -E 's/^version = "[^"]+"/version = "X.Y.Z"/'
+Cargo.toml`, then `cargo check --release` to verify it parses.
 
-```
-sed -i '' -E 's/^version = "[^"]+"/version = "X.Y.Z"/' Cargo.toml
-cargo check --release   # fast verify it parses
-```
+**6. Commit.** One commit `chore: release vX.Y.Z` staging `Cargo.toml`
++ `docs/benchmark-history.tsv` + `docs/benchmark-history.md` (on top of
+any pre-existing WIP commits).
 
-### 6. Single commit
-
-Stage and commit all release-related changes together:
-
-- `Cargo.toml`
-- `docs/benchmark-history.tsv`
-- `docs/benchmark-history.md`
-
-Conventional Commits message: `chore: release vX.Y.Z`. If the branch
-already had unrelated WIP commits, this is the final commit on top of
-them.
-
-### 7. PR + auto-merge
+**7. PR + auto-merge.**
 
 ```
-gh pr create --title "release vX.Y.Z" --body "<short summary>"
+gh pr create --title "release vX.Y.Z" --body "<summary>"
 gh pr merge --auto --merge
 ```
 
-Body should include:
-- One line summary of what's in the release (high-level, not file diff)
-- A note that history columns were appended for vX.Y.Z
-- Bench summary line (e.g. "no regression > 5%" or "regressed: <list>, see #issue")
+Body: one-line release summary, a note that history columns were
+appended for vX.Y.Z, and a bench line ("no regression > 5%" or
+"regressed: <list>, see #issue"). Wait for auto-merge in the
+**background** — don't poll.
 
-Wait for auto-merge in the **background** — do not poll synchronously.
-
-### 8. Tag + push
-
-After auto-merge completes:
+**8. Tag + push.** After auto-merge completes:
 
 ```
 git checkout main && git pull --ff-only
@@ -137,45 +88,23 @@ git tag -a vX.Y.Z -m "release vX.Y.Z"
 git push origin vX.Y.Z
 ```
 
-Tag push triggers `.github/workflows/release.yml`, which builds
-binaries for `linux-x86_64` and `macos-arm64`, creates the GitHub
-Release with auto-generated notes, and bumps the
-[homebrew-tap](https://github.com/m5d215/homebrew-tap) formula. No
-manual edits to either are needed.
+Tag push triggers `release.yml`: binaries for `linux-x86_64` /
+`macos-arm64`, GitHub Release with auto-generated notes, and Homebrew
+tap formula bump — all automatic, no manual edits.
 
-### 9. Wrap-up
-
-Report to the user:
-- PR number and merge SHA
-- Tag pushed
-- Link to release Actions run (`gh run list --workflow=release.yml -L 1`)
-- Bench delta summary (best speedup / worst regression vs previous version)
+**9. Wrap-up.** Report: PR # + merge SHA, tag pushed, release Actions
+run (`gh run list --workflow=release.yml -L 1`), bench delta (best
+speedup / worst regression vs the previous version).
 
 ## Constraints
 
-- The `bench/comprehensive.sh` run is the long pole (~10 min). Use
-  `run_in_background: true` and let the notification fire — never poll
-  with `sleep`.
 - Never amend or force-push. If a step fails after commit, fix forward
   with a new commit.
-- Pre-flight `cargo build --release` warnings are blocking — investigate
-  and fix, never `--allow warnings` or similar.
-- If on a non-main branch with WIP, the release commits ride on top of
-  whatever's there. The user invoking `/release` from such a branch is
-  asserting that bundling is intentional.
-- **If you `git bisect` mid-release** (e.g. step 4 regression
-  investigation), `git bisect reset` does NOT rebuild. The leftover
-  `target/release/jq-jit` is the binary of whatever commit bisect
-  evaluated last. **Always `cargo build --release` before re-running
-  the bench or any perf comparison.** Hard-learned in v1.5.0
-  (commits `67a28be` → `5d80c22`): the post-bisect re-bench wrote a
-  stale-binary v1.5.0 column into the TSV and almost shipped a wrong
-  regression analysis. Verify with `md5 -q target/release/jq-jit` if
-  in doubt.
-
-## Files this skill writes to
-
-- `Cargo.toml` (version field only)
-- `docs/benchmark-history.tsv` (append rows)
-- `docs/benchmark-history.md` (regenerate from TSV)
-- `.git/` (commit, tag, push)
+- Never poll the bench with `sleep`; rely on the background completion
+  notification.
+- **Post-`git bisect` (e.g. step 4 investigation): `git bisect reset`
+  does NOT rebuild.** The leftover `target/release/jq-jit` belongs to
+  whatever commit bisect evaluated last. Always `cargo build --release`
+  before any re-bench or perf comparison — a stale binary once nearly
+  shipped a wrong v1.5.0 regression analysis (`67a28be`→`5d80c22`).
+  Verify with `md5 -q target/release/jq-jit` if unsure.


### PR DESCRIPTION
Slim down `.claude/skills/release/SKILL.md` from 182 to 115 lines.

## Changes
- **Remove the `## Invocation` section entirely** — the frontmatter `description` already makes the skill addressable via the `Skill` tool; the `/release` slash-collision context lives in `CLAUDE.local.md`.
- **Remove `## Files this skill writes to`** — redundant; the workflow steps already name every file written.
- Collapse the verbose numbered `### N.` subsections into terse one-line steps; trim explanatory prose.

## Preserved (intentionally)
- All operational directives: zero-warnings gate, background bench / no-poll, regression-gate thresholds + TSV dedup caveat.
- Both recurrence-guarding war stories: bench-data drift on `FAIL/TIMEOUT` (#316), and the mandatory `cargo build --release` after `git bisect` before any re-bench (v1.5.0 `67a28be`→`5d80c22` lesson).

Docs-only change to a skill markdown file — no Rust build/test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)