### PR TITLE
testing: metamorphic equivalence harness (#683)

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -756,8 +756,13 @@ fn contains_func_call(expr: &Expr, target: usize) -> bool {
 /// This tracks input flow: Pipe's right side gets new input from left's output.
 fn expr_uses_outer_input(expr: &Expr) -> bool {
     match expr {
-        Expr::Input => true,
-        Expr::LoadVar { .. } | Expr::Literal(_) | Expr::Empty | Expr::Not
+        // `Expr::Not` evaluates `!(input.is_truthy())` — it reads `.`.
+        // Misclassifying it as input-free caused the Reduce fast path
+        // to feed `Value::Null` to the source when the source contained
+        // `not` (e.g. `reduce ({a: not}) as $x (null; . + $x)` on input
+        // `[]` returning `{a:true}` instead of `{a:false}`). See #683.
+        Expr::Input | Expr::Not => true,
+        Expr::LoadVar { .. } | Expr::Literal(_) | Expr::Empty
         | Expr::Env | Expr::Builtins | Expr::ReadInput | Expr::ReadInputs
         | Expr::ModuleMeta | Expr::GenLabel | Expr::Loc { .. } => false,
         // Pipe: only left receives our input; right gets left's output

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -627,6 +627,76 @@ impl Expr {
         }
     }
 
+    /// Returns true if this expression contains at least one free `Input`
+    /// node — i.e. at least one place where `substitute_input` would
+    /// actually rewrite something. Distinct from `is_input_free`, which
+    /// only checks whether Input refs (if any) are *free* (not bound by
+    /// Pipe/Reduce/Foreach/etc.).
+    ///
+    /// Use this to guard beta-reductions like
+    /// `Pipe(E, F) → F[E/Input] when F.is_input_free()`: if `F` has no
+    /// Input nodes, the substitution is identity and `E`'s evaluation
+    /// (including any error it would raise) gets silently dropped. See
+    /// #683.
+    pub fn references_input(&self) -> bool {
+        match self {
+            Expr::Input | Expr::Not => true,
+            Expr::Literal(_) | Expr::LoadVar { .. } | Expr::Empty
+            | Expr::Env | Expr::Builtins | Expr::ReadInput | Expr::ReadInputs
+            | Expr::ModuleMeta | Expr::GenLabel | Expr::Loc { .. } => false,
+            Expr::BinOp { lhs, rhs, .. } => lhs.references_input() || rhs.references_input(),
+            Expr::UnaryOp { operand, .. } | Expr::Negate { operand } => operand.references_input(),
+            Expr::Index { expr, key } | Expr::IndexOpt { expr, key } => {
+                expr.references_input() || key.references_input()
+            }
+            Expr::Collect { generator } => generator.references_input(),
+            Expr::Comma { left, right } => left.references_input() || right.references_input(),
+            Expr::Each { input_expr } | Expr::EachOpt { input_expr } => input_expr.references_input(),
+            Expr::IfThenElse { cond, then_branch, else_branch } => {
+                cond.references_input()
+                    || then_branch.references_input()
+                    || else_branch.references_input()
+            }
+            Expr::ObjectConstruct { pairs } => {
+                pairs.iter().any(|(k, v)| k.references_input() || v.references_input())
+            }
+            Expr::Alternative { primary, fallback } => {
+                primary.references_input() || fallback.references_input()
+            }
+            Expr::Format { expr, .. } => expr.references_input(),
+            // Debug/Stderr pass through current input.
+            Expr::Debug { .. } | Expr::Stderr { .. } => true,
+            Expr::Slice { expr, from, to } => {
+                expr.references_input()
+                    || from.as_ref().is_some_and(|e| e.references_input())
+                    || to.as_ref().is_some_and(|e| e.references_input())
+            }
+            Expr::StringInterpolation { parts } => parts.iter().any(|p| match p {
+                StringPart::Literal(_) => false,
+                StringPart::Expr(e) => e.references_input(),
+            }),
+            // CallBuiltin implicitly receives current input as its first arg.
+            Expr::CallBuiltin { .. } => true,
+            Expr::Error { msg } => msg.as_ref().is_some_and(|m| m.references_input()),
+            // Conservative: anything below this point may use input but is
+            // also a binding construct — assume it does so the beta-reduction
+            // bails out and falls through to the structural Pipe code.
+            Expr::Pipe { .. } | Expr::Reduce { .. } | Expr::Foreach { .. }
+            | Expr::LetBinding { .. } | Expr::TryCatch { .. } | Expr::While { .. }
+            | Expr::Until { .. } | Expr::Repeat { .. } | Expr::Label { .. }
+            | Expr::Update { .. } | Expr::Assign { .. } | Expr::AllShort { .. }
+            | Expr::AnyShort { .. } | Expr::Limit { .. }
+            | Expr::Range { .. } | Expr::Recurse { .. }
+            | Expr::PathExpr { .. } | Expr::SetPath { .. } | Expr::GetPath { .. }
+            | Expr::DelPaths { .. }
+            | Expr::FuncCall { .. } | Expr::Break { .. }
+            | Expr::RegexTest { .. } | Expr::RegexMatch { .. } | Expr::RegexCapture { .. }
+            | Expr::RegexScan { .. } | Expr::RegexSub { .. } | Expr::RegexGsub { .. }
+            | Expr::ClosureOp { .. } | Expr::AlternativeDestructure { .. }
+            | Expr::Memoize { .. } => true,
+        }
+    }
+
     /// Substitute all Input nodes with `replacement`.
     /// Only valid when `is_input_free()` is true.
     pub fn substitute_input(&self, replacement: &Expr) -> Expr {

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -677,8 +677,18 @@ impl Flattener {
                         }
                     }
                 }
-                // Beta-reduction: Pipe(E, F) → F[E/Input] when E is scalar and F has free Input
-                if new_left.is_simple_scalar() && new_right.is_input_free() {
+                // Beta-reduction: Pipe(E, F) → F[E/Input] when E is scalar
+                // and F has free Input. Additionally require F to actually
+                // *reference* Input — without that check, F being input-free
+                // by virtue of having no Input nodes at all makes the
+                // substitution a no-op, silently dropping E's evaluation
+                // (including any error it would raise). See #683 — a
+                // `Pipe(.x, 0)` source inside `reduce` collapsed to `0` and
+                // suppressed the "Cannot index boolean" error on `.x`.
+                if new_left.is_simple_scalar()
+                    && new_right.is_input_free()
+                    && new_right.references_input()
+                {
                     return new_right.substitute_input(&new_left);
                 }
                 Expr::Pipe { left: new_left, right: new_right }
@@ -1408,10 +1418,15 @@ impl Flattener {
                 for (k, v) in pairs {
                     // Fast path: literal string key avoids creating/dropping a Value
                     if let Expr::Literal(Literal::Str(s)) = k {
-                        // Fused path: if value is .field from input, use ObjCopyField
-                        // to combine field extraction + push into a single runtime call
+                        // Fused path: if value is `.field?` (IndexOpt) from
+                        // input, use ObjCopyField to combine field extraction
+                        // + push into a single runtime call. Restricted to
+                        // IndexOpt because the ObjCopyField runtime swallows
+                        // type errors (treats non-object/non-null as null),
+                        // which is the IndexOpt semantics but not the plain
+                        // Index semantics — Index must error. See #683.
                         let used_copy_field = if all_unique_str_keys {
-                            if let Expr::Index { expr: base, key } | Expr::IndexOpt { expr: base, key } = v {
+                            if let Expr::IndexOpt { expr: base, key } = v {
                                 if matches!(base.as_ref(), Expr::Input) {
                                     if let Expr::Literal(Literal::Str(field)) = key.as_ref() {
                                         self.emit(JitOp::ObjCopyField {
@@ -1680,6 +1695,25 @@ impl Flattener {
                 out
             }
             Expr::Reduce { source, init, var_index, acc_index, update } => {
+                // Pre-check source compilability. The dispatch below uses
+                // `flatten_gen_with_each_output(source, …)` without checking
+                // the return value, so a source that can't be JIT-compiled
+                // silently emits no loop body — leaving the accumulator at
+                // its init value and masking any error the source would
+                // have raised (e.g. `reduce (if values then . else . end |
+                // reverse) as $x (null; .+$x)` on `false` returned `null`
+                // instead of erroring). Bail to the interpreter when the
+                // source isn't compilable. See #683.
+                {
+                    let mut test = self.test_flattener();
+                    let t_in = test.alloc_slot();
+                    if !test.flatten_gen(source, t_in) {
+                        self.has_unresolved_recursion = true;
+                        let out = self.alloc_slot();
+                        self.emit(JitOp::Null { dst: out });
+                        return out;
+                    }
+                }
                 // Detect reduce gen as $x ([]; . + [f($x)]) → [gen | f(.)]
                 // where init is [] and update is . + [inner] with inner not using accumulator
                 if matches!(init.as_ref(), Expr::Collect { generator } if matches!(generator.as_ref(), Expr::Empty)) {
@@ -2382,8 +2416,11 @@ impl Flattener {
                     };
                     for (k, v) in pairs {
                         if let Expr::Literal(Literal::Str(s)) = k {
+                            // Restricted to IndexOpt for the same reason as
+                            // the sibling ObjCopyField site — see comment at
+                            // the other call site and #683.
                             let used_copy_field = if all_unique_str_keys {
-                                if let Expr::Index { expr: base, key } | Expr::IndexOpt { expr: base, key } = v {
+                                if let Expr::IndexOpt { expr: base, key } = v {
                                     if matches!(base.as_ref(), Expr::Input) {
                                         if let Expr::Literal(Literal::Str(field)) = key.as_ref() {
                                             self.emit(JitOp::ObjCopyField {
@@ -6574,7 +6611,12 @@ extern "C" fn jit_rt_unaryop(dst: *mut Value, op: i32, input: *const Value) -> i
                 return 0;
             }
         }
-        // Fast path: reverse (op 9)
+        // Fast path: reverse (op 9). `reverse` desugars to
+        // `[.[length - 1 - range(0; length)]]`, so non-empty strings
+        // error via `.[idx]` on a string. Empty string and null yield
+        // `[]` (the range is empty). Non-array/non-string inputs fall
+        // through to the slow path, which produces the right error
+        // message. See #683.
         if op == 9 {
             match &*input {
                 Value::Arr(a) => {
@@ -6583,11 +6625,11 @@ extern "C" fn jit_rt_unaryop(dst: *mut Value, op: i32, input: *const Value) -> i
                     std::ptr::write(dst, Value::Arr(Rc::new(r)));
                     return 0;
                 }
-                Value::Str(s) => {
-                    std::ptr::write(dst, Value::from_string(s.chars().rev().collect()));
+                Value::Null => {
+                    std::ptr::write(dst, Value::Arr(Rc::new(vec![])));
                     return 0;
                 }
-                Value::Null => {
+                Value::Str(s) if s.is_empty() => {
                     std::ptr::write(dst, Value::Arr(Rc::new(vec![])));
                     return 0;
                 }
@@ -6691,15 +6733,24 @@ extern "C" fn jit_rt_throw_error(msg: *const Value, env: *mut JitEnv) -> i64 {
     }
 }
 /// In-place reverse: Rc::make_mut avoids inner Vec clone when refcount == 1.
+///
+/// `reverse` is `def reverse: [.[length - 1 - range(0; length)]];`. For a
+/// non-empty string that desugaring indexes the string with numbers,
+/// which jq rejects ("Cannot index string with number"). The empty
+/// string yields `[]` because the `range` is empty. Mirror the runtime
+/// `rt_reverse` shape here instead of silently reversing codepoints —
+/// surfaced by the metamorphic harness (#683) via
+/// `reduce ((type) | ({a: reverse})) as $x ...` on `null`.
 extern "C" fn jit_rt_reverse_inplace(v: *mut Value) -> i64 {
     unsafe {
         match &mut *v {
             Value::Arr(a) => { Rc::make_mut(a).reverse(); 0 }
-            Value::Str(s) => {
-                *v = Value::from_string(s.chars().rev().collect());
-                0
-            }
             Value::Null => { *v = Value::Arr(Rc::new(vec![])); 0 }
+            Value::Str(s) if s.is_empty() => { *v = Value::Arr(Rc::new(vec![])); 0 }
+            Value::Str(_) => {
+                set_jit_error("Cannot index string with number".to_string());
+                GEN_ERROR
+            }
             _ => { set_jit_error(format!("{} cannot be reversed", (*v).type_name())); GEN_ERROR }
         }
     }
@@ -8461,6 +8512,13 @@ impl JitCompiler {
         if !fl.flatten_gen(compile_expr, input_slot) {
             bail!("Expression not JIT-compilable");
         }
+        // Sub-trees can request a JIT bailout mid-flatten (e.g. a reduce
+        // source whose `flatten_gen_with_each_output` would silently emit
+        // no loop body — see #683 and the Reduce arm in flatten_scalar).
+        // Bail here so the binary falls back to the interpreter.
+        if fl.has_unresolved_recursion {
+            bail!("Expression not JIT-compilable: subtree requested bailout");
+        }
         fl.emit(JitOp::ReturnContinue);
 
         // Store closure ops for runtime access
@@ -9810,7 +9868,12 @@ pub fn is_jit_compilable_with_funcs(expr: &Expr, funcs: &[CompiledFunc]) -> bool
     let inlined = fl.inline_func_calls(expr);
     if fl.has_unresolved_recursion { return false; }
     let input = fl.alloc_slot();
-    fl.flatten_gen(&inlined, input)
+    let ok = fl.flatten_gen(&inlined, input);
+    // Subtrees may set `has_unresolved_recursion` mid-flatten to request
+    // a JIT bailout (see #683 — Reduce arm in flatten_scalar). Re-check
+    // here so the feasibility query agrees with `compile_with_funcs`.
+    if fl.has_unresolved_recursion { return false; }
+    ok
 }
 
 unsafe extern "C" fn collect_callback(value: *const Value, ctx: *mut u8) -> i64 {

--- a/tests/metamorphic.rs
+++ b/tests/metamorphic.rs
@@ -1,0 +1,493 @@
+//! Metamorphic equivalence harness (#683).
+//!
+//! Generates `(filter, input)` pairs and asserts a fixed set of
+//! jq-language algebraic equivalences hold across jq-jit's pipeline
+//! (raw-byte fast paths, `simplify_expr`, parser rewrites, JIT). The
+//! reference is jq-jit itself: each equivalence renders two textually
+//! distinct filters that jq's semantics guarantee produce identical
+//! output streams on any input, and the harness runs both through the
+//! same jq-jit binary.
+//!
+//! ## Why this catches bugs the existing harnesses miss
+//!
+//! - `diff_*` / `fuzz_*` pin against reference jq, which catches
+//!   value-level divergences but is blind to "both jq-jit pipeline
+//!   paths happen to be wrong in the same way."
+//! - `selfdiff_jit_interp` pins JIT vs interpreter on *identical*
+//!   filters, which catches layer drift but not rewrites that fire on
+//!   shapes they shouldn't.
+//!
+//! The bugs that motivate this harness all fit the
+//! "rewrite-claims-equivalence-but-violates-it-on-some-shape" template:
+//!
+//! - `[gen] | add` rewrite firing on multi-valued `gen` (#56)
+//! - `path(.a)` constant-folded to `["a"]` regardless of input type (#46)
+//! - `paths` rewrite missing the `length > 0` guard
+//! - `limit(n; ...)` collapsing to `first` for `n >= 1`
+//!
+//! ## Equivalences
+//!
+//! Each one is a single `#[test]` proptest. Generators are kept small
+//! (depth ≤ 3) so shrinks land on minimal cases that are easy to
+//! triage. To add a new equivalence: drop a new `#[test]` calling
+//! `run_equivalence(...)` with a strategy that emits `(lhs_filter,
+//! rhs_filter, input)` triples.
+//!
+//! 1. `f`            ≡  `f | .`
+//! 2. `f, empty`     ≡  `f`
+//! 3. `(f | g) | h`  ≡  `f | (g | h)`
+//! 4. `[f] | .[]`    ≡  `f`              *(single-valued `f` only)*
+//! 5. `paths`        ≡  `path(..) | select(length > 0)`
+//! 6. `[gen] | add`  ≡  `reduce gen as $x (null; . + $x)`
+//!                                       *(single-valued `gen` only)*
+//!
+//! The single-valued restriction on (4) and (6) mirrors
+//! `is_single_valued_expr` in `src/interpreter.rs` — it's the precondition
+//! the corresponding rewrites guard themselves on. Testing the broader
+//! multi-valued case is a follow-up once the single-valued surface lands
+//! clean.
+//!
+//! ## Knobs
+//!
+//! - `JQJIT_PROPTEST_CASES` — case budget per property (default 128)
+//! - `JQJIT_PROPTEST_TIMEOUT_SECS` — per-subprocess wall-clock cap
+//!   (default 3)
+//!
+//! When a divergence shrinks, paste the minimal `(filter, input)` into
+//! `tests/regression.test` with reference jq's output as expected, fix
+//! the underlying rewrite or guard, then re-run.
+
+mod common;
+
+use std::time::Duration;
+
+use proptest::prelude::*;
+use proptest::test_runner::{TestCaseError, TestRunner};
+
+use common::diff_harness::{jq_jit_path, run_filter};
+use common::json_normalize::normalize;
+
+// ===== filter AST =====
+
+#[derive(Debug, Clone)]
+enum Filter {
+    Identity,
+    Field(String),
+    Index(i32),
+    IntLit(i32),
+    UnaryBuiltin(&'static str),
+    Pipe(Box<Filter>, Box<Filter>),
+    ArrayCons(Vec<Filter>),
+    ObjCons(Vec<(String, Filter)>),
+    Map(Box<Filter>),
+    If(Box<Filter>, Box<Filter>, Box<Filter>),
+    /// `.f1 OP .f2`
+    FieldCmpField(String, &'static str, String),
+    /// `.f OP N`
+    FieldCmpInt(String, &'static str, i32),
+}
+
+/// Multi-valued generators that the single-valued strategy must reject.
+/// Kept in a separate AST node tree so the multi-valued strategy can
+/// produce them and the single-valued one cannot.
+#[derive(Debug, Clone)]
+enum MultiFilter {
+    /// Single-valued island; anything below this point is single-valued.
+    Single(Filter),
+    Comma(Box<MultiFilter>, Box<MultiFilter>),
+    /// `range(n)` — produces 0,1,…,n-1.
+    RangeN(u32),
+    /// `.[]` — produces one value per array element / object value.
+    EachUnchecked,
+    /// `limit(n; gen)` — produces ≤n values from `gen`.
+    Limit(u32, Box<MultiFilter>),
+    Pipe(Box<MultiFilter>, Box<MultiFilter>),
+}
+
+const IDENTS: &[&str] = &["a", "b", "x", "y"];
+
+const SAFE_BUILTINS: &[&str] = &[
+    "length",
+    "type",
+    "tostring",
+    "not",
+    "keys",
+    "values",
+    "reverse",
+    "sort",
+    "to_entries",
+];
+
+const CMP_OPS: &[&str] = &["==", "!=", "<", ">", "<=", ">="];
+
+fn render(f: &Filter) -> String {
+    match f {
+        Filter::Identity => ".".into(),
+        Filter::Field(n) => format!(".{}", n),
+        Filter::Index(n) => format!(".[{}]", n),
+        Filter::IntLit(n) => n.to_string(),
+        Filter::UnaryBuiltin(n) => (*n).to_string(),
+        Filter::Pipe(a, b) => format!("({}) | ({})", render(a), render(b)),
+        Filter::ArrayCons(items) => {
+            if items.is_empty() {
+                "[]".into()
+            } else {
+                let parts: Vec<String> = items.iter().map(render).collect();
+                format!("[{}]", parts.join(", "))
+            }
+        }
+        Filter::ObjCons(pairs) => {
+            if pairs.is_empty() {
+                "{}".into()
+            } else {
+                let parts: Vec<String> = pairs
+                    .iter()
+                    .map(|(k, v)| format!("{}: ({})", k, render(v)))
+                    .collect();
+                format!("{{{}}}", parts.join(", "))
+            }
+        }
+        Filter::Map(inner) => format!("map({})", render(inner)),
+        Filter::If(c, t, e) => format!(
+            "if ({}) then ({}) else ({}) end",
+            render(c),
+            render(t),
+            render(e)
+        ),
+        Filter::FieldCmpField(a, op, b) => format!(".{} {} .{}", a, op, b),
+        Filter::FieldCmpInt(f, op, n) => format!(".{} {} {}", f, op, n),
+    }
+}
+
+fn render_multi(f: &MultiFilter) -> String {
+    match f {
+        MultiFilter::Single(s) => render(s),
+        MultiFilter::Comma(a, b) => format!("({}), ({})", render_multi(a), render_multi(b)),
+        MultiFilter::RangeN(n) => format!("range({})", n),
+        MultiFilter::EachUnchecked => ".[]".into(),
+        MultiFilter::Limit(n, g) => format!("limit({}; {})", n, render_multi(g)),
+        MultiFilter::Pipe(a, b) => format!("({}) | ({})", render_multi(a), render_multi(b)),
+    }
+}
+
+// ===== strategies =====
+
+fn ident_strategy() -> impl Strategy<Value = String> {
+    prop::sample::select(IDENTS).prop_map(|s| s.to_string())
+}
+
+fn cmp_op_strategy() -> impl Strategy<Value = &'static str> {
+    prop::sample::select(CMP_OPS)
+}
+
+fn leaf_single() -> impl Strategy<Value = Filter> {
+    prop_oneof![
+        Just(Filter::Identity),
+        ident_strategy().prop_map(Filter::Field),
+        (-2i32..=2).prop_map(Filter::Index),
+        (-3i32..=3).prop_map(Filter::IntLit),
+        prop::sample::select(SAFE_BUILTINS).prop_map(Filter::UnaryBuiltin),
+        (ident_strategy(), cmp_op_strategy(), ident_strategy())
+            .prop_map(|(a, op, b)| Filter::FieldCmpField(a, op, b)),
+        (ident_strategy(), cmp_op_strategy(), -3i32..=3)
+            .prop_map(|(f, op, n)| Filter::FieldCmpInt(f, op, n)),
+    ]
+}
+
+/// Single-valued filter strategy. Every filter produced yields exactly
+/// one value per input (or errors). Mirrors the
+/// `is_single_valued_expr` precondition in `src/interpreter.rs`.
+fn single_filter_strategy() -> impl Strategy<Value = Filter> {
+    leaf_single().prop_recursive(3, 16, 3, |inner| {
+        prop_oneof![
+            (inner.clone(), inner.clone())
+                .prop_map(|(a, b)| Filter::Pipe(Box::new(a), Box::new(b))),
+            prop::collection::vec(inner.clone(), 0..=3).prop_map(Filter::ArrayCons),
+            prop::collection::vec((ident_strategy(), inner.clone()), 0..=3)
+                .prop_map(Filter::ObjCons),
+            inner.clone().prop_map(|f| Filter::Map(Box::new(f))),
+            (inner.clone(), inner.clone(), inner.clone())
+                .prop_map(|(c, t, e)| Filter::If(Box::new(c), Box::new(t), Box::new(e))),
+        ]
+    })
+}
+
+/// Multi-valued strategy. Includes generators (`,`, `range`, `.[]`,
+/// `limit`) plus all single-valued shapes.
+fn multi_filter_strategy() -> impl Strategy<Value = MultiFilter> {
+    let leaf = prop_oneof![
+        single_filter_strategy().prop_map(MultiFilter::Single),
+        Just(MultiFilter::EachUnchecked),
+        (0u32..=3).prop_map(MultiFilter::RangeN),
+    ];
+    leaf.prop_recursive(3, 12, 3, |inner| {
+        prop_oneof![
+            (inner.clone(), inner.clone())
+                .prop_map(|(a, b)| MultiFilter::Comma(Box::new(a), Box::new(b))),
+            (inner.clone(), inner.clone())
+                .prop_map(|(a, b)| MultiFilter::Pipe(Box::new(a), Box::new(b))),
+            (1u32..=3, inner.clone()).prop_map(|(n, g)| MultiFilter::Limit(n, Box::new(g))),
+        ]
+    })
+}
+
+// ===== JSON input shape =====
+
+#[derive(Debug, Clone)]
+enum Json {
+    Null,
+    Bool(bool),
+    Int(i32),
+    Str(String),
+    Arr(Vec<Json>),
+    Obj(Vec<(String, Json)>),
+}
+
+fn render_json(v: &Json) -> String {
+    match v {
+        Json::Null => "null".into(),
+        Json::Bool(b) => b.to_string(),
+        Json::Int(n) => n.to_string(),
+        Json::Str(s) => serde_json::to_string(s).unwrap(),
+        Json::Arr(items) => {
+            let parts: Vec<String> = items.iter().map(render_json).collect();
+            format!("[{}]", parts.join(","))
+        }
+        Json::Obj(pairs) => {
+            let parts: Vec<String> = pairs
+                .iter()
+                .map(|(k, v)| format!("{}:{}", serde_json::to_string(k).unwrap(), render_json(v)))
+                .collect();
+            format!("{{{}}}", parts.join(","))
+        }
+    }
+}
+
+fn json_leaf() -> impl Strategy<Value = Json> {
+    prop_oneof![
+        Just(Json::Null),
+        any::<bool>().prop_map(Json::Bool),
+        (-3i32..=3).prop_map(Json::Int),
+        prop::sample::select(vec!["", "a", "ab", "hello"])
+            .prop_map(|s| Json::Str(s.to_string())),
+    ]
+}
+
+fn json_strategy() -> impl Strategy<Value = Json> {
+    json_leaf().prop_recursive(3, 12, 3, |inner| {
+        prop_oneof![
+            prop::collection::vec(inner.clone(), 0..=3).prop_map(Json::Arr),
+            prop::collection::vec((ident_strategy(), inner.clone()), 0..=3).prop_map(Json::Obj),
+        ]
+    })
+}
+
+// ===== runner =====
+
+fn run_one(filter: &str, input: &str, timeout: Duration) -> Option<common::diff_harness::RunOutput> {
+    run_filter(jq_jit_path(), filter, input, timeout)
+}
+
+/// Assert two filters produce identical output streams on `input`. Both
+/// erroring counts as agreement; one-sided error or value divergence
+/// fails the proptest case.
+fn assert_equivalent(
+    label: &str,
+    lhs_filter: &str,
+    rhs_filter: &str,
+    input: &str,
+    timeout: Duration,
+) -> Result<(), TestCaseError> {
+    let Some(l) = run_one(lhs_filter, input, timeout) else {
+        return Ok(());
+    };
+    let Some(r) = run_one(rhs_filter, input, timeout) else {
+        return Ok(());
+    };
+
+    let crash_markers = ["panicked", "SIGSEGV", "Assertion failed", "stack overflow"];
+    for (which, out) in [("lhs", &l), ("rhs", &r)] {
+        if crash_markers.iter().any(|m| out.stdout.contains(m)) {
+            return Err(TestCaseError::fail(format!(
+                "[{}] {} crashed\n  filter: {}\n  input:  {}\n  out:    {}",
+                label,
+                which,
+                if which == "lhs" { lhs_filter } else { rhs_filter },
+                input,
+                out.stdout.trim()
+            )));
+        }
+    }
+
+    if l.is_error && r.is_error {
+        return Ok(());
+    }
+    if l.is_error != r.is_error {
+        return Err(TestCaseError::fail(format!(
+            "[{}] error-class mismatch (lhs error={}, rhs error={})\n  lhs:    {}\n  rhs:    {}\n  input:  {}\n  lhs_out: {}\n  rhs_out: {}",
+            label,
+            l.is_error,
+            r.is_error,
+            lhs_filter,
+            rhs_filter,
+            input,
+            l.stdout.trim(),
+            r.stdout.trim(),
+        )));
+    }
+
+    let (l_norm, r_norm) = match (normalize(&l.stdout), normalize(&r.stdout)) {
+        (Ok(a), Ok(b)) => (a, b),
+        // One side emitted non-JSON; treat as inconclusive (the
+        // existing `selfdiff_jit_interp` policy). Reference jq diffing
+        // is the other harnesses' job.
+        _ => return Ok(()),
+    };
+
+    if l_norm != r_norm {
+        return Err(TestCaseError::fail(format!(
+            "[{}] value mismatch\n  lhs:    {}\n  rhs:    {}\n  input:  {}\n  lhs_out: {}\n  rhs_out: {}",
+            label, lhs_filter, rhs_filter, input, l_norm, r_norm
+        )));
+    }
+    Ok(())
+}
+
+fn proptest_cases() -> u32 {
+    std::env::var("JQJIT_PROPTEST_CASES")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(128)
+}
+
+fn proptest_timeout() -> Duration {
+    let secs: u64 = std::env::var("JQJIT_PROPTEST_TIMEOUT_SECS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(3);
+    Duration::from_secs(secs)
+}
+
+fn proptest_config() -> ProptestConfig {
+    ProptestConfig {
+        cases: proptest_cases(),
+        failure_persistence: None,
+        max_shrink_time: 15_000,
+        ..ProptestConfig::default()
+    }
+}
+
+fn run_equivalence<S, F>(label: &'static str, strategy: S, to_filters: F)
+where
+    S: Strategy,
+    F: Fn(S::Value) -> (String, String, String),
+{
+    let timeout = proptest_timeout();
+    let mut runner = TestRunner::new(proptest_config());
+    let result = runner.run(&strategy, |value| {
+        let (lhs, rhs, input) = to_filters(value);
+        assert_equivalent(label, &lhs, &rhs, &input, timeout)
+    });
+    if let Err(e) = result {
+        panic!("metamorphic [{}] failed:\n{}", label, e);
+    }
+}
+
+// ===== tests =====
+
+/// 1. `f`  ≡  `f | .`
+#[test]
+fn equiv_identity_postfix_pipe() {
+    run_equivalence(
+        "f ≡ f | .",
+        (single_filter_strategy(), json_strategy()),
+        |(f, input)| {
+            let f_str = render(&f);
+            let lhs = f_str.clone();
+            let rhs = format!("({}) | .", f_str);
+            (lhs, rhs, render_json(&input))
+        },
+    );
+}
+
+/// 2. `f, empty`  ≡  `f`
+#[test]
+fn equiv_comma_empty_drop() {
+    run_equivalence(
+        "f, empty ≡ f",
+        (multi_filter_strategy(), json_strategy()),
+        |(f, input)| {
+            let f_str = render_multi(&f);
+            let lhs = format!("({}), empty", f_str);
+            let rhs = f_str;
+            (lhs, rhs, render_json(&input))
+        },
+    );
+}
+
+/// 3. `(f | g) | h`  ≡  `f | (g | h)`
+#[test]
+fn equiv_pipe_associativity() {
+    run_equivalence(
+        "(f|g)|h ≡ f|(g|h)",
+        (
+            multi_filter_strategy(),
+            multi_filter_strategy(),
+            multi_filter_strategy(),
+            json_strategy(),
+        ),
+        |(f, g, h, input)| {
+            let f_str = render_multi(&f);
+            let g_str = render_multi(&g);
+            let h_str = render_multi(&h);
+            let lhs = format!("(({}) | ({})) | ({})", f_str, g_str, h_str);
+            let rhs = format!("({}) | (({}) | ({}))", f_str, g_str, h_str);
+            (lhs, rhs, render_json(&input))
+        },
+    );
+}
+
+/// 4. `[f] | .[]`  ≡  `f`   *(single-valued `f`)*
+#[test]
+fn equiv_arr_iter_roundtrip() {
+    run_equivalence(
+        "[f]|.[] ≡ f  (single-valued f)",
+        (single_filter_strategy(), json_strategy()),
+        |(f, input)| {
+            let f_str = render(&f);
+            let lhs = format!("[{}] | .[]", f_str);
+            let rhs = f_str;
+            (lhs, rhs, render_json(&input))
+        },
+    );
+}
+
+/// 5. `paths`  ≡  `path(..) | select(length > 0)`
+#[test]
+fn equiv_paths_definition() {
+    run_equivalence(
+        "paths ≡ path(..) | select(length > 0)",
+        json_strategy(),
+        |input| {
+            let lhs = "[paths]".to_string();
+            let rhs = "[path(..) | select(length > 0)]".to_string();
+            (lhs, rhs, render_json(&input))
+        },
+    );
+}
+
+/// 6. `[gen] | add`  ≡  `reduce gen as $x (null; . + $x)`
+///    *(single-valued `gen`)*
+#[test]
+fn equiv_collect_add_reduce() {
+    run_equivalence(
+        "[gen]|add ≡ reduce gen as $x (null;.+$x)  (single-valued gen)",
+        (single_filter_strategy(), json_strategy()),
+        |(g, input)| {
+            let g_str = render(&g);
+            let lhs = format!("[{}] | add", g_str);
+            let rhs = format!("reduce ({}) as $x (null; . + $x)", g_str);
+            (lhs, rhs, render_json(&input))
+        },
+    );
+}

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -10166,3 +10166,58 @@ null
 def big_add($x; $y): [$x[0] + $y[0], $x[1] + $y[1]]; big_add(big_add([3,3]; [4,4]); [2,2])
 null
 [9,9]
+
+# Issue #683: Reduce source containing `not` was evaluated against
+# `Value::Null` instead of the outer input. `expr_uses_outer_input`
+# misclassified `Expr::Not` as input-free, so the source_needs_input
+# branch fed Null and `not` on Null returned true instead of negating
+# the actual input. Surfaced by the metamorphic harness via
+# `[{a: not}] | add` ≢ `reduce ({a: not}) as $x (null; . + $x)` on `[]`.
+reduce ({a: (not)}) as $x (null; . + $x)
+[]
+{"a":false}
+
+# Issue #683: JIT Pipe beta-reduction `Pipe(E, F) → F[E/Input]` fired even
+# when F had no Input refs, making the substitution a no-op and silently
+# dropping E's evaluation. `.x | 0` on `false` collapsed to `0`, hiding
+# the "Cannot index boolean" error. Wrapping in try/catch lets us pin the
+# error class with a stable expected value. Adding `F.references_input()`
+# to the beta-reduction guard preserves the would-be error.
+try (reduce (.x | 0) as $x (null; . + $x)) catch "ERROR"
+false
+"ERROR"
+
+# Issue #683: JIT `reverse` fast path silently reversed string codepoints
+# (`"null"` → `"llun"`) instead of erroring. `reverse` desugars to
+# `[.[length - 1 - range(0; length)]]`, which indexes the input with
+# numbers — strings reject that. Empty string still yields `[]` (range
+# empty). Surfaced via `[type | {a: reverse}] | add` ≢ corresponding
+# reduce form on `null` (both must error identically).
+try (reverse) catch "ERROR"
+"abc"
+"ERROR"
+
+# Issue #683: Reduce-in-scalar-position dispatches via
+# `flatten_gen_with_each_output(source, …)` and ignored its return
+# value, so a source the JIT couldn't compile silently emitted no loop
+# body — leaving the accumulator at its init value and masking any
+# error the source would have raised. `values` desugars to
+# `if (type != "null") then . else empty end`, whose `empty` branch
+# makes the whole if non-scalar — exactly the shape the per-iteration
+# dispatch bails on. Pre-check the source at the top of the Reduce
+# arm; on failure mark the Flattener for compile-time bailout so the
+# binary falls back to the interpreter.
+try (reduce ((if values then . else . end) | reverse) as $x (null; . + $x)) catch "ERROR"
+false
+"ERROR"
+
+# Issue #683: ObjCopyField fused fast path for `{key: .field}` and
+# `{key: .field?}` silently treated non-object/non-null input as null,
+# swallowing the would-be type error from plain `.field`. `false |
+# {a: .a}` should error ("Cannot index boolean with string \"a\"")
+# but jq-jit's JIT returned `{"a":null}` instead. Restricting the
+# optimization to IndexOpt (`.field?`) — whose semantics actually do
+# swallow the error — preserves the plain Index error class.
+try {a: .a} catch "ERROR"
+false
+"ERROR"


### PR DESCRIPTION
## Summary

- New `tests/metamorphic.rs`: proptest harness that runs six
  jq-language algebraic equivalences across jq-jit's pipeline
  (raw-byte fast paths, `simplify_expr`, parser rewrites, JIT) with
  jq-jit itself as the oracle — no external `jq` needed.
- Surfaces and fixes four JIT error-suppression bugs:
  - `Expr::Not` misclassified as input-free in `expr_uses_outer_input`.
  - Pipe beta-reduction in `inline_func_calls` discarding LHS when RHS
    has no `Input` nodes (new `Expr::references_input` guards the
    rewrite).
  - JIT `reverse` fast path reversing string codepoints instead of
    erroring (now mirrors the runtime: `[]` for null/empty-string,
    error for non-empty string).
  - `Expr::Reduce` in `flatten_scalar` not checking
    `flatten_gen_with_each_output`'s return value — uncompilable
    sources silently produced no loop body. Pre-check + bailout flag
    routes to the interpreter.
  - `ObjCopyField` fused path for `{key: .field}` swallowing the type
    error on non-object input. Restricted to `.field?` (IndexOpt),
    whose semantics actually swallow.

Closes #683. The remaining three epochs of the four-axis bug-hunt
plan live in #684 (static invariant grep tests), #685 (4-way
layer-pinned self-diff), #686 (per-exclusion mini fuzzes).

## Test plan

- [x] `cargo test --release` — all suites green including new
  `tests/metamorphic.rs` (6 properties × default 128 cases)
- [x] `JQJIT_PROPTEST_CASES=2000 cargo test --release --test metamorphic`
  — all six properties hold over 12k total cases
- [x] All four bug fixes pinned in `tests/regression.test`;
  `compat_regression` and `selfdiff_jit_interp` both pass on the new
  cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)