### PR TITLE
test: enforce maintenance.md §3 invariants via static grep tests (#684)

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -223,6 +223,9 @@ invariant 回帰は `tests/regression.test` の "Issue #30" ブロックと
 - `src/interpreter.rs` の `simplify_expr` pipe ハンドラ（`is_single_valued` ローカル helper）
 
 新しい generator-ish な `Expr` variant を足したら `is_single_valued` の reject リストにも入れる。判定が微妙なら "safe default は false" で、rewrite を発火させない方にブレる。
+`tests/enforce_is_single_valued.rs` が `is_single_valued_expr` の全 variant 分類を
+`tests/enforce_is_single_valued.allowlist`（`reject` / `accept_explicit` / `recurse` / `default_false`）と
+突き合わせる。新しい variant を足したら allowlist の更新も強制される。
 
 ### `first()` / `limit(1)` 書き換えのスコープ
 
@@ -256,13 +259,21 @@ eval env にコピーする。個別の handler は seeding を意識せずに�
 - cached Env を reuse するなら `reset_delegated_env(&env, &[&delegated_expr])`
 
 を呼ぶ。`Rc::new(RefCell::new(crate::eval::Env::new(vec![])))` を直接書いては
-いけない（書くと let-binding がまた消える）。
+いけない（書くと let-binding がまた消える）。`tests/enforce_jit_env_seeding.rs`
+が `src/jit.rs` 内の bare `Env::new` 直書きを `tests/enforce_jit_env_seeding.allowlist`
+の grandfathered count で固定して検知する。
+また `tests/enforce_closure_op_env_seeding.rs` が新規 `__<op>__:` dispatcher の
+seeding 漏れ（`new_delegated_env` / `reset_delegated_env` 呼び出し欠落）を検知する
+（eval 委譲しない tag は `tests/enforce_closure_op_env_seeding.allowlist` に
+理由付きで登録）。
 
 また、`collect_loadvar_indices` は **全 `Expr` variant を再帰的に歩く契約**。
 Index / ObjectConstruct / StringInterpolation / CallBuiltin / FuncCall 等に
 LoadVar が埋もれていても拾える。新しい `Expr` variant を足した時は、この
 walker にも再帰呼び出しを追加すること（足し忘れると let-binding が潜って
-silently null になる）。
+silently null になる）。`tests/enforce_collect_loadvar_exhaustive.rs` が
+`src/ir.rs` の `Expr` enum を parse して、walker 本体に各 variant が出現することを
+強制する。
 
 ### `paths` / `paths(f)` は root を落とす
 
@@ -279,7 +290,7 @@ raw-byte fast path は「missing field を null で返す」動きをするも�
 対策:
 
 - `detect_expr` は top-level `try EXPR`（Empty catch）を **剥がさない**。剥がすと fast path 一式が `(expr)?` でもそのまま発火して、null-masking が観測される。今は剥がしていない。
-- 新しい raw-byte fast path を足す時は、**非期待型の入力でも正しく error を raise する**ように書くか、そうでないなら入力型を先頭バイトで判別して bail。bail は構造的に名前付きで返す: `src/fast_path.rs` の `RawApplyOutcome::Bail`（#83 Phase B、pilot は `apply_field_access_raw`）。caller 側で `RawApplyOutcome::Bail` の時は `process_input` 経由で `Filter::execute_cb` に落とすと、Phase A の typed probe + generic eval が引き継ぐ。inline `match raw[0]` の implicit fall-through だと「commit point」が review で見えないので、新規 apply-site は必ずこの形を踏襲する。
+- 新しい raw-byte fast path を足す時は、**非期待型の入力でも正しく error を raise する**ように書くか、そうでないなら入力型を先頭バイトで判別して bail。bail は構造的に名前付きで返す: `src/fast_path.rs` の `RawApplyOutcome::Bail`（#83 Phase B、pilot は `apply_field_access_raw`）。caller 側で `RawApplyOutcome::Bail` の時は `process_input` 経由で `Filter::execute_cb` に落とすと、Phase A の typed probe + generic eval が引き継ぐ。inline `match raw[0]` の implicit fall-through だと「commit point」が review で見えないので、新規 apply-site は必ずこの形を踏襲する。`tests/enforce_raw_apply_bail.rs` が `pub fn apply_*_raw` 全件について `-> RawApplyOutcome` 返り値と本体内の `RawApplyOutcome::Bail` 出現を静的に検査する。
 - 検出（手動）: `diff ループ` で `f` と `(f)?` の両方を jq と突き合わせる。`(f)?` だけ divergence したら null-masking。
 - 検出（自動・常設）: `tests/fuzz_error_wrap.rs` (#172) が
   ランダムな single-valued な `(filter, input)` を生成して、jq が error する時

--- a/tests/enforce_closure_op_env_seeding.allowlist
+++ b/tests/enforce_closure_op_env_seeding.allowlist
@@ -1,0 +1,23 @@
+# Closure-op tags exempted from the
+# `tests/enforce_closure_op_env_seeding.rs` env-seeding check.
+#
+# Format: `<tag>` per line (without the `__` … `__:` wrapper). Anything
+# after the tag on the same line is treated as a comment.
+#
+# A tag belongs here only if it is NOT an eval-delegation dispatcher —
+# i.e. its handler never calls `eval_*_standalone` or `eval::eval` with
+# the delegated expression, so a delegated `eval::Env` is never built.
+#
+# Currently exempted tags:
+#
+# - `loc`     — `__loc__:<file>:<line>` carries a constant value emitted
+#               by `JitOp::CallBuiltin` and the handler just constructs
+#               a `{"file":..., "line":...}` literal. No eval delegation.
+#
+# - `jqerror` — `__jqerror__:` is a runtime error-message prefix used by
+#               `set_jit_error` / try-catch unwinding to disambiguate
+#               jq-raised errors from host panics. It is not a closure-op
+#               dispatcher.
+
+loc       constant value, no eval delegation
+jqerror   error-message marker, no eval delegation

--- a/tests/enforce_closure_op_env_seeding.rs
+++ b/tests/enforce_closure_op_env_seeding.rs
@@ -1,0 +1,194 @@
+//! Enforce maintenance.md §3 "JIT → eval 委譲時の env seeding": every
+//! `__<op>__:` runtime dispatcher in `src/jit.rs` that delegates to the
+//! eval interpreter must seed its `eval::Env` via `new_delegated_env`
+//! or `reset_delegated_env`.
+//!
+//! `__<op>__:` tags surface in two places:
+//!
+//! * **emitters** — `format!("__<op>__:...")` calls inside JIT op
+//!   construction, which embed the tag in a `JitOp::CallBuiltin` name.
+//! * **dispatchers** — `name.strip_prefix("__<op>__:")` arms in the
+//!   runtime trampoline, which decode the tag and invoke the matching
+//!   eval-side `eval_*_standalone` helper.
+//!
+//! Dispatchers that build a fresh `Env` must call `new_delegated_env`
+//! (or `reset_delegated_env` for cached envs) so JIT-set let-bindings
+//! are seeded into the delegated env. A bare `Env::new(...)` here is
+//! how the `(.a, .b) += 100` regression slipped in.
+//!
+//! Some tags are not eval-delegation dispatchers — `__loc__:` returns a
+//! constant from a JIT-side parser literal, `__jqerror__:` is a runtime
+//! error-message marker — and they live in
+//! `tests/enforce_closure_op_env_seeding.allowlist` with the reason.
+
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+const TARGET_FILE: &str = "src/jit.rs";
+
+fn read_target() -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(TARGET_FILE);
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("read {}: {}", TARGET_FILE, e))
+}
+
+/// Collect every `__<name>__:` tag literal from string-quoted contexts
+/// (`"__loc__:..."`, `format!("__loc__:...")`, `strip_prefix("__loc__:")`).
+fn collect_tags(src: &str) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    let bytes = src.as_bytes();
+    let needle = b"\"__";
+    let mut i = 0;
+    while i + needle.len() < bytes.len() {
+        if &bytes[i..i + needle.len()] == needle {
+            // Scan forward to find the closing `__` followed by `:`.
+            let mut j = i + 3;
+            while j + 3 < bytes.len() {
+                if &bytes[j..j + 3] == b"__:" {
+                    let name = &src[i + 3..j];
+                    if name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+                        && !name.is_empty()
+                    {
+                        out.insert(name.to_string());
+                    }
+                    break;
+                }
+                if bytes[j] == b'"' || bytes[j] == b'\n' { break; }
+                j += 1;
+            }
+            i = j + 1;
+            continue;
+        }
+        i += 1;
+    }
+    out
+}
+
+/// Find the dispatcher handler block for a given tag: the block of code
+/// starting at `name.strip_prefix("__<tag>__:")` and ending at the next
+/// `if let Some(rest) = name.strip_prefix(` or `if name ==` line, or EOF.
+fn extract_handler_block<'a>(src: &'a str, tag: &str) -> Option<&'a str> {
+    let needle = format!("name.strip_prefix(\"__{}__:\")", tag);
+    let start = src.find(&needle)?;
+    // Walk forward from `start` to find the matching `}` at brace depth 0
+    // relative to this `if let` block, OR until we hit the next dispatcher
+    // arm at the outer level.
+    let bytes = src.as_bytes();
+    let mut depth: i32 = 0;
+    let mut seen_brace = false;
+    let mut i = start;
+    while i < bytes.len() {
+        let ch = bytes[i];
+        if ch == b'{' { depth += 1; seen_brace = true; }
+        else if ch == b'}' { depth -= 1; }
+        if seen_brace && depth == 0 { return Some(&src[start..=i]); }
+        i += 1;
+    }
+    Some(&src[start..])
+}
+
+fn load_allowlist() -> BTreeSet<String> {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/enforce_closure_op_env_seeding.allowlist");
+    let content = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("read allowlist: {}", e));
+    let mut out = BTreeSet::new();
+    for (n, raw) in content.lines().enumerate() {
+        let line = raw.trim();
+        if line.is_empty() || line.starts_with('#') { continue; }
+        // Allowlist line format: `<tag>` (rest of line is comment/justification).
+        let tag = line.split_whitespace().next()
+            .unwrap_or_else(|| panic!("allowlist line {}: empty", n + 1));
+        out.insert(tag.to_string());
+    }
+    out
+}
+
+#[test]
+fn closure_op_dispatchers_seed_delegated_env() {
+    let src = read_target();
+    let tags = collect_tags(&src);
+    let allowed = load_allowlist();
+
+    eprintln!();
+    eprintln!("=== closure-op dispatcher env-seeding enforcement ===");
+    eprintln!("target:      {}", TARGET_FILE);
+    eprintln!("tags found:  {:?}", tags);
+    eprintln!("allowlisted: {:?}", allowed);
+
+    // Sanity: known tags must be present (catches a parser breakage).
+    for required in ["assign", "update", "path", "paths_filtered", "closure_op"] {
+        assert!(
+            tags.contains(required),
+            "tag parser sanity: expected to find `__{}__:` literal in {}",
+            required, TARGET_FILE,
+        );
+    }
+
+    let mut missing_seeding: Vec<String> = Vec::new();
+    let mut no_dispatcher: Vec<String> = Vec::new();
+    let mut stale_allowlist: Vec<String> = Vec::new();
+
+    for tag in &tags {
+        if allowed.contains(tag) { continue; }
+        let Some(block) = extract_handler_block(&src, tag) else {
+            // No `strip_prefix` dispatcher for this tag — it's an emitter-only
+            // literal (e.g. a regex pattern or a comment). Skip silently.
+            no_dispatcher.push(tag.clone());
+            continue;
+        };
+        let has_seed = block.contains("new_delegated_env(")
+            || block.contains("reset_delegated_env(");
+        if !has_seed {
+            missing_seeding.push(tag.clone());
+        }
+    }
+
+    for tag in &allowed {
+        if !tags.contains(tag) {
+            stale_allowlist.push(tag.clone());
+        }
+    }
+
+    if !missing_seeding.is_empty() {
+        eprintln!();
+        eprintln!("=== Closure-op dispatchers missing env seeding ===");
+        for tag in &missing_seeding {
+            eprintln!("  __{}__:", tag);
+        }
+        eprintln!();
+        eprintln!("Each dispatcher must construct its delegated `eval::Env`");
+        eprintln!("via `new_delegated_env(&[&delegated_expr, ...])` (fresh) or");
+        eprintln!("`reset_delegated_env(&env, &[&delegated_expr, ...])` (cached)");
+        eprintln!("so JIT-set let-bindings are seeded into the env.");
+        eprintln!();
+        eprintln!("If a tag genuinely does not delegate to eval (e.g. a constant");
+        eprintln!("emitter like `__loc__:` or an error-message marker like");
+        eprintln!("`__jqerror__:`), add it to the allowlist with a justifying");
+        eprintln!("comment.");
+        eprintln!();
+        eprintln!("See maintenance.md §3 \"JIT → eval 委譲時の env seeding\".");
+    }
+
+    if !no_dispatcher.is_empty() {
+        eprintln!();
+        eprintln!("=== Tags with no dispatcher arm (informational) ===");
+        for tag in &no_dispatcher {
+            eprintln!("  __{}__:", tag);
+        }
+    }
+
+    if !stale_allowlist.is_empty() {
+        eprintln!();
+        eprintln!("=== Stale allowlist entries ===");
+        for tag in &stale_allowlist {
+            eprintln!("  __{}__:  no longer found in {}", tag, TARGET_FILE);
+        }
+    }
+
+    assert!(
+        missing_seeding.is_empty() && stale_allowlist.is_empty(),
+        "closure-op env seeding: {} dispatcher(s) missing seeding, {} stale allowlist entries",
+        missing_seeding.len(), stale_allowlist.len(),
+    );
+}

--- a/tests/enforce_collect_loadvar_exhaustive.rs
+++ b/tests/enforce_collect_loadvar_exhaustive.rs
@@ -1,0 +1,142 @@
+//! Enforce maintenance.md §3 "JIT → eval 委譲時の env seeding":
+//! `Flattener::collect_loadvar_indices` (in `src/jit.rs`) must mention every
+//! `Expr` variant defined in `src/ir.rs`.
+//!
+//! Every JIT→eval closure-op dispatcher walks the delegated expression with
+//! this helper to seed `$var`s into the freshly-built `eval::Env`. A missing
+//! variant silently drops any `LoadVar` buried inside (an Index, an
+//! ObjectConstruct pair, a StringInterpolation expression part, a CallBuiltin
+//! arg, ...) and the closure op runs against a `null`-shaped env.
+//!
+//! This test parses the `Expr` enum out of `src/ir.rs` and the body of
+//! `collect_loadvar_indices` out of `src/jit.rs`, then asserts that every
+//! variant name appears at least once in the function body — either in an
+//! explicit recurse arm or in a no-children leaf arm. Add a new variant and
+//! forget to extend the walker → this test fails with the missing names.
+
+use std::path::PathBuf;
+
+fn read_source(rel: &str) -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(rel);
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("read {}: {}", rel, e))
+}
+
+/// Extract every variant identifier from `pub enum Expr { ... }` in ir.rs.
+///
+/// Tracks brace depth so we only consider lines at the enum body's top
+/// level (depth 0). Struct-variant fields like `cond: Box<Expr>` live at
+/// deeper depth and are skipped.
+fn parse_expr_variants(src: &str) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    let mut in_enum = false;
+    let mut depth: i32 = 0;
+    for line in src.lines() {
+        if !in_enum {
+            if line.contains("pub enum Expr {") {
+                in_enum = true;
+            }
+            continue;
+        }
+        let code = match line.find("//") {
+            Some(i) => &line[..i],
+            None => line,
+        };
+        let trimmed = code.trim();
+        if depth == 0 && !trimmed.is_empty() {
+            let first = trimmed.chars().next().unwrap();
+            if first == '}' { break; }
+            if first.is_ascii_uppercase() {
+                let name: String = trimmed.chars()
+                    .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
+                    .collect();
+                if !name.is_empty() && !out.contains(&name) {
+                    out.push(name);
+                }
+            }
+        }
+        for ch in code.chars() {
+            if ch == '{' { depth += 1; }
+            if ch == '}' { depth -= 1; }
+        }
+    }
+    out
+}
+
+/// Extract the body text of a function definition by name.
+///
+/// Scans for `fn <name>(` (any leading visibility / qualifiers), then walks
+/// braces from the opening `{` to its matching `}` and returns the slice
+/// between them.
+fn extract_fn_body<'a>(src: &'a str, name: &str) -> &'a str {
+    let needle = format!("fn {}(", name);
+    let start = src.find(&needle)
+        .unwrap_or_else(|| panic!("could not find `fn {}(` in source", name));
+    let brace = src[start..].find('{')
+        .unwrap_or_else(|| panic!("no opening brace after `fn {}`", name));
+    let body_start = start + brace + 1;
+    let mut depth: i32 = 1;
+    let bytes = src.as_bytes();
+    let mut i = body_start;
+    while i < bytes.len() && depth > 0 {
+        match bytes[i] {
+            b'{' => depth += 1,
+            b'}' => depth -= 1,
+            _ => {}
+        }
+        if depth == 0 { return &src[body_start..i]; }
+        i += 1;
+    }
+    panic!("could not find matching `}}` for `fn {}`", name);
+}
+
+#[test]
+fn collect_loadvar_indices_covers_every_expr_variant() {
+    let ir_src = read_source("src/ir.rs");
+    let jit_src = read_source("src/jit.rs");
+
+    let variants = parse_expr_variants(&ir_src);
+    assert!(
+        variants.len() > 20,
+        "Expr variant parser sanity check failed: only {} variants extracted ({:?})",
+        variants.len(), variants,
+    );
+
+    let body = extract_fn_body(&jit_src, "collect_loadvar_indices");
+
+    let mut missing: Vec<&str> = Vec::new();
+    for v in &variants {
+        let token = format!("Expr::{}", v);
+        if !body.contains(&token) {
+            missing.push(v.as_str());
+        }
+    }
+
+    eprintln!();
+    eprintln!("=== `collect_loadvar_indices` Expr exhaustiveness ===");
+    eprintln!("parsed Expr variants:  {}", variants.len());
+    eprintln!("walker mentions:       {}", variants.len() - missing.len());
+
+    if !missing.is_empty() {
+        eprintln!();
+        eprintln!("=== Expr variants missing from `collect_loadvar_indices` ===");
+        for v in &missing {
+            eprintln!("  Expr::{}", v);
+        }
+        eprintln!();
+        eprintln!("Every variant must appear at least once in");
+        eprintln!("`Flattener::collect_loadvar_indices` (src/jit.rs). For variants");
+        eprintln!("that hold sub-expressions, recurse into each one. For leaf");
+        eprintln!("variants without sub-expressions, add them to the no-children");
+        eprintln!("arm. Skipping a variant silently drops any `$var` buried inside");
+        eprintln!("the delegated expression, which degrades JIT→eval closure ops");
+        eprintln!("to a null-seeded env (see maintenance.md §3 \"JIT → eval");
+        eprintln!("委譲時の env seeding\").");
+    }
+
+    assert!(
+        missing.is_empty(),
+        "collect_loadvar_indices missing {} Expr variant(s): {:?}",
+        missing.len(), missing,
+    );
+}

--- a/tests/enforce_is_single_valued.allowlist
+++ b/tests/enforce_is_single_valued.allowlist
@@ -1,0 +1,103 @@
+# Classification of every `Expr` variant for the `is_single_valued_expr`
+# helper in `src/interpreter.rs` (maintenance.md §3
+# "`[gen] | add` は single-valued 要素のみ畳める").
+#
+# Format: `<Variant>  <classification>` per line.
+# Anything else on the line is treated as a comment.
+#
+# Classifications:
+#
+#   reject           — explicit `Expr::X { .. } => false` arm. For variants
+#                      that yield 0 or many values (generator-ish). The
+#                      `[gen] | add` rewrite must not fold these.
+#
+#   accept_explicit  — explicit `Expr::X { .. } => true` (or in a `| ... =>`
+#                      group). For leaf variants known to always yield
+#                      exactly one value.
+#
+#   recurse          — explicit arm that delegates the decision to
+#                      sub-expressions (e.g. Pipe checks both sides).
+#
+#   default_false    — falls through to the catch-all `_ => false`. Safe
+#                      default for "we don't know, conservatively assume
+#                      multi-valued". A new variant added with this
+#                      classification can't accidentally enable a
+#                      generator-folding rewrite.
+#
+# Adding a new `Expr` variant without updating this allowlist fails the
+# enforcement test in `tests/enforce_is_single_valued.rs`, forcing a
+# deliberate classification choice.
+
+# --- accept: yields exactly one value ---
+Input               accept_explicit
+Literal             accept_explicit
+LoadVar             accept_explicit
+Not                 accept_explicit
+Slice               accept_explicit
+StringInterpolation accept_explicit
+ObjectConstruct     accept_explicit
+RegexTest           accept_explicit
+RegexSub            accept_explicit
+RegexGsub           accept_explicit
+Collect             accept_explicit
+
+# --- recurse: depends on sub-expressions ---
+BinOp               recurse
+UnaryOp             recurse
+Negate              recurse
+Index               recurse
+Pipe                recurse
+IfThenElse          recurse
+Alternative         recurse
+LetBinding          recurse
+
+# --- reject: generator-ish, yields 0 or many ---
+Empty               reject
+Each                reject
+EachOpt             reject
+Comma               reject
+Recurse             reject
+Range               reject
+Limit               reject
+RegexMatch          reject
+RegexScan           reject
+RegexCapture        reject
+IndexOpt            reject
+TryCatch            reject
+
+# --- default_false: conservatively assume multi-valued / unknown ---
+# These currently fall through to `_ => false`. Promote to an explicit
+# classification (and add an arm to `is_single_valued_expr`) only with a
+# matching audit — promoting to `accept_explicit` is what enables a
+# `[gen] | add` rewrite to fold a previously-rejected shape.
+Reduce              default_false
+Foreach             default_false
+Label               default_false
+Break               default_false
+Update              default_false
+Assign              default_false
+PathExpr            default_false
+SetPath             default_false
+GetPath             default_false
+DelPaths            default_false
+FuncCall            default_false
+While               default_false
+Until               default_false
+Repeat              default_false
+AllShort            default_false
+AnyShort            default_false
+Error               default_false
+Format              default_false
+ClosureOp           default_false
+AlternativeDestructure default_false
+Loc                 default_false
+Env                 default_false
+Builtins            default_false
+ReadInput           default_false
+ReadInputs          default_false
+Debug               default_false
+Stderr              default_false
+ModuleMeta          default_false
+GenLabel            default_false
+CallBuiltin         default_false
+Memoize             default_false

--- a/tests/enforce_is_single_valued.rs
+++ b/tests/enforce_is_single_valued.rs
@@ -1,0 +1,232 @@
+//! Enforce maintenance.md §3 "`[gen] | add` は single-valued 要素のみ畳める":
+//! every `Expr` variant must have a deliberate classification in
+//! `is_single_valued_expr` (`src/interpreter.rs`), driven by an external
+//! allowlist that classifies each variant as:
+//!
+//! * `reject`           — explicit reject arm returning `false`, for variants
+//!                        that yield 0 or many values (Empty, Each, Comma,
+//!                        Recurse, Range, Limit, IndexOpt, TryCatch, regex
+//!                        multi-emitters, ...).
+//! * `accept_explicit`  — explicit accept arm returning `true`, for leaf
+//!                        variants known to always yield exactly one value
+//!                        (Input, Literal, LoadVar, Collect, ...).
+//! * `recurse`          — explicit recurse arm that delegates the decision
+//!                        to sub-expressions (Pipe, IfThenElse, BinOp,
+//!                        Alternative, ...).
+//! * `default_false`    — falls through to the catch-all `_ => false`. Safe
+//!                        default for "we don't know, conservatively assume
+//!                        multi-valued" so a new variant can't accidentally
+//!                        enable a generator-folding rewrite.
+//!
+//! Adding a new `Expr` variant without updating the allowlist fails this
+//! test, forcing a deliberate classification choice. Forgetting to add the
+//! variant to `is_single_valued_expr` itself when the allowlist says
+//! `reject`/`accept_explicit`/`recurse` also fails, with a useful message.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+fn read_source(rel: &str) -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(rel);
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("read {}: {}", rel, e))
+}
+
+fn parse_expr_variants(src: &str) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    let mut in_enum = false;
+    let mut depth: i32 = 0;
+    for line in src.lines() {
+        if !in_enum {
+            if line.contains("pub enum Expr {") { in_enum = true; }
+            continue;
+        }
+        let code = match line.find("//") { Some(i) => &line[..i], None => line };
+        let trimmed = code.trim();
+        if depth == 0 && !trimmed.is_empty() {
+            let first = trimmed.chars().next().unwrap();
+            if first == '}' { break; }
+            if first.is_ascii_uppercase() {
+                let name: String = trimmed.chars()
+                    .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
+                    .collect();
+                if !name.is_empty() && !out.contains(&name) {
+                    out.push(name);
+                }
+            }
+        }
+        for ch in code.chars() {
+            if ch == '{' { depth += 1; }
+            if ch == '}' { depth -= 1; }
+        }
+    }
+    out
+}
+
+fn extract_fn_body<'a>(src: &'a str, name: &str) -> &'a str {
+    let needle = format!("fn {}(", name);
+    let start = src.find(&needle)
+        .unwrap_or_else(|| panic!("could not find `fn {}(` in source", name));
+    let brace = src[start..].find('{')
+        .unwrap_or_else(|| panic!("no opening brace after `fn {}`", name));
+    let body_start = start + brace + 1;
+    let mut depth: i32 = 1;
+    let bytes = src.as_bytes();
+    let mut i = body_start;
+    while i < bytes.len() && depth > 0 {
+        match bytes[i] {
+            b'{' => depth += 1,
+            b'}' => depth -= 1,
+            _ => {}
+        }
+        if depth == 0 { return &src[body_start..i]; }
+        i += 1;
+    }
+    panic!("could not find matching `}}` for `fn {}`", name);
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Classification { Reject, AcceptExplicit, Recurse, DefaultFalse }
+
+fn load_allowlist() -> BTreeMap<String, Classification> {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/enforce_is_single_valued.allowlist");
+    let content = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("read allowlist: {}", e));
+    let mut out: BTreeMap<String, Classification> = BTreeMap::new();
+    for (n, raw) in content.lines().enumerate() {
+        let line = raw.trim();
+        if line.is_empty() || line.starts_with('#') { continue; }
+        let mut iter = line.split_whitespace();
+        let variant = iter.next()
+            .unwrap_or_else(|| panic!("allowlist line {}: empty variant", n + 1));
+        let kind = iter.next()
+            .unwrap_or_else(|| panic!("allowlist line {}: missing classification", n + 1));
+        let classification = match kind {
+            "reject" => Classification::Reject,
+            "accept_explicit" => Classification::AcceptExplicit,
+            "recurse" => Classification::Recurse,
+            "default_false" => Classification::DefaultFalse,
+            other => panic!(
+                "allowlist line {}: unknown classification `{}` (expected reject / accept_explicit / recurse / default_false)",
+                n + 1, other,
+            ),
+        };
+        if out.insert(variant.to_string(), classification).is_some() {
+            panic!("allowlist line {}: duplicate entry for `{}`", n + 1, variant);
+        }
+    }
+    out
+}
+
+#[test]
+fn is_single_valued_expr_classifies_every_variant() {
+    let ir_src = read_source("src/ir.rs");
+    let interp_src = read_source("src/interpreter.rs");
+    let variants = parse_expr_variants(&ir_src);
+    let allowlist = load_allowlist();
+    let body = extract_fn_body(&interp_src, "is_single_valued_expr");
+
+    eprintln!();
+    eprintln!("=== `is_single_valued_expr` variant-classification enforcement ===");
+    eprintln!("parsed Expr variants: {}", variants.len());
+    eprintln!("allowlist entries:    {}", allowlist.len());
+
+    let mut unclassified: Vec<String> = Vec::new();
+    let mut stale_allowlist: Vec<String> = Vec::new();
+    let mut missing_in_body: Vec<(String, Classification)> = Vec::new();
+    let mut unexpected_in_body: Vec<String> = Vec::new();
+
+    for v in &variants {
+        if !allowlist.contains_key(v) {
+            unclassified.push(v.clone());
+        }
+    }
+    for v in allowlist.keys() {
+        if !variants.contains(v) {
+            stale_allowlist.push(v.clone());
+        }
+    }
+
+    // Catch-all sanity: the body must end with `_ => false` so the
+    // `default_false` classification is meaningfully enforced.
+    assert!(
+        body.contains("_ => false"),
+        "`is_single_valued_expr` must include a `_ => false` catch-all arm",
+    );
+
+    for v in &variants {
+        let token = format!("Expr::{}", v);
+        let appears = body.contains(&token);
+        match allowlist.get(v) {
+            None => continue, // already flagged as unclassified
+            Some(Classification::Reject)
+            | Some(Classification::AcceptExplicit)
+            | Some(Classification::Recurse) => {
+                if !appears {
+                    missing_in_body.push((v.clone(), *allowlist.get(v).unwrap()));
+                }
+            }
+            Some(Classification::DefaultFalse) => {
+                if appears {
+                    unexpected_in_body.push(v.clone());
+                }
+            }
+        }
+    }
+
+    if !unclassified.is_empty() {
+        eprintln!();
+        eprintln!("=== Expr variants missing from allowlist ===");
+        for v in &unclassified {
+            eprintln!("  {}", v);
+        }
+        eprintln!();
+        eprintln!("Each new variant needs a deliberate classification in");
+        eprintln!("`tests/enforce_is_single_valued.allowlist`:");
+        eprintln!("  reject           — explicit `false` arm (generator-like)");
+        eprintln!("  accept_explicit  — explicit `true` arm (always 1 value)");
+        eprintln!("  recurse          — explicit recurse arm (delegates to children)");
+        eprintln!("  default_false    — falls through to `_ => false` (safe default)");
+    }
+
+    if !stale_allowlist.is_empty() {
+        eprintln!();
+        eprintln!("=== Stale allowlist entries (Expr variant no longer exists) ===");
+        for v in &stale_allowlist {
+            eprintln!("  {}", v);
+        }
+    }
+
+    if !missing_in_body.is_empty() {
+        eprintln!();
+        eprintln!("=== Variants classified non-default but missing from `is_single_valued_expr` ===");
+        for (v, c) in &missing_in_body {
+            eprintln!("  Expr::{:<26}  classified `{:?}`", v, c);
+        }
+        eprintln!();
+        eprintln!("Either add the explicit arm to `is_single_valued_expr` in");
+        eprintln!("`src/interpreter.rs`, or downgrade the classification to");
+        eprintln!("`default_false` in the allowlist.");
+    }
+
+    if !unexpected_in_body.is_empty() {
+        eprintln!();
+        eprintln!("=== Variants classified `default_false` but explicitly mentioned in body ===");
+        for v in &unexpected_in_body {
+            eprintln!("  Expr::{}", v);
+        }
+        eprintln!();
+        eprintln!("Either remove the explicit arm or upgrade the classification");
+        eprintln!("(reject / accept_explicit / recurse) in the allowlist.");
+    }
+
+    assert!(
+        unclassified.is_empty()
+            && stale_allowlist.is_empty()
+            && missing_in_body.is_empty()
+            && unexpected_in_body.is_empty(),
+        "is_single_valued_expr classification: {} unclassified, {} stale, {} missing-in-body, {} unexpected-in-body",
+        unclassified.len(), stale_allowlist.len(), missing_in_body.len(), unexpected_in_body.len(),
+    );
+}

--- a/tests/enforce_jit_env_seeding.allowlist
+++ b/tests/enforce_jit_env_seeding.allowlist
@@ -1,0 +1,25 @@
+# Grandfathered bare `Rc::new(RefCell::new(crate::eval::Env::new(...)))`
+# sites in src/jit.rs. Format: `<path>  <count>`.
+#
+# `tests/enforce_jit_env_seeding.rs` enforces this count exactly: any new
+# bare construction site (regression of maintenance.md §3 "JIT → eval
+# 委譲時の env seeding") fails the test, and reducing the count without
+# updating this file also fails.
+#
+# Shrink-only policy: route the site through `new_delegated_env` /
+# `reset_delegated_env` and lower the count here. When the count reaches
+# zero, remove the line. The goal is for `new_delegated_env` to be the
+# only place that calls `Env::new` directly.
+#
+# Currently allowlisted sites (all in src/jit.rs):
+#
+# - Two `thread_local!` cache `get_or_insert_with` closures that build the
+#   cached `eval::Env` lazily and call `reset_delegated_env` immediately
+#   after to seed it. (Sites: the `PATHS_FILTER_ENV` cache in the
+#   `__paths_filtered__:` handler and the `CLOSURE_OP_ENV` cache in the
+#   `__closure_op__:` handler.) These satisfy the invariant in practice
+#   because the seeding happens inline; the test for closure-op env
+#   seeding (tests/enforce_closure_op_env_seeding.rs) verifies that.
+# - The body of `new_delegated_env` itself, which IS the helper.
+
+src/jit.rs  3

--- a/tests/enforce_jit_env_seeding.rs
+++ b/tests/enforce_jit_env_seeding.rs
@@ -1,0 +1,98 @@
+//! Enforce maintenance.md §3 "JIT → eval 委譲時の env seeding": every
+//! delegated `eval::Env` constructed inside `src/jit.rs` must go through
+//! `new_delegated_env` / `reset_delegated_env`, not a bare
+//! `Rc::new(RefCell::new(crate::eval::Env::new(...)))`.
+//!
+//! The seeding helpers walk the delegated expression with
+//! `Flattener::collect_loadvar_indices` and copy every `$var` it references
+//! out of the JIT env. Skipping them is the failure mode behind the
+//! `(.a, .b) += 100` regression where `$r` from the parser-emitted
+//! `let $r = 100 in update(...)` was silently lost and the update no-op'd.
+//!
+//! A new bare `Rc::new(RefCell::new(crate::eval::Env::new(...)))` in
+//! `src/jit.rs` makes this test fail with a useful message. The three
+//! currently grandfathered sites (the body of `new_delegated_env` itself
+//! plus the two `thread_local!` cache `get_or_insert_with` blocks that
+//! call `reset_delegated_env` immediately after) live in
+//! `tests/enforce_jit_env_seeding.allowlist`.
+
+use std::path::PathBuf;
+
+const GUARDED_PATTERN: &str = "Rc::new(RefCell::new(crate::eval::Env::new(";
+const TARGET_FILE: &str = "src/jit.rs";
+
+fn count_hits() -> usize {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(TARGET_FILE);
+    let content = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("read {}: {}", TARGET_FILE, e));
+    content.matches(GUARDED_PATTERN).count()
+}
+
+fn load_allowed_count() -> usize {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/enforce_jit_env_seeding.allowlist");
+    let content = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("read allowlist: {}", e));
+    let mut out: Option<usize> = None;
+    for (n, raw) in content.lines().enumerate() {
+        let line = raw.trim();
+        if line.is_empty() || line.starts_with('#') { continue; }
+        let Some((file, count_str)) = line.rsplit_once(char::is_whitespace) else {
+            panic!("allowlist line {}: expected `<path>  <count>` (got `{}`)", n + 1, raw);
+        };
+        let file = file.trim();
+        let count: usize = count_str.trim().parse()
+            .unwrap_or_else(|_| panic!("allowlist line {}: `{}` is not a valid count", n + 1, count_str));
+        if file != TARGET_FILE {
+            panic!("allowlist line {}: only {} is allowed, got `{}`", n + 1, TARGET_FILE, file);
+        }
+        if out.is_some() {
+            panic!("allowlist has multiple entries for {}", TARGET_FILE);
+        }
+        out = Some(count);
+    }
+    out.unwrap_or_else(|| panic!("allowlist missing entry for {}", TARGET_FILE))
+}
+
+#[test]
+fn jit_delegated_env_construction_routes_through_helpers() {
+    let actual = count_hits();
+    let allowed = load_allowed_count();
+
+    eprintln!();
+    eprintln!("=== JIT → eval delegated Env construction enforcement ===");
+    eprintln!("pattern:     {}", GUARDED_PATTERN);
+    eprintln!("target:      {}", TARGET_FILE);
+    eprintln!("allowlisted: {}", allowed);
+    eprintln!("actual:      {}", actual);
+
+    if actual > allowed {
+        eprintln!();
+        eprintln!("=== New bare `Env::new(...)` construction in {} ===", TARGET_FILE);
+        eprintln!("Was {} sites, now {}.\n", allowed, actual);
+        eprintln!("Route through one of:");
+        eprintln!("  new_delegated_env(&[&delegated_expr, ...])     // fresh Env, auto-seeds $vars");
+        eprintln!("  reset_delegated_env(&env, &[&delegated_expr])  // cached Env, re-seeds $vars");
+        eprintln!();
+        eprintln!("These helpers walk the delegated expression with");
+        eprintln!("Flattener::collect_loadvar_indices and copy every $var the");
+        eprintln!("delegated expression references out of the JIT env. Skipping");
+        eprintln!("them is what broke `(.a, .b) += 100` (see maintenance.md §3");
+        eprintln!("\"JIT → eval 委譲時の env seeding\").");
+        eprintln!();
+        eprintln!("If a new bare site is genuinely necessary (e.g. a new cached-Env");
+        eprintln!("thread_local that calls reset_delegated_env immediately after");
+        eprintln!("get_or_insert_with), bump the allowlist count with a justifying");
+        eprintln!("comment.");
+    } else if actual < allowed {
+        eprintln!();
+        eprintln!("=== Fewer bare `Env::new(...)` sites than allowlisted ===");
+        eprintln!("Was {}, now {} — update tests/enforce_jit_env_seeding.allowlist.", allowed, actual);
+    }
+
+    assert_eq!(
+        actual, allowed,
+        "JIT env seeding enforcement: expected {} bare `Env::new(...)` in {}, found {}",
+        allowed, TARGET_FILE, actual,
+    );
+}

--- a/tests/enforce_raw_apply_bail.rs
+++ b/tests/enforce_raw_apply_bail.rs
@@ -1,0 +1,144 @@
+//! Enforce maintenance.md §3 "Fast path と `?` / `try` の相互作用": every
+//! `pub fn apply_*_raw` in `src/fast_path.rs` must return `RawApplyOutcome`
+//! AND mention `RawApplyOutcome::Bail` in its body.
+//!
+//! The `RawApplyOutcome` return shape (#83 Phase B) replaced implicit
+//! `match raw[0]` fall-throughs that silently emitted `null` for
+//! non-expected input types — the null-masking class of #50. Any new
+//! raw apply-site that elides the `Bail` outcome regresses the
+//! invariant: the missing type-check ships as a silent `null` cell.
+//!
+//! This test enumerates `pub fn apply_*_raw` from `src/fast_path.rs` and
+//! verifies the contract structurally. It is a static contract check,
+//! not a semantic correctness check — a function that returns
+//! `RawApplyOutcome::Emit` for all paths still fails to encode "no
+//! type-mismatch is possible", so the assertion catches the canonical
+//! "forgot the bail" shape without false positives.
+
+use std::path::PathBuf;
+
+const TARGET_FILE: &str = "src/fast_path.rs";
+
+fn read_target() -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(TARGET_FILE);
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("read {}: {}", TARGET_FILE, e))
+}
+
+/// One `pub fn apply_*_raw` declaration in source order.
+struct ApplySite {
+    name: String,
+    /// Concatenated signature text from `pub fn` to the opening `{` of the body.
+    signature: String,
+    /// Body text between the opening `{` and matching `}` (exclusive).
+    body: String,
+}
+
+/// Enumerate `pub fn apply_*_raw` sites by line, terminating each at the
+/// next line that begins with `}` at column 0 (the canonical rustfmt
+/// shape for top-level function bodies). This avoids the need to
+/// brace-balance through string literals, char literals, and comments.
+fn enumerate_apply_sites(src: &str) -> Vec<ApplySite> {
+    let lines: Vec<&str> = src.lines().collect();
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i < lines.len() {
+        let line = lines[i];
+        if !line.starts_with("pub fn apply_") {
+            i += 1;
+            continue;
+        }
+        let after_fn = &line[7..];
+        let name: String = after_fn.chars()
+            .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
+            .collect();
+        if !name.starts_with("apply_") || !name.ends_with("_raw") {
+            i += 1;
+            continue;
+        }
+        // Signature = lines from `pub fn` up to and including the line
+        // containing the opening `{` of the body.
+        let mut sig_end = i;
+        while sig_end < lines.len() && !lines[sig_end].contains('{') {
+            sig_end += 1;
+        }
+        let signature = lines[i..=sig_end.min(lines.len() - 1)].join("\n");
+        // Body = lines after sig_end up to the first line starting with
+        // `}` at column 0.
+        let body_start = sig_end + 1;
+        let mut body_end = body_start;
+        while body_end < lines.len() && !lines[body_end].starts_with('}') {
+            body_end += 1;
+        }
+        let body = lines[body_start..body_end].join("\n");
+        out.push(ApplySite { name, signature, body });
+        i = body_end + 1;
+    }
+    out
+}
+
+#[test]
+fn raw_apply_sites_use_bail_outcome() {
+    let src = read_target();
+    let sites = enumerate_apply_sites(&src);
+
+    assert!(
+        sites.len() >= 50,
+        "raw-apply enumerator sanity: only found {} `pub fn apply_*_raw` in {} (expected many more)",
+        sites.len(), TARGET_FILE,
+    );
+
+    eprintln!();
+    eprintln!("=== Raw-apply Bail-outcome enforcement ===");
+    eprintln!("target:                 {}", TARGET_FILE);
+    eprintln!("pub fn apply_*_raw:     {}", sites.len());
+
+    let mut missing_return_type: Vec<String> = Vec::new();
+    let mut missing_bail: Vec<String> = Vec::new();
+
+    for site in &sites {
+        if !site.signature.contains("RawApplyOutcome") {
+            missing_return_type.push(site.name.clone());
+        }
+        if !site.body.contains("RawApplyOutcome::Bail") {
+            missing_bail.push(site.name.clone());
+        }
+    }
+
+    if !missing_return_type.is_empty() {
+        eprintln!();
+        eprintln!("=== `apply_*_raw` not returning `RawApplyOutcome` ===");
+        for n in &missing_return_type {
+            eprintln!("  {}", n);
+        }
+        eprintln!();
+        eprintln!("Raw apply-sites must declare `-> RawApplyOutcome` (or");
+        eprintln!("`-> Result<RawApplyOutcome, _>` etc.) so callers can");
+        eprintln!("distinguish `Emit` from `Bail` and route the bail through");
+        eprintln!("`process_input` → `Filter::execute_cb` (#83 Phase B).");
+    }
+
+    if !missing_bail.is_empty() {
+        eprintln!();
+        eprintln!("=== `apply_*_raw` body missing `RawApplyOutcome::Bail` ===");
+        for n in &missing_bail {
+            eprintln!("  {}", n);
+        }
+        eprintln!();
+        eprintln!("Every raw fast path must have an explicit bail exit: any input");
+        eprintln!("shape the apply-site can't guarantee jq-compatible semantics");
+        eprintln!("for MUST `return RawApplyOutcome::Bail`. Implicit");
+        eprintln!("`match raw[0]` fall-through that emits `null` for non-expected");
+        eprintln!("types is the null-masking bug class (#50). If the function");
+        eprintln!("genuinely never bails (e.g. its input was pre-classified by a");
+        eprintln!("detector), document it with a doc-comment that includes the");
+        eprintln!("token `RawApplyOutcome::Bail` so the discipline is still");
+        eprintln!("visible at the apply-site.");
+    }
+
+    assert!(
+        missing_return_type.is_empty() && missing_bail.is_empty(),
+        "raw-apply Bail discipline: {} missing return type, {} missing Bail",
+        missing_return_type.len(), missing_bail.len(),
+    );
+}


### PR DESCRIPTION
## Summary

Promote four maintenance.md §3 invariants from reviewer-attention discipline to mechanical contract tests, plus an enforcement pin for the existing `RawApplyOutcome::Bail` discipline. Closes #684.

Five new `tests/enforce_*.rs` files, each pinning one §3 invariant:

| Test | Invariant | Mechanism |
|---|---|---|
| `enforce_jit_env_seeding` | JIT → eval 委譲時の env seeding | grandfathered count of bare `Env::new` in `src/jit.rs` |
| `enforce_collect_loadvar_exhaustive` | JIT → eval 委譲時の env seeding | every `Expr` variant appears in walker body |
| `enforce_closure_op_env_seeding` | JIT → eval 委譲時の env seeding | every `__<op>__:` dispatcher calls `*_delegated_env` |
| `enforce_is_single_valued` | `[gen] \| add` は single-valued 要素のみ畳める | every `Expr` variant has a deliberate classification |
| `enforce_raw_apply_bail` | Fast path と `?` / `try` の相互作用 | every `pub fn apply_*_raw` returns `RawApplyOutcome` and contains `Bail` |

Allowlists follow the shrink-only convention from `tests/enforce_value_factories.allowlist`. `docs/maintenance.md` §3 cross-references each enforcement test at its narrative.

## Test plan

- [x] `cargo test --release` (21 test binaries, 0 failures)
- [x] Deliberate fault injection: bare `Rc::new(RefCell::new(Env::new(...)))` added inside `new_delegated_env` body → `enforce_jit_env_seeding` fails with "Was 3 sites, now 4" and a "route through one of: new_delegated_env / reset_delegated_env" hint
- [x] Each test file names the §3 invariant verbatim in a top-of-file comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)