### PR TITLE
test: 4-way layer-pinned self-diff harness (#685)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -171,6 +171,33 @@ fn force_interpreter_enabled() -> bool {
     })
 }
 
+/// Layer-pinning knob (issue #685): when `JQJIT_DISABLE_RAW_BYTE` is set,
+/// every `detect_*` raw-byte fast path in this binary is skipped and the
+/// dispatch falls through to `process_input` / `Filter::execute_cb`. JIT
+/// and `simplify_expr` stay on. Combined with `JQJIT_DISABLE_SIMPLIFY`
+/// and `JQJIT_FORCE_INTERPRETER`, this gives the 4-way matrix used by
+/// `tests/selfdiff_layers.rs` to localize divergence to one layer.
+fn disable_raw_byte_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var_os("JQJIT_DISABLE_RAW_BYTE")
+            .map(|v| !v.is_empty() && v != "0")
+            .unwrap_or(false)
+    })
+}
+
+/// Layer-pinning knob (issue #685): when `JQJIT_DISABLE_SIMPLIFY` is set,
+/// the `simplify_expr` rewrite pass short-circuits to identity. The
+/// raw-byte detectors and JIT remain on. See `disable_raw_byte_enabled`.
+fn disable_simplify_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var_os("JQJIT_DISABLE_SIMPLIFY")
+            .map(|v| !v.is_empty() && v != "0")
+            .unwrap_or(false)
+    })
+}
+
 fn jqjit_trace_fast_path(name: &str, filter_text: &str) {
     use std::sync::atomic::{AtomicBool, Ordering};
     static EMITTED: AtomicBool = AtomicBool::new(false);
@@ -2221,6 +2248,8 @@ fn main() {
 
 fn real_main() {
     let mut force_interp = force_interpreter_enabled();
+    let disable_raw_byte = disable_raw_byte_enabled();
+    let disable_simplify = disable_simplify_enabled();
     let mut force_jit = false;
     let mut memo_max_entries: Option<usize> = None;
     let mut debug_memo = false;
@@ -2480,6 +2509,13 @@ fn real_main() {
     if force_interp {
         jq_jit::interpreter::set_force_interpreter(true);
     }
+    // Layer-pinning knob (issue #685). `disable_raw_byte` is consumed
+    // locally below where `use_raw_fast_paths` is computed; the simplify
+    // knob threads into `interpreter::set_disable_simplify` so the
+    // `simplify_expr` pass returns identity.
+    if disable_simplify {
+        jq_jit::interpreter::set_disable_simplify(true);
+    }
 
     let filter_str = match filter_str {
         Some(f) => f,
@@ -2714,8 +2750,13 @@ fn real_main() {
     // Raw byte fast paths bypass Value construction and cannot inject color codes.
     // Disable them when color output is requested.
     // Self-diff mode (#323) also disables them so every filter shape is
-    // serviced by Filter::execute_cb on the eval path.
-    let use_raw_fast_paths = (use_compact_buf || use_pretty_buf) && !color_output && !force_interp;
+    // serviced by Filter::execute_cb on the eval path. Layer-pinning knob
+    // `JQJIT_DISABLE_RAW_BYTE` (#685) is the single gate for the (a) layer
+    // — every `detect_*` site downstream is gated on this one flag.
+    let use_raw_fast_paths = (use_compact_buf || use_pretty_buf)
+        && !color_output
+        && !force_interp
+        && !disable_raw_byte;
 
     // JQJIT_TRACE: emit a single [trace] line naming the first fast path that
     // fires. `trace_detect!` wraps `Option`-returning detectors; `trace_is!`

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -26,6 +26,22 @@ pub fn force_interpreter() -> bool {
     FORCE_INTERPRETER.load(std::sync::atomic::Ordering::Relaxed)
 }
 
+/// Layer-pinning knob for issue #685: when set, [`simplify_expr`] returns its
+/// input unchanged, disabling every fast-path-detection rewrite (the (b)
+/// layer in `docs/maintenance.md` §2). Used by
+/// `tests/selfdiff_layers.rs` to isolate which fast-path layer is
+/// responsible when the 2-way self-diff disagrees.
+static DISABLE_SIMPLIFY: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+pub fn set_disable_simplify(on: bool) {
+    DISABLE_SIMPLIFY.store(on, std::sync::atomic::Ordering::Relaxed);
+}
+
+pub fn disable_simplify() -> bool {
+    DISABLE_SIMPLIFY.load(std::sync::atomic::Ordering::Relaxed)
+}
+
 /// Comparison value: either numeric or string.
 #[derive(Debug, Clone)]
 pub enum CmpVal {
@@ -612,7 +628,14 @@ pub(crate) fn is_single_valued_expr(e: &crate::ir::Expr) -> bool {
 /// Pipe(Input, X) → X, Pipe(X, Input) → X.
 /// Pipe(E, F) → F[E/.] when E is scalar and F has free Input.
 /// Also applies semantic rewrites (to_entries|from_entries → identity).
+///
+/// Short-circuits to identity when [`disable_simplify`] is on (issue #685
+/// layer-pinning knob `JQJIT_DISABLE_SIMPLIFY`). All recursive calls also
+/// route through this guard, so a single top-level guard suffices.
 fn simplify_expr(expr: &crate::ir::Expr) -> crate::ir::Expr {
+    if disable_simplify() {
+        return expr.clone();
+    }
     use crate::ir::{Expr, Literal, UnaryOp};
     match expr {
         Expr::Pipe { left, right } => {

--- a/tests/README.md
+++ b/tests/README.md
@@ -32,6 +32,7 @@ determines the file prefix and how the test is consumed.
 | `fuzz_full.rs` | fuzz | Same idea, *full* grammar. `#[ignore]` because it surfaces known type-dispatch divergences (#83) until the contract lands. | proptest generators | jq-1.8.x |
 | `fuzz_error_wrap.rs` | fuzz | Property: `(filter)?` produces empty output whenever `filter` would error. Locks in the bug class behind the 2026-04-26 sweep (#172). | proptest generators | jq-1.8.x |
 | `selfdiff_jit_interp.rs` | selfdiff | JIT/fast-path output equals generic-interpreter output, runs the regression corpus twice with `JQJIT_FORCE_INTERPRETER=1` toggled. | `tests/regression.test` | none |
+| `selfdiff_layers.rs` | selfdiff | 4-way layer-pinned diff: baseline / no-raw-byte / no-simplify / pure-interp. When 2-way `selfdiff_jit_interp` flags a divergence, the matrix here points at the offending layer. | `tests/regression.test` | none |
 | `contract_fast_path.rs` | contract | Per-fast-path unit tests: hit, bail, edge cases. ~424 `#[test]` fns, one file per fast path category. | inline | none |
 | `contract_value_factories.rs` | contract | `Value::object_from_pairs` / `_from_normalized_pairs` / number factories: dedup, repr preservation. | inline | none |
 | `coverage_fast_path.rs` | coverage | Every `detect_*` fast path in `src/bin/jq-jit.rs` is hit by at least one corpus case. Runs the corpus with `JQJIT_TRACE=1` and asserts the trace coverage. | scrapes `src/`, runs `tests/differential/corpus.test`, allowlist `tests/coverage_fast_path.allowlist` | none |
@@ -62,7 +63,7 @@ When adding a new diff or compat test, reuse these — do **not** copy
 
 | Path | Format | Consumed by |
 |---|---|---|
-| `tests/regression.test` | 3-line group: filter / input / expected output | `compat_regression`, `selfdiff_jit_interp` |
+| `tests/regression.test` | 3-line group: filter / input / expected output | `compat_regression`, `selfdiff_jit_interp`, `selfdiff_layers` |
 | `tests/official/jq.test` | Same format, plus `%%FAIL` blocks (skipped) | `compat_official` |
 | `tests/differential/corpus.test` | 3-line group: filter / input / (no expected; reference `jq` is the oracle) | `diff_corpus`, `coverage_fast_path` |
 | `tests/corpus/<name>.{jq,json}` | filter file + input file pair | `diff_scenarios` |
@@ -79,8 +80,10 @@ The 3-line group format is documented in `tests/common/jq_test_format.rs`.
 | `JQJIT_PROPTEST_CASES` | 256 (`fuzz_restricted`) / 200 (`fuzz_error_wrap`) / 500 (`fuzz_full`) | `fuzz_*` | proptest case budget. Crank to 100k+ for nightly sweeps. |
 | `JQJIT_PROPTEST_TIMEOUT_SECS` | 3 | `fuzz_*` | Per-subprocess wall-clock cap. |
 | `JQJIT_TRACE` | unset | the binary, used by `coverage_fast_path` | Print `[trace] filter='…' matched=<name>` to stderr for each invocation. |
-| `JQJIT_FORCE_INTERPRETER` | unset | the binary, used by `selfdiff_jit_interp` | Disable all raw-byte fast paths and JIT compilation; route through the generic interpreter. |
-| `JIT_INTERP_DIFF_LIMIT` | unset | `selfdiff_jit_interp` | Truncate the regression corpus to the first N cases (local dev). |
+| `JQJIT_FORCE_INTERPRETER` | unset | the binary, used by `selfdiff_jit_interp` / `selfdiff_layers` | Disable all raw-byte fast paths and JIT compilation; route through the generic interpreter. |
+| `JQJIT_DISABLE_RAW_BYTE` | unset | the binary, used by `selfdiff_layers` | Layer-pinning knob (#685): skip every `detect_*` raw-byte fast path in `src/bin/jq-jit.rs`. JIT and `simplify_expr` stay on. |
+| `JQJIT_DISABLE_SIMPLIFY` | unset | the binary, used by `selfdiff_layers` | Layer-pinning knob (#685): short-circuit `simplify_expr` to identity. Raw-byte detectors and JIT stay on. |
+| `JIT_INTERP_DIFF_LIMIT` | unset | `selfdiff_jit_interp`, `selfdiff_layers` | Truncate the regression corpus to the first N cases (local dev). |
 
 ## Decision tree: where do I put a new test case?
 

--- a/tests/selfdiff_layers.rs
+++ b/tests/selfdiff_layers.rs
@@ -1,0 +1,345 @@
+//! 4-way layer-pinned self-diff harness (issue #685): run every regression
+//! case through four configurations of the internal fast-path stack and
+//! assert identical output. When the diff disagrees, the matrix points at
+//! the offending fast-path layer in `docs/maintenance.md` §2.
+//!
+//! | config       | raw-byte | simplify_expr | JIT |
+//! |--------------|----------|---------------|-----|
+//! | baseline     | on       | on            | on  |
+//! | no-raw-byte  | off      | on            | on  |
+//! | no-simplify  | on       | off           | on  |
+//! | pure-interp  | off      | off           | off |
+//!
+//! `JQJIT_DISABLE_RAW_BYTE=1` (issue #685) gates layer (a) at the
+//! `use_raw_fast_paths` check in `src/bin/jq-jit.rs`.
+//! `JQJIT_DISABLE_SIMPLIFY=1` gates layer (b) at the top of `simplify_expr`
+//! in `src/interpreter.rs`. `JQJIT_FORCE_INTERPRETER=1` (issue #323) gates
+//! (a)+(d) by routing `Filter::execute*` through the generic interpreter.
+//!
+//! Set `JIT_INTERP_DIFF_LIMIT=N` to truncate the corpus during local
+//! development; the default runs every case in `tests/regression.test`,
+//! the same convention as `tests/selfdiff_jit_interp.rs`.
+//!
+//! This harness does not replace `tests/selfdiff_jit_interp.rs` — that one
+//! tests the 2-way diff and ships a `KNOWN_DIVERGENCES` allowlist tied to
+//! specific upstream issues. The 4-way harness uses the same allowlist
+//! semantics so a known 2-way divergence does not double-fail here.
+
+mod common;
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::Duration;
+
+use common::json_normalize::{normalize_value, serialize_sorted};
+
+struct Case {
+    filter: String,
+    input: String,
+    line: usize,
+}
+
+fn parse_corpus(content: &str) -> Vec<Case> {
+    let mut cases = Vec::new();
+    let mut block: Vec<(String, usize)> = Vec::new();
+
+    let flush = |block: &mut Vec<(String, usize)>, cases: &mut Vec<Case>| {
+        if block.len() >= 3 {
+            let (filter, line) = block[0].clone();
+            let input = block[1].0.clone();
+            cases.push(Case { filter, input, line });
+        }
+        block.clear();
+    };
+
+    for (idx, line) in content.lines().enumerate() {
+        let line_no = idx + 1;
+        if line.trim_start().starts_with('#') {
+            continue;
+        }
+        if line.trim().is_empty() {
+            flush(&mut block, &mut cases);
+            continue;
+        }
+        block.push((line.to_string(), line_no));
+    }
+    flush(&mut block, &mut cases);
+    cases
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Config {
+    Baseline,
+    NoRawByte,
+    NoSimplify,
+    PureInterp,
+}
+
+impl Config {
+    fn label(self) -> &'static str {
+        match self {
+            Config::Baseline => "baseline",
+            Config::NoRawByte => "no-raw-byte",
+            Config::NoSimplify => "no-simplify",
+            Config::PureInterp => "pure-interp",
+        }
+    }
+
+    /// Env vars that switch this config on. Always sets/clears all three
+    /// knobs so a leaked env from the caller can't poison the matrix.
+    fn env(self) -> [(&'static str, Option<&'static str>); 3] {
+        match self {
+            Config::Baseline => [
+                ("JQJIT_DISABLE_RAW_BYTE", None),
+                ("JQJIT_DISABLE_SIMPLIFY", None),
+                ("JQJIT_FORCE_INTERPRETER", None),
+            ],
+            Config::NoRawByte => [
+                ("JQJIT_DISABLE_RAW_BYTE", Some("1")),
+                ("JQJIT_DISABLE_SIMPLIFY", None),
+                ("JQJIT_FORCE_INTERPRETER", None),
+            ],
+            Config::NoSimplify => [
+                ("JQJIT_DISABLE_RAW_BYTE", None),
+                ("JQJIT_DISABLE_SIMPLIFY", Some("1")),
+                ("JQJIT_FORCE_INTERPRETER", None),
+            ],
+            Config::PureInterp => [
+                ("JQJIT_DISABLE_RAW_BYTE", Some("1")),
+                ("JQJIT_DISABLE_SIMPLIFY", Some("1")),
+                ("JQJIT_FORCE_INTERPRETER", Some("1")),
+            ],
+        }
+    }
+}
+
+const CONFIGS: &[Config] = &[
+    Config::Baseline,
+    Config::NoRawByte,
+    Config::NoSimplify,
+    Config::PureInterp,
+];
+
+#[derive(Debug)]
+struct RunOutput {
+    stdout: String,
+    is_error: bool,
+}
+
+fn run_once(bin: &str, filter: &str, input: &str, config: Config) -> Option<RunOutput> {
+    let lib_dir = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/modules");
+    let mut cmd = Command::new(bin);
+    cmd.arg("-L").arg(lib_dir).arg("-c").arg(filter);
+    for (key, val) in config.env() {
+        match val {
+            Some(v) => { cmd.env(key, v); }
+            None => { cmd.env_remove(key); }
+        }
+    }
+    cmd.stdin(std::process::Stdio::piped());
+    cmd.stdout(std::process::Stdio::piped());
+    cmd.stderr(std::process::Stdio::null());
+
+    let mut child = cmd.spawn().ok()?;
+    {
+        use std::io::Write;
+        let mut stdin = child.stdin.take()?;
+        let _ = stdin.write_all(input.as_bytes());
+        let _ = stdin.write_all(b"\n");
+    }
+
+    let timeout = Duration::from_secs(10);
+    let start = std::time::Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                let out = child.wait_with_output().ok()?;
+                let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+                #[cfg(unix)]
+                {
+                    use std::os::unix::process::ExitStatusExt;
+                    if let Some(sig) = status.signal() {
+                        return Some(RunOutput {
+                            stdout: format!("<killed by signal {}>", sig),
+                            is_error: true,
+                        });
+                    }
+                }
+                let is_error = !status.success();
+                return Some(RunOutput { stdout, is_error });
+            }
+            Ok(None) => {
+                if start.elapsed() > timeout {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return Some(RunOutput {
+                        stdout: "<timeout after 10s>".to_string(),
+                        is_error: true,
+                    });
+                }
+                std::thread::sleep(Duration::from_millis(5));
+            }
+            Err(_) => return None,
+        }
+    }
+}
+
+/// Lossy variant of `common::json_normalize::normalize` — matches the
+/// semantics in `selfdiff_jit_interp.rs` so both harnesses treat
+/// raw-error stderr-shaped stdout lines the same way.
+fn normalize(output: &str) -> String {
+    let mut lines = Vec::new();
+    for line in output.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<serde_json::Value>(trimmed) {
+            Ok(val) => lines.push(serialize_sorted(&normalize_value(val))),
+            Err(_) => lines.push(trimmed.to_string()),
+        }
+    }
+    lines.join("\n")
+}
+
+/// Cases that diverge in the underlying 2-way self-diff
+/// (`tests/selfdiff_jit_interp.rs`). The 4-way harness inherits these so
+/// known upstream-tracked divergences do not double-fail. Keep in sync
+/// with `selfdiff_jit_interp.rs::KNOWN_DIVERGENCES`.
+const KNOWN_DIVERGENCES: &[usize] = &[2197, 2202, 2207, 2333, 2338];
+
+#[test]
+fn layer_pinned_self_diff() {
+    let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
+
+    let corpus_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/regression.test");
+    let content = std::fs::read_to_string(&corpus_path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {}", corpus_path.display(), e));
+    let mut cases = parse_corpus(&content);
+    assert!(!cases.is_empty(), "regression corpus is empty");
+
+    if let Ok(limit) = std::env::var("JIT_INTERP_DIFF_LIMIT") {
+        if let Ok(n) = limit.parse::<usize>() {
+            cases.truncate(n);
+        }
+    }
+
+    let mut pass = 0usize;
+    let mut fail = 0usize;
+    let mut spawn_fail = 0usize;
+    let mut known_diverged = 0usize;
+    let mut unexpected_pass: Vec<usize> = Vec::new();
+    let mut failures: Vec<String> = Vec::new();
+
+    for case in &cases {
+        let known = KNOWN_DIVERGENCES.contains(&case.line);
+
+        // Run all four configs. Baseline is the oracle every other config
+        // is compared against.
+        let mut runs: Vec<(Config, RunOutput)> = Vec::with_capacity(CONFIGS.len());
+        let mut spawn_failed = false;
+        for &config in CONFIGS {
+            match run_once(jq_jit, &case.filter, &case.input, config) {
+                Some(out) => runs.push((config, out)),
+                None => { spawn_failed = true; break; }
+            }
+        }
+        if spawn_failed {
+            spawn_fail += 1;
+            failures.push(format!(
+                "  line {}: spawn failure\n    filter: {}\n    input:  {}",
+                case.line, case.filter, case.input
+            ));
+            continue;
+        }
+
+        // Per-config normalized output (stdout) and error class. The
+        // oracle is config[0] (Baseline).
+        let normalized: Vec<(Config, String, bool)> = runs.iter()
+            .map(|(c, r)| (*c, normalize(&r.stdout), r.is_error))
+            .collect();
+        let (_, ref oracle_out, oracle_err) = normalized[0];
+
+        // Detect any disagreement.
+        let mut disagreeing: Vec<&(Config, String, bool)> = Vec::new();
+        for entry in normalized.iter().skip(1) {
+            let (_, ref out, err) = *entry;
+            if out != oracle_out || err != oracle_err {
+                disagreeing.push(entry);
+            }
+        }
+
+        if disagreeing.is_empty() {
+            if known { unexpected_pass.push(case.line); }
+            pass += 1;
+            continue;
+        }
+        if known {
+            known_diverged += 1;
+            continue;
+        }
+
+        fail += 1;
+        let mut buf = String::new();
+        buf.push_str(&format!(
+            "  line {}: layer divergence\n    filter: {}\n    input:  {}\n",
+            case.line, case.filter, case.input,
+        ));
+        buf.push_str(&format!(
+            "    baseline    (error={}): {}\n",
+            oracle_err, oracle_out,
+        ));
+        for &&(config, ref out, err) in disagreeing.iter() {
+            buf.push_str(&format!(
+                "    {:<11} (error={}): {}\n",
+                config.label(), err, out,
+            ));
+        }
+        // Layer-localisation hint: which layer is implicated by the
+        // disagreeing config set?
+        let configs_off: Vec<&'static str> = disagreeing.iter()
+            .map(|(c, _, _)| c.label())
+            .collect();
+        buf.push_str(&format!(
+            "    → disagreeing configs: [{}]\n",
+            configs_off.join(", "),
+        ));
+        buf.push_str(&format!(
+            "      (only `{}` differs ⇒ that layer is implicated;\n",
+            configs_off.join(", "),
+        ));
+        buf.push_str("       multiple configs differ ⇒ inspect baseline output for the canonical answer)\n");
+        failures.push(buf);
+    }
+
+    eprintln!();
+    eprintln!("=== 4-way layer-pinned self-diff ===");
+    eprintln!("configs:     {} (baseline / no-raw-byte / no-simplify / pure-interp)", CONFIGS.len());
+    eprintln!("PASS:        {}", pass);
+    eprintln!("FAIL:        {}", fail);
+    eprintln!("SPAWN:       {}", spawn_fail);
+    eprintln!("KNOWN-DIV:   {}", known_diverged);
+    eprintln!("TOTAL:       {}", cases.len());
+
+    if !failures.is_empty() {
+        eprintln!();
+        eprintln!("=== Layer divergences ===");
+        for f in &failures {
+            eprintln!("{}", f);
+        }
+    }
+
+    assert_eq!(
+        fail + spawn_fail,
+        0,
+        "{} layer-pinned divergences out of {}",
+        fail + spawn_fail,
+        cases.len(),
+    );
+
+    assert!(
+        unexpected_pass.is_empty(),
+        "KNOWN_DIVERGENCES is stale — these line(s) now agree across all four configs and should be removed (also check `selfdiff_jit_interp.rs::KNOWN_DIVERGENCES`): {:?}",
+        unexpected_pass,
+    );
+}


### PR DESCRIPTION
## Summary

Closes #685.

Two new layer-pinning env knobs plus a 4-way self-diff harness:

- \`JQJIT_DISABLE_RAW_BYTE=1\` — skip every \`detect_*\` in \`src/bin/jq-jit.rs\`. JIT and \`simplify_expr\` stay on.
- \`JQJIT_DISABLE_SIMPLIFY=1\` — short-circuit \`simplify_expr\` to identity. Raw-byte and JIT stay on.
- \`tests/selfdiff_layers.rs\` — runs every regression case under all four configs (baseline / no-raw-byte / no-simplify / pure-interp) and asserts identical output. When the 2-way \`selfdiff_jit_interp\` disagrees, the matrix here points at the offending layer.

Each layer disablement is a single guard at the entry point of its layer (raw-byte: one boolean at \`use_raw_fast_paths\`; simplify: one guard at the top of \`simplify_expr\`; JIT: existing \`force_interpreter\`).

| config       | raw-byte | simplify_expr | JIT |
|--------------|----------|---------------|-----|
| baseline     | on       | on            | on  |
| no-raw-byte  | off      | on            | on  |
| no-simplify  | on       | off           | on  |
| pure-interp  | off      | off           | off |

\`KNOWN_DIVERGENCES\` mirrors the 5 upstream-tracked cases in \`selfdiff_jit_interp.rs::KNOWN_DIVERGENCES\` (the \`1e1000\`/\`tojson\` class, #415) so they do not double-fail. Honours \`JIT_INTERP_DIFF_LIMIT\` for local truncation, same convention as the 2-way harness.

Part of the four-axis bug-hunt plan (epoch 3): #683 (epoch 1), #684 (epoch 2), this PR (#685, epoch 3), #686 (epoch 4).

## Test plan

- [x] \`cargo test --release\` — all 21 binaries pass, including \`selfdiff_layers\` (1793 pass / 5 known-div / 0 fail across 1798 regression cases × 4 configs = ~7.2k runs in ~48s)
- [x] \`selfdiff_jit_interp\` still passes unchanged
- [x] Manual smoke: \`JQJIT_TRACE=1 JQJIT_DISABLE_RAW_BYTE=1 ... '.a'\` confirms detect_field_access is bypassed (trace says \`matched=eval\` instead)
- [ ] CI green on ubuntu / macos / windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)