### PR TITLE
test: per-exclusion mini fuzz harnesses (#686)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -1492,12 +1492,35 @@ fn resolved_would_error(
         // `if .x cmp N then … else … end`: each branch's `Const` cond
         // evaluator falls through to `false` when the field isn't a
         // number, taking the wrong branch (#341). Bail any CondChain
-        // whose Const-branch fields aren't numeric.
-        ResolvedRemap::CondChain(branches, _) => {
-            branches.iter().any(|b| {
+        // whose Const-branch fields aren't numeric. Branch outputs are
+        // also checked: a `Computed`/`Remap` output that would itself
+        // bail when emitted directly (e.g. `FieldCmpField` on a
+        // null/null pair landing on the emitter's null-literal
+        // fallback at line ~1581) must bail here too — the metamorphic
+        // harness surfaced this via `{a: (if .c >= .a then .a > .c else 0 end)}`
+        // on `{a:null,c:null}`, which emitted `{a:null}` instead of
+        // `{a:false}`.
+        ResolvedRemap::CondChain(branches, else_out) => {
+            fn output_would_err(
+                out: &ResolvedBranchOutput,
+                raw: &[u8],
+                ranges: &[(usize, usize)],
+            ) -> bool {
+                match out {
+                    ResolvedBranchOutput::Computed(rv) => resolved_would_error(rv, raw, ranges),
+                    ResolvedBranchOutput::Remap(items) => {
+                        items.iter().any(|rv| resolved_would_error(rv, raw, ranges))
+                    }
+                    _ => false,
+                }
+            }
+            let cond_bail = branches.iter().any(|b| {
                 matches!(b.cond_rhs, ResolvedCondRhs::Const(_))
                     && parse_json_num(bytes_of(b.cond_field_idx)).is_none()
-            })
+            });
+            let output_bail = branches.iter().any(|b| output_would_err(&b.output, raw, ranges))
+                || output_would_err(else_out, raw, ranges);
+            cond_bail || output_bail
         }
         // `.a + ":" + (.b | tostring)`: `Field` parts silently coerce
         // non-string fields to raw bytes (jq raises

--- a/tests/README.md
+++ b/tests/README.md
@@ -31,6 +31,11 @@ determines the file prefix and how the test is consumed.
 | `fuzz_restricted.rs` | fuzz | Random `(filter, input)` pairs from a deliberately *narrow* grammar (no `try/catch`, no `..`, integer-only inputs). Default-on. | proptest generators | jq-1.8.x |
 | `fuzz_full.rs` | fuzz | Same idea, *full* grammar. `#[ignore]` because it surfaces known type-dispatch divergences (#83) until the contract lands. | proptest generators | jq-1.8.x |
 | `fuzz_error_wrap.rs` | fuzz | Property: `(filter)?` produces empty output whenever `filter` would error. Locks in the bug class behind the 2026-04-26 sweep (#172). | proptest generators | jq-1.8.x |
+| `fuzz_axis_recurse.rs` | fuzz | Per-exclusion mini-axis (#686): `..` recurse re-enabled, every other shape held constant. Default 200 cases. | proptest generators | jq-1.8.x |
+| `fuzz_axis_float_input.rs` | fuzz | Per-exclusion mini-axis (#686): float JSON input values re-enabled. Default 200 cases. | proptest generators | jq-1.8.x |
+| `fuzz_axis_iterate.rs` | fuzz | Per-exclusion mini-axis (#686): bare `.[]` (iterate-all) re-enabled. Default 200 cases. | proptest generators | jq-1.8.x |
+| `fuzz_axis_assign.rs` | fuzz | Per-exclusion mini-axis (#686): `.f = …` / `.f \|= …` / `.f += …` assignment forms re-enabled. Default 200 cases. | proptest generators | jq-1.8.x |
+| `fuzz_axis_const_pipe.rs` | fuzz | Per-exclusion mini-axis (#686): `Pipe(_, <constant-rhs>)` biased to surface simplify-fold divergences. Default 200 cases. | proptest generators | jq-1.8.x |
 | `selfdiff_jit_interp.rs` | selfdiff | JIT/fast-path output equals generic-interpreter output, runs the regression corpus twice with `JQJIT_FORCE_INTERPRETER=1` toggled. | `tests/regression.test` | none |
 | `selfdiff_layers.rs` | selfdiff | 4-way layer-pinned diff: baseline / no-raw-byte / no-simplify / pure-interp. When 2-way `selfdiff_jit_interp` flags a divergence, the matrix here points at the offending layer. | `tests/regression.test` | none |
 | `contract_fast_path.rs` | contract | Per-fast-path unit tests: hit, bail, edge cases. ~424 `#[test]` fns, one file per fast path category. | inline | none |
@@ -77,7 +82,7 @@ The 3-line group format is documented in `tests/common/jq_test_format.rs`.
 |---|---|---|---|
 | `JQ_BIN` | unset | every `diff_*` and `fuzz_*` test | Override the reference jq binary. Must be jq-1.8.x. |
 | `CI` | (set by GitHub Actions) | every `diff_*` and `fuzz_*` test | When set and no jq-1.8.x is found, the test panics instead of skipping. |
-| `JQJIT_PROPTEST_CASES` | 256 (`fuzz_restricted`) / 200 (`fuzz_error_wrap`) / 500 (`fuzz_full`) | `fuzz_*` | proptest case budget. Crank to 100k+ for nightly sweeps. |
+| `JQJIT_PROPTEST_CASES` | 256 (`fuzz_restricted`) / 200 (`fuzz_error_wrap`, `fuzz_axis_*`) / 500 (`fuzz_full`) | `fuzz_*` | proptest case budget. Crank to 100k+ for nightly sweeps. |
 | `JQJIT_PROPTEST_TIMEOUT_SECS` | 3 | `fuzz_*` | Per-subprocess wall-clock cap. |
 | `JQJIT_TRACE` | unset | the binary, used by `coverage_fast_path` | Print `[trace] filter='…' matched=<name>` to stderr for each invocation. |
 | `JQJIT_FORCE_INTERPRETER` | unset | the binary, used by `selfdiff_jit_interp` / `selfdiff_layers` | Disable all raw-byte fast paths and JIT compilation; route through the generic interpreter. |
@@ -148,7 +153,7 @@ CI workflows are at `.github/workflows/ci.yml` (push/PR) and `release.yml`
 |---|---|---|
 | `compat_official`, `compat_regression` | always | always |
 | `contract_*`, `coverage_fast_path`, `enforce_value_factories`, `selfdiff_jit_interp` | always | always |
-| `diff_corpus`, `diff_scenarios`, `fuzz_restricted`, `fuzz_error_wrap` | runs if jq-1.8.x is found, else skipped (eprintln) | always (CI installs jq-1.8.1) |
+| `diff_corpus`, `diff_scenarios`, `fuzz_restricted`, `fuzz_error_wrap`, `fuzz_axis_*` | runs if jq-1.8.x is found, else skipped (eprintln) | always (CI installs jq-1.8.1) |
 | `fuzz_full` | `#[ignore]` — needs `-- --ignored` | not run |
 
 To run a single test: `cargo test --release --test <file_stem>`. Examples:

--- a/tests/fuzz_axis_assign.rs
+++ b/tests/fuzz_axis_assign.rs
@@ -1,0 +1,132 @@
+//! Axis fuzz: `.f = expr` / `.f |= expr` / `.f += expr` re-enabled
+//! (#686 axis 4 — substitutes for the issue's defunct "dup_keys" axis;
+//! object-key dedup is now generated freely in
+//! [`common::filter_strategy::base_json_strategy`] and tracked by #233 /
+//! #325, leaving assignments as the next major real exclusion).
+//!
+//! [`tests/fuzz_restricted.rs`] has no AST variant for any assignment
+//! form. The shared [`common::filter_strategy::FilterExpr`] omits them
+//! because the conservative single-valued contract holds for *value*
+//! filters only; assignment is a path-context operation with its own
+//! fast-path family (`detect_assign_*`, `detect_update_*`,
+//! `detect_arith_update_*`). This axis re-enables the three most common
+//! forms in isolation.
+//!
+//! Filter shape: `((.f <op> <rhs>) | .)?` where `.f` draws from
+//! [`common::filter_strategy::IDENT_POOL`] and `<rhs>` is the shared
+//! single-valued base. The trailing `| .` is just to force the assigned
+//! value out through the pipeline; the outer `?` swallows path-error
+//! messages on inputs whose top-level type doesn't admit field
+//! assignment (numbers, strings).
+//!
+//! ## Knobs
+//!
+//! * `JQJIT_PROPTEST_CASES` — case budget (default 200)
+//! * `JQJIT_PROPTEST_TIMEOUT_SECS` — per-subprocess cap (default 3)
+//! * `JQ_BIN` — override the reference jq binary
+
+mod common;
+
+use std::time::Duration;
+
+use proptest::prelude::*;
+
+use common::diff_harness::{jq_jit_path, require_jq, run_filter};
+use common::filter_strategy::{
+    base_filter_strategy, base_json_strategy, conservative_json_leaf,
+    conservative_leaf_strategy, ident_strategy, render, render_json,
+};
+use common::json_normalize::normalize;
+
+const TEST_LABEL: &str = "fuzz_axis_assign";
+
+/// The three assignment operators jq treats as a closed family. `=`
+/// (plain), `|=` (update-with-pipeline, applies `expr` to the existing
+/// value at the path), `+=` (arithmetic-update). Adding `-=`/`*=`/`/=`
+/// is the natural next widening once these three land clean.
+const ASSIGN_OPS: &[&str] = &["=", "|=", "+="];
+
+#[test]
+fn fuzz_axis_assign_against_jq_1_8() {
+    let Some(jq) = require_jq(TEST_LABEL) else { return };
+    let jq_jit = jq_jit_path().to_string();
+
+    let cases: u32 = std::env::var("JQJIT_PROPTEST_CASES")
+        .ok().and_then(|s| s.parse().ok()).unwrap_or(200);
+    let timeout_secs: u64 = std::env::var("JQJIT_PROPTEST_TIMEOUT_SECS")
+        .ok().and_then(|s| s.parse().ok()).unwrap_or(3);
+    let timeout = Duration::from_secs(timeout_secs);
+
+    let compared = std::sync::atomic::AtomicUsize::new(0);
+    let both_error = std::sync::atomic::AtomicUsize::new(0);
+
+    let cfg = ProptestConfig {
+        cases, failure_persistence: None, max_shrink_time: 15_000,
+        ..ProptestConfig::default()
+    };
+
+    let mut runner = proptest::test_runner::TestRunner::new(cfg);
+    let strategy = (
+        ident_strategy(),
+        prop::sample::select(ASSIGN_OPS),
+        base_filter_strategy(conservative_leaf_strategy(), 3, 16, 3),
+        base_json_strategy(conservative_json_leaf(), 3, 12, 3),
+    );
+
+    let result = runner.run(&strategy, |(lhs_field, op, rhs, input_shape)| {
+        let filter = format!("((.{} {} ({})) | .)?", lhs_field, op, render(&rhs));
+        let input = render_json(&input_shape);
+
+        let Some(r_jq) = run_filter(&jq, &filter, &input, timeout) else { return Ok(()); };
+        let Some(r_jit) = run_filter(&jq_jit, &filter, &input, timeout) else { return Ok(()); };
+
+        let crash_markers = ["panicked", "SIGSEGV", "Assertion failed", "stack overflow", "RUST_BACKTRACE"];
+        if crash_markers.iter().any(|m| r_jit.stdout.contains(m)) {
+            return Err(TestCaseError::fail(format!(
+                "jq-jit crashed\n  filter: {}\n  input:  {}\n  stderr: {}",
+                filter, input, r_jit.stdout.trim()
+            )));
+        }
+
+        if r_jq.is_error && r_jit.is_error {
+            both_error.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            return Ok(());
+        }
+        if r_jq.is_error != r_jit.is_error {
+            return Err(TestCaseError::fail(format!(
+                "error mismatch (jq error={}, jit error={})\n  filter: {}\n  input:  {}\n  jq:  {}\n  jit: {}",
+                r_jq.is_error, r_jit.is_error, filter, input,
+                r_jq.stdout.trim(), r_jit.stdout.trim()
+            )));
+        }
+
+        let a_norm = match normalize(&r_jq.stdout) { Ok(s) => s, Err(_) => return Ok(()) };
+        let b_norm = match normalize(&r_jit.stdout) {
+            Ok(s) => s,
+            Err(e) => return Err(TestCaseError::fail(format!(
+                "jq-jit emitted non-JSON\n  filter: {}\n  input:  {}\n  err: {}\n  jit: {}",
+                filter, input, e, r_jit.stdout.trim()
+            ))),
+        };
+
+        compared.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        if a_norm != b_norm {
+            return Err(TestCaseError::fail(format!(
+                "value mismatch\n  filter: {}\n  input:  {}\n  jq:  {}\n  jit: {}",
+                filter, input, a_norm, b_norm
+            )));
+        }
+        Ok(())
+    });
+
+    eprintln!(
+        "=== fuzz_axis_assign (vs {}) ===\n  compared: {}\n  both_errored: {}",
+        jq,
+        compared.load(std::sync::atomic::Ordering::Relaxed),
+        both_error.load(std::sync::atomic::Ordering::Relaxed),
+    );
+
+    if let Err(e) = result {
+        panic!("fuzz_axis_assign failed:\n{}", e);
+    }
+}

--- a/tests/fuzz_axis_const_pipe.rs
+++ b/tests/fuzz_axis_const_pipe.rs
@@ -1,0 +1,139 @@
+//! Axis fuzz: `Pipe(<lhs>, <const-rhs>)` biased (#686 axis 5).
+//!
+//! [`tests/fuzz_restricted.rs`]'s recursive generator produces Pipe
+//! shapes freely, but the constant-RHS subset is statistically rare —
+//! a `<const>` leaf has the same probability as any other leaf, so most
+//! random Pipes have RHSs that reference input.
+//!
+//! Constant-RHS Pipe (`(<lhs>) | <constant>`) is its own fast-path
+//! shape: jq evaluates `<lhs>` for cardinality (errors propagate,
+//! multi-valued LHS emits the constant N times) but the RHS is
+//! input-independent. The simplify layer (#685 axis b) tries to fold
+//! `_ | const` into `const`; that fold is only safe when `<lhs>` is
+//! statically known to be single-valued and side-effect-free, and
+//! getting the analysis wrong is exactly the kind of divergence this
+//! axis aims to surface.
+//!
+//! Filter shape: `((<lhs>) | <const>)?` where `<lhs>` is the shared
+//! single-valued-safe base and `<const>` is a literal leaf
+//! (`null`, bool, integer, string, empty array / object). The outer
+//! `?` swallows the per-LHS-value errors so the property under test is
+//! whether the constant emits with the *cardinality* and *value* jq
+//! expects.
+//!
+//! ## Knobs
+//!
+//! * `JQJIT_PROPTEST_CASES` — case budget (default 200)
+//! * `JQJIT_PROPTEST_TIMEOUT_SECS` — per-subprocess cap (default 3)
+//! * `JQ_BIN` — override the reference jq binary
+
+mod common;
+
+use std::time::Duration;
+
+use proptest::prelude::*;
+
+use common::diff_harness::{jq_jit_path, require_jq, run_filter};
+use common::filter_strategy::{
+    base_filter_strategy, base_json_strategy, conservative_json_leaf,
+    conservative_leaf_strategy, render, render_json,
+};
+use common::json_normalize::normalize;
+
+const TEST_LABEL: &str = "fuzz_axis_const_pipe";
+
+/// Literal RHS pool. Every entry is a complete jq filter that ignores
+/// its input and emits exactly one canonical value. The empty `[]` /
+/// `{}` shapes exercise the array / object construct fast paths in the
+/// constant subset; `null` / `true` / `false` and the integer / string
+/// pool catch the literal-fast-path detectors.
+const CONST_RHS: &[&str] = &[
+    "null", "true", "false",
+    "0", "1", "-1", "42",
+    "\"\"", "\"x\"", "\"hello\"",
+    "[]", "{}",
+];
+
+#[test]
+fn fuzz_axis_const_pipe_against_jq_1_8() {
+    let Some(jq) = require_jq(TEST_LABEL) else { return };
+    let jq_jit = jq_jit_path().to_string();
+
+    let cases: u32 = std::env::var("JQJIT_PROPTEST_CASES")
+        .ok().and_then(|s| s.parse().ok()).unwrap_or(200);
+    let timeout_secs: u64 = std::env::var("JQJIT_PROPTEST_TIMEOUT_SECS")
+        .ok().and_then(|s| s.parse().ok()).unwrap_or(3);
+    let timeout = Duration::from_secs(timeout_secs);
+
+    let compared = std::sync::atomic::AtomicUsize::new(0);
+    let both_error = std::sync::atomic::AtomicUsize::new(0);
+
+    let cfg = ProptestConfig {
+        cases, failure_persistence: None, max_shrink_time: 15_000,
+        ..ProptestConfig::default()
+    };
+
+    let mut runner = proptest::test_runner::TestRunner::new(cfg);
+    let strategy = (
+        base_filter_strategy(conservative_leaf_strategy(), 3, 16, 3),
+        prop::sample::select(CONST_RHS),
+        base_json_strategy(conservative_json_leaf(), 3, 12, 3),
+    );
+
+    let result = runner.run(&strategy, |(lhs, rhs, input_shape)| {
+        let filter = format!("(({}) | {})?", render(&lhs), rhs);
+        let input = render_json(&input_shape);
+
+        let Some(r_jq) = run_filter(&jq, &filter, &input, timeout) else { return Ok(()); };
+        let Some(r_jit) = run_filter(&jq_jit, &filter, &input, timeout) else { return Ok(()); };
+
+        let crash_markers = ["panicked", "SIGSEGV", "Assertion failed", "stack overflow", "RUST_BACKTRACE"];
+        if crash_markers.iter().any(|m| r_jit.stdout.contains(m)) {
+            return Err(TestCaseError::fail(format!(
+                "jq-jit crashed\n  filter: {}\n  input:  {}\n  stderr: {}",
+                filter, input, r_jit.stdout.trim()
+            )));
+        }
+
+        if r_jq.is_error && r_jit.is_error {
+            both_error.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            return Ok(());
+        }
+        if r_jq.is_error != r_jit.is_error {
+            return Err(TestCaseError::fail(format!(
+                "error mismatch (jq error={}, jit error={})\n  filter: {}\n  input:  {}\n  jq:  {}\n  jit: {}",
+                r_jq.is_error, r_jit.is_error, filter, input,
+                r_jq.stdout.trim(), r_jit.stdout.trim()
+            )));
+        }
+
+        let a_norm = match normalize(&r_jq.stdout) { Ok(s) => s, Err(_) => return Ok(()) };
+        let b_norm = match normalize(&r_jit.stdout) {
+            Ok(s) => s,
+            Err(e) => return Err(TestCaseError::fail(format!(
+                "jq-jit emitted non-JSON\n  filter: {}\n  input:  {}\n  err: {}\n  jit: {}",
+                filter, input, e, r_jit.stdout.trim()
+            ))),
+        };
+
+        compared.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        if a_norm != b_norm {
+            return Err(TestCaseError::fail(format!(
+                "value mismatch\n  filter: {}\n  input:  {}\n  jq:  {}\n  jit: {}",
+                filter, input, a_norm, b_norm
+            )));
+        }
+        Ok(())
+    });
+
+    eprintln!(
+        "=== fuzz_axis_const_pipe (vs {}) ===\n  compared: {}\n  both_errored: {}",
+        jq,
+        compared.load(std::sync::atomic::Ordering::Relaxed),
+        both_error.load(std::sync::atomic::Ordering::Relaxed),
+    );
+
+    if let Err(e) = result {
+        panic!("fuzz_axis_const_pipe failed:\n{}", e);
+    }
+}

--- a/tests/fuzz_axis_float_input.rs
+++ b/tests/fuzz_axis_float_input.rs
@@ -1,0 +1,203 @@
+//! Axis fuzz: float values in JSON *input* re-enabled (#686 axis 2).
+//!
+//! [`tests/fuzz_restricted.rs`] excludes input-side float literals
+//! ("jq's number printer normalizes formatting in ways the harness's
+//! `serde_json` re-parse can mask, leading to false-positive shrinks").
+//! Filter-side float literals stayed in via
+//! [`fuzz_restricted::FLOAT_LITERALS`], but the input-side path is its
+//! own surface: parser → value factory → fast-path numeric ops →
+//! printer.
+//!
+//! This axis re-enables float input values in isolation, with a narrow
+//! pool that round-trips through `serde_json`'s `f64` parser cleanly
+//! (no overflow forms, no non-finite, no denormals) so a shrunk failure
+//! points at a *value-level* divergence rather than a known printer
+//! asymmetry. The shared
+//! [`common::json_normalize::normalize_value`] already folds
+//! integer-valued `f64` into integers, so `1.0` vs `1` comparisons are
+//! handled at the harness level.
+//!
+//! Filter shape: `(<inner>)?` with `<inner>` drawn from the shared
+//! single-valued-safe base. Outer `?` swallows the type-error message
+//! divergences that arise when a filter expecting an array hits a float.
+//!
+//! ## Knobs
+//!
+//! * `JQJIT_PROPTEST_CASES` — case budget (default 200)
+//! * `JQJIT_PROPTEST_TIMEOUT_SECS` — per-subprocess cap (default 3)
+//! * `JQ_BIN` — override the reference jq binary
+
+mod common;
+
+use std::time::Duration;
+
+use proptest::prelude::*;
+
+use common::diff_harness::{jq_jit_path, require_jq, run_filter};
+use common::filter_strategy::{
+    base_filter_strategy, conservative_leaf_strategy, ident_strategy, render,
+};
+use common::json_normalize::normalize;
+
+const TEST_LABEL: &str = "fuzz_axis_float_input";
+
+/// Float values that round-trip through `serde_json::from_str::<Value>`
+/// → `Number::as_f64` cleanly on both jq-1.8 and jq-jit. All are finite,
+/// in-range, and have unambiguous canonical formatting. The integer-
+/// valued samples (`0.0`, `1.0`, `-2.0`) catch the `f64 == i64` fold path
+/// in `normalize_value`; the fractional samples exercise the genuine
+/// floating arithmetic path.
+const INPUT_FLOATS: &[f64] = &[
+    0.0, 1.0, -1.0, 2.0, -2.0,
+    0.5, -0.5, 1.5, -1.5,
+    0.125, 1024.0, 0.001, -0.001,
+];
+
+#[derive(Debug, Clone)]
+enum FloatJson {
+    Null,
+    Bool(bool),
+    IntN(i32),
+    FloatN(f64),
+    Str(String),
+    Arr(Vec<FloatJson>),
+    Obj(Vec<(String, FloatJson)>),
+}
+
+fn render_float_json(v: &FloatJson) -> String {
+    match v {
+        FloatJson::Null => "null".into(),
+        FloatJson::Bool(b) => b.to_string(),
+        FloatJson::IntN(n) => n.to_string(),
+        FloatJson::FloatN(f) => {
+            // Force a trailing `.0` so integer-valued floats render as
+            // `1.0`, not `1` — otherwise the f64 pool would collapse into
+            // the IntN distribution for this axis and defeat the purpose.
+            let mut s = format!("{}", f);
+            if !s.contains('.') && !s.contains('e') && !s.contains('E') {
+                s.push_str(".0");
+            }
+            s
+        }
+        FloatJson::Str(s) => serde_json::to_string(s).unwrap(),
+        FloatJson::Arr(items) => {
+            let parts: Vec<String> = items.iter().map(render_float_json).collect();
+            format!("[{}]", parts.join(","))
+        }
+        FloatJson::Obj(pairs) => {
+            let parts: Vec<String> = pairs
+                .iter()
+                .map(|(k, v)| format!("{}:{}", serde_json::to_string(k).unwrap(), render_float_json(v)))
+                .collect();
+            format!("{{{}}}", parts.join(","))
+        }
+    }
+}
+
+fn json_leaf() -> impl Strategy<Value = FloatJson> {
+    // Float-heavy leaf distribution (3:1 over the other leaves) so every
+    // case has at least one float somewhere, which is the axis thesis.
+    prop_oneof![
+        3 => prop::sample::select(INPUT_FLOATS).prop_map(FloatJson::FloatN),
+        1 => prop_oneof![
+            Just(FloatJson::Null),
+            any::<bool>().prop_map(FloatJson::Bool),
+            (-3i32..=3).prop_map(FloatJson::IntN),
+            prop::sample::select(vec!["", "a", "ab", "0", "hello"])
+                .prop_map(|s| FloatJson::Str(s.to_string())),
+        ],
+    ]
+}
+
+fn json_strategy() -> impl Strategy<Value = FloatJson> {
+    json_leaf().prop_recursive(3, 12, 3, |inner| {
+        prop_oneof![
+            prop::collection::vec(inner.clone(), 0..=3).prop_map(FloatJson::Arr),
+            prop::collection::vec((ident_strategy(), inner.clone()), 0..=3)
+                .prop_map(FloatJson::Obj),
+        ]
+    })
+}
+
+#[test]
+fn fuzz_axis_float_input_against_jq_1_8() {
+    let Some(jq) = require_jq(TEST_LABEL) else { return };
+    let jq_jit = jq_jit_path().to_string();
+
+    let cases: u32 = std::env::var("JQJIT_PROPTEST_CASES")
+        .ok().and_then(|s| s.parse().ok()).unwrap_or(200);
+    let timeout_secs: u64 = std::env::var("JQJIT_PROPTEST_TIMEOUT_SECS")
+        .ok().and_then(|s| s.parse().ok()).unwrap_or(3);
+    let timeout = Duration::from_secs(timeout_secs);
+
+    let compared = std::sync::atomic::AtomicUsize::new(0);
+    let both_error = std::sync::atomic::AtomicUsize::new(0);
+
+    let cfg = ProptestConfig {
+        cases, failure_persistence: None, max_shrink_time: 15_000,
+        ..ProptestConfig::default()
+    };
+
+    let mut runner = proptest::test_runner::TestRunner::new(cfg);
+    let strategy = (
+        base_filter_strategy(conservative_leaf_strategy(), 3, 16, 3),
+        json_strategy(),
+    );
+
+    let result = runner.run(&strategy, |(inner, input_shape)| {
+        let filter = format!("({})?", render(&inner));
+        let input = render_float_json(&input_shape);
+
+        let Some(r_jq) = run_filter(&jq, &filter, &input, timeout) else { return Ok(()); };
+        let Some(r_jit) = run_filter(&jq_jit, &filter, &input, timeout) else { return Ok(()); };
+
+        let crash_markers = ["panicked", "SIGSEGV", "Assertion failed", "stack overflow", "RUST_BACKTRACE"];
+        if crash_markers.iter().any(|m| r_jit.stdout.contains(m)) {
+            return Err(TestCaseError::fail(format!(
+                "jq-jit crashed\n  filter: {}\n  input:  {}\n  stderr: {}",
+                filter, input, r_jit.stdout.trim()
+            )));
+        }
+
+        if r_jq.is_error && r_jit.is_error {
+            both_error.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            return Ok(());
+        }
+        if r_jq.is_error != r_jit.is_error {
+            return Err(TestCaseError::fail(format!(
+                "error mismatch (jq error={}, jit error={})\n  filter: {}\n  input:  {}\n  jq:  {}\n  jit: {}",
+                r_jq.is_error, r_jit.is_error, filter, input,
+                r_jq.stdout.trim(), r_jit.stdout.trim()
+            )));
+        }
+
+        let a_norm = match normalize(&r_jq.stdout) { Ok(s) => s, Err(_) => return Ok(()) };
+        let b_norm = match normalize(&r_jit.stdout) {
+            Ok(s) => s,
+            Err(e) => return Err(TestCaseError::fail(format!(
+                "jq-jit emitted non-JSON\n  filter: {}\n  input:  {}\n  err: {}\n  jit: {}",
+                filter, input, e, r_jit.stdout.trim()
+            ))),
+        };
+
+        compared.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        if a_norm != b_norm {
+            return Err(TestCaseError::fail(format!(
+                "value mismatch\n  filter: {}\n  input:  {}\n  jq:  {}\n  jit: {}",
+                filter, input, a_norm, b_norm
+            )));
+        }
+        Ok(())
+    });
+
+    eprintln!(
+        "=== fuzz_axis_float_input (vs {}) ===\n  compared: {}\n  both_errored: {}",
+        jq,
+        compared.load(std::sync::atomic::Ordering::Relaxed),
+        both_error.load(std::sync::atomic::Ordering::Relaxed),
+    );
+
+    if let Err(e) = result {
+        panic!("fuzz_axis_float_input failed:\n{}", e);
+    }
+}

--- a/tests/fuzz_axis_iterate.rs
+++ b/tests/fuzz_axis_iterate.rs
@@ -1,0 +1,131 @@
+//! Axis fuzz: `.[]` (iterate-all) re-enabled (#686 axis 3).
+//!
+//! [`tests/fuzz_restricted.rs`] has no AST variant for `.[]` — the
+//! shared [`common::filter_strategy::FilterExpr`] omits it because the
+//! conservative single-valued base is the contract that strategy
+//! provides, and `.[]` is the canonical multi-valued shape. Random
+//! recursion in fuzz_restricted produces something *close* via
+//! `Map(Identity)` (`map(.)` → `[.[]]`) and `Limit(n; …)`, but the bare
+//! `.[]` placed at the head of the pipeline is a different fast-path
+//! shape: it touches the raw-byte iterate-all detector
+//! (`detect_iterate_all_then_*` family) without the array-construct
+//! wrapping. This axis re-enables that bare form.
+//!
+//! Filter shape: `((.[]) | (<inner>))?` where `<inner>` is the shared
+//! single-valued base. Outer `?` swallows per-element type errors from
+//! iterating into mixed inputs.
+//!
+//! Note: the iteration order on objects in jq is grammar-defined as
+//! lexicographic-by-key (jq sorts on print), but the *yield* order
+//! through `.[]` is insertion order. The shared
+//! [`common::json_normalize::normalize`] sorts object keys for the final
+//! value-level compare; for top-level array iteration, both
+//! implementations yield in array order. So normalization handles both
+//! cases without needing harness-specific reordering.
+//!
+//! ## Knobs
+//!
+//! * `JQJIT_PROPTEST_CASES` — case budget (default 200)
+//! * `JQJIT_PROPTEST_TIMEOUT_SECS` — per-subprocess cap (default 3)
+//! * `JQ_BIN` — override the reference jq binary
+
+mod common;
+
+use std::time::Duration;
+
+use proptest::prelude::*;
+
+use common::diff_harness::{jq_jit_path, require_jq, run_filter};
+use common::filter_strategy::{
+    base_filter_strategy, base_json_strategy, conservative_json_leaf,
+    conservative_leaf_strategy, render, render_json,
+};
+use common::json_normalize::normalize;
+
+const TEST_LABEL: &str = "fuzz_axis_iterate";
+
+#[test]
+fn fuzz_axis_iterate_against_jq_1_8() {
+    let Some(jq) = require_jq(TEST_LABEL) else { return };
+    let jq_jit = jq_jit_path().to_string();
+
+    let cases: u32 = std::env::var("JQJIT_PROPTEST_CASES")
+        .ok().and_then(|s| s.parse().ok()).unwrap_or(200);
+    let timeout_secs: u64 = std::env::var("JQJIT_PROPTEST_TIMEOUT_SECS")
+        .ok().and_then(|s| s.parse().ok()).unwrap_or(3);
+    let timeout = Duration::from_secs(timeout_secs);
+
+    let compared = std::sync::atomic::AtomicUsize::new(0);
+    let both_error = std::sync::atomic::AtomicUsize::new(0);
+
+    let cfg = ProptestConfig {
+        cases, failure_persistence: None, max_shrink_time: 15_000,
+        ..ProptestConfig::default()
+    };
+
+    let mut runner = proptest::test_runner::TestRunner::new(cfg);
+    let strategy = (
+        base_filter_strategy(conservative_leaf_strategy(), 3, 16, 3),
+        base_json_strategy(conservative_json_leaf(), 3, 12, 3),
+    );
+
+    let result = runner.run(&strategy, |(inner, input_shape)| {
+        // `.[]` placed at the head — each element / value of the input
+        // becomes the input to `<inner>`. Outer `?` swallows per-element
+        // type errors.
+        let filter = format!("((.[]) | ({}))?", render(&inner));
+        let input = render_json(&input_shape);
+
+        let Some(r_jq) = run_filter(&jq, &filter, &input, timeout) else { return Ok(()); };
+        let Some(r_jit) = run_filter(&jq_jit, &filter, &input, timeout) else { return Ok(()); };
+
+        let crash_markers = ["panicked", "SIGSEGV", "Assertion failed", "stack overflow", "RUST_BACKTRACE"];
+        if crash_markers.iter().any(|m| r_jit.stdout.contains(m)) {
+            return Err(TestCaseError::fail(format!(
+                "jq-jit crashed\n  filter: {}\n  input:  {}\n  stderr: {}",
+                filter, input, r_jit.stdout.trim()
+            )));
+        }
+
+        if r_jq.is_error && r_jit.is_error {
+            both_error.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            return Ok(());
+        }
+        if r_jq.is_error != r_jit.is_error {
+            return Err(TestCaseError::fail(format!(
+                "error mismatch (jq error={}, jit error={})\n  filter: {}\n  input:  {}\n  jq:  {}\n  jit: {}",
+                r_jq.is_error, r_jit.is_error, filter, input,
+                r_jq.stdout.trim(), r_jit.stdout.trim()
+            )));
+        }
+
+        let a_norm = match normalize(&r_jq.stdout) { Ok(s) => s, Err(_) => return Ok(()) };
+        let b_norm = match normalize(&r_jit.stdout) {
+            Ok(s) => s,
+            Err(e) => return Err(TestCaseError::fail(format!(
+                "jq-jit emitted non-JSON\n  filter: {}\n  input:  {}\n  err: {}\n  jit: {}",
+                filter, input, e, r_jit.stdout.trim()
+            ))),
+        };
+
+        compared.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        if a_norm != b_norm {
+            return Err(TestCaseError::fail(format!(
+                "value mismatch\n  filter: {}\n  input:  {}\n  jq:  {}\n  jit: {}",
+                filter, input, a_norm, b_norm
+            )));
+        }
+        Ok(())
+    });
+
+    eprintln!(
+        "=== fuzz_axis_iterate (vs {}) ===\n  compared: {}\n  both_errored: {}",
+        jq,
+        compared.load(std::sync::atomic::Ordering::Relaxed),
+        both_error.load(std::sync::atomic::Ordering::Relaxed),
+    );
+
+    if let Err(e) = result {
+        panic!("fuzz_axis_iterate failed:\n{}", e);
+    }
+}

--- a/tests/fuzz_axis_recurse.rs
+++ b/tests/fuzz_axis_recurse.rs
@@ -1,0 +1,127 @@
+//! Axis fuzz: `..` (recurse) re-enabled (#686 axis 1).
+//!
+//! [`tests/fuzz_restricted.rs`] excludes `..` because output ordering is
+//! grammar-defined and the permutations explode the search space without
+//! finding new bugs — when it ran across every shape, the shrinker
+//! collapsed onto recurse-ordering noise and hid value-level divergences.
+//! This axis re-enables `..` in isolation so any residual value-level
+//! divergences in the recurse path can't hide behind a louder error class.
+//!
+//! Filter shape: `((..) | (<inner>))?` where `<inner>` is the
+//! single-valued-safe shared base
+//! ([`common::filter_strategy::base_filter_strategy`]). The outer `(...)?`
+//! swallows the per-subvalue type errors that `..` naturally produces (a
+//! filter that demands an object will error on the array nodes recurse
+//! visits, and that's an expected divergence in error message wording,
+//! not a value divergence) — the property under test is value-level
+//! parity on the cases that *do* produce output.
+//!
+//! ## Knobs
+//!
+//! * `JQJIT_PROPTEST_CASES` — case budget (default 200)
+//! * `JQJIT_PROPTEST_TIMEOUT_SECS` — per-subprocess cap (default 3)
+//! * `JQ_BIN` — override the reference jq binary
+//!
+//! When a failure shrinks, paste the minimal `(<inner>, JsonShape)` into
+//! `tests/regression.test`, with the `..` prefix made explicit in the
+//! filter column.
+
+mod common;
+
+use std::time::Duration;
+
+use proptest::prelude::*;
+
+use common::diff_harness::{jq_jit_path, require_jq, run_filter};
+use common::filter_strategy::{
+    base_filter_strategy, base_json_strategy, conservative_json_leaf,
+    conservative_leaf_strategy, render, render_json,
+};
+use common::json_normalize::normalize;
+
+const TEST_LABEL: &str = "fuzz_axis_recurse";
+
+#[test]
+fn fuzz_axis_recurse_against_jq_1_8() {
+    let Some(jq) = require_jq(TEST_LABEL) else { return };
+    let jq_jit = jq_jit_path().to_string();
+
+    let cases: u32 = std::env::var("JQJIT_PROPTEST_CASES")
+        .ok().and_then(|s| s.parse().ok()).unwrap_or(200);
+    let timeout_secs: u64 = std::env::var("JQJIT_PROPTEST_TIMEOUT_SECS")
+        .ok().and_then(|s| s.parse().ok()).unwrap_or(3);
+    let timeout = Duration::from_secs(timeout_secs);
+
+    let compared = std::sync::atomic::AtomicUsize::new(0);
+    let both_error = std::sync::atomic::AtomicUsize::new(0);
+
+    let cfg = ProptestConfig {
+        cases, failure_persistence: None, max_shrink_time: 15_000,
+        ..ProptestConfig::default()
+    };
+
+    let mut runner = proptest::test_runner::TestRunner::new(cfg);
+    let strategy = (
+        base_filter_strategy(conservative_leaf_strategy(), 3, 16, 3),
+        base_json_strategy(conservative_json_leaf(), 3, 12, 3),
+    );
+
+    let result = runner.run(&strategy, |(inner, input_shape)| {
+        // `..` placed at the head: every sub-value of the input becomes
+        // the input to `<inner>`. Outer `?` swallows per-subvalue errors.
+        let filter = format!("((..) | ({}))?", render(&inner));
+        let input = render_json(&input_shape);
+
+        let Some(r_jq) = run_filter(&jq, &filter, &input, timeout) else { return Ok(()); };
+        let Some(r_jit) = run_filter(&jq_jit, &filter, &input, timeout) else { return Ok(()); };
+
+        let crash_markers = ["panicked", "SIGSEGV", "Assertion failed", "stack overflow", "RUST_BACKTRACE"];
+        if crash_markers.iter().any(|m| r_jit.stdout.contains(m)) {
+            return Err(TestCaseError::fail(format!(
+                "jq-jit crashed\n  filter: {}\n  input:  {}\n  stderr: {}",
+                filter, input, r_jit.stdout.trim()
+            )));
+        }
+
+        if r_jq.is_error && r_jit.is_error {
+            both_error.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            return Ok(());
+        }
+        if r_jq.is_error != r_jit.is_error {
+            return Err(TestCaseError::fail(format!(
+                "error mismatch (jq error={}, jit error={})\n  filter: {}\n  input:  {}\n  jq:  {}\n  jit: {}",
+                r_jq.is_error, r_jit.is_error, filter, input,
+                r_jq.stdout.trim(), r_jit.stdout.trim()
+            )));
+        }
+
+        let a_norm = match normalize(&r_jq.stdout) { Ok(s) => s, Err(_) => return Ok(()) };
+        let b_norm = match normalize(&r_jit.stdout) {
+            Ok(s) => s,
+            Err(e) => return Err(TestCaseError::fail(format!(
+                "jq-jit emitted non-JSON\n  filter: {}\n  input:  {}\n  err: {}\n  jit: {}",
+                filter, input, e, r_jit.stdout.trim()
+            ))),
+        };
+
+        compared.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        if a_norm != b_norm {
+            return Err(TestCaseError::fail(format!(
+                "value mismatch\n  filter: {}\n  input:  {}\n  jq:  {}\n  jit: {}",
+                filter, input, a_norm, b_norm
+            )));
+        }
+        Ok(())
+    });
+
+    eprintln!(
+        "=== fuzz_axis_recurse (vs {}) ===\n  compared: {}\n  both_errored: {}",
+        jq,
+        compared.load(std::sync::atomic::Ordering::Relaxed),
+        both_error.load(std::sync::atomic::Ordering::Relaxed),
+    );
+
+    if let Err(e) = result {
+        panic!("fuzz_axis_recurse failed:\n{}", e);
+    }
+}

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -10221,3 +10221,18 @@ false
 try {a: .a} catch "ERROR"
 false
 "ERROR"
+
+# Issue #686 axis fuzz follow-up: raw-byte `detect_computed_remap` for
+# `{key: (if .a cmp .b then <FieldCmpField> else <const> end)}` shape
+# bailed only when the conditional's own field check would emit `null`
+# (#341), missing the case where the branch *output* would. With both
+# `.a` and `.c` null, the if-cond `.c >= .a` evaluates true on the
+# null/null branch, and the then-branch `.a > .c` lands on the
+# `FieldCmpField` emitter's null-literal fallback (line ~1581) instead
+# of computing the actual ordering. Surfaced by the metamorphic
+# harness as `[X] | add ≢ reduce X as $x (null; . + $x)` for this X.
+# Fix: extend `ResolvedRemap::CondChain`'s `resolved_would_error` to
+# also probe each branch output.
+{a: (if (.c >= .a) then (.a > .c) else 0 end)}
+{"a":null,"c":null}
+{"a":false}


### PR DESCRIPTION
## Summary

Five `tests/fuzz_axis_*.rs` files, each re-enabling exactly one
`fuzz_restricted` exclusion so the shrinker can't collapse onto a
louder error class (closes #686, completing the four-axis bug-hunt
plan #683 / #684 / #685 / #686).

| file | re-enables |
|---|---|
| `fuzz_axis_recurse.rs`     | `..` placed at the head of the pipeline |
| `fuzz_axis_float_input.rs` | JSON input values include float literals |
| `fuzz_axis_iterate.rs`     | bare `.[]` placed at the head of the pipeline |
| `fuzz_axis_assign.rs`      | `.f = …` / `.f \|= …` / `.f += …` forms |
| `fuzz_axis_const_pipe.rs`  | `Pipe(<lhs>, <constant-rhs>)` biased |

Each axis:
- builds on `tests/common/filter_strategy.rs` (#688) for the shared
  single-valued base — confirms the extension model that #688's docs
  set up.
- wraps generated filters in `(filter)?` to swallow expected
  error-message divergences (per #686's instruction).
- defaults to 200 cases — `cargo test --release` for all five stays
  under ~25s on dev hardware, in line with the issue's "small,
  dedicated, cheap" target.
- shares knobs with the rest of `fuzz_*` (`JQJIT_PROPTEST_CASES`,
  `JQJIT_PROPTEST_TIMEOUT_SECS`, `JQ_BIN`).

## Bug found and fixed

The metamorphic harness (#683 / #688) surfaced a latent bug in
`src/bin/jq-jit.rs` while CI was first running: raw-byte
`detect_computed_remap` for `{key: (if .a cmp .b then <FieldCmpField>
else <const> end)}` committed even when the picked branch's output
would land on the inner emitter's null-literal fallback. Minimal
repro: `{a: (if .c >= .a then .a > .c else 0 end)}` on
`{a:null,c:null}` → `{a:null}` (jq says `{a:false}`).

Fixed in commit `9b2b234`: extended `ResolvedRemap::CondChain`'s
`resolved_would_error` to also probe each branch output. Pinned in
`tests/regression.test` with the corrected expected output.

## Issue-list deviations

Two of the five files named in the issue no longer correspond to real
exclusions in `fuzz_restricted.rs` and were substituted:

| issue's name | substituted with | reason |
|---|---|---|
| `fuzz_axis_slice.rs`     | `fuzz_axis_iterate.rs` | `.[:]` is a parse error on both jq and jq-jit (#438); `SliceLo` / `SliceHi` already cover all generatable forms. Bare `.[]` is the next implicit exclusion — no AST variant. |
| `fuzz_axis_dup_keys.rs`  | `fuzz_axis_assign.rs`  | Duplicate object keys generate freely now (#233 / #325 paths dedupe last-wins). Assignment forms (`=`, `\|=`, `+=`) are the next implicit exclusion — no AST variant. |

## Test plan

- [x] `cargo build --release --tests`
- [x] `cargo clippy --release --tests` clean on new files
- [x] All 5 axes pass at default budget (200 cases, ~5s each)
- [x] Full `cargo test --release` green locally post-fix
- [x] CI green on ubuntu / macos / windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)