### PR TITLE
release v1.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jq-jit"
-version = "1.6.1"
+version = "1.7.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jq-jit"
-version = "1.6.1"
+version = "1.7.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A JIT-compiling implementation of jq using Cranelift"

--- a/docs/benchmark-history.md
+++ b/docs/benchmark-history.md
@@ -6,265 +6,265 @@ Recent slice (last 5 columns). Full history lives in
 
 ```text
 --- NDJSON workloads (2M objects) ---
-  Benchmark                    v1.5.4  v1.5.5  v1.5.6  v1.6.0  v1.6.1
+  Benchmark                    v1.5.5  v1.5.6  v1.6.0  v1.6.1  v1.7.0
   ---                          ------  ------  ------  ------  ------
-  empty                        0.017s  0.017s  0.017s  0.017s  0.018s
-  identity -c                  0.088s  0.087s  0.087s  0.088s  0.087s
-  identity (pretty)            0.103s  0.102s  0.105s  0.106s  0.107s
-  field access .name           0.096s  0.094s  0.095s  0.096s  0.097s
-  nested .x,.y,.name           0.151s  0.150s  0.150s  0.155s  0.150s
-  arithmetic .x + .y           0.085s  0.086s  0.083s  0.086s  0.084s
-  select .x > 1500000          0.083s  0.083s  0.082s  0.083s  0.087s
-  string concat                0.094s  0.093s  0.093s  0.092s  0.095s
-  object construct             0.115s  0.115s  0.111s  0.115s  0.116s
-  array construct              0.107s  0.106s  0.103s  0.107s  0.106s
-  .[]                          0.105s  0.106s  0.101s  0.105s  0.104s
-  to_entries                   0.157s  0.162s  0.159s  0.159s  0.159s
-  keys                         0.107s  0.106s  0.109s  0.105s  0.107s
-  keys_unsorted                0.094s  0.095s  0.095s  0.095s  0.097s
-  length                       0.085s  0.086s  0.085s  0.087s  0.088s
-  has("x")                     0.037s  0.037s  0.034s  0.039s  0.039s
-  type                         0.022s  0.023s  0.022s  0.023s  0.023s
-  del(.name)                   0.103s  0.102s  0.104s  0.103s  0.107s
-  @csv                         0.127s  0.124s  0.123s  0.124s  0.120s
-  split/join                   0.091s  0.091s  0.089s  0.090s  0.094s
-  select|field                 0.103s  0.097s  0.095s  0.101s  0.099s
-  select|remap                 0.100s  0.100s  0.095s  0.098s  0.100s
-  computed remap               0.194s  0.192s  0.191s  0.190s  0.192s
-  [.x,.y]|add                  0.084s  0.086s  0.082s  0.084s  0.084s
-  [.x,.y]|avg                  0.107s  0.112s  0.106s  0.109s  0.111s
-  map(*2)|add                  0.105s  0.106s  0.103s  0.106s  0.107s
-  keys|length                  0.254s  0.252s  0.251s  0.253s  0.259s
-  .+{z=0}                      0.152s  0.147s  0.146s  0.150s  0.150s
-  split|first                  0.090s  0.090s  0.090s  0.091s  0.092s
-  slice[0..5]                  0.093s  0.092s  0.092s  0.093s  0.095s
-  dynkey {(.name)}             0.109s  0.104s  0.102s  0.106s  0.108s
-  .x += 1                      0.128s  0.125s  0.125s  0.129s  0.128s
-  {a}+{b} merge                0.136s  0.130s  0.135s  0.132s  0.133s
-  .x*2+1                       0.060s  0.060s  0.060s  0.060s  0.061s
-  .x+.y*2                      0.098s  0.100s  0.096s  0.100s  0.099s
-  .x > .y                      0.078s  0.081s  0.077s  0.079s  0.078s
-  to_entries|len               0.397s  0.394s  0.400s  0.400s  0.405s
-  .x|.+1 (pipe)                0.058s  0.058s  0.058s  0.058s  0.059s
-  .x|.*2|.+1                   0.059s  0.060s  0.059s  0.060s  0.060s
-  .name|.+"_x"                 0.094s  0.092s  0.092s  0.094s  0.097s
-  .x>N | not                   0.051s  0.050s  0.049s  0.049s  0.051s
-  and (2 cmp)                  0.081s  0.085s  0.080s  0.085s  0.082s
-  if-then-else                 0.051s  0.052s  0.052s  0.051s  0.053s
-  sel(and)|field               0.078s  0.083s  0.077s  0.080s  0.079s
-  sel(and)|remap               0.077s  0.083s  0.077s  0.079s  0.079s
-  arith|cmp                    0.055s  0.055s  0.053s  0.054s  0.056s
-  if cmp .field                0.115s  0.114s  0.114s  0.113s  0.118s
-  split|length                 0.089s  0.088s  0.090s  0.089s  0.093s
-  [x,y]|min                    0.089s  0.095s  0.090s  0.092s  0.092s
-  [x,y]|max                    0.094s  0.097s  0.092s  0.096s  0.097s
-  [x,y]|sort|.[0]              0.091s  0.094s  0.090s  0.093s  0.092s
-  .name|len>5                  0.094s  0.092s  0.092s  0.093s  0.094s
-  sel(len>5)|.x                0.111s  0.110s  0.111s  0.113s  0.111s
-  if .x>.y .name               0.091s  0.092s  0.089s  0.093s  0.092s
-  sel(.x>.y)|.name             0.070s  0.076s  0.072s  0.075s  0.074s
-  .x*2|tostring                0.057s  0.057s  0.056s  0.057s  0.058s
-  .x*.x+1                      0.066s  0.066s  0.066s  0.066s  0.067s
-  {k=.name,v=tostr}            0.154s  0.146s  0.144s  0.151s  0.147s
-  str add chain                0.393s  0.378s  0.385s  0.388s  0.388s
-  if>.y .name|empty            0.073s  0.080s  0.073s  0.077s  0.073s
-  if .x%2==0                   0.054s  0.056s  0.054s  0.055s  0.054s
-  if .x*2+1>1M                 0.056s  0.056s  0.054s  0.055s  0.055s
-  sel(.x%2==0)|.name           0.084s  0.083s  0.083s  0.083s  0.084s
-  sel(.x*2+1>1M)               0.158s  0.159s  0.159s  0.160s  0.157s
-  .x|@json                     0.048s  0.047s  0.048s  0.048s  0.049s
-  .x|@text                     0.048s  0.048s  0.047s  0.048s  0.049s
-  .name|@json                  0.108s  0.104s  0.103s  0.103s  0.102s
-  sel|[arr]                    0.147s  0.146s  0.143s  0.147s  0.143s
-  sel(and)|[arr]               0.078s  0.082s  0.077s  0.081s  0.077s
-  if>.y [arr]                  0.183s  0.176s  0.173s  0.178s  0.175s
-  if sw then .f                0.139s  0.138s  0.139s  0.143s  0.143s
-  dynkey {(.n)=.x*2}           0.113s  0.113s  0.114s  0.115s  0.117s
-  sel(and)|.x*.y               0.077s  0.082s  0.076s  0.079s  0.077s
-  sel>N|str chain              0.159s  0.154s  0.151s  0.156s  0.152s
-  .f+"_"+arith_ts              0.140s  0.133s  0.132s  0.136s  0.134s
-  sel(sw)|str ch               0.310s  0.303s  0.307s  0.304s  0.308s
-  split|rev|join               0.117s  0.114s  0.114s  0.118s  0.117s
-  dynkey+static                0.339s  0.344s  0.331s  0.338s  0.340s
-  if>.y str chain              0.174s  0.167s  0.165s  0.166s  0.167s
-  remap+str chain              0.160s  0.153s  0.148s  0.159s  0.156s
-  sel(len>8)                   0.161s  0.160s  0.165s  0.161s  0.163s
-  up|split|join                0.095s  0.099s  0.097s  0.098s  0.098s
-  .name|index                  0.123s  0.121s  0.121s  0.120s  0.121s
-  .name|index+1                0.126s  0.125s  0.123s  0.124s  0.126s
-  .name|rindex                 0.129s  0.129s  0.127s  0.130s  0.131s
-  .name|indices                0.155s  0.157s  0.146s  0.159s  0.161s
-  [x,y]|sort                   0.156s  0.153s  0.152s  0.156s  0.154s
-  .name|scan                   0.211s  0.209s  0.208s  0.209s  0.214s
-  .name|gsub                   0.166s  0.163s  0.168s  0.168s  0.170s
-  walk(if num .+1)             0.142s  0.145s  0.143s  0.142s  0.140s
-  tojson                       0.108s  0.106s  0.104s  0.106s  0.106s
-  {name,x}                     0.134s  0.129s  0.133s  0.130s  0.129s
-  .z//.name                    0.155s  0.157s  0.157s  0.157s  0.158s
-  .x|=test(re)                 0.172s  0.173s  0.180s  0.171s  0.176s
-  ./sep|first                  0.187s  0.184s  0.182s  0.190s  0.185s
-  .y=(.x*2)                    0.179s  0.179s  0.178s  0.181s  0.180s
-  .y=(.x+.y)                   0.229s  0.229s  0.233s  0.238s  0.234s
-  objects                      0.137s  0.128s  0.138s  0.134s  0.138s
-  .tag|=if..then N             0.618s  0.607s  0.614s  0.617s  0.611s
-  .x=(.x+1)                    0.128s  0.122s  0.128s  0.129s  0.127s
-  sel>N|.y+=1                  0.122s  0.123s  0.121s  0.124s  0.122s
-  sel(and)|.x+=1               0.110s  0.109s  0.111s  0.111s  0.111s
-  sel(sw)|.x+=1                0.165s  0.163s  0.164s  0.165s  0.163s
-  match(re)                    0.375s  0.361s  0.369s  0.364s  0.367s
-  capture(re)                  0.306s  0.298s  0.296s  0.297s  0.299s
-  first(.name,.x)              0.097s  0.096s  0.097s  0.098s  0.097s
-  if .x==null                  0.047s  0.047s  0.046s  0.048s  0.047s
-  we(sw(.key))                 0.108s  0.107s  0.110s  0.110s  0.105s
-  sel(sw or ew)                0.214s  0.207s  0.205s  0.202s  0.207s
-  path(.name,.x)               0.278s  0.274s  0.274s  0.276s  0.278s
-  sel(str+num+num)             0.150s  0.151s  0.152s  0.152s  0.153s
-  nested if|field              0.077s  0.082s  0.076s  0.081s  0.077s
-  .f|floor|.*2                 0.061s  0.061s  0.061s  0.061s  0.061s
-  split|len>1                  0.120s  0.118s  0.114s  0.118s  0.119s
-  .name|len|.*2                0.104s  0.102s  0.103s  0.104s  0.103s
-  if len>5 .x .y               0.116s  0.115s  0.113s  0.118s  0.113s
-  sel(len>5)|remap             0.209s  0.206s  0.207s  0.207s  0.202s
-  .x|tostr|len                 0.060s  0.058s  0.059s  0.062s  0.060s
-  if .x>.y .x .y               0.094s  0.098s  0.093s  0.097s  0.094s
-  split|last|tonum             0.095s  0.095s  0.096s  0.096s  0.097s
-  split|rev|.[0]               0.091s  0.094s  0.090s  0.096s  0.091s
-  split|.[0]+.[1]              0.113s  0.115s  0.114s  0.113s  0.115s
-  .[]|strings                  0.105s  0.106s  0.104s  0.106s  0.106s
-  .[]|numbers                  0.124s  0.124s  0.124s  0.129s  0.125s
-  [x,y]|any(>1M)               0.082s  0.087s  0.082s  0.084s  0.082s
-  sel(dc|sw)                   0.099s  0.102s  0.097s  0.098s  0.101s
-  [[x,y],[n]]|flat             0.464s  0.456s  0.460s  0.460s  0.462s
-  .x|floor|.*2                 0.061s  0.061s  0.061s  0.061s  0.060s
-  tojson|fromjson              0.087s  0.087s  0.085s  0.087s  0.084s
-  [.x]|add                     0.058s  0.060s  0.060s  0.060s  0.060s
-  if>N {o}+.                   0.138s  0.134s  0.135s  0.136s  0.135s
-  if>N .+{o}                   0.137s  0.134s  0.138s  0.135s  0.135s
-  if .n=="s" .+{o}             0.168s  0.161s  0.161s  0.158s  0.161s
-  sel(.n>"s")                  0.090s  0.089s  0.089s  0.089s  0.090s
-  [x,y,z]|min                  0.314s  0.309s  0.309s  0.308s  0.311s
-  if .n|len>5 l s              0.102s  0.102s  0.100s  0.100s  0.101s
-  if .x|flr>N b s              0.054s  0.056s  0.056s  0.056s  0.055s
-  if .n|test l e               0.108s  0.103s  0.106s  0.105s  0.105s
-  if .n|sw l e                 0.083s  0.083s  0.084s  0.083s  0.085s
-  if .n|ew l e                 0.085s  0.084s  0.084s  0.084s  0.086s
-  .n|len|tostr                 0.090s  0.091s  0.092s  0.092s  0.091s
+  empty                        0.017s  0.017s  0.017s  0.018s  0.017s
+  identity -c                  0.087s  0.087s  0.088s  0.087s  0.086s
+  identity (pretty)            0.102s  0.105s  0.106s  0.107s  0.106s
+  field access .name           0.094s  0.095s  0.096s  0.097s  0.093s
+  nested .x,.y,.name           0.150s  0.150s  0.155s  0.150s  0.147s
+  arithmetic .x + .y           0.086s  0.083s  0.086s  0.084s  0.083s
+  select .x > 1500000          0.083s  0.082s  0.083s  0.087s  0.084s
+  string concat                0.093s  0.093s  0.092s  0.095s  0.092s
+  object construct             0.115s  0.111s  0.115s  0.116s  0.114s
+  array construct              0.106s  0.103s  0.107s  0.106s  0.105s
+  .[]                          0.106s  0.101s  0.105s  0.104s  0.102s
+  to_entries                   0.162s  0.159s  0.159s  0.159s  0.163s
+  keys                         0.106s  0.109s  0.105s  0.107s  0.105s
+  keys_unsorted                0.095s  0.095s  0.095s  0.097s  0.094s
+  length                       0.086s  0.085s  0.087s  0.088s  0.084s
+  has("x")                     0.037s  0.034s  0.039s  0.039s  0.037s
+  type                         0.023s  0.022s  0.023s  0.023s  0.023s
+  del(.name)                   0.102s  0.104s  0.103s  0.107s  0.101s
+  @csv                         0.124s  0.123s  0.124s  0.120s  0.118s
+  split/join                   0.091s  0.089s  0.090s  0.094s  0.090s
+  select|field                 0.097s  0.095s  0.101s  0.099s  0.097s
+  select|remap                 0.100s  0.095s  0.098s  0.100s  0.099s
+  computed remap               0.192s  0.191s  0.190s  0.192s  0.191s
+  [.x,.y]|add                  0.086s  0.082s  0.084s  0.084s  0.083s
+  [.x,.y]|avg                  0.112s  0.106s  0.109s  0.111s  0.106s
+  map(*2)|add                  0.106s  0.103s  0.106s  0.107s  0.104s
+  keys|length                  0.252s  0.251s  0.253s  0.259s  0.255s
+  .+{z=0}                      0.147s  0.146s  0.150s  0.150s  0.146s
+  split|first                  0.090s  0.090s  0.091s  0.092s  0.089s
+  slice[0..5]                  0.092s  0.092s  0.093s  0.095s  0.094s
+  dynkey {(.name)}             0.104s  0.102s  0.106s  0.108s  0.104s
+  .x += 1                      0.125s  0.125s  0.129s  0.128s  0.121s
+  {a}+{b} merge                0.130s  0.135s  0.132s  0.133s  0.130s
+  .x*2+1                       0.060s  0.060s  0.060s  0.061s  0.060s
+  .x+.y*2                      0.100s  0.096s  0.100s  0.099s  0.100s
+  .x > .y                      0.081s  0.077s  0.079s  0.078s  0.077s
+  to_entries|len               0.394s  0.400s  0.400s  0.405s  0.397s
+  .x|.+1 (pipe)                0.058s  0.058s  0.058s  0.059s  0.059s
+  .x|.*2|.+1                   0.060s  0.059s  0.060s  0.060s  0.060s
+  .name|.+"_x"                 0.092s  0.092s  0.094s  0.097s  0.094s
+  .x>N | not                   0.050s  0.049s  0.049s  0.051s  0.049s
+  and (2 cmp)                  0.085s  0.080s  0.085s  0.082s  0.080s
+  if-then-else                 0.052s  0.052s  0.051s  0.053s  0.052s
+  sel(and)|field               0.083s  0.077s  0.080s  0.079s  0.076s
+  sel(and)|remap               0.083s  0.077s  0.079s  0.079s  0.077s
+  arith|cmp                    0.055s  0.053s  0.054s  0.056s  0.054s
+  if cmp .field                0.114s  0.114s  0.113s  0.118s  0.113s
+  split|length                 0.088s  0.090s  0.089s  0.093s  0.089s
+  [x,y]|min                    0.095s  0.090s  0.092s  0.092s  0.090s
+  [x,y]|max                    0.097s  0.092s  0.096s  0.097s  0.095s
+  [x,y]|sort|.[0]              0.094s  0.090s  0.093s  0.092s  0.089s
+  .name|len>5                  0.092s  0.092s  0.093s  0.094s  0.090s
+  sel(len>5)|.x                0.110s  0.111s  0.113s  0.111s  0.107s
+  if .x>.y .name               0.092s  0.089s  0.093s  0.092s  0.093s
+  sel(.x>.y)|.name             0.076s  0.072s  0.075s  0.074s  0.071s
+  .x*2|tostring                0.057s  0.056s  0.057s  0.058s  0.057s
+  .x*.x+1                      0.066s  0.066s  0.066s  0.067s  0.067s
+  {k=.name,v=tostr}            0.146s  0.144s  0.151s  0.147s  0.144s
+  str add chain                0.378s  0.385s  0.388s  0.388s  0.385s
+  if>.y .name|empty            0.080s  0.073s  0.077s  0.073s  0.073s
+  if .x%2==0                   0.056s  0.054s  0.055s  0.054s  0.055s
+  if .x*2+1>1M                 0.056s  0.054s  0.055s  0.055s  0.056s
+  sel(.x%2==0)|.name           0.083s  0.083s  0.083s  0.084s  0.084s
+  sel(.x*2+1>1M)               0.159s  0.159s  0.160s  0.157s  0.159s
+  .x|@json                     0.047s  0.048s  0.048s  0.049s  0.047s
+  .x|@text                     0.048s  0.047s  0.048s  0.049s  0.048s
+  .name|@json                  0.104s  0.103s  0.103s  0.102s  0.101s
+  sel|[arr]                    0.146s  0.143s  0.147s  0.143s  0.149s
+  sel(and)|[arr]               0.082s  0.077s  0.081s  0.077s  0.079s
+  if>.y [arr]                  0.176s  0.173s  0.178s  0.175s  0.179s
+  if sw then .f                0.138s  0.139s  0.143s  0.143s  0.139s
+  dynkey {(.n)=.x*2}           0.113s  0.114s  0.115s  0.117s  0.115s
+  sel(and)|.x*.y               0.082s  0.076s  0.079s  0.077s  0.077s
+  sel>N|str chain              0.154s  0.151s  0.156s  0.152s  0.155s
+  .f+"_"+arith_ts              0.133s  0.132s  0.136s  0.134s  0.133s
+  sel(sw)|str ch               0.303s  0.307s  0.304s  0.308s  0.307s
+  split|rev|join               0.114s  0.114s  0.118s  0.117s  0.117s
+  dynkey+static                0.344s  0.331s  0.338s  0.340s  0.338s
+  if>.y str chain              0.167s  0.165s  0.166s  0.167s  0.171s
+  remap+str chain              0.153s  0.148s  0.159s  0.156s  0.156s
+  sel(len>8)                   0.160s  0.165s  0.161s  0.163s  0.162s
+  up|split|join                0.099s  0.097s  0.098s  0.098s  0.095s
+  .name|index                  0.121s  0.121s  0.120s  0.121s  0.118s
+  .name|index+1                0.125s  0.123s  0.124s  0.126s  0.122s
+  .name|rindex                 0.129s  0.127s  0.130s  0.131s  0.127s
+  .name|indices                0.157s  0.146s  0.159s  0.161s  0.155s
+  [x,y]|sort                   0.153s  0.152s  0.156s  0.154s  0.153s
+  .name|scan                   0.209s  0.208s  0.209s  0.214s  0.207s
+  .name|gsub                   0.163s  0.168s  0.168s  0.170s  0.167s
+  walk(if num .+1)             0.145s  0.143s  0.142s  0.140s  0.141s
+  tojson                       0.106s  0.104s  0.106s  0.106s  0.104s
+  {name,x}                     0.129s  0.133s  0.130s  0.129s  0.128s
+  .z//.name                    0.157s  0.157s  0.157s  0.158s  0.154s
+  .x|=test(re)                 0.173s  0.180s  0.171s  0.176s  0.172s
+  ./sep|first                  0.184s  0.182s  0.190s  0.185s  0.182s
+  .y=(.x*2)                    0.179s  0.178s  0.181s  0.180s  0.174s
+  .y=(.x+.y)                   0.229s  0.233s  0.238s  0.234s  0.228s
+  objects                      0.128s  0.138s  0.134s  0.138s  0.134s
+  .tag|=if..then N             0.607s  0.614s  0.617s  0.611s  0.627s
+  .x=(.x+1)                    0.122s  0.128s  0.129s  0.127s  0.124s
+  sel>N|.y+=1                  0.123s  0.121s  0.124s  0.122s  0.122s
+  sel(and)|.x+=1               0.109s  0.111s  0.111s  0.111s  0.109s
+  sel(sw)|.x+=1                0.163s  0.164s  0.165s  0.163s  0.159s
+  match(re)                    0.361s  0.369s  0.364s  0.367s  0.362s
+  capture(re)                  0.298s  0.296s  0.297s  0.299s  0.302s
+  first(.name,.x)              0.096s  0.097s  0.098s  0.097s  0.094s
+  if .x==null                  0.047s  0.046s  0.048s  0.047s  0.046s
+  we(sw(.key))                 0.107s  0.110s  0.110s  0.105s  0.108s
+  sel(sw or ew)                0.207s  0.205s  0.202s  0.207s  0.205s
+  path(.name,.x)               0.274s  0.274s  0.276s  0.278s  0.278s
+  sel(str+num+num)             0.151s  0.152s  0.152s  0.153s  0.150s
+  nested if|field              0.082s  0.076s  0.081s  0.077s  0.077s
+  .f|floor|.*2                 0.061s  0.061s  0.061s  0.061s  0.060s
+  split|len>1                  0.118s  0.114s  0.118s  0.119s  0.115s
+  .name|len|.*2                0.102s  0.103s  0.104s  0.103s  0.103s
+  if len>5 .x .y               0.115s  0.113s  0.118s  0.113s  0.113s
+  sel(len>5)|remap             0.206s  0.207s  0.207s  0.202s  0.201s
+  .x|tostr|len                 0.058s  0.059s  0.062s  0.060s  0.059s
+  if .x>.y .x .y               0.098s  0.093s  0.097s  0.094s  0.094s
+  split|last|tonum             0.095s  0.096s  0.096s  0.097s  0.096s
+  split|rev|.[0]               0.094s  0.090s  0.096s  0.091s  0.091s
+  split|.[0]+.[1]              0.115s  0.114s  0.113s  0.115s  0.113s
+  .[]|strings                  0.106s  0.104s  0.106s  0.106s  0.105s
+  .[]|numbers                  0.124s  0.124s  0.129s  0.125s  0.124s
+  [x,y]|any(>1M)               0.087s  0.082s  0.084s  0.082s  0.082s
+  sel(dc|sw)                   0.102s  0.097s  0.098s  0.101s  0.098s
+  [[x,y],[n]]|flat             0.456s  0.460s  0.460s  0.462s  0.464s
+  .x|floor|.*2                 0.061s  0.061s  0.061s  0.060s  0.061s
+  tojson|fromjson              0.087s  0.085s  0.087s  0.084s  0.082s
+  [.x]|add                     0.060s  0.060s  0.060s  0.060s  0.059s
+  if>N {o}+.                   0.134s  0.135s  0.136s  0.135s  0.138s
+  if>N .+{o}                   0.134s  0.138s  0.135s  0.135s  0.136s
+  if .n=="s" .+{o}             0.161s  0.161s  0.158s  0.161s  0.157s
+  sel(.n>"s")                  0.089s  0.089s  0.089s  0.090s  0.091s
+  [x,y,z]|min                  0.309s  0.309s  0.308s  0.311s  0.307s
+  if .n|len>5 l s              0.102s  0.100s  0.100s  0.101s  0.100s
+  if .x|flr>N b s              0.056s  0.056s  0.056s  0.055s  0.055s
+  if .n|test l e               0.103s  0.106s  0.105s  0.105s  0.105s
+  if .n|sw l e                 0.083s  0.084s  0.083s  0.085s  0.082s
+  if .n|ew l e                 0.084s  0.084s  0.084s  0.086s  0.085s
+  .n|len|tostr                 0.091s  0.092s  0.092s  0.091s  0.090s
 
 --- String operations (2M objects) ---
-  Benchmark                    v1.5.4  v1.5.5  v1.5.6  v1.6.0  v1.6.1
+  Benchmark                    v1.5.5  v1.5.6  v1.6.0  v1.6.1  v1.7.0
   ---                          ------  ------  ------  ------  ------
-  ascii_downcase               0.107s  0.108s  0.105s  0.105s  0.106s
-  ascii_upcase                 0.104s  0.108s  0.103s  0.104s  0.106s
-  ltrimstr                     0.099s  0.096s  0.095s  0.096s  0.099s
-  rtrimstr                     0.101s  0.099s  0.098s  0.098s  0.099s
-  split                        0.168s  0.168s  0.162s  0.170s  0.165s
-  case+split                   0.116s  0.113s  0.115s  0.118s  0.116s
-  join                         0.095s  0.090s  0.091s  0.096s  0.093s
-  startswith                   0.096s  0.095s  0.095s  0.098s  0.098s
-  endswith                     0.099s  0.097s  0.096s  0.098s  0.098s
-  tostring                     0.063s  0.062s  0.063s  0.063s  0.063s
-  tonumber                     0.113s  0.114s  0.110s  0.112s  0.111s
-  string interpolation         0.121s  0.115s  0.118s  0.120s  0.116s
+  ascii_downcase               0.108s  0.105s  0.105s  0.106s  0.104s
+  ascii_upcase                 0.108s  0.103s  0.104s  0.106s  0.103s
+  ltrimstr                     0.096s  0.095s  0.096s  0.099s  0.097s
+  rtrimstr                     0.099s  0.098s  0.098s  0.099s  0.097s
+  split                        0.168s  0.162s  0.170s  0.165s  0.162s
+  case+split                   0.113s  0.115s  0.118s  0.116s  0.121s
+  join                         0.090s  0.091s  0.096s  0.093s  0.093s
+  startswith                   0.095s  0.095s  0.098s  0.098s  0.095s
+  endswith                     0.097s  0.096s  0.098s  0.098s  0.096s
+  tostring                     0.062s  0.063s  0.063s  0.063s  0.063s
+  tonumber                     0.114s  0.110s  0.112s  0.111s  0.110s
+  string interpolation         0.115s  0.118s  0.120s  0.116s  0.118s
 
 --- String ops (200K objects) ---
-  Benchmark                    v1.5.4  v1.5.5  v1.5.6  v1.6.0  v1.6.1
+  Benchmark                    v1.5.5  v1.5.6  v1.6.0  v1.6.1  v1.7.0
   ---                          ------  ------  ------  ------  ------
-  test (regex)                 0.014s  0.014s  0.015s  0.015s  0.015s
-  match (regex)                0.032s  0.032s  0.033s  0.032s  0.033s
+  test (regex)                 0.014s  0.015s  0.015s  0.015s  0.014s
+  match (regex)                0.032s  0.033s  0.032s  0.033s  0.032s
   @base64                      0.012s  0.012s  0.012s  0.012s  0.012s
-  @uri                         0.012s  0.013s  0.012s  0.012s  0.013s
-  @html                        0.012s  0.013s  0.012s  0.012s  0.013s
-  @csv (array)                 0.016s  0.015s  0.015s  0.016s  0.016s
-  @tsv (array)                 0.015s  0.014s  0.015s  0.015s  0.015s
-  gsub                         0.018s  0.018s  0.019s  0.019s  0.019s
-  case+gsub                    0.177s  0.176s  0.181s  0.181s  0.181s
-  case+test                    0.118s  0.118s  0.119s  0.116s  0.124s
-  ltrim+tonum+arith            0.115s  0.112s  0.111s  0.113s  0.113s
+  @uri                         0.013s  0.012s  0.012s  0.013s  0.012s
+  @html                        0.013s  0.012s  0.012s  0.013s  0.012s
+  @csv (array)                 0.015s  0.015s  0.016s  0.016s  0.016s
+  @tsv (array)                 0.014s  0.015s  0.015s  0.015s  0.015s
+  gsub                         0.018s  0.019s  0.019s  0.019s  0.019s
+  case+gsub                    0.176s  0.181s  0.181s  0.181s  0.180s
+  case+test                    0.118s  0.119s  0.116s  0.124s  0.120s
+  ltrim+tonum+arith            0.112s  0.111s  0.113s  0.113s  0.111s
 
 --- Numeric & math (2M objects) ---
-  Benchmark                    v1.5.4  v1.5.5  v1.5.6  v1.6.0  v1.6.1
+  Benchmark                    v1.5.5  v1.5.6  v1.6.0  v1.6.1  v1.7.0
   ---                          ------  ------  ------  ------  ------
-  floor                        0.056s  0.057s  0.057s  0.059s  0.056s
-  sqrt                         0.078s  0.079s  0.079s  0.078s  0.079s
-  modulo                       0.058s  0.058s  0.057s  0.057s  0.057s
-  if-elif-else                 0.124s  0.124s  0.121s  0.124s  0.125s
-  select|del                   0.092s  0.090s  0.092s  0.090s  0.090s
-  select|merge                 0.118s  0.119s  0.120s  0.121s  0.118s
-  select(test)|merge           0.022s  0.021s  0.022s  0.021s  0.022s
+  floor                        0.057s  0.057s  0.059s  0.056s  0.057s
+  sqrt                         0.079s  0.079s  0.078s  0.079s  0.079s
+  modulo                       0.058s  0.057s  0.057s  0.057s  0.059s
+  if-elif-else                 0.124s  0.121s  0.124s  0.125s  0.123s
+  select|del                   0.090s  0.092s  0.090s  0.090s  0.091s
+  select|merge                 0.119s  0.120s  0.121s  0.118s  0.121s
+  select(test)|merge           0.021s  0.022s  0.021s  0.022s  0.021s
 
 --- Array generators ---
-  Benchmark                    v1.5.4  v1.5.5  v1.5.6  v1.6.0  v1.6.1
+  Benchmark                    v1.5.5  v1.5.6  v1.6.0  v1.6.1  v1.7.0
   ---                          ------  ------  ------  ------  ------
-  range(2M) | length           0.012s  0.011s  0.011s  0.012s  0.012s
+  range(2M) | length           0.011s  0.011s  0.012s  0.012s  0.012s
   reverse(2M)                  0.018s  0.018s  0.018s  0.018s  0.018s
   sort(2M)                     0.023s  0.023s  0.023s  0.023s  0.023s
-  unique(1M)                   0.030s  0.030s  0.030s  0.031s  0.030s
-  flatten(500K)                0.011s  0.010s  0.010s  0.011s  0.011s
-  min, max(2M)                 0.019s  0.021s  0.018s  0.022s  0.021s
+  unique(1M)                   0.030s  0.030s  0.031s  0.030s  0.030s
+  flatten(500K)                0.010s  0.010s  0.011s  0.011s  0.011s
+  min, max(2M)                 0.021s  0.018s  0.022s  0.021s  0.019s
   add numbers(2M)              0.013s  0.013s  0.013s  0.013s  0.013s
-  any/all(2M)                  0.028s  0.028s  0.028s  0.029s  0.028s
-  limit(10; range(10M))        0.002s  0.002s  0.002s  0.003s  0.002s
-  first(range(10M))            0.002s  0.002s  0.002s  0.003s  0.002s
-  last(range(2M))              0.002s  0.002s  0.002s  0.003s  0.002s
-  indices(1M)                  0.016s  0.016s  0.016s  0.017s  0.017s
+  any/all(2M)                  0.028s  0.028s  0.029s  0.028s  0.029s
+  limit(10; range(10M))        0.002s  0.002s  0.003s  0.002s  0.003s
+  first(range(10M))            0.002s  0.002s  0.003s  0.002s  0.003s
+  last(range(2M))              0.002s  0.002s  0.003s  0.002s  0.003s
+  indices(1M)                  0.016s  0.016s  0.017s  0.017s  0.017s
 
 --- Reduce & foreach ---
-  Benchmark                    v1.5.4  v1.5.5  v1.5.6  v1.6.0  v1.6.1
+  Benchmark                    v1.5.5  v1.5.6  v1.6.0  v1.6.1  v1.7.0
   ---                          ------  ------  ------  ------  ------
   reduce (sum)                 0.009s  0.009s  0.009s  0.009s  0.009s
   reduce (array build)         0.004s  0.004s  0.004s  0.004s  0.004s
-  reduce (obj build)           0.010s  0.009s  0.009s  0.010s  0.010s
-  reduce (setpath)             0.017s  0.016s  0.016s  0.017s  0.016s
+  reduce (obj build)           0.009s  0.009s  0.010s  0.010s  0.010s
+  reduce (setpath)             0.016s  0.016s  0.017s  0.016s  0.016s
   foreach (running sum)        0.010s  0.010s  0.010s  0.010s  0.010s
-  foreach + emit               0.010s  0.010s  0.010s  0.011s  0.011s
-  reduce (sum-of-squares)      0.034s  0.033s  0.033s  0.036s  0.034s
-  reduce (conditional)         0.036s  0.036s  0.035s  0.037s  0.036s
-  reduce (product)             0.034s  0.034s  0.034s  0.036s  0.035s
-  foreach (conditional)        0.010s  0.010s  0.010s  0.011s  0.010s
-  until (100M)                 0.302s  0.300s  0.301s  0.307s  0.303s
-  reduce (harmonic)            0.033s  0.033s  0.033s  0.035s  0.033s
-  reduce (floor pipe)          0.034s  0.033s  0.032s  0.035s  0.034s
-  reduce (sqrt pipe)           0.033s  0.033s  0.032s  0.035s  0.033s
+  foreach + emit               0.010s  0.010s  0.011s  0.011s  0.010s
+  reduce (sum-of-squares)      0.033s  0.033s  0.036s  0.034s  0.034s
+  reduce (conditional)         0.036s  0.035s  0.037s  0.036s  0.035s
+  reduce (product)             0.034s  0.034s  0.036s  0.035s  0.034s
+  foreach (conditional)        0.010s  0.010s  0.011s  0.010s  0.010s
+  until (100M)                 0.300s  0.301s  0.307s  0.303s  0.305s
+  reduce (harmonic)            0.033s  0.033s  0.035s  0.033s  0.033s
+  reduce (floor pipe)          0.033s  0.032s  0.035s  0.034s  0.033s
+  reduce (sqrt pipe)           0.033s  0.032s  0.035s  0.033s  0.033s
   reduce (sin+cos)             0.052s  0.052s  0.052s  0.052s  0.052s
 
 --- Object operations ---
-  Benchmark                    v1.5.4  v1.5.5  v1.5.6  v1.6.0  v1.6.1
+  Benchmark                    v1.5.5  v1.5.6  v1.6.0  v1.6.1  v1.7.0
   ---                          ------  ------  ------  ------  ------
   large obj construct          0.004s  0.004s  0.004s  0.004s  0.004s
-  large obj keys               0.011s  0.011s  0.011s  0.012s  0.011s
+  large obj keys               0.011s  0.011s  0.012s  0.011s  0.011s
   large obj to_entries         0.012s  0.012s  0.012s  0.012s  0.012s
   with_entries                 0.009s  0.009s  0.009s  0.009s  0.009s
 
 --- Assignment operators ---
-  Benchmark                    v1.5.4  v1.5.5  v1.5.6  v1.6.0  v1.6.1
+  Benchmark                    v1.5.5  v1.5.6  v1.6.0  v1.6.1  v1.7.0
   ---                          ------  ------  ------  ------  ------
   .[] |= f (100K)              0.005s  0.005s  0.005s  0.005s  0.005s
-  .[] += 1 (100K)              0.005s  0.005s  0.005s  0.006s  0.005s
+  .[] += 1 (100K)              0.005s  0.005s  0.006s  0.005s  0.005s
   .[k] = v reduce(50K)         0.008s  0.008s  0.008s  0.008s  0.008s
 
 --- String-heavy generators ---
-  Benchmark                    v1.5.4  v1.5.5  v1.5.6  v1.6.0  v1.6.1
+  Benchmark                    v1.5.5  v1.5.6  v1.6.0  v1.6.1  v1.7.0
   ---                          ------  ------  ------  ------  ------
-  gsub(100K)                   0.027s  0.026s  0.027s  0.027s  0.027s
-  join large(100K)             0.005s  0.005s  0.006s  0.006s  0.005s
-  explode/implode(100K)        0.028s  0.027s  0.028s  0.028s  0.028s
+  gsub(100K)                   0.026s  0.027s  0.027s  0.027s  0.027s
+  join large(100K)             0.005s  0.006s  0.006s  0.005s  0.005s
+  explode/implode(100K)        0.027s  0.028s  0.028s  0.028s  0.027s
   reduce str concat(100K)      0.008s  0.008s  0.008s  0.008s  0.008s
 
 --- Try-catch & alternative ---
-  Benchmark                    v1.5.4  v1.5.5  v1.5.6  v1.6.0  v1.6.1
+  Benchmark                    v1.5.5  v1.5.6  v1.6.0  v1.6.1  v1.7.0
   ---                          ------  ------  ------  ------  ------
-  alternative //               0.033s  0.032s  0.032s  0.035s  0.035s
-  try-catch                    0.023s  0.023s  0.023s  0.024s  0.024s
+  alternative //               0.032s  0.032s  0.035s  0.035s  0.035s
+  try-catch                    0.023s  0.023s  0.024s  0.024s  0.024s
   label-break                  0.004s  0.004s  0.004s  0.004s  0.004s
 
 --- Type conversion ---
-  Benchmark                    v1.5.4  v1.5.5  v1.5.6  v1.6.0  v1.6.1
+  Benchmark                    v1.5.5  v1.5.6  v1.6.0  v1.6.1  v1.7.0
   ---                          ------  ------  ------  ------  ------
-  tojson/fromjson(100K)        0.022s  0.022s  0.022s  0.023s  0.022s
-  null propagation(2M)         0.090s  0.089s  0.090s  0.093s  0.091s
+  tojson/fromjson(100K)        0.022s  0.022s  0.023s  0.022s  0.022s
+  null propagation(2M)         0.089s  0.090s  0.093s  0.091s  0.091s
 
 --- jaq-derived ---
-  Benchmark                    v1.5.4  v1.5.5  v1.5.6  v1.6.0  v1.6.1
+  Benchmark                    v1.5.5  v1.5.6  v1.6.0  v1.6.1  v1.7.0
   ---                          ------  ------  ------  ------  ------
   jaq: reverse                 -       -       -       -       -
   jaq: sort                    -       -       -       -       -
@@ -291,9 +291,9 @@ Recent slice (last 5 columns). Full history lives in
   jaq: str-slice               -       -       -       -       -
 
 --- Memoization (jqx) ---
-  Benchmark                    v1.5.4  v1.5.5  v1.5.6  v1.6.0  v1.6.1
+  Benchmark                    v1.5.5  v1.5.6  v1.6.0  v1.6.1  v1.7.0
   ---                          ------  ------  ------  ------  ------
-  memo fib (1K)                -       -       -       0.004s  0.003s
-  memo collatz sum (10K)       -       -       -       0.017s  0.017s
-  memo by .id (100K, 1K keys)  -       -       -       0.021s  0.020s
+  memo fib (1K)                -       -       0.004s  0.003s  0.003s
+  memo collatz sum (10K)       -       -       0.017s  0.017s  0.016s
+  memo by .id (100K, 1K keys)  -       -       0.021s  0.020s  0.020s
 ```

--- a/docs/benchmark-history.tsv
+++ b/docs/benchmark-history.tsv
@@ -4480,3 +4480,220 @@ Type conversion	null propagation(2M)	v1.6.1	0.091
 Memoization (jqx)	memo fib (1K)	v1.6.1	0.003
 Memoization (jqx)	memo collatz sum (10K)	v1.6.1	0.017
 Memoization (jqx)	memo by .id (100K, 1K keys)	v1.6.1	0.020
+NDJSON workloads (2M objects)	empty	v1.7.0	0.017
+NDJSON workloads (2M objects)	identity -c	v1.7.0	0.086
+NDJSON workloads (2M objects)	identity (pretty)	v1.7.0	0.106
+NDJSON workloads (2M objects)	field access .name	v1.7.0	0.093
+NDJSON workloads (2M objects)	nested .x,.y,.name	v1.7.0	0.147
+NDJSON workloads (2M objects)	arithmetic .x + .y	v1.7.0	0.083
+NDJSON workloads (2M objects)	select .x > 1500000	v1.7.0	0.084
+NDJSON workloads (2M objects)	string concat	v1.7.0	0.092
+NDJSON workloads (2M objects)	object construct	v1.7.0	0.114
+NDJSON workloads (2M objects)	array construct	v1.7.0	0.105
+NDJSON workloads (2M objects)	.[]	v1.7.0	0.102
+NDJSON workloads (2M objects)	to_entries	v1.7.0	0.163
+NDJSON workloads (2M objects)	keys	v1.7.0	0.105
+NDJSON workloads (2M objects)	keys_unsorted	v1.7.0	0.094
+NDJSON workloads (2M objects)	length	v1.7.0	0.084
+NDJSON workloads (2M objects)	has("x")	v1.7.0	0.037
+NDJSON workloads (2M objects)	type	v1.7.0	0.023
+NDJSON workloads (2M objects)	del(.name)	v1.7.0	0.101
+NDJSON workloads (2M objects)	@csv	v1.7.0	0.118
+NDJSON workloads (2M objects)	split/join	v1.7.0	0.090
+NDJSON workloads (2M objects)	select|field	v1.7.0	0.097
+NDJSON workloads (2M objects)	select|remap	v1.7.0	0.099
+NDJSON workloads (2M objects)	computed remap	v1.7.0	0.191
+NDJSON workloads (2M objects)	[.x,.y]|add	v1.7.0	0.083
+NDJSON workloads (2M objects)	[.x,.y]|avg	v1.7.0	0.106
+NDJSON workloads (2M objects)	map(*2)|add	v1.7.0	0.104
+NDJSON workloads (2M objects)	keys|length	v1.7.0	0.255
+NDJSON workloads (2M objects)	.+{z=0}	v1.7.0	0.146
+NDJSON workloads (2M objects)	split|first	v1.7.0	0.089
+NDJSON workloads (2M objects)	slice[0..5]	v1.7.0	0.094
+NDJSON workloads (2M objects)	dynkey {(.name)}	v1.7.0	0.104
+NDJSON workloads (2M objects)	.x += 1	v1.7.0	0.121
+NDJSON workloads (2M objects)	{a}+{b} merge	v1.7.0	0.130
+NDJSON workloads (2M objects)	.x*2+1	v1.7.0	0.060
+NDJSON workloads (2M objects)	.x+.y*2	v1.7.0	0.100
+NDJSON workloads (2M objects)	.x > .y	v1.7.0	0.077
+NDJSON workloads (2M objects)	to_entries|len	v1.7.0	0.397
+NDJSON workloads (2M objects)	.x|.+1 (pipe)	v1.7.0	0.059
+NDJSON workloads (2M objects)	.x|.*2|.+1	v1.7.0	0.060
+NDJSON workloads (2M objects)	.name|.+"_x"	v1.7.0	0.094
+NDJSON workloads (2M objects)	.x>N | not	v1.7.0	0.049
+NDJSON workloads (2M objects)	and (2 cmp)	v1.7.0	0.080
+NDJSON workloads (2M objects)	if-then-else	v1.7.0	0.052
+NDJSON workloads (2M objects)	sel(and)|field	v1.7.0	0.076
+NDJSON workloads (2M objects)	sel(and)|remap	v1.7.0	0.077
+NDJSON workloads (2M objects)	arith|cmp	v1.7.0	0.054
+NDJSON workloads (2M objects)	if cmp .field	v1.7.0	0.113
+NDJSON workloads (2M objects)	split|length	v1.7.0	0.089
+NDJSON workloads (2M objects)	[x,y]|min	v1.7.0	0.090
+NDJSON workloads (2M objects)	[x,y]|max	v1.7.0	0.095
+NDJSON workloads (2M objects)	[x,y]|sort|.[0]	v1.7.0	0.089
+NDJSON workloads (2M objects)	.name|len>5	v1.7.0	0.090
+NDJSON workloads (2M objects)	sel(len>5)|.x	v1.7.0	0.107
+NDJSON workloads (2M objects)	if .x>.y .name	v1.7.0	0.093
+NDJSON workloads (2M objects)	sel(.x>.y)|.name	v1.7.0	0.071
+NDJSON workloads (2M objects)	.x*2|tostring	v1.7.0	0.057
+NDJSON workloads (2M objects)	.x*.x+1	v1.7.0	0.067
+NDJSON workloads (2M objects)	{k=.name,v=tostr}	v1.7.0	0.144
+NDJSON workloads (2M objects)	str add chain	v1.7.0	0.385
+NDJSON workloads (2M objects)	if>.y .name|empty	v1.7.0	0.073
+NDJSON workloads (2M objects)	if .x%2==0	v1.7.0	0.055
+NDJSON workloads (2M objects)	if .x*2+1>1M	v1.7.0	0.056
+NDJSON workloads (2M objects)	sel(.x%2==0)|.name	v1.7.0	0.084
+NDJSON workloads (2M objects)	sel(.x*2+1>1M)	v1.7.0	0.159
+NDJSON workloads (2M objects)	.x|@json	v1.7.0	0.047
+NDJSON workloads (2M objects)	.x|@text	v1.7.0	0.048
+NDJSON workloads (2M objects)	.name|@json	v1.7.0	0.101
+NDJSON workloads (2M objects)	sel|[arr]	v1.7.0	0.149
+NDJSON workloads (2M objects)	sel(and)|[arr]	v1.7.0	0.079
+NDJSON workloads (2M objects)	if>.y [arr]	v1.7.0	0.179
+NDJSON workloads (2M objects)	if sw then .f	v1.7.0	0.139
+NDJSON workloads (2M objects)	dynkey {(.n)=.x*2}	v1.7.0	0.115
+NDJSON workloads (2M objects)	sel(and)|.x*.y	v1.7.0	0.077
+NDJSON workloads (2M objects)	sel>N|str chain	v1.7.0	0.155
+NDJSON workloads (2M objects)	.f+"_"+arith_ts	v1.7.0	0.133
+NDJSON workloads (2M objects)	sel(sw)|str ch	v1.7.0	0.307
+NDJSON workloads (2M objects)	split|rev|join	v1.7.0	0.117
+NDJSON workloads (2M objects)	dynkey+static	v1.7.0	0.338
+NDJSON workloads (2M objects)	if>.y str chain	v1.7.0	0.171
+NDJSON workloads (2M objects)	remap+str chain	v1.7.0	0.156
+NDJSON workloads (2M objects)	sel(len>8)	v1.7.0	0.162
+NDJSON workloads (2M objects)	up|split|join	v1.7.0	0.095
+NDJSON workloads (2M objects)	.name|index	v1.7.0	0.118
+NDJSON workloads (2M objects)	.name|index+1	v1.7.0	0.122
+NDJSON workloads (2M objects)	.name|rindex	v1.7.0	0.127
+NDJSON workloads (2M objects)	.name|indices	v1.7.0	0.155
+NDJSON workloads (2M objects)	[x,y]|sort	v1.7.0	0.153
+NDJSON workloads (2M objects)	.name|scan	v1.7.0	0.207
+NDJSON workloads (2M objects)	.name|gsub	v1.7.0	0.167
+NDJSON workloads (2M objects)	walk(if num .+1)	v1.7.0	0.141
+NDJSON workloads (2M objects)	tojson	v1.7.0	0.104
+NDJSON workloads (2M objects)	{name,x}	v1.7.0	0.128
+NDJSON workloads (2M objects)	.z//.name	v1.7.0	0.154
+NDJSON workloads (2M objects)	.x|=test(re)	v1.7.0	0.172
+NDJSON workloads (2M objects)	./sep|first	v1.7.0	0.182
+NDJSON workloads (2M objects)	.y=(.x*2)	v1.7.0	0.174
+NDJSON workloads (2M objects)	.y=(.x+.y)	v1.7.0	0.228
+NDJSON workloads (2M objects)	objects	v1.7.0	0.134
+NDJSON workloads (2M objects)	.tag|=if..then N	v1.7.0	0.627
+NDJSON workloads (2M objects)	.x=(.x+1)	v1.7.0	0.124
+NDJSON workloads (2M objects)	sel>N|.y+=1	v1.7.0	0.122
+NDJSON workloads (2M objects)	sel(and)|.x+=1	v1.7.0	0.109
+NDJSON workloads (2M objects)	sel(sw)|.x+=1	v1.7.0	0.159
+NDJSON workloads (2M objects)	match(re)	v1.7.0	0.362
+NDJSON workloads (2M objects)	capture(re)	v1.7.0	0.302
+NDJSON workloads (2M objects)	first(.name,.x)	v1.7.0	0.094
+NDJSON workloads (2M objects)	if .x==null	v1.7.0	0.046
+NDJSON workloads (2M objects)	we(sw(.key))	v1.7.0	0.108
+NDJSON workloads (2M objects)	sel(sw or ew)	v1.7.0	0.205
+NDJSON workloads (2M objects)	path(.name,.x)	v1.7.0	0.278
+NDJSON workloads (2M objects)	sel(str+num+num)	v1.7.0	0.150
+NDJSON workloads (2M objects)	nested if|field	v1.7.0	0.077
+NDJSON workloads (2M objects)	.f|floor|.*2	v1.7.0	0.060
+NDJSON workloads (2M objects)	split|len>1	v1.7.0	0.115
+NDJSON workloads (2M objects)	.name|len|.*2	v1.7.0	0.103
+NDJSON workloads (2M objects)	if len>5 .x .y	v1.7.0	0.113
+NDJSON workloads (2M objects)	sel(len>5)|remap	v1.7.0	0.201
+NDJSON workloads (2M objects)	.x|tostr|len	v1.7.0	0.059
+NDJSON workloads (2M objects)	if .x>.y .x .y	v1.7.0	0.094
+NDJSON workloads (2M objects)	split|last|tonum	v1.7.0	0.096
+NDJSON workloads (2M objects)	split|rev|.[0]	v1.7.0	0.091
+NDJSON workloads (2M objects)	split|.[0]+.[1]	v1.7.0	0.113
+NDJSON workloads (2M objects)	.[]|strings	v1.7.0	0.105
+NDJSON workloads (2M objects)	.[]|numbers	v1.7.0	0.124
+NDJSON workloads (2M objects)	[x,y]|any(>1M)	v1.7.0	0.082
+NDJSON workloads (2M objects)	sel(dc|sw)	v1.7.0	0.098
+NDJSON workloads (2M objects)	[[x,y],[n]]|flat	v1.7.0	0.464
+NDJSON workloads (2M objects)	.x|floor|.*2	v1.7.0	0.061
+NDJSON workloads (2M objects)	tojson|fromjson	v1.7.0	0.082
+NDJSON workloads (2M objects)	[.x]|add	v1.7.0	0.059
+NDJSON workloads (2M objects)	if>N {o}+.	v1.7.0	0.138
+NDJSON workloads (2M objects)	if>N .+{o}	v1.7.0	0.136
+NDJSON workloads (2M objects)	if .n=="s" .+{o}	v1.7.0	0.157
+NDJSON workloads (2M objects)	sel(.n>"s")	v1.7.0	0.091
+NDJSON workloads (2M objects)	[x,y,z]|min	v1.7.0	0.307
+NDJSON workloads (2M objects)	if .n|len>5 l s	v1.7.0	0.100
+NDJSON workloads (2M objects)	if .x|flr>N b s	v1.7.0	0.055
+NDJSON workloads (2M objects)	if .n|test l e	v1.7.0	0.105
+NDJSON workloads (2M objects)	if .n|sw l e	v1.7.0	0.082
+NDJSON workloads (2M objects)	if .n|ew l e	v1.7.0	0.085
+NDJSON workloads (2M objects)	.n|len|tostr	v1.7.0	0.090
+String operations (2M objects)	ascii_downcase	v1.7.0	0.104
+String operations (2M objects)	ascii_upcase	v1.7.0	0.103
+String operations (2M objects)	ltrimstr	v1.7.0	0.097
+String operations (2M objects)	rtrimstr	v1.7.0	0.097
+String operations (2M objects)	split	v1.7.0	0.162
+String operations (2M objects)	case+split	v1.7.0	0.121
+String operations (2M objects)	join	v1.7.0	0.093
+String operations (2M objects)	startswith	v1.7.0	0.095
+String operations (2M objects)	endswith	v1.7.0	0.096
+String operations (2M objects)	tostring	v1.7.0	0.063
+String operations (2M objects)	tonumber	v1.7.0	0.110
+String operations (2M objects)	string interpolation	v1.7.0	0.118
+String ops (200K objects)	test (regex)	v1.7.0	0.014
+String ops (200K objects)	match (regex)	v1.7.0	0.032
+String ops (200K objects)	@base64	v1.7.0	0.012
+String ops (200K objects)	@uri	v1.7.0	0.012
+String ops (200K objects)	@html	v1.7.0	0.012
+String ops (200K objects)	@csv (array)	v1.7.0	0.016
+String ops (200K objects)	@tsv (array)	v1.7.0	0.015
+String ops (200K objects)	gsub	v1.7.0	0.019
+String ops (200K objects)	case+gsub	v1.7.0	0.180
+String ops (200K objects)	case+test	v1.7.0	0.120
+String ops (200K objects)	ltrim+tonum+arith	v1.7.0	0.111
+Numeric & math (2M objects)	floor	v1.7.0	0.057
+Numeric & math (2M objects)	sqrt	v1.7.0	0.079
+Numeric & math (2M objects)	modulo	v1.7.0	0.059
+Numeric & math (2M objects)	if-elif-else	v1.7.0	0.123
+Numeric & math (2M objects)	select|del	v1.7.0	0.091
+Numeric & math (2M objects)	select|merge	v1.7.0	0.121
+Numeric & math (2M objects)	select(test)|merge	v1.7.0	0.021
+Array generators	range(2M) | length	v1.7.0	0.012
+Array generators	reverse(2M)	v1.7.0	0.018
+Array generators	sort(2M)	v1.7.0	0.023
+Array generators	unique(1M)	v1.7.0	0.030
+Array generators	flatten(500K)	v1.7.0	0.011
+Array generators	min, max(2M)	v1.7.0	0.019
+Array generators	add numbers(2M)	v1.7.0	0.013
+Array generators	any/all(2M)	v1.7.0	0.029
+Array generators	limit(10; range(10M))	v1.7.0	0.003
+Array generators	first(range(10M))	v1.7.0	0.003
+Array generators	last(range(2M))	v1.7.0	0.003
+Array generators	indices(1M)	v1.7.0	0.017
+Reduce & foreach	reduce (sum)	v1.7.0	0.009
+Reduce & foreach	reduce (array build)	v1.7.0	0.004
+Reduce & foreach	reduce (obj build)	v1.7.0	0.010
+Reduce & foreach	reduce (setpath)	v1.7.0	0.016
+Reduce & foreach	foreach (running sum)	v1.7.0	0.010
+Reduce & foreach	foreach + emit	v1.7.0	0.010
+Reduce & foreach	reduce (sum-of-squares)	v1.7.0	0.034
+Reduce & foreach	reduce (conditional)	v1.7.0	0.035
+Reduce & foreach	reduce (product)	v1.7.0	0.034
+Reduce & foreach	foreach (conditional)	v1.7.0	0.010
+Reduce & foreach	until (100M)	v1.7.0	0.305
+Reduce & foreach	reduce (harmonic)	v1.7.0	0.033
+Reduce & foreach	reduce (floor pipe)	v1.7.0	0.033
+Reduce & foreach	reduce (sqrt pipe)	v1.7.0	0.033
+Reduce & foreach	reduce (sin+cos)	v1.7.0	0.052
+Object operations	large obj construct	v1.7.0	0.004
+Object operations	large obj keys	v1.7.0	0.011
+Object operations	large obj to_entries	v1.7.0	0.012
+Object operations	with_entries	v1.7.0	0.009
+Assignment operators	.[] |= f (100K)	v1.7.0	0.005
+Assignment operators	.[] += 1 (100K)	v1.7.0	0.005
+Assignment operators	.[k] = v reduce(50K)	v1.7.0	0.008
+String-heavy generators	gsub(100K)	v1.7.0	0.027
+String-heavy generators	join large(100K)	v1.7.0	0.005
+String-heavy generators	explode/implode(100K)	v1.7.0	0.027
+String-heavy generators	reduce str concat(100K)	v1.7.0	0.008
+Try-catch & alternative	alternative //	v1.7.0	0.035
+Try-catch & alternative	try-catch	v1.7.0	0.024
+Try-catch & alternative	label-break	v1.7.0	0.004
+Type conversion	tojson/fromjson(100K)	v1.7.0	0.022
+Type conversion	null propagation(2M)	v1.7.0	0.091
+Memoization (jqx)	memo fib (1K)	v1.7.0	0.003
+Memoization (jqx)	memo collatz sum (10K)	v1.7.0	0.016
+Memoization (jqx)	memo by .id (100K, 1K keys)	v1.7.0	0.020


### PR DESCRIPTION
## Summary

Release v1.7.0 — minor bump (introduces `JQJIT_DISABLE_RAW_BYTE` / `JQJIT_DISABLE_SIMPLIFY` env knobs for self-diff layer pinning), plus the metamorphic / 4-way self-diff / fuzz_axis harness suite from #683 / #685 / #686 / #688.

## Bench (v1.6.1 → v1.7.0)

Benchmark history columns appended (`docs/benchmark-history.{tsv,md}`).

- **No real regression.** The 3 rows flagged > 1.05x (`limit(10; range(10M))`, `first(range(10M))`, `last(range(2M))`) are all 0.002s → 0.003s — sub-ms timer quantization noise. Same benchmarks have flipped 2↔3ms every other release for the last 10+ versions (v1.6.0=3ms, v1.6.1=2ms, v1.7.0=3ms again).
- **10 improvements ≥5%** including `del(.name)` (−5.6%), `.x += 1` (−5.5%), `min, max(2M)` (−9.5%), `foreach + emit` (−9.1%), `@html` / `@uri` (−7.7%), `test (regex)` (−6.7%), `memo collatz sum` (−5.9%).
- No FAIL/TIMEOUT rows.

## Test plan

- [x] `cargo build --release` zero warnings
- [x] `cargo test --release` — 458 passed / 0 failed
- [x] `bench/comprehensive.sh` completed, history appended