### PR TITLE
release v1.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jq-jit"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jq-jit"
-version = "1.7.0"
+version = "1.7.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A JIT-compiling implementation of jq using Cranelift"

--- a/docs/benchmark-history.md
+++ b/docs/benchmark-history.md
@@ -6,265 +6,265 @@ Recent slice (last 5 columns). Full history lives in
 
 ```text
 --- NDJSON workloads (2M objects) ---
-  Benchmark                    v1.5.5  v1.5.6  v1.6.0  v1.6.1  v1.7.0
+  Benchmark                    v1.5.6  v1.6.0  v1.6.1  v1.7.0  v1.7.1
   ---                          ------  ------  ------  ------  ------
-  empty                        0.017s  0.017s  0.017s  0.018s  0.017s
-  identity -c                  0.087s  0.087s  0.088s  0.087s  0.086s
-  identity (pretty)            0.102s  0.105s  0.106s  0.107s  0.106s
-  field access .name           0.094s  0.095s  0.096s  0.097s  0.093s
-  nested .x,.y,.name           0.150s  0.150s  0.155s  0.150s  0.147s
-  arithmetic .x + .y           0.086s  0.083s  0.086s  0.084s  0.083s
-  select .x > 1500000          0.083s  0.082s  0.083s  0.087s  0.084s
-  string concat                0.093s  0.093s  0.092s  0.095s  0.092s
-  object construct             0.115s  0.111s  0.115s  0.116s  0.114s
-  array construct              0.106s  0.103s  0.107s  0.106s  0.105s
-  .[]                          0.106s  0.101s  0.105s  0.104s  0.102s
-  to_entries                   0.162s  0.159s  0.159s  0.159s  0.163s
-  keys                         0.106s  0.109s  0.105s  0.107s  0.105s
-  keys_unsorted                0.095s  0.095s  0.095s  0.097s  0.094s
-  length                       0.086s  0.085s  0.087s  0.088s  0.084s
-  has("x")                     0.037s  0.034s  0.039s  0.039s  0.037s
-  type                         0.023s  0.022s  0.023s  0.023s  0.023s
-  del(.name)                   0.102s  0.104s  0.103s  0.107s  0.101s
-  @csv                         0.124s  0.123s  0.124s  0.120s  0.118s
-  split/join                   0.091s  0.089s  0.090s  0.094s  0.090s
-  select|field                 0.097s  0.095s  0.101s  0.099s  0.097s
-  select|remap                 0.100s  0.095s  0.098s  0.100s  0.099s
-  computed remap               0.192s  0.191s  0.190s  0.192s  0.191s
-  [.x,.y]|add                  0.086s  0.082s  0.084s  0.084s  0.083s
-  [.x,.y]|avg                  0.112s  0.106s  0.109s  0.111s  0.106s
-  map(*2)|add                  0.106s  0.103s  0.106s  0.107s  0.104s
-  keys|length                  0.252s  0.251s  0.253s  0.259s  0.255s
-  .+{z=0}                      0.147s  0.146s  0.150s  0.150s  0.146s
-  split|first                  0.090s  0.090s  0.091s  0.092s  0.089s
-  slice[0..5]                  0.092s  0.092s  0.093s  0.095s  0.094s
-  dynkey {(.name)}             0.104s  0.102s  0.106s  0.108s  0.104s
-  .x += 1                      0.125s  0.125s  0.129s  0.128s  0.121s
-  {a}+{b} merge                0.130s  0.135s  0.132s  0.133s  0.130s
-  .x*2+1                       0.060s  0.060s  0.060s  0.061s  0.060s
-  .x+.y*2                      0.100s  0.096s  0.100s  0.099s  0.100s
-  .x > .y                      0.081s  0.077s  0.079s  0.078s  0.077s
-  to_entries|len               0.394s  0.400s  0.400s  0.405s  0.397s
-  .x|.+1 (pipe)                0.058s  0.058s  0.058s  0.059s  0.059s
-  .x|.*2|.+1                   0.060s  0.059s  0.060s  0.060s  0.060s
-  .name|.+"_x"                 0.092s  0.092s  0.094s  0.097s  0.094s
-  .x>N | not                   0.050s  0.049s  0.049s  0.051s  0.049s
-  and (2 cmp)                  0.085s  0.080s  0.085s  0.082s  0.080s
-  if-then-else                 0.052s  0.052s  0.051s  0.053s  0.052s
-  sel(and)|field               0.083s  0.077s  0.080s  0.079s  0.076s
-  sel(and)|remap               0.083s  0.077s  0.079s  0.079s  0.077s
-  arith|cmp                    0.055s  0.053s  0.054s  0.056s  0.054s
-  if cmp .field                0.114s  0.114s  0.113s  0.118s  0.113s
-  split|length                 0.088s  0.090s  0.089s  0.093s  0.089s
-  [x,y]|min                    0.095s  0.090s  0.092s  0.092s  0.090s
-  [x,y]|max                    0.097s  0.092s  0.096s  0.097s  0.095s
-  [x,y]|sort|.[0]              0.094s  0.090s  0.093s  0.092s  0.089s
-  .name|len>5                  0.092s  0.092s  0.093s  0.094s  0.090s
-  sel(len>5)|.x                0.110s  0.111s  0.113s  0.111s  0.107s
-  if .x>.y .name               0.092s  0.089s  0.093s  0.092s  0.093s
-  sel(.x>.y)|.name             0.076s  0.072s  0.075s  0.074s  0.071s
-  .x*2|tostring                0.057s  0.056s  0.057s  0.058s  0.057s
-  .x*.x+1                      0.066s  0.066s  0.066s  0.067s  0.067s
-  {k=.name,v=tostr}            0.146s  0.144s  0.151s  0.147s  0.144s
-  str add chain                0.378s  0.385s  0.388s  0.388s  0.385s
-  if>.y .name|empty            0.080s  0.073s  0.077s  0.073s  0.073s
-  if .x%2==0                   0.056s  0.054s  0.055s  0.054s  0.055s
-  if .x*2+1>1M                 0.056s  0.054s  0.055s  0.055s  0.056s
-  sel(.x%2==0)|.name           0.083s  0.083s  0.083s  0.084s  0.084s
-  sel(.x*2+1>1M)               0.159s  0.159s  0.160s  0.157s  0.159s
-  .x|@json                     0.047s  0.048s  0.048s  0.049s  0.047s
-  .x|@text                     0.048s  0.047s  0.048s  0.049s  0.048s
-  .name|@json                  0.104s  0.103s  0.103s  0.102s  0.101s
-  sel|[arr]                    0.146s  0.143s  0.147s  0.143s  0.149s
-  sel(and)|[arr]               0.082s  0.077s  0.081s  0.077s  0.079s
-  if>.y [arr]                  0.176s  0.173s  0.178s  0.175s  0.179s
-  if sw then .f                0.138s  0.139s  0.143s  0.143s  0.139s
-  dynkey {(.n)=.x*2}           0.113s  0.114s  0.115s  0.117s  0.115s
-  sel(and)|.x*.y               0.082s  0.076s  0.079s  0.077s  0.077s
-  sel>N|str chain              0.154s  0.151s  0.156s  0.152s  0.155s
-  .f+"_"+arith_ts              0.133s  0.132s  0.136s  0.134s  0.133s
-  sel(sw)|str ch               0.303s  0.307s  0.304s  0.308s  0.307s
-  split|rev|join               0.114s  0.114s  0.118s  0.117s  0.117s
-  dynkey+static                0.344s  0.331s  0.338s  0.340s  0.338s
-  if>.y str chain              0.167s  0.165s  0.166s  0.167s  0.171s
-  remap+str chain              0.153s  0.148s  0.159s  0.156s  0.156s
-  sel(len>8)                   0.160s  0.165s  0.161s  0.163s  0.162s
-  up|split|join                0.099s  0.097s  0.098s  0.098s  0.095s
-  .name|index                  0.121s  0.121s  0.120s  0.121s  0.118s
-  .name|index+1                0.125s  0.123s  0.124s  0.126s  0.122s
-  .name|rindex                 0.129s  0.127s  0.130s  0.131s  0.127s
-  .name|indices                0.157s  0.146s  0.159s  0.161s  0.155s
-  [x,y]|sort                   0.153s  0.152s  0.156s  0.154s  0.153s
-  .name|scan                   0.209s  0.208s  0.209s  0.214s  0.207s
-  .name|gsub                   0.163s  0.168s  0.168s  0.170s  0.167s
-  walk(if num .+1)             0.145s  0.143s  0.142s  0.140s  0.141s
-  tojson                       0.106s  0.104s  0.106s  0.106s  0.104s
-  {name,x}                     0.129s  0.133s  0.130s  0.129s  0.128s
-  .z//.name                    0.157s  0.157s  0.157s  0.158s  0.154s
-  .x|=test(re)                 0.173s  0.180s  0.171s  0.176s  0.172s
-  ./sep|first                  0.184s  0.182s  0.190s  0.185s  0.182s
-  .y=(.x*2)                    0.179s  0.178s  0.181s  0.180s  0.174s
-  .y=(.x+.y)                   0.229s  0.233s  0.238s  0.234s  0.228s
-  objects                      0.128s  0.138s  0.134s  0.138s  0.134s
-  .tag|=if..then N             0.607s  0.614s  0.617s  0.611s  0.627s
-  .x=(.x+1)                    0.122s  0.128s  0.129s  0.127s  0.124s
-  sel>N|.y+=1                  0.123s  0.121s  0.124s  0.122s  0.122s
-  sel(and)|.x+=1               0.109s  0.111s  0.111s  0.111s  0.109s
-  sel(sw)|.x+=1                0.163s  0.164s  0.165s  0.163s  0.159s
-  match(re)                    0.361s  0.369s  0.364s  0.367s  0.362s
-  capture(re)                  0.298s  0.296s  0.297s  0.299s  0.302s
-  first(.name,.x)              0.096s  0.097s  0.098s  0.097s  0.094s
-  if .x==null                  0.047s  0.046s  0.048s  0.047s  0.046s
-  we(sw(.key))                 0.107s  0.110s  0.110s  0.105s  0.108s
-  sel(sw or ew)                0.207s  0.205s  0.202s  0.207s  0.205s
-  path(.name,.x)               0.274s  0.274s  0.276s  0.278s  0.278s
-  sel(str+num+num)             0.151s  0.152s  0.152s  0.153s  0.150s
-  nested if|field              0.082s  0.076s  0.081s  0.077s  0.077s
-  .f|floor|.*2                 0.061s  0.061s  0.061s  0.061s  0.060s
-  split|len>1                  0.118s  0.114s  0.118s  0.119s  0.115s
-  .name|len|.*2                0.102s  0.103s  0.104s  0.103s  0.103s
-  if len>5 .x .y               0.115s  0.113s  0.118s  0.113s  0.113s
-  sel(len>5)|remap             0.206s  0.207s  0.207s  0.202s  0.201s
-  .x|tostr|len                 0.058s  0.059s  0.062s  0.060s  0.059s
-  if .x>.y .x .y               0.098s  0.093s  0.097s  0.094s  0.094s
-  split|last|tonum             0.095s  0.096s  0.096s  0.097s  0.096s
-  split|rev|.[0]               0.094s  0.090s  0.096s  0.091s  0.091s
-  split|.[0]+.[1]              0.115s  0.114s  0.113s  0.115s  0.113s
-  .[]|strings                  0.106s  0.104s  0.106s  0.106s  0.105s
-  .[]|numbers                  0.124s  0.124s  0.129s  0.125s  0.124s
-  [x,y]|any(>1M)               0.087s  0.082s  0.084s  0.082s  0.082s
-  sel(dc|sw)                   0.102s  0.097s  0.098s  0.101s  0.098s
-  [[x,y],[n]]|flat             0.456s  0.460s  0.460s  0.462s  0.464s
-  .x|floor|.*2                 0.061s  0.061s  0.061s  0.060s  0.061s
-  tojson|fromjson              0.087s  0.085s  0.087s  0.084s  0.082s
-  [.x]|add                     0.060s  0.060s  0.060s  0.060s  0.059s
-  if>N {o}+.                   0.134s  0.135s  0.136s  0.135s  0.138s
-  if>N .+{o}                   0.134s  0.138s  0.135s  0.135s  0.136s
-  if .n=="s" .+{o}             0.161s  0.161s  0.158s  0.161s  0.157s
-  sel(.n>"s")                  0.089s  0.089s  0.089s  0.090s  0.091s
-  [x,y,z]|min                  0.309s  0.309s  0.308s  0.311s  0.307s
-  if .n|len>5 l s              0.102s  0.100s  0.100s  0.101s  0.100s
-  if .x|flr>N b s              0.056s  0.056s  0.056s  0.055s  0.055s
-  if .n|test l e               0.103s  0.106s  0.105s  0.105s  0.105s
-  if .n|sw l e                 0.083s  0.084s  0.083s  0.085s  0.082s
-  if .n|ew l e                 0.084s  0.084s  0.084s  0.086s  0.085s
-  .n|len|tostr                 0.091s  0.092s  0.092s  0.091s  0.090s
+  empty                        0.017s  0.017s  0.018s  0.017s  0.017s
+  identity -c                  0.087s  0.088s  0.087s  0.086s  0.084s
+  identity (pretty)            0.105s  0.106s  0.107s  0.106s  0.102s
+  field access .name           0.095s  0.096s  0.097s  0.093s  0.090s
+  nested .x,.y,.name           0.150s  0.155s  0.150s  0.147s  0.146s
+  arithmetic .x + .y           0.083s  0.086s  0.084s  0.083s  0.082s
+  select .x > 1500000          0.082s  0.083s  0.087s  0.084s  0.080s
+  string concat                0.093s  0.092s  0.095s  0.092s  0.092s
+  object construct             0.111s  0.115s  0.116s  0.114s  0.110s
+  array construct              0.103s  0.107s  0.106s  0.105s  0.105s
+  .[]                          0.101s  0.105s  0.104s  0.102s  0.101s
+  to_entries                   0.159s  0.159s  0.159s  0.163s  0.154s
+  keys                         0.109s  0.105s  0.107s  0.105s  0.100s
+  keys_unsorted                0.095s  0.095s  0.097s  0.094s  0.092s
+  length                       0.085s  0.087s  0.088s  0.084s  0.087s
+  has("x")                     0.034s  0.039s  0.039s  0.037s  0.036s
+  type                         0.022s  0.023s  0.023s  0.023s  0.022s
+  del(.name)                   0.104s  0.103s  0.107s  0.101s  0.099s
+  @csv                         0.123s  0.124s  0.120s  0.118s  0.117s
+  split/join                   0.089s  0.090s  0.094s  0.090s  0.089s
+  select|field                 0.095s  0.101s  0.099s  0.097s  0.094s
+  select|remap                 0.095s  0.098s  0.100s  0.099s  0.097s
+  computed remap               0.191s  0.190s  0.192s  0.191s  0.187s
+  [.x,.y]|add                  0.082s  0.084s  0.084s  0.083s  0.083s
+  [.x,.y]|avg                  0.106s  0.109s  0.111s  0.106s  0.106s
+  map(*2)|add                  0.103s  0.106s  0.107s  0.104s  0.102s
+  keys|length                  0.251s  0.253s  0.259s  0.255s  0.251s
+  .+{z=0}                      0.146s  0.150s  0.150s  0.146s  0.145s
+  split|first                  0.090s  0.091s  0.092s  0.089s  0.088s
+  slice[0..5]                  0.092s  0.093s  0.095s  0.094s  0.094s
+  dynkey {(.name)}             0.102s  0.106s  0.108s  0.104s  0.106s
+  .x += 1                      0.125s  0.129s  0.128s  0.121s  0.122s
+  {a}+{b} merge                0.135s  0.132s  0.133s  0.130s  0.129s
+  .x*2+1                       0.060s  0.060s  0.061s  0.060s  0.059s
+  .x+.y*2                      0.096s  0.100s  0.099s  0.100s  0.096s
+  .x > .y                      0.077s  0.079s  0.078s  0.077s  0.076s
+  to_entries|len               0.400s  0.400s  0.405s  0.397s  0.397s
+  .x|.+1 (pipe)                0.058s  0.058s  0.059s  0.059s  0.056s
+  .x|.*2|.+1                   0.059s  0.060s  0.060s  0.060s  0.058s
+  .name|.+"_x"                 0.092s  0.094s  0.097s  0.094s  0.092s
+  .x>N | not                   0.049s  0.049s  0.051s  0.049s  0.048s
+  and (2 cmp)                  0.080s  0.085s  0.082s  0.080s  0.080s
+  if-then-else                 0.052s  0.051s  0.053s  0.052s  0.051s
+  sel(and)|field               0.077s  0.080s  0.079s  0.076s  0.076s
+  sel(and)|remap               0.077s  0.079s  0.079s  0.077s  0.077s
+  arith|cmp                    0.053s  0.054s  0.056s  0.054s  0.053s
+  if cmp .field                0.114s  0.113s  0.118s  0.113s  0.110s
+  split|length                 0.090s  0.089s  0.093s  0.089s  0.088s
+  [x,y]|min                    0.090s  0.092s  0.092s  0.090s  0.089s
+  [x,y]|max                    0.092s  0.096s  0.097s  0.095s  0.092s
+  [x,y]|sort|.[0]              0.090s  0.093s  0.092s  0.089s  0.088s
+  .name|len>5                  0.092s  0.093s  0.094s  0.090s  0.089s
+  sel(len>5)|.x                0.111s  0.113s  0.111s  0.107s  0.107s
+  if .x>.y .name               0.089s  0.093s  0.092s  0.093s  0.088s
+  sel(.x>.y)|.name             0.072s  0.075s  0.074s  0.071s  0.070s
+  .x*2|tostring                0.056s  0.057s  0.058s  0.057s  0.055s
+  .x*.x+1                      0.066s  0.066s  0.067s  0.067s  0.064s
+  {k=.name,v=tostr}            0.144s  0.151s  0.147s  0.144s  0.145s
+  str add chain                0.385s  0.388s  0.388s  0.385s  0.378s
+  if>.y .name|empty            0.073s  0.077s  0.073s  0.073s  0.072s
+  if .x%2==0                   0.054s  0.055s  0.054s  0.055s  0.054s
+  if .x*2+1>1M                 0.054s  0.055s  0.055s  0.056s  0.054s
+  sel(.x%2==0)|.name           0.083s  0.083s  0.084s  0.084s  0.081s
+  sel(.x*2+1>1M)               0.159s  0.160s  0.157s  0.159s  0.154s
+  .x|@json                     0.048s  0.048s  0.049s  0.047s  0.047s
+  .x|@text                     0.047s  0.048s  0.049s  0.048s  0.047s
+  .name|@json                  0.103s  0.103s  0.102s  0.101s  0.101s
+  sel|[arr]                    0.143s  0.147s  0.143s  0.149s  0.144s
+  sel(and)|[arr]               0.077s  0.081s  0.077s  0.079s  0.076s
+  if>.y [arr]                  0.173s  0.178s  0.175s  0.179s  0.174s
+  if sw then .f                0.139s  0.143s  0.143s  0.139s  0.135s
+  dynkey {(.n)=.x*2}           0.114s  0.115s  0.117s  0.115s  0.112s
+  sel(and)|.x*.y               0.076s  0.079s  0.077s  0.077s  0.078s
+  sel>N|str chain              0.151s  0.156s  0.152s  0.155s  0.153s
+  .f+"_"+arith_ts              0.132s  0.136s  0.134s  0.133s  0.132s
+  sel(sw)|str ch               0.307s  0.304s  0.308s  0.307s  0.298s
+  split|rev|join               0.114s  0.118s  0.117s  0.117s  0.112s
+  dynkey+static                0.331s  0.338s  0.340s  0.338s  0.332s
+  if>.y str chain              0.165s  0.166s  0.167s  0.171s  0.168s
+  remap+str chain              0.148s  0.159s  0.156s  0.156s  0.154s
+  sel(len>8)                   0.165s  0.161s  0.163s  0.162s  0.159s
+  up|split|join                0.097s  0.098s  0.098s  0.095s  0.100s
+  .name|index                  0.121s  0.120s  0.121s  0.118s  0.117s
+  .name|index+1                0.123s  0.124s  0.126s  0.122s  0.122s
+  .name|rindex                 0.127s  0.130s  0.131s  0.127s  0.125s
+  .name|indices                0.146s  0.159s  0.161s  0.155s  0.149s
+  [x,y]|sort                   0.152s  0.156s  0.154s  0.153s  0.154s
+  .name|scan                   0.208s  0.209s  0.214s  0.207s  0.213s
+  .name|gsub                   0.168s  0.168s  0.170s  0.167s  0.166s
+  walk(if num .+1)             0.143s  0.142s  0.140s  0.141s  0.137s
+  tojson                       0.104s  0.106s  0.106s  0.104s  0.105s
+  {name,x}                     0.133s  0.130s  0.129s  0.128s  0.128s
+  .z//.name                    0.157s  0.157s  0.158s  0.154s  0.155s
+  .x|=test(re)                 0.180s  0.171s  0.176s  0.172s  0.170s
+  ./sep|first                  0.182s  0.190s  0.185s  0.182s  0.180s
+  .y=(.x*2)                    0.178s  0.181s  0.180s  0.174s  0.175s
+  .y=(.x+.y)                   0.233s  0.238s  0.234s  0.228s  0.226s
+  objects                      0.138s  0.134s  0.138s  0.134s  0.137s
+  .tag|=if..then N             0.614s  0.617s  0.611s  0.627s  0.614s
+  .x=(.x+1)                    0.128s  0.129s  0.127s  0.124s  0.126s
+  sel>N|.y+=1                  0.121s  0.124s  0.122s  0.122s  0.120s
+  sel(and)|.x+=1               0.111s  0.111s  0.111s  0.109s  0.109s
+  sel(sw)|.x+=1                0.164s  0.165s  0.163s  0.159s  0.156s
+  match(re)                    0.369s  0.364s  0.367s  0.362s  0.368s
+  capture(re)                  0.296s  0.297s  0.299s  0.302s  0.299s
+  first(.name,.x)              0.097s  0.098s  0.097s  0.094s  0.095s
+  if .x==null                  0.046s  0.048s  0.047s  0.046s  0.046s
+  we(sw(.key))                 0.110s  0.110s  0.105s  0.108s  0.107s
+  sel(sw or ew)                0.205s  0.202s  0.207s  0.205s  0.199s
+  path(.name,.x)               0.274s  0.276s  0.278s  0.278s  0.271s
+  sel(str+num+num)             0.152s  0.152s  0.153s  0.150s  0.151s
+  nested if|field              0.076s  0.081s  0.077s  0.077s  0.077s
+  .f|floor|.*2                 0.061s  0.061s  0.061s  0.060s  0.061s
+  split|len>1                  0.114s  0.118s  0.119s  0.115s  0.113s
+  .name|len|.*2                0.103s  0.104s  0.103s  0.103s  0.100s
+  if len>5 .x .y               0.113s  0.118s  0.113s  0.113s  0.115s
+  sel(len>5)|remap             0.207s  0.207s  0.202s  0.201s  0.199s
+  .x|tostr|len                 0.059s  0.062s  0.060s  0.059s  0.058s
+  if .x>.y .x .y               0.093s  0.097s  0.094s  0.094s  0.094s
+  split|last|tonum             0.096s  0.096s  0.097s  0.096s  0.095s
+  split|rev|.[0]               0.090s  0.096s  0.091s  0.091s  0.090s
+  split|.[0]+.[1]              0.114s  0.113s  0.115s  0.113s  0.112s
+  .[]|strings                  0.104s  0.106s  0.106s  0.105s  0.104s
+  .[]|numbers                  0.124s  0.129s  0.125s  0.124s  0.124s
+  [x,y]|any(>1M)               0.082s  0.084s  0.082s  0.082s  0.083s
+  sel(dc|sw)                   0.097s  0.098s  0.101s  0.098s  0.098s
+  [[x,y],[n]]|flat             0.460s  0.460s  0.462s  0.464s  0.456s
+  .x|floor|.*2                 0.061s  0.061s  0.060s  0.061s  0.061s
+  tojson|fromjson              0.085s  0.087s  0.084s  0.082s  0.084s
+  [.x]|add                     0.060s  0.060s  0.060s  0.059s  0.059s
+  if>N {o}+.                   0.135s  0.136s  0.135s  0.138s  0.136s
+  if>N .+{o}                   0.138s  0.135s  0.135s  0.136s  0.132s
+  if .n=="s" .+{o}             0.161s  0.158s  0.161s  0.157s  0.159s
+  sel(.n>"s")                  0.089s  0.089s  0.090s  0.091s  0.087s
+  [x,y,z]|min                  0.309s  0.308s  0.311s  0.307s  0.312s
+  if .n|len>5 l s              0.100s  0.100s  0.101s  0.100s  0.099s
+  if .x|flr>N b s              0.056s  0.056s  0.055s  0.055s  0.054s
+  if .n|test l e               0.106s  0.105s  0.105s  0.105s  0.104s
+  if .n|sw l e                 0.084s  0.083s  0.085s  0.082s  0.084s
+  if .n|ew l e                 0.084s  0.084s  0.086s  0.085s  0.083s
+  .n|len|tostr                 0.092s  0.092s  0.091s  0.090s  0.092s
 
 --- String operations (2M objects) ---
-  Benchmark                    v1.5.5  v1.5.6  v1.6.0  v1.6.1  v1.7.0
+  Benchmark                    v1.5.6  v1.6.0  v1.6.1  v1.7.0  v1.7.1
   ---                          ------  ------  ------  ------  ------
-  ascii_downcase               0.108s  0.105s  0.105s  0.106s  0.104s
-  ascii_upcase                 0.108s  0.103s  0.104s  0.106s  0.103s
-  ltrimstr                     0.096s  0.095s  0.096s  0.099s  0.097s
-  rtrimstr                     0.099s  0.098s  0.098s  0.099s  0.097s
-  split                        0.168s  0.162s  0.170s  0.165s  0.162s
-  case+split                   0.113s  0.115s  0.118s  0.116s  0.121s
-  join                         0.090s  0.091s  0.096s  0.093s  0.093s
-  startswith                   0.095s  0.095s  0.098s  0.098s  0.095s
-  endswith                     0.097s  0.096s  0.098s  0.098s  0.096s
-  tostring                     0.062s  0.063s  0.063s  0.063s  0.063s
-  tonumber                     0.114s  0.110s  0.112s  0.111s  0.110s
-  string interpolation         0.115s  0.118s  0.120s  0.116s  0.118s
+  ascii_downcase               0.105s  0.105s  0.106s  0.104s  0.104s
+  ascii_upcase                 0.103s  0.104s  0.106s  0.103s  0.102s
+  ltrimstr                     0.095s  0.096s  0.099s  0.097s  0.096s
+  rtrimstr                     0.098s  0.098s  0.099s  0.097s  0.097s
+  split                        0.162s  0.170s  0.165s  0.162s  0.164s
+  case+split                   0.115s  0.118s  0.116s  0.121s  0.116s
+  join                         0.091s  0.096s  0.093s  0.093s  0.094s
+  startswith                   0.095s  0.098s  0.098s  0.095s  0.094s
+  endswith                     0.096s  0.098s  0.098s  0.096s  0.097s
+  tostring                     0.063s  0.063s  0.063s  0.063s  0.062s
+  tonumber                     0.110s  0.112s  0.111s  0.110s  0.109s
+  string interpolation         0.118s  0.120s  0.116s  0.118s  0.119s
 
 --- String ops (200K objects) ---
-  Benchmark                    v1.5.5  v1.5.6  v1.6.0  v1.6.1  v1.7.0
+  Benchmark                    v1.5.6  v1.6.0  v1.6.1  v1.7.0  v1.7.1
   ---                          ------  ------  ------  ------  ------
-  test (regex)                 0.014s  0.015s  0.015s  0.015s  0.014s
-  match (regex)                0.032s  0.033s  0.032s  0.033s  0.032s
+  test (regex)                 0.015s  0.015s  0.015s  0.014s  0.014s
+  match (regex)                0.033s  0.032s  0.033s  0.032s  0.033s
   @base64                      0.012s  0.012s  0.012s  0.012s  0.012s
-  @uri                         0.013s  0.012s  0.012s  0.013s  0.012s
-  @html                        0.013s  0.012s  0.012s  0.013s  0.012s
-  @csv (array)                 0.015s  0.015s  0.016s  0.016s  0.016s
-  @tsv (array)                 0.014s  0.015s  0.015s  0.015s  0.015s
-  gsub                         0.018s  0.019s  0.019s  0.019s  0.019s
-  case+gsub                    0.176s  0.181s  0.181s  0.181s  0.180s
-  case+test                    0.118s  0.119s  0.116s  0.124s  0.120s
-  ltrim+tonum+arith            0.112s  0.111s  0.113s  0.113s  0.111s
+  @uri                         0.012s  0.012s  0.013s  0.012s  0.012s
+  @html                        0.012s  0.012s  0.013s  0.012s  0.012s
+  @csv (array)                 0.015s  0.016s  0.016s  0.016s  0.016s
+  @tsv (array)                 0.015s  0.015s  0.015s  0.015s  0.015s
+  gsub                         0.019s  0.019s  0.019s  0.019s  0.019s
+  case+gsub                    0.181s  0.181s  0.181s  0.180s  0.176s
+  case+test                    0.119s  0.116s  0.124s  0.120s  0.118s
+  ltrim+tonum+arith            0.111s  0.113s  0.113s  0.111s  0.111s
 
 --- Numeric & math (2M objects) ---
-  Benchmark                    v1.5.5  v1.5.6  v1.6.0  v1.6.1  v1.7.0
+  Benchmark                    v1.5.6  v1.6.0  v1.6.1  v1.7.0  v1.7.1
   ---                          ------  ------  ------  ------  ------
-  floor                        0.057s  0.057s  0.059s  0.056s  0.057s
-  sqrt                         0.079s  0.079s  0.078s  0.079s  0.079s
-  modulo                       0.058s  0.057s  0.057s  0.057s  0.059s
-  if-elif-else                 0.124s  0.121s  0.124s  0.125s  0.123s
-  select|del                   0.090s  0.092s  0.090s  0.090s  0.091s
-  select|merge                 0.119s  0.120s  0.121s  0.118s  0.121s
-  select(test)|merge           0.021s  0.022s  0.021s  0.022s  0.021s
+  floor                        0.057s  0.059s  0.056s  0.057s  0.056s
+  sqrt                         0.079s  0.078s  0.079s  0.079s  0.078s
+  modulo                       0.057s  0.057s  0.057s  0.059s  0.057s
+  if-elif-else                 0.121s  0.124s  0.125s  0.123s  0.123s
+  select|del                   0.092s  0.090s  0.090s  0.091s  0.091s
+  select|merge                 0.120s  0.121s  0.118s  0.121s  0.118s
+  select(test)|merge           0.022s  0.021s  0.022s  0.021s  0.021s
 
 --- Array generators ---
-  Benchmark                    v1.5.5  v1.5.6  v1.6.0  v1.6.1  v1.7.0
+  Benchmark                    v1.5.6  v1.6.0  v1.6.1  v1.7.0  v1.7.1
   ---                          ------  ------  ------  ------  ------
-  range(2M) | length           0.011s  0.011s  0.012s  0.012s  0.012s
+  range(2M) | length           0.011s  0.012s  0.012s  0.012s  0.011s
   reverse(2M)                  0.018s  0.018s  0.018s  0.018s  0.018s
   sort(2M)                     0.023s  0.023s  0.023s  0.023s  0.023s
-  unique(1M)                   0.030s  0.030s  0.031s  0.030s  0.030s
-  flatten(500K)                0.010s  0.010s  0.011s  0.011s  0.011s
-  min, max(2M)                 0.021s  0.018s  0.022s  0.021s  0.019s
+  unique(1M)                   0.030s  0.031s  0.030s  0.030s  0.030s
+  flatten(500K)                0.010s  0.011s  0.011s  0.011s  0.011s
+  min, max(2M)                 0.018s  0.022s  0.021s  0.019s  0.020s
   add numbers(2M)              0.013s  0.013s  0.013s  0.013s  0.013s
-  any/all(2M)                  0.028s  0.028s  0.029s  0.028s  0.029s
-  limit(10; range(10M))        0.002s  0.002s  0.003s  0.002s  0.003s
-  first(range(10M))            0.002s  0.002s  0.003s  0.002s  0.003s
-  last(range(2M))              0.002s  0.002s  0.003s  0.002s  0.003s
-  indices(1M)                  0.016s  0.016s  0.017s  0.017s  0.017s
+  any/all(2M)                  0.028s  0.029s  0.028s  0.029s  0.028s
+  limit(10; range(10M))        0.002s  0.003s  0.002s  0.003s  0.002s
+  first(range(10M))            0.002s  0.003s  0.002s  0.003s  0.002s
+  last(range(2M))              0.002s  0.003s  0.002s  0.003s  0.002s
+  indices(1M)                  0.016s  0.017s  0.017s  0.017s  0.017s
 
 --- Reduce & foreach ---
-  Benchmark                    v1.5.5  v1.5.6  v1.6.0  v1.6.1  v1.7.0
+  Benchmark                    v1.5.6  v1.6.0  v1.6.1  v1.7.0  v1.7.1
   ---                          ------  ------  ------  ------  ------
   reduce (sum)                 0.009s  0.009s  0.009s  0.009s  0.009s
   reduce (array build)         0.004s  0.004s  0.004s  0.004s  0.004s
-  reduce (obj build)           0.009s  0.009s  0.010s  0.010s  0.010s
-  reduce (setpath)             0.016s  0.016s  0.017s  0.016s  0.016s
+  reduce (obj build)           0.009s  0.010s  0.010s  0.010s  0.009s
+  reduce (setpath)             0.016s  0.017s  0.016s  0.016s  0.016s
   foreach (running sum)        0.010s  0.010s  0.010s  0.010s  0.010s
-  foreach + emit               0.010s  0.010s  0.011s  0.011s  0.010s
-  reduce (sum-of-squares)      0.033s  0.033s  0.036s  0.034s  0.034s
-  reduce (conditional)         0.036s  0.035s  0.037s  0.036s  0.035s
-  reduce (product)             0.034s  0.034s  0.036s  0.035s  0.034s
-  foreach (conditional)        0.010s  0.010s  0.011s  0.010s  0.010s
-  until (100M)                 0.300s  0.301s  0.307s  0.303s  0.305s
-  reduce (harmonic)            0.033s  0.033s  0.035s  0.033s  0.033s
-  reduce (floor pipe)          0.033s  0.032s  0.035s  0.034s  0.033s
-  reduce (sqrt pipe)           0.033s  0.032s  0.035s  0.033s  0.033s
+  foreach + emit               0.010s  0.011s  0.011s  0.010s  0.010s
+  reduce (sum-of-squares)      0.033s  0.036s  0.034s  0.034s  0.033s
+  reduce (conditional)         0.035s  0.037s  0.036s  0.035s  0.035s
+  reduce (product)             0.034s  0.036s  0.035s  0.034s  0.034s
+  foreach (conditional)        0.010s  0.011s  0.010s  0.010s  0.010s
+  until (100M)                 0.301s  0.307s  0.303s  0.305s  0.303s
+  reduce (harmonic)            0.033s  0.035s  0.033s  0.033s  0.033s
+  reduce (floor pipe)          0.032s  0.035s  0.034s  0.033s  0.033s
+  reduce (sqrt pipe)           0.032s  0.035s  0.033s  0.033s  0.033s
   reduce (sin+cos)             0.052s  0.052s  0.052s  0.052s  0.052s
 
 --- Object operations ---
-  Benchmark                    v1.5.5  v1.5.6  v1.6.0  v1.6.1  v1.7.0
+  Benchmark                    v1.5.6  v1.6.0  v1.6.1  v1.7.0  v1.7.1
   ---                          ------  ------  ------  ------  ------
   large obj construct          0.004s  0.004s  0.004s  0.004s  0.004s
-  large obj keys               0.011s  0.011s  0.012s  0.011s  0.011s
+  large obj keys               0.011s  0.012s  0.011s  0.011s  0.011s
   large obj to_entries         0.012s  0.012s  0.012s  0.012s  0.012s
   with_entries                 0.009s  0.009s  0.009s  0.009s  0.009s
 
 --- Assignment operators ---
-  Benchmark                    v1.5.5  v1.5.6  v1.6.0  v1.6.1  v1.7.0
+  Benchmark                    v1.5.6  v1.6.0  v1.6.1  v1.7.0  v1.7.1
   ---                          ------  ------  ------  ------  ------
   .[] |= f (100K)              0.005s  0.005s  0.005s  0.005s  0.005s
-  .[] += 1 (100K)              0.005s  0.005s  0.006s  0.005s  0.005s
+  .[] += 1 (100K)              0.005s  0.006s  0.005s  0.005s  0.006s
   .[k] = v reduce(50K)         0.008s  0.008s  0.008s  0.008s  0.008s
 
 --- String-heavy generators ---
-  Benchmark                    v1.5.5  v1.5.6  v1.6.0  v1.6.1  v1.7.0
+  Benchmark                    v1.5.6  v1.6.0  v1.6.1  v1.7.0  v1.7.1
   ---                          ------  ------  ------  ------  ------
-  gsub(100K)                   0.026s  0.027s  0.027s  0.027s  0.027s
-  join large(100K)             0.005s  0.006s  0.006s  0.005s  0.005s
-  explode/implode(100K)        0.027s  0.028s  0.028s  0.028s  0.027s
+  gsub(100K)                   0.027s  0.027s  0.027s  0.027s  0.026s
+  join large(100K)             0.006s  0.006s  0.005s  0.005s  0.006s
+  explode/implode(100K)        0.028s  0.028s  0.028s  0.027s  0.028s
   reduce str concat(100K)      0.008s  0.008s  0.008s  0.008s  0.008s
 
 --- Try-catch & alternative ---
-  Benchmark                    v1.5.5  v1.5.6  v1.6.0  v1.6.1  v1.7.0
+  Benchmark                    v1.5.6  v1.6.0  v1.6.1  v1.7.0  v1.7.1
   ---                          ------  ------  ------  ------  ------
-  alternative //               0.032s  0.032s  0.035s  0.035s  0.035s
-  try-catch                    0.023s  0.023s  0.024s  0.024s  0.024s
+  alternative //               0.032s  0.035s  0.035s  0.035s  0.035s
+  try-catch                    0.023s  0.024s  0.024s  0.024s  0.024s
   label-break                  0.004s  0.004s  0.004s  0.004s  0.004s
 
 --- Type conversion ---
-  Benchmark                    v1.5.5  v1.5.6  v1.6.0  v1.6.1  v1.7.0
+  Benchmark                    v1.5.6  v1.6.0  v1.6.1  v1.7.0  v1.7.1
   ---                          ------  ------  ------  ------  ------
-  tojson/fromjson(100K)        0.022s  0.022s  0.023s  0.022s  0.022s
-  null propagation(2M)         0.089s  0.090s  0.093s  0.091s  0.091s
+  tojson/fromjson(100K)        0.022s  0.023s  0.022s  0.022s  0.022s
+  null propagation(2M)         0.090s  0.093s  0.091s  0.091s  0.093s
 
 --- jaq-derived ---
-  Benchmark                    v1.5.5  v1.5.6  v1.6.0  v1.6.1  v1.7.0
+  Benchmark                    v1.5.6  v1.6.0  v1.6.1  v1.7.0  v1.7.1
   ---                          ------  ------  ------  ------  ------
   jaq: reverse                 -       -       -       -       -
   jaq: sort                    -       -       -       -       -
@@ -291,9 +291,9 @@ Recent slice (last 5 columns). Full history lives in
   jaq: str-slice               -       -       -       -       -
 
 --- Memoization (jqx) ---
-  Benchmark                    v1.5.5  v1.5.6  v1.6.0  v1.6.1  v1.7.0
+  Benchmark                    v1.5.6  v1.6.0  v1.6.1  v1.7.0  v1.7.1
   ---                          ------  ------  ------  ------  ------
-  memo fib (1K)                -       -       0.004s  0.003s  0.003s
-  memo collatz sum (10K)       -       -       0.017s  0.017s  0.016s
-  memo by .id (100K, 1K keys)  -       -       0.021s  0.020s  0.020s
+  memo fib (1K)                -       0.004s  0.003s  0.003s  0.003s
+  memo collatz sum (10K)       -       0.017s  0.017s  0.016s  0.016s
+  memo by .id (100K, 1K keys)  -       0.021s  0.020s  0.020s  0.020s
 ```

--- a/docs/benchmark-history.tsv
+++ b/docs/benchmark-history.tsv
@@ -4061,7 +4061,7 @@ NDJSON workloads (2M objects)	to_entries	v1.6.0	0.159
 NDJSON workloads (2M objects)	keys	v1.6.0	0.105
 NDJSON workloads (2M objects)	keys_unsorted	v1.6.0	0.095
 NDJSON workloads (2M objects)	length	v1.6.0	0.087
-NDJSON workloads (2M objects)	has("x")	v1.6.0	0.039
+NDJSON workloads (2M objects)	"has(""x"")"	v1.6.0	0.039
 NDJSON workloads (2M objects)	type	v1.6.0	0.023
 NDJSON workloads (2M objects)	del(.name)	v1.6.0	0.103
 NDJSON workloads (2M objects)	@csv	v1.6.0	0.124
@@ -4085,7 +4085,7 @@ NDJSON workloads (2M objects)	.x > .y	v1.6.0	0.079
 NDJSON workloads (2M objects)	to_entries|len	v1.6.0	0.400
 NDJSON workloads (2M objects)	.x|.+1 (pipe)	v1.6.0	0.058
 NDJSON workloads (2M objects)	.x|.*2|.+1	v1.6.0	0.060
-NDJSON workloads (2M objects)	.name|.+"_x"	v1.6.0	0.094
+NDJSON workloads (2M objects)	".name|.+""_x"""	v1.6.0	0.094
 NDJSON workloads (2M objects)	.x>N | not	v1.6.0	0.049
 NDJSON workloads (2M objects)	and (2 cmp)	v1.6.0	0.085
 NDJSON workloads (2M objects)	if-then-else	v1.6.0	0.051
@@ -4120,7 +4120,7 @@ NDJSON workloads (2M objects)	if sw then .f	v1.6.0	0.143
 NDJSON workloads (2M objects)	dynkey {(.n)=.x*2}	v1.6.0	0.115
 NDJSON workloads (2M objects)	sel(and)|.x*.y	v1.6.0	0.079
 NDJSON workloads (2M objects)	sel>N|str chain	v1.6.0	0.156
-NDJSON workloads (2M objects)	.f+"_"+arith_ts	v1.6.0	0.136
+NDJSON workloads (2M objects)	".f+""_""+arith_ts"	v1.6.0	0.136
 NDJSON workloads (2M objects)	sel(sw)|str ch	v1.6.0	0.304
 NDJSON workloads (2M objects)	split|rev|join	v1.6.0	0.118
 NDJSON workloads (2M objects)	dynkey+static	v1.6.0	0.338
@@ -4178,8 +4178,8 @@ NDJSON workloads (2M objects)	tojson|fromjson	v1.6.0	0.087
 NDJSON workloads (2M objects)	[.x]|add	v1.6.0	0.060
 NDJSON workloads (2M objects)	if>N {o}+.	v1.6.0	0.136
 NDJSON workloads (2M objects)	if>N .+{o}	v1.6.0	0.135
-NDJSON workloads (2M objects)	if .n=="s" .+{o}	v1.6.0	0.158
-NDJSON workloads (2M objects)	sel(.n>"s")	v1.6.0	0.089
+NDJSON workloads (2M objects)	"if .n==""s"" .+{o}"	v1.6.0	0.158
+NDJSON workloads (2M objects)	"sel(.n>""s"")"	v1.6.0	0.089
 NDJSON workloads (2M objects)	[x,y,z]|min	v1.6.0	0.308
 NDJSON workloads (2M objects)	if .n|len>5 l s	v1.6.0	0.100
 NDJSON workloads (2M objects)	if .x|flr>N b s	v1.6.0	0.056
@@ -4278,7 +4278,7 @@ NDJSON workloads (2M objects)	to_entries	v1.6.1	0.159
 NDJSON workloads (2M objects)	keys	v1.6.1	0.107
 NDJSON workloads (2M objects)	keys_unsorted	v1.6.1	0.097
 NDJSON workloads (2M objects)	length	v1.6.1	0.088
-NDJSON workloads (2M objects)	has("x")	v1.6.1	0.039
+NDJSON workloads (2M objects)	"has(""x"")"	v1.6.1	0.039
 NDJSON workloads (2M objects)	type	v1.6.1	0.023
 NDJSON workloads (2M objects)	del(.name)	v1.6.1	0.107
 NDJSON workloads (2M objects)	@csv	v1.6.1	0.120
@@ -4302,7 +4302,7 @@ NDJSON workloads (2M objects)	.x > .y	v1.6.1	0.078
 NDJSON workloads (2M objects)	to_entries|len	v1.6.1	0.405
 NDJSON workloads (2M objects)	.x|.+1 (pipe)	v1.6.1	0.059
 NDJSON workloads (2M objects)	.x|.*2|.+1	v1.6.1	0.060
-NDJSON workloads (2M objects)	.name|.+"_x"	v1.6.1	0.097
+NDJSON workloads (2M objects)	".name|.+""_x"""	v1.6.1	0.097
 NDJSON workloads (2M objects)	.x>N | not	v1.6.1	0.051
 NDJSON workloads (2M objects)	and (2 cmp)	v1.6.1	0.082
 NDJSON workloads (2M objects)	if-then-else	v1.6.1	0.053
@@ -4337,7 +4337,7 @@ NDJSON workloads (2M objects)	if sw then .f	v1.6.1	0.143
 NDJSON workloads (2M objects)	dynkey {(.n)=.x*2}	v1.6.1	0.117
 NDJSON workloads (2M objects)	sel(and)|.x*.y	v1.6.1	0.077
 NDJSON workloads (2M objects)	sel>N|str chain	v1.6.1	0.152
-NDJSON workloads (2M objects)	.f+"_"+arith_ts	v1.6.1	0.134
+NDJSON workloads (2M objects)	".f+""_""+arith_ts"	v1.6.1	0.134
 NDJSON workloads (2M objects)	sel(sw)|str ch	v1.6.1	0.308
 NDJSON workloads (2M objects)	split|rev|join	v1.6.1	0.117
 NDJSON workloads (2M objects)	dynkey+static	v1.6.1	0.340
@@ -4395,8 +4395,8 @@ NDJSON workloads (2M objects)	tojson|fromjson	v1.6.1	0.084
 NDJSON workloads (2M objects)	[.x]|add	v1.6.1	0.060
 NDJSON workloads (2M objects)	if>N {o}+.	v1.6.1	0.135
 NDJSON workloads (2M objects)	if>N .+{o}	v1.6.1	0.135
-NDJSON workloads (2M objects)	if .n=="s" .+{o}	v1.6.1	0.161
-NDJSON workloads (2M objects)	sel(.n>"s")	v1.6.1	0.090
+NDJSON workloads (2M objects)	"if .n==""s"" .+{o}"	v1.6.1	0.161
+NDJSON workloads (2M objects)	"sel(.n>""s"")"	v1.6.1	0.090
 NDJSON workloads (2M objects)	[x,y,z]|min	v1.6.1	0.311
 NDJSON workloads (2M objects)	if .n|len>5 l s	v1.6.1	0.101
 NDJSON workloads (2M objects)	if .x|flr>N b s	v1.6.1	0.055
@@ -4495,7 +4495,7 @@ NDJSON workloads (2M objects)	to_entries	v1.7.0	0.163
 NDJSON workloads (2M objects)	keys	v1.7.0	0.105
 NDJSON workloads (2M objects)	keys_unsorted	v1.7.0	0.094
 NDJSON workloads (2M objects)	length	v1.7.0	0.084
-NDJSON workloads (2M objects)	has("x")	v1.7.0	0.037
+NDJSON workloads (2M objects)	"has(""x"")"	v1.7.0	0.037
 NDJSON workloads (2M objects)	type	v1.7.0	0.023
 NDJSON workloads (2M objects)	del(.name)	v1.7.0	0.101
 NDJSON workloads (2M objects)	@csv	v1.7.0	0.118
@@ -4519,7 +4519,7 @@ NDJSON workloads (2M objects)	.x > .y	v1.7.0	0.077
 NDJSON workloads (2M objects)	to_entries|len	v1.7.0	0.397
 NDJSON workloads (2M objects)	.x|.+1 (pipe)	v1.7.0	0.059
 NDJSON workloads (2M objects)	.x|.*2|.+1	v1.7.0	0.060
-NDJSON workloads (2M objects)	.name|.+"_x"	v1.7.0	0.094
+NDJSON workloads (2M objects)	".name|.+""_x"""	v1.7.0	0.094
 NDJSON workloads (2M objects)	.x>N | not	v1.7.0	0.049
 NDJSON workloads (2M objects)	and (2 cmp)	v1.7.0	0.080
 NDJSON workloads (2M objects)	if-then-else	v1.7.0	0.052
@@ -4554,7 +4554,7 @@ NDJSON workloads (2M objects)	if sw then .f	v1.7.0	0.139
 NDJSON workloads (2M objects)	dynkey {(.n)=.x*2}	v1.7.0	0.115
 NDJSON workloads (2M objects)	sel(and)|.x*.y	v1.7.0	0.077
 NDJSON workloads (2M objects)	sel>N|str chain	v1.7.0	0.155
-NDJSON workloads (2M objects)	.f+"_"+arith_ts	v1.7.0	0.133
+NDJSON workloads (2M objects)	".f+""_""+arith_ts"	v1.7.0	0.133
 NDJSON workloads (2M objects)	sel(sw)|str ch	v1.7.0	0.307
 NDJSON workloads (2M objects)	split|rev|join	v1.7.0	0.117
 NDJSON workloads (2M objects)	dynkey+static	v1.7.0	0.338
@@ -4612,8 +4612,8 @@ NDJSON workloads (2M objects)	tojson|fromjson	v1.7.0	0.082
 NDJSON workloads (2M objects)	[.x]|add	v1.7.0	0.059
 NDJSON workloads (2M objects)	if>N {o}+.	v1.7.0	0.138
 NDJSON workloads (2M objects)	if>N .+{o}	v1.7.0	0.136
-NDJSON workloads (2M objects)	if .n=="s" .+{o}	v1.7.0	0.157
-NDJSON workloads (2M objects)	sel(.n>"s")	v1.7.0	0.091
+NDJSON workloads (2M objects)	"if .n==""s"" .+{o}"	v1.7.0	0.157
+NDJSON workloads (2M objects)	"sel(.n>""s"")"	v1.7.0	0.091
 NDJSON workloads (2M objects)	[x,y,z]|min	v1.7.0	0.307
 NDJSON workloads (2M objects)	if .n|len>5 l s	v1.7.0	0.100
 NDJSON workloads (2M objects)	if .x|flr>N b s	v1.7.0	0.055
@@ -4697,3 +4697,220 @@ Type conversion	null propagation(2M)	v1.7.0	0.091
 Memoization (jqx)	memo fib (1K)	v1.7.0	0.003
 Memoization (jqx)	memo collatz sum (10K)	v1.7.0	0.016
 Memoization (jqx)	memo by .id (100K, 1K keys)	v1.7.0	0.020
+NDJSON workloads (2M objects)	empty	v1.7.1	0.017
+NDJSON workloads (2M objects)	identity -c	v1.7.1	0.084
+NDJSON workloads (2M objects)	identity (pretty)	v1.7.1	0.102
+NDJSON workloads (2M objects)	field access .name	v1.7.1	0.090
+NDJSON workloads (2M objects)	nested .x,.y,.name	v1.7.1	0.146
+NDJSON workloads (2M objects)	arithmetic .x + .y	v1.7.1	0.082
+NDJSON workloads (2M objects)	select .x > 1500000	v1.7.1	0.080
+NDJSON workloads (2M objects)	string concat	v1.7.1	0.092
+NDJSON workloads (2M objects)	object construct	v1.7.1	0.110
+NDJSON workloads (2M objects)	array construct	v1.7.1	0.105
+NDJSON workloads (2M objects)	.[]	v1.7.1	0.101
+NDJSON workloads (2M objects)	to_entries	v1.7.1	0.154
+NDJSON workloads (2M objects)	keys	v1.7.1	0.100
+NDJSON workloads (2M objects)	keys_unsorted	v1.7.1	0.092
+NDJSON workloads (2M objects)	length	v1.7.1	0.087
+NDJSON workloads (2M objects)	"has(""x"")"	v1.7.1	0.036
+NDJSON workloads (2M objects)	type	v1.7.1	0.022
+NDJSON workloads (2M objects)	del(.name)	v1.7.1	0.099
+NDJSON workloads (2M objects)	@csv	v1.7.1	0.117
+NDJSON workloads (2M objects)	split/join	v1.7.1	0.089
+NDJSON workloads (2M objects)	select|field	v1.7.1	0.094
+NDJSON workloads (2M objects)	select|remap	v1.7.1	0.097
+NDJSON workloads (2M objects)	computed remap	v1.7.1	0.187
+NDJSON workloads (2M objects)	[.x,.y]|add	v1.7.1	0.083
+NDJSON workloads (2M objects)	[.x,.y]|avg	v1.7.1	0.106
+NDJSON workloads (2M objects)	map(*2)|add	v1.7.1	0.102
+NDJSON workloads (2M objects)	keys|length	v1.7.1	0.251
+NDJSON workloads (2M objects)	.+{z=0}	v1.7.1	0.145
+NDJSON workloads (2M objects)	split|first	v1.7.1	0.088
+NDJSON workloads (2M objects)	slice[0..5]	v1.7.1	0.094
+NDJSON workloads (2M objects)	dynkey {(.name)}	v1.7.1	0.106
+NDJSON workloads (2M objects)	.x += 1	v1.7.1	0.122
+NDJSON workloads (2M objects)	{a}+{b} merge	v1.7.1	0.129
+NDJSON workloads (2M objects)	.x*2+1	v1.7.1	0.059
+NDJSON workloads (2M objects)	.x+.y*2	v1.7.1	0.096
+NDJSON workloads (2M objects)	.x > .y	v1.7.1	0.076
+NDJSON workloads (2M objects)	to_entries|len	v1.7.1	0.397
+NDJSON workloads (2M objects)	.x|.+1 (pipe)	v1.7.1	0.056
+NDJSON workloads (2M objects)	.x|.*2|.+1	v1.7.1	0.058
+NDJSON workloads (2M objects)	".name|.+""_x"""	v1.7.1	0.092
+NDJSON workloads (2M objects)	.x>N | not	v1.7.1	0.048
+NDJSON workloads (2M objects)	and (2 cmp)	v1.7.1	0.080
+NDJSON workloads (2M objects)	if-then-else	v1.7.1	0.051
+NDJSON workloads (2M objects)	sel(and)|field	v1.7.1	0.076
+NDJSON workloads (2M objects)	sel(and)|remap	v1.7.1	0.077
+NDJSON workloads (2M objects)	arith|cmp	v1.7.1	0.053
+NDJSON workloads (2M objects)	if cmp .field	v1.7.1	0.110
+NDJSON workloads (2M objects)	split|length	v1.7.1	0.088
+NDJSON workloads (2M objects)	[x,y]|min	v1.7.1	0.089
+NDJSON workloads (2M objects)	[x,y]|max	v1.7.1	0.092
+NDJSON workloads (2M objects)	[x,y]|sort|.[0]	v1.7.1	0.088
+NDJSON workloads (2M objects)	.name|len>5	v1.7.1	0.089
+NDJSON workloads (2M objects)	sel(len>5)|.x	v1.7.1	0.107
+NDJSON workloads (2M objects)	if .x>.y .name	v1.7.1	0.088
+NDJSON workloads (2M objects)	sel(.x>.y)|.name	v1.7.1	0.070
+NDJSON workloads (2M objects)	.x*2|tostring	v1.7.1	0.055
+NDJSON workloads (2M objects)	.x*.x+1	v1.7.1	0.064
+NDJSON workloads (2M objects)	{k=.name,v=tostr}	v1.7.1	0.145
+NDJSON workloads (2M objects)	str add chain	v1.7.1	0.378
+NDJSON workloads (2M objects)	if>.y .name|empty	v1.7.1	0.072
+NDJSON workloads (2M objects)	if .x%2==0	v1.7.1	0.054
+NDJSON workloads (2M objects)	if .x*2+1>1M	v1.7.1	0.054
+NDJSON workloads (2M objects)	sel(.x%2==0)|.name	v1.7.1	0.081
+NDJSON workloads (2M objects)	sel(.x*2+1>1M)	v1.7.1	0.154
+NDJSON workloads (2M objects)	.x|@json	v1.7.1	0.047
+NDJSON workloads (2M objects)	.x|@text	v1.7.1	0.047
+NDJSON workloads (2M objects)	.name|@json	v1.7.1	0.101
+NDJSON workloads (2M objects)	sel|[arr]	v1.7.1	0.144
+NDJSON workloads (2M objects)	sel(and)|[arr]	v1.7.1	0.076
+NDJSON workloads (2M objects)	if>.y [arr]	v1.7.1	0.174
+NDJSON workloads (2M objects)	if sw then .f	v1.7.1	0.135
+NDJSON workloads (2M objects)	dynkey {(.n)=.x*2}	v1.7.1	0.112
+NDJSON workloads (2M objects)	sel(and)|.x*.y	v1.7.1	0.078
+NDJSON workloads (2M objects)	sel>N|str chain	v1.7.1	0.153
+NDJSON workloads (2M objects)	".f+""_""+arith_ts"	v1.7.1	0.132
+NDJSON workloads (2M objects)	sel(sw)|str ch	v1.7.1	0.298
+NDJSON workloads (2M objects)	split|rev|join	v1.7.1	0.112
+NDJSON workloads (2M objects)	dynkey+static	v1.7.1	0.332
+NDJSON workloads (2M objects)	if>.y str chain	v1.7.1	0.168
+NDJSON workloads (2M objects)	remap+str chain	v1.7.1	0.154
+NDJSON workloads (2M objects)	sel(len>8)	v1.7.1	0.159
+NDJSON workloads (2M objects)	up|split|join	v1.7.1	0.100
+NDJSON workloads (2M objects)	.name|index	v1.7.1	0.117
+NDJSON workloads (2M objects)	.name|index+1	v1.7.1	0.122
+NDJSON workloads (2M objects)	.name|rindex	v1.7.1	0.125
+NDJSON workloads (2M objects)	.name|indices	v1.7.1	0.149
+NDJSON workloads (2M objects)	[x,y]|sort	v1.7.1	0.154
+NDJSON workloads (2M objects)	.name|scan	v1.7.1	0.213
+NDJSON workloads (2M objects)	.name|gsub	v1.7.1	0.166
+NDJSON workloads (2M objects)	walk(if num .+1)	v1.7.1	0.137
+NDJSON workloads (2M objects)	tojson	v1.7.1	0.105
+NDJSON workloads (2M objects)	{name,x}	v1.7.1	0.128
+NDJSON workloads (2M objects)	.z//.name	v1.7.1	0.155
+NDJSON workloads (2M objects)	.x|=test(re)	v1.7.1	0.170
+NDJSON workloads (2M objects)	./sep|first	v1.7.1	0.180
+NDJSON workloads (2M objects)	.y=(.x*2)	v1.7.1	0.175
+NDJSON workloads (2M objects)	.y=(.x+.y)	v1.7.1	0.226
+NDJSON workloads (2M objects)	objects	v1.7.1	0.137
+NDJSON workloads (2M objects)	.tag|=if..then N	v1.7.1	0.614
+NDJSON workloads (2M objects)	.x=(.x+1)	v1.7.1	0.126
+NDJSON workloads (2M objects)	sel>N|.y+=1	v1.7.1	0.120
+NDJSON workloads (2M objects)	sel(and)|.x+=1	v1.7.1	0.109
+NDJSON workloads (2M objects)	sel(sw)|.x+=1	v1.7.1	0.156
+NDJSON workloads (2M objects)	match(re)	v1.7.1	0.368
+NDJSON workloads (2M objects)	capture(re)	v1.7.1	0.299
+NDJSON workloads (2M objects)	first(.name,.x)	v1.7.1	0.095
+NDJSON workloads (2M objects)	if .x==null	v1.7.1	0.046
+NDJSON workloads (2M objects)	we(sw(.key))	v1.7.1	0.107
+NDJSON workloads (2M objects)	sel(sw or ew)	v1.7.1	0.199
+NDJSON workloads (2M objects)	path(.name,.x)	v1.7.1	0.271
+NDJSON workloads (2M objects)	sel(str+num+num)	v1.7.1	0.151
+NDJSON workloads (2M objects)	nested if|field	v1.7.1	0.077
+NDJSON workloads (2M objects)	.f|floor|.*2	v1.7.1	0.061
+NDJSON workloads (2M objects)	split|len>1	v1.7.1	0.113
+NDJSON workloads (2M objects)	.name|len|.*2	v1.7.1	0.100
+NDJSON workloads (2M objects)	if len>5 .x .y	v1.7.1	0.115
+NDJSON workloads (2M objects)	sel(len>5)|remap	v1.7.1	0.199
+NDJSON workloads (2M objects)	.x|tostr|len	v1.7.1	0.058
+NDJSON workloads (2M objects)	if .x>.y .x .y	v1.7.1	0.094
+NDJSON workloads (2M objects)	split|last|tonum	v1.7.1	0.095
+NDJSON workloads (2M objects)	split|rev|.[0]	v1.7.1	0.090
+NDJSON workloads (2M objects)	split|.[0]+.[1]	v1.7.1	0.112
+NDJSON workloads (2M objects)	.[]|strings	v1.7.1	0.104
+NDJSON workloads (2M objects)	.[]|numbers	v1.7.1	0.124
+NDJSON workloads (2M objects)	[x,y]|any(>1M)	v1.7.1	0.083
+NDJSON workloads (2M objects)	sel(dc|sw)	v1.7.1	0.098
+NDJSON workloads (2M objects)	[[x,y],[n]]|flat	v1.7.1	0.456
+NDJSON workloads (2M objects)	.x|floor|.*2	v1.7.1	0.061
+NDJSON workloads (2M objects)	tojson|fromjson	v1.7.1	0.084
+NDJSON workloads (2M objects)	[.x]|add	v1.7.1	0.059
+NDJSON workloads (2M objects)	if>N {o}+.	v1.7.1	0.136
+NDJSON workloads (2M objects)	if>N .+{o}	v1.7.1	0.132
+NDJSON workloads (2M objects)	"if .n==""s"" .+{o}"	v1.7.1	0.159
+NDJSON workloads (2M objects)	"sel(.n>""s"")"	v1.7.1	0.087
+NDJSON workloads (2M objects)	[x,y,z]|min	v1.7.1	0.312
+NDJSON workloads (2M objects)	if .n|len>5 l s	v1.7.1	0.099
+NDJSON workloads (2M objects)	if .x|flr>N b s	v1.7.1	0.054
+NDJSON workloads (2M objects)	if .n|test l e	v1.7.1	0.104
+NDJSON workloads (2M objects)	if .n|sw l e	v1.7.1	0.084
+NDJSON workloads (2M objects)	if .n|ew l e	v1.7.1	0.083
+NDJSON workloads (2M objects)	.n|len|tostr	v1.7.1	0.092
+String operations (2M objects)	ascii_downcase	v1.7.1	0.104
+String operations (2M objects)	ascii_upcase	v1.7.1	0.102
+String operations (2M objects)	ltrimstr	v1.7.1	0.096
+String operations (2M objects)	rtrimstr	v1.7.1	0.097
+String operations (2M objects)	split	v1.7.1	0.164
+String operations (2M objects)	case+split	v1.7.1	0.116
+String operations (2M objects)	join	v1.7.1	0.094
+String operations (2M objects)	startswith	v1.7.1	0.094
+String operations (2M objects)	endswith	v1.7.1	0.097
+String operations (2M objects)	tostring	v1.7.1	0.062
+String operations (2M objects)	tonumber	v1.7.1	0.109
+String operations (2M objects)	string interpolation	v1.7.1	0.119
+String ops (200K objects)	test (regex)	v1.7.1	0.014
+String ops (200K objects)	match (regex)	v1.7.1	0.033
+String ops (200K objects)	@base64	v1.7.1	0.012
+String ops (200K objects)	@uri	v1.7.1	0.012
+String ops (200K objects)	@html	v1.7.1	0.012
+String ops (200K objects)	@csv (array)	v1.7.1	0.016
+String ops (200K objects)	@tsv (array)	v1.7.1	0.015
+String ops (200K objects)	gsub	v1.7.1	0.019
+String ops (200K objects)	case+gsub	v1.7.1	0.176
+String ops (200K objects)	case+test	v1.7.1	0.118
+String ops (200K objects)	ltrim+tonum+arith	v1.7.1	0.111
+Numeric & math (2M objects)	floor	v1.7.1	0.056
+Numeric & math (2M objects)	sqrt	v1.7.1	0.078
+Numeric & math (2M objects)	modulo	v1.7.1	0.057
+Numeric & math (2M objects)	if-elif-else	v1.7.1	0.123
+Numeric & math (2M objects)	select|del	v1.7.1	0.091
+Numeric & math (2M objects)	select|merge	v1.7.1	0.118
+Numeric & math (2M objects)	select(test)|merge	v1.7.1	0.021
+Array generators	range(2M) | length	v1.7.1	0.011
+Array generators	reverse(2M)	v1.7.1	0.018
+Array generators	sort(2M)	v1.7.1	0.023
+Array generators	unique(1M)	v1.7.1	0.030
+Array generators	flatten(500K)	v1.7.1	0.011
+Array generators	min, max(2M)	v1.7.1	0.020
+Array generators	add numbers(2M)	v1.7.1	0.013
+Array generators	any/all(2M)	v1.7.1	0.028
+Array generators	limit(10; range(10M))	v1.7.1	0.002
+Array generators	first(range(10M))	v1.7.1	0.002
+Array generators	last(range(2M))	v1.7.1	0.002
+Array generators	indices(1M)	v1.7.1	0.017
+Reduce & foreach	reduce (sum)	v1.7.1	0.009
+Reduce & foreach	reduce (array build)	v1.7.1	0.004
+Reduce & foreach	reduce (obj build)	v1.7.1	0.009
+Reduce & foreach	reduce (setpath)	v1.7.1	0.016
+Reduce & foreach	foreach (running sum)	v1.7.1	0.010
+Reduce & foreach	foreach + emit	v1.7.1	0.010
+Reduce & foreach	reduce (sum-of-squares)	v1.7.1	0.033
+Reduce & foreach	reduce (conditional)	v1.7.1	0.035
+Reduce & foreach	reduce (product)	v1.7.1	0.034
+Reduce & foreach	foreach (conditional)	v1.7.1	0.010
+Reduce & foreach	until (100M)	v1.7.1	0.303
+Reduce & foreach	reduce (harmonic)	v1.7.1	0.033
+Reduce & foreach	reduce (floor pipe)	v1.7.1	0.033
+Reduce & foreach	reduce (sqrt pipe)	v1.7.1	0.033
+Reduce & foreach	reduce (sin+cos)	v1.7.1	0.052
+Object operations	large obj construct	v1.7.1	0.004
+Object operations	large obj keys	v1.7.1	0.011
+Object operations	large obj to_entries	v1.7.1	0.012
+Object operations	with_entries	v1.7.1	0.009
+Assignment operators	.[] |= f (100K)	v1.7.1	0.005
+Assignment operators	.[] += 1 (100K)	v1.7.1	0.006
+Assignment operators	.[k] = v reduce(50K)	v1.7.1	0.008
+String-heavy generators	gsub(100K)	v1.7.1	0.026
+String-heavy generators	join large(100K)	v1.7.1	0.006
+String-heavy generators	explode/implode(100K)	v1.7.1	0.028
+String-heavy generators	reduce str concat(100K)	v1.7.1	0.008
+Try-catch & alternative	alternative //	v1.7.1	0.035
+Try-catch & alternative	try-catch	v1.7.1	0.024
+Try-catch & alternative	label-break	v1.7.1	0.004
+Type conversion	tojson/fromjson(100K)	v1.7.1	0.022
+Type conversion	null propagation(2M)	v1.7.1	0.093
+Memoization (jqx)	memo fib (1K)	v1.7.1	0.003
+Memoization (jqx)	memo collatz sum (10K)	v1.7.1	0.016
+Memoization (jqx)	memo by .id (100K, 1K keys)	v1.7.1	0.020

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -3878,21 +3878,22 @@ impl Flattener {
         // Only handle generator values (keys must be scalar)
         if !pairs.iter().all(|(k, _)| is_scalar(k)) { return false; }
 
-        // Convert: {k1: gen1, k2: gen2} =>
-        //   gen1 as $__v0 | gen2 as $__v1 | {k1: $__v0, k2: $__v1}
-        // Use high var indices to avoid conflicts (starting at 10000)
+        // Convert: {k1: v1, k2: v2, ...} =>
+        //   v1 as $__v0 | v2 as $__v1 | ... | {k1: $__v0, k2: $__v1, ...}
+        // Bind *every* value (scalar or generator) in source order so left-to-right
+        // evaluation matches jq: an earlier slot's error must propagate even when a
+        // later slot is `empty` (#693). Keeping scalars inline would defer their
+        // evaluation past any subsequent generator's bind, swallowing the error if
+        // that generator yields zero outputs.
+        // Use high var indices to avoid conflicts (starting at 10000).
         let base_var: u16 = 10000;
-        let mut scalar_pairs = Vec::new();
-        let mut bindings = Vec::new();
+        let mut scalar_pairs = Vec::with_capacity(pairs.len());
+        let mut bindings = Vec::with_capacity(pairs.len());
 
         for (i, (k, v)) in pairs.iter().enumerate() {
-            if is_scalar(v) {
-                scalar_pairs.push((k.clone(), v.clone()));
-            } else {
-                let var_idx = base_var + i as u16;
-                bindings.push((var_idx, v.clone()));
-                scalar_pairs.push((k.clone(), Expr::LoadVar { var_index: var_idx }));
-            }
+            let var_idx = base_var + i as u16;
+            bindings.push((var_idx, v.clone()));
+            scalar_pairs.push((k.clone(), Expr::LoadVar { var_index: var_idx }));
         }
 
         // Build the scalar object construct

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -10236,3 +10236,35 @@ false
 {a: (if (.c >= .a) then (.a > .c) else 0 end)}
 {"a":null,"c":null}
 {"a":false}
+
+# Issue #693 (release v1.7.0 fuzz regression): JIT's
+# `flatten_obj_construct_gen` rewrote `{k1: scalar, k2: gen}` as
+# `gen as $v | {k1: scalar, k2: $v}`, keeping scalars inline while
+# binding only generators. When the trailing generator was `empty`,
+# the LetBinding produced zero outputs and the body — including the
+# leading scalar slot's would-be error — was skipped. jq evaluates
+# slots left-to-right, so an earlier slot's error must propagate even
+# when a later slot is empty. Fix: bind every slot value in source
+# order, so the scalar is evaluated (and may error) before the empty
+# generator short-circuits.
+try {a: (0|.a), b: empty} catch "ERROR"
+null
+"ERROR"
+
+# Earlier-slot error + later empty in non-trailing position
+try {a: 1, b: (0|.a), c: empty} catch "ERROR"
+null
+"ERROR"
+
+# Original fuzz-found shape (via `.a |= ...` axis): the `?` at the
+# outer level should catch the would-be error from the inner update,
+# yielding no output. Pre-fix the JIT silently produced `{}`.
+[((.a |= ({a: (((0) | (.)) | (.a > .a)), a: (values)})) | .)?]
+{}
+[]
+
+# Empty in earlier slot still short-circuits correctly (no error from
+# later slots leaks). jq matches.
+[{a: empty, b: (0|.a)}]
+null
+[]


### PR DESCRIPTION
## Summary

Patch release fixing the JIT object-construct error-swallow bug that broke v1.7.0's release pipeline (`fuzz_axis_assign` failed on Linux/Windows CI; no v1.7.0 GH Release or Homebrew tap bump was produced).

## What changed

**Fix (commit `73cf555`):** `flatten_obj_construct_gen` in `src/jit.rs` rewrote `{k1: scalar, k2: gen}` as `gen as $v | {k1: scalar, k2: $v}`, leaving scalars inline while binding only generators. When the trailing generator yielded `empty`, the `LetBinding` short-circuited and never evaluated the leading scalar — so an earlier slot's would-be error was swallowed.

jq evaluates object slots left-to-right; an earlier slot's error must propagate even when a later slot is empty. Fix: bind every slot value in source order so left-to-right evaluation is preserved.

Pre-existing on v1.6.1 too — the fuzz harness added in #686 just started catching it on v1.7.0's CI.

**Regression tests:** 4 cases added to `tests/regression.test` covering the minimal repro, the original fuzz-found shape, the non-trailing-empty variant, and the empty-first short-circuit (which should still produce no output without leaking the later slot's error).

## Bench (v1.7.0 → v1.7.1)

- No real regression. The 4 rows >1.05x are all in the 5-10ms range where 1ms is the timer quantization floor (≥10% noise). Re-run verified: only `join large(100K)` (5→6ms, 1.20x) was reproducible across two runs; everything else swung between 1.00x and 1.07x between runs.
- **8 improvements ≥5%** including the v1.7.0 "regressions" (`first/last/limit(range)`) bouncing back to 2ms — confirming they were timer jitter, not real regressions.

## Test plan

- [x] `cargo build --release` zero warnings
- [x] `cargo test --release` — 458 outer / 1984 inner (regression) passed / 0 failed
- [x] `tests/fuzz_axis_assign.rs` — the test that failed v1.7.0 CI — passes
- [x] `bench/comprehensive.sh` ran twice; history appended for v1.7.1