### PR TITLE
perf(jit): make mutate(...) transparent to in-place fusion

### DIFF
--- a/bench/comprehensive.sh
+++ b/bench/comprehensive.sh
@@ -337,6 +337,12 @@ bench_gen ".[k] = v reduce(50K)"       50000    'reduce range(.) as $i ({}; .["k
 # (#664) without this; expectation here is < 10× of stock jq on a
 # proportionally-sized accumulator.
 bench_gen "p126-shape nested reduce"   5000      '[range(0; .)] | reduce range(1; 30) as $a (.; reduce range($a; 60) as $b (.; if 2*$a*$b >= length then . else (((length/2 - $a*$b) / ($a+$b)) | floor) as $c_max | reduce range($b; $c_max+1) as $c (.; (2*($a*$b + $b*$c + $c*$a)) as $base | if $base >= length then . else ($a+$b+$c) as $s | reduce range(1; 30) as $n (.; ($base + 4*$s*($n-1) + 4*($n-1)*($n-2)) as $layer | if $layer >= length then . else .[$layer] += 1 end) end) end)) | add'
+# Same shape with `mutate(...)` wrapping the leaf. The marker must be
+# transparent to the nested-reduce fusion at every depth — anchors the
+# regression where mutate(...) at the leaf used to bail the fusion via
+# `detect_inplace_update_in_branch` (no Mutate arm), turning the 4-deep
+# 20000-element variant from ~0.8s into ~180s (#666 follow-up).
+bench_gen "p126-shape w/ mutate"        5000      '[range(0; .)] | reduce range(1; 30) as $a (.; reduce range($a; 60) as $b (.; if 2*$a*$b >= length then . else (((length/2 - $a*$b) / ($a+$b)) | floor) as $c_max | reduce range($b; $c_max+1) as $c (.; (2*($a*$b + $b*$c + $c*$a)) as $base | if $base >= length then . else ($a+$b+$c) as $s | reduce range(1; 30) as $n (.; ($base + 4*$s*($n-1) + 4*($n-1)*($n-2)) as $layer | if $layer >= length then . else mutate(.[$layer] += 1) end) end) end)) | add'
 
 echo ""
 echo "--- String-heavy generators ---"

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1493,6 +1493,124 @@ fn eval_linear_recursive_gen(
     }
 }
 
+/// Body of `Expr::Update` extracted so `Expr::Mutate { kind: Update }` can
+/// dispatch into the same path-update logic without cloning the path/value
+/// sub-trees per invocation. See the comment on the Mutate arm in eval().
+fn eval_update_body(
+    path_expr: &Expr, update_expr: &Expr, input: Value, env: &EnvRef,
+    cb: &mut dyn FnMut(Value) -> GenResult,
+) -> GenResult {
+    let mut paths = Vec::new();
+    let path_result = eval_path(path_expr, input.clone(), env, &mut |p| { paths.push(p); Ok(true) });
+    if let Err(e) = path_result {
+        let msg = format!("{}", e);
+        if let Some(json) = msg.strip_prefix("__pathexpr_result__:") {
+            bail!("Invalid path expression with result {}", json);
+        }
+        return Err(e);
+    }
+    // Move `input` into `result` so `rt_setpath_mut`'s `Rc::make_mut` can
+    // mutate in place when the caller exclusively owns the value. The
+    // previous `input.clone()` bumped the refcount and forced a full
+    // container clone per iteration, defeating the in-place
+    // `reduce gen as $x (acc; .[$x] += 1)` shape whenever the source
+    // generator made the reduce fall off the JIT's fast path (#652).
+    // `eval_path`'s clone above is dropped before this point, so the move
+    // is safe as long as `input` itself was exclusively held.
+    let mut result = input;
+    let mut del_paths = Vec::new();
+    for path in &paths {
+        let old_val = crate::runtime::rt_getpath(&result, path).unwrap_or(Value::Null);
+        let mut has_output = false;
+        let mut new_val = old_val.clone();
+        // jq `|=` takes the FIRST value the RHS emits and discards the
+        // rest (`{a:1} | .a |= (1,2)` is `{a:1}`, not `{a:2}`). Returning
+        // `Ok(false)` from the callback stops the generator after the
+        // first hit; without it the interpreter ended up with the last
+        // emitted value and diverged from JIT / fast-path on the same
+        // filter (#323 self-diff caught this).
+        eval(update_expr, old_val, env, &mut |v| {
+            has_output = true;
+            new_val = v;
+            Ok(false)
+        })?;
+        if has_output {
+            // `rt_setpath_mut` mutates `result` via Rc::make_mut, so each
+            // level is cloned at most once across the loop instead of once
+            // per touched leaf. Heavy `|=` workloads such as
+            // `(.. | scalars) |= .+1` over a deep tree drop from O(N*D) to
+            // O(distinct internal nodes). See #551.
+            let path_slice = match path {
+                Value::Arr(a) => a.as_slice(),
+                _ => bail!("Path must be specified as an array"),
+            };
+            crate::runtime::rt_setpath_mut(&mut result, path_slice, new_val)?;
+        } else {
+            del_paths.push(path.clone());
+        }
+    }
+    if !del_paths.is_empty() {
+        let dp = Value::Arr(Rc::new(del_paths));
+        result = crate::runtime::rt_delpaths(&result, &dp)?;
+    }
+    cb(result)
+}
+
+/// Body of `Expr::Assign` extracted so `Expr::Mutate { kind: Assign }` can
+/// dispatch into the same path-set logic without cloning the path/value
+/// sub-trees per invocation.
+fn eval_assign_body(
+    path_expr: &Expr, value_expr: &Expr, input: Value, env: &EnvRef,
+    cb: &mut dyn FnMut(Value) -> GenResult,
+) -> GenResult {
+    // Scalar-value fast path: compute new_val via eval_one so the
+    // generator form's `input.clone()` never sits alive in an outer
+    // callback frame. Once paths are collected, `input` has refcount 1
+    // again, so we can move it into `result` and rt_setpath_mut's
+    // Rc::make_mut mutates in place instead of deep-cloning the
+    // accumulator on every iteration (#659).
+    if let Ok(new_val) = eval_one(value_expr, &input, env) {
+        let mut paths = Vec::new();
+        let path_result = eval_path(path_expr, input.clone(), env, &mut |p| { paths.push(p); Ok(true) });
+        if let Err(e) = path_result {
+            let msg = format!("{}", e);
+            if let Some(json) = msg.strip_prefix("__pathexpr_result__:") {
+                bail!("Invalid path expression with result {}", json);
+            }
+            return Err(e);
+        }
+        let mut result = input;
+        for path in &paths {
+            let path_slice = match path {
+                Value::Arr(a) => a.as_slice(),
+                _ => bail!("Path must be specified as an array"),
+            };
+            crate::runtime::rt_setpath_mut(&mut result, path_slice, new_val.clone())?;
+        }
+        return cb(result);
+    }
+    eval(value_expr, input.clone(), env, &mut |new_val| {
+        let mut paths = Vec::new();
+        let path_result = eval_path(path_expr, input.clone(), env, &mut |p| { paths.push(p); Ok(true) });
+        if let Err(e) = path_result {
+            let msg = format!("{}", e);
+            if let Some(json) = msg.strip_prefix("__pathexpr_result__:") {
+                bail!("Invalid path expression with result {}", json);
+            }
+            return Err(e);
+        }
+        let mut result = input.clone();
+        for path in &paths {
+            let path_slice = match path {
+                Value::Arr(a) => a.as_slice(),
+                _ => bail!("Path must be specified as an array"),
+            };
+            crate::runtime::rt_setpath_mut(&mut result, path_slice, new_val.clone())?;
+        }
+        cb(result)
+    })
+}
+
 pub fn eval(
     expr: &Expr, input: Value, env: &EnvRef,
     cb: &mut dyn FnMut(Value) -> GenResult,
@@ -2124,12 +2242,17 @@ pub fn eval(
 
         Expr::Reduce { source, init, var_index, acc_index, update } => {
             // Unwrap `. |= f` and `. = f` to just `f` — path `.` is identity.
+            // `mutate(. |= f)` / `mutate(. = f)` is the same shape under the
+            // marker; peel through Mutate so the marker doesn't suppress this
+            // peephole (#666 follow-up).
             let update = match update.as_ref() {
                 Expr::Update { path_expr, update_expr }
                     if matches!(path_expr.as_ref(), Expr::Input) => {
                         update_expr.as_ref()
                     },
                 Expr::Assign { path_expr, value_expr }
+                    if matches!(path_expr.as_ref(), Expr::Input) => value_expr.as_ref(),
+                Expr::Mutate { path_expr, value_expr, .. }
                     if matches!(path_expr.as_ref(), Expr::Input) => value_expr.as_ref(),
                 _ => update.as_ref(),
             };
@@ -2550,110 +2673,11 @@ pub fn eval(
         }
 
         Expr::Update { path_expr, update_expr } => {
-            let mut paths = Vec::new();
-            let path_result = eval_path(path_expr, input.clone(), env, &mut |p| { paths.push(p); Ok(true) });
-            if let Err(e) = path_result {
-                let msg = format!("{}", e);
-                if let Some(json) = msg.strip_prefix("__pathexpr_result__:") {
-                    bail!("Invalid path expression with result {}", json);
-                }
-                return Err(e);
-            }
-            // Move `input` into `result` so `rt_setpath_mut`'s `Rc::make_mut`
-            // can mutate in place when the caller exclusively owns the value.
-            // The previous `input.clone()` bumped the refcount and forced a
-            // full container clone per iteration, defeating the in-place
-            // `reduce gen as $x (acc; .[$x] += 1)` shape whenever the source
-            // generator made the reduce fall off the JIT's fast path (#652).
-            // `eval_path`'s clone above is dropped before this point, so the
-            // move is safe as long as `input` itself was exclusively held.
-            let mut result = input;
-            let mut del_paths = Vec::new();
-            for path in &paths {
-                let old_val = crate::runtime::rt_getpath(&result, path).unwrap_or(Value::Null);
-                let mut has_output = false;
-                let mut new_val = old_val.clone();
-                // jq `|=` takes the FIRST value the RHS emits and discards the
-                // rest (`{a:1} | .a |= (1,2)` is `{a:1}`, not `{a:2}`). Returning
-                // `Ok(false)` from the callback stops the generator after the
-                // first hit; without it the interpreter ended up with the last
-                // emitted value and diverged from JIT / fast-path on the same
-                // filter (#323 self-diff caught this).
-                eval(update_expr, old_val, env, &mut |v| {
-                    has_output = true;
-                    new_val = v;
-                    Ok(false)
-                })?;
-                if has_output {
-                    // `rt_setpath_mut` mutates `result` via Rc::make_mut, so
-                    // each level is cloned at most once across the loop instead
-                    // of once per touched leaf. Heavy `|=` workloads such as
-                    // `(.. | scalars) |= .+1` over a deep tree drop from
-                    // O(N*D) to O(distinct internal nodes). See #551.
-                    let path_slice = match path {
-                        Value::Arr(a) => a.as_slice(),
-                        _ => bail!("Path must be specified as an array"),
-                    };
-                    crate::runtime::rt_setpath_mut(&mut result, path_slice, new_val)?;
-                } else {
-                    // No output = delete this path
-                    del_paths.push(path.clone());
-                }
-            }
-            if !del_paths.is_empty() {
-                let dp = Value::Arr(Rc::new(del_paths));
-                result = crate::runtime::rt_delpaths(&result, &dp)?;
-            }
-            cb(result)
+            return eval_update_body(path_expr, update_expr, input, env, cb);
         }
 
         Expr::Assign { path_expr, value_expr } => {
-            // Scalar-value fast path: compute new_val via eval_one so the
-            // generator form's `input.clone()` never sits alive in an outer
-            // callback frame. Once paths are collected, `input` has refcount
-            // 1 again, so we can move it into `result` and rt_setpath_mut's
-            // Rc::make_mut mutates in place instead of deep-cloning the
-            // accumulator on every iteration (#659).
-            if let Ok(new_val) = eval_one(value_expr, &input, env) {
-                let mut paths = Vec::new();
-                let path_result = eval_path(path_expr, input.clone(), env, &mut |p| { paths.push(p); Ok(true) });
-                if let Err(e) = path_result {
-                    let msg = format!("{}", e);
-                    if let Some(json) = msg.strip_prefix("__pathexpr_result__:") {
-                        bail!("Invalid path expression with result {}", json);
-                    }
-                    return Err(e);
-                }
-                let mut result = input;
-                for path in &paths {
-                    let path_slice = match path {
-                        Value::Arr(a) => a.as_slice(),
-                        _ => bail!("Path must be specified as an array"),
-                    };
-                    crate::runtime::rt_setpath_mut(&mut result, path_slice, new_val.clone())?;
-                }
-                return cb(result);
-            }
-            eval(value_expr, input.clone(), env, &mut |new_val| {
-                let mut paths = Vec::new();
-                let path_result = eval_path(path_expr, input.clone(), env, &mut |p| { paths.push(p); Ok(true) });
-                if let Err(e) = path_result {
-                    let msg = format!("{}", e);
-                    if let Some(json) = msg.strip_prefix("__pathexpr_result__:") {
-                        bail!("Invalid path expression with result {}", json);
-                    }
-                    return Err(e);
-                }
-                let mut result = input.clone();
-                for path in &paths {
-                    let path_slice = match path {
-                        Value::Arr(a) => a.as_slice(),
-                        _ => bail!("Path must be specified as an array"),
-                    };
-                    crate::runtime::rt_setpath_mut(&mut result, path_slice, new_val.clone())?;
-                }
-                cb(result)
-            })
+            return eval_assign_body(path_expr, value_expr, input, env, cb);
         }
 
         Expr::Mutate { path_expr, value_expr, kind } => {
@@ -2663,18 +2687,18 @@ pub fn eval(
             // `result` rather than cloning. The marker's payoff is in the
             // JIT, where it suppresses the input Clone before setpath calls
             // so refcount stays at 1 in nested `reduce` contexts. See #666.
+            //
+            // Dispatch directly into the eval Update/Assign helpers — the
+            // previous implementation built a fresh `Expr::Update` /
+            // `Expr::Assign` per invocation, cloning the path and value
+            // sub-trees every reduce iteration. That clone was the
+            // observable mutate(...) regression vs. the unmarked form
+            // (#666 follow-up).
             trace_mutate_event(*kind, &input);
-            let forwarded = match kind {
-                MutateKind::Update => Expr::Update {
-                    path_expr: path_expr.clone(),
-                    update_expr: value_expr.clone(),
-                },
-                MutateKind::Assign => Expr::Assign {
-                    path_expr: path_expr.clone(),
-                    value_expr: value_expr.clone(),
-                },
+            return match kind {
+                MutateKind::Update => eval_update_body(path_expr, value_expr, input, env, cb),
+                MutateKind::Assign => eval_assign_body(path_expr, value_expr, input, env, cb),
             };
-            eval(&forwarded, input, env, cb)
         }
 
         Expr::PathExpr { expr: path_expr } => {

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -2022,6 +2022,7 @@ fn simplify_expr(expr: &crate::ir::Expr) -> crate::ir::Expr {
                             }
                             Expr::Update { path_expr, update_expr } => is_single_output(path_expr) && is_single_output(update_expr),
                             Expr::Assign { path_expr, value_expr } => is_single_output(path_expr) && is_single_output(value_expr),
+                            Expr::Mutate { path_expr, value_expr, .. } => is_single_output(path_expr) && is_single_output(value_expr),
                             Expr::Alternative { primary, fallback } => is_single_output(primary) && is_single_output(fallback),
                             _ => false,
                         }
@@ -2261,6 +2262,7 @@ fn expr_is_single_output(e: &crate::ir::Expr) -> bool {
         }
         Expr::Update { path_expr, update_expr } => expr_is_single_output(path_expr) && expr_is_single_output(update_expr),
         Expr::Assign { path_expr, value_expr } => expr_is_single_output(path_expr) && expr_is_single_output(value_expr),
+        Expr::Mutate { path_expr, value_expr, .. } => expr_is_single_output(path_expr) && expr_is_single_output(value_expr),
         Expr::Alternative { primary, fallback } => expr_is_single_output(primary) && expr_is_single_output(fallback),
         _ => false,
     }
@@ -2534,7 +2536,7 @@ impl Filter {
         }
         fn check(e: &Expr) -> bool {
             match e {
-                Expr::Update { .. } => true,
+                Expr::Update { .. } | Expr::Mutate { .. } => true,
                 Expr::While { .. } | Expr::Until { .. } | Expr::Repeat { .. } => true,
                 Expr::Reduce { source, .. } | Expr::Foreach { source, .. } => {
                     references_input(source)
@@ -2575,6 +2577,7 @@ impl Filter {
                 Expr::Update { path_expr, update_expr } | Expr::Assign { path_expr, value_expr: update_expr } => {
                     walk(path_expr) || walk(update_expr)
                 }
+                Expr::Mutate { path_expr, value_expr, .. } => walk(path_expr) || walk(value_expr),
                 _ => false,
             }
         }
@@ -2604,6 +2607,7 @@ impl Filter {
                 Expr::Label { body, .. } => walk(body),
                 Expr::CallBuiltin { args, .. } => args.iter().any(|a| walk(a)),
                 Expr::Update { path_expr, update_expr } | Expr::Assign { path_expr, value_expr: update_expr } => walk(path_expr) || walk(update_expr),
+                Expr::Mutate { path_expr, value_expr, .. } => walk(path_expr) || walk(value_expr),
                 Expr::ClosureOp { input_expr, key_expr, .. } => walk(input_expr) || walk(key_expr),
                 Expr::Format { expr: e, .. } => walk(e),
                 Expr::Limit { count, generator } => walk(count) || walk(generator),
@@ -2631,7 +2635,8 @@ impl Filter {
         fn walk(e: &Expr) -> bool {
             match e {
                 Expr::Reduce { .. } | Expr::Foreach { .. } | Expr::Recurse { .. }
-                | Expr::Update { .. } | Expr::While { .. } | Expr::Until { .. }
+                | Expr::Update { .. } | Expr::Mutate { .. }
+                | Expr::While { .. } | Expr::Until { .. }
                 | Expr::Repeat { .. } => true,
                 Expr::Pipe { left, right } | Expr::Comma { left, right }
                 | Expr::BinOp { lhs: left, rhs: right, .. }
@@ -2712,6 +2717,7 @@ impl Filter {
                 Expr::Update { path_expr, update_expr } | Expr::Assign { path_expr, value_expr: update_expr } => {
                     count(path_expr) + count(update_expr)
                 }
+                Expr::Mutate { path_expr, value_expr, .. } => count(path_expr) + count(value_expr),
                 Expr::ClosureOp { input_expr, key_expr, .. } => count(input_expr) + count(key_expr),
                 Expr::Format { expr, .. } | Expr::PathExpr { expr } | Expr::Debug { expr } | Expr::Stderr { expr } => count(expr),
                 Expr::Limit { count: c, generator } => count(c) + count(generator),

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -295,6 +295,14 @@ fn is_scalar(expr: &Expr) -> bool {
         Expr::Update { path_expr, update_expr } => {
             extract_simple_path(path_expr).is_some() && is_scalar(update_expr)
         }
+        // mutate(path = v) / mutate(path |= f) is semantically identical to
+        // its wrapped Assign/Update — same scalar-ness so containing Reduces
+        // don't bail to interpreter for missing the arm. #666 follow-up: the
+        // marker was a perf regression because is_scalar(Mutate) = false
+        // poisoned `is_scalar(reduce.update)` and the JIT Reduce arm bailed.
+        Expr::Mutate { path_expr, value_expr, .. } => {
+            extract_simple_path(path_expr).is_some() && is_scalar(value_expr)
+        }
         // Regex operations produce exactly one value
         Expr::RegexTest { input_expr, re, flags } => is_scalar(input_expr) && is_scalar(re) && is_scalar(flags),
         // match/capture are generators (0 or 1 outputs) — non-match produces empty
@@ -2082,6 +2090,55 @@ impl Flattener {
                 let result = self.flatten_scalar(&body, input_slot);
                 self.expanding_funcs.remove(func_id);
                 result
+            }
+            // mutate(path = v) / mutate(path |= f) — semantically identical
+            // to the wrapped Assign/Update at the JIT layer. Dispatch to the
+            // same scalar-emit code so containing scalar contexts (e.g. a
+            // standalone `mutate(.a = 10)` at the top of the filter) don't
+            // fall through to the default Null emit. See is_scalar.
+            Expr::Mutate { path_expr, value_expr, kind: MutateKind::Assign } => {
+                if let Some(path_components) = extract_simple_path(path_expr) {
+                    let val = self.flatten_scalar(value_expr, input_slot);
+                    let path_arr = self.build_path_array(&path_components, input_slot);
+                    let inp = self.alloc_slot();
+                    self.emit(JitOp::Clone { dst: inp, src: input_slot });
+                    let out = self.alloc_slot();
+                    self.emit_propagating(JitOp::CallBuiltin { dst: out, name: "setpath".to_string(), args: vec![inp, path_arr, val] });
+                    self.emit(JitOp::Drop { slot: inp });
+                    self.emit(JitOp::Drop { slot: path_arr });
+                    self.emit(JitOp::Drop { slot: val });
+                    out
+                } else {
+                    let out = self.alloc_slot();
+                    self.emit(JitOp::Null { dst: out });
+                    out
+                }
+            }
+            Expr::Mutate { path_expr, value_expr, kind: MutateKind::Update } => {
+                if let Some(path_components) = extract_simple_path(path_expr) {
+                    let path_arr = self.build_path_array(&path_components, input_slot);
+                    let inp = self.alloc_slot();
+                    self.emit(JitOp::Clone { dst: inp, src: input_slot });
+                    let path_clone = self.alloc_slot();
+                    self.emit(JitOp::Clone { dst: path_clone, src: path_arr });
+                    let old_val = self.alloc_slot();
+                    self.emit_propagating(JitOp::CallBuiltin { dst: old_val, name: "getpath".to_string(), args: vec![inp, path_clone] });
+                    self.emit(JitOp::Drop { slot: inp });
+                    self.emit(JitOp::Drop { slot: path_clone });
+                    let new_val = self.flatten_scalar(value_expr, old_val);
+                    self.emit(JitOp::Drop { slot: old_val });
+                    let inp2 = self.alloc_slot();
+                    self.emit(JitOp::Clone { dst: inp2, src: input_slot });
+                    let out = self.alloc_slot();
+                    self.emit_propagating(JitOp::CallBuiltin { dst: out, name: "setpath".to_string(), args: vec![inp2, path_arr, new_val] });
+                    self.emit(JitOp::Drop { slot: inp2 });
+                    self.emit(JitOp::Drop { slot: new_val });
+                    out
+                } else {
+                    let out = self.alloc_slot();
+                    self.emit(JitOp::Null { dst: out });
+                    out
+                }
             }
             // Assign with simple path: setpath(path, value)
             Expr::Assign { path_expr, value_expr } => {
@@ -5730,6 +5787,21 @@ fn detect_inplace_assign_in_branch<'a>(expr: &'a Expr, cond: &Expr) -> Option<In
             });
         }
     }
+    // Mirror the Mutate peel from `detect_inplace_assign` — otherwise an
+    // `if cond then . else mutate(.x = v) end` leaf bails the nested-reduce
+    // fusion at any depth where the skip-if wraps the mutate(...) marker.
+    // (#666 follow-up: P126 4-deep shape is the worst-case regression here.)
+    if let Expr::Mutate { path_expr, value_expr, kind: MutateKind::Assign } = expr {
+        let pc = extract_simple_path(path_expr)?;
+        if !pc.is_empty() && is_scalar(value_expr) {
+            return Some(InplaceAssignInfo {
+                let_bindings: vec![],
+                path_components: pc,
+                value_expr,
+                skip_cond: None,
+            });
+        }
+    }
     if let Expr::LetBinding { var_index, value, body } = expr {
         if !is_scalar(value) { return None; }
         if crate::eval::expr_uses_var(cond, *var_index) { return None; }
@@ -5806,6 +5878,19 @@ fn detect_inplace_update_in_branch<'a>(expr: &'a Expr, cond: &Expr) -> Option<In
                 let_bindings: vec![],
                 path_components: pc,
                 update_expr,
+                skip_cond: None,
+            });
+        }
+    }
+    // Mirror the Mutate peel from `detect_inplace_update` — see the analogous
+    // comment in `detect_inplace_assign_in_branch`.
+    if let Expr::Mutate { path_expr, value_expr, kind: MutateKind::Update } = expr {
+        let pc = extract_simple_path(path_expr)?;
+        if !pc.is_empty() && is_scalar(value_expr) {
+            return Some(InplaceUpdateInfo {
+                let_bindings: vec![],
+                path_components: pc,
+                update_expr: value_expr,
                 skip_cond: None,
             });
         }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -10324,6 +10324,27 @@ reduce range(3) as $a (.; if $a == 1 then . else reduce range(2) as $b (.; .[$a*
 [0,0,0,0,0,0]
 [1,1,0,0,1,1]
 
+# #666 follow-up: `mutate(...)` must be transparent to the nested-reduce
+# in-place fusion at any depth. Earlier the marker poisoned `is_scalar`
+# on the enclosing Reduce (the helper had no Mutate arm), forcing
+# `flatten_gen`'s Reduce arm to bail to the interpreter — the leaf still
+# trace-printed `mode=in_place refcount=1` because eval's Mutate arm
+# called rt_setpath_mut, but the surrounding loop dropped off the JIT.
+# Depth-3 with mutate(...) at the leaf must match the unmarked shape.
+reduce range(2) as $a (.; reduce range(2) as $b (.; reduce range(2) as $c (.; mutate(.[($a*4+$b*2+$c)] += 1))))
+[0,0,0,0,0,0,0,0]
+[1,1,1,1,1,1,1,1]
+
+# Same depth with an `if cond then . else mutate(...) end` skip-if
+# wrapping the leaf. detect_inplace_*_in_branch had only an `Update` /
+# `Assign` arm — the Mutate-wrapped equivalent bailed the fusion at the
+# branch peel even though the bare `Update`/`Assign` form fused, so
+# adding mutate(...) around the leaf used to silently turn a 0.8s
+# 4-deep reduce into a 180s+ run (the P126 cuboid-counter shape).
+reduce range(3) as $a (.; if $a == 1 then . else reduce range(2) as $b (.; mutate(.[$a*2+$b] += 1)) end)
+[0,0,0,0,0,0]
+[1,1,0,0,1,1]
+
 # Issue #698: FieldCmpNum fast path used to return 0 (false) for null
 # base / absent key / explicit null at the key, breaking jq's
 # null-vs-number ordering (null < every number). Surfaced by


### PR DESCRIPTION
## Summary
- `mutate(...)` was a net perf regression at every shape it was tested on, even though `--trace-mutate` confirmed `mode=in_place refcount=1` ran. Six independent gaps poisoned the marker's transparency: `is_scalar(Mutate)` defaulted to false (so a containing Reduce bailed JIT), `detect_inplace_*_in_branch` had no Mutate arm (so the `if cond then . else mutate(...) end` shape disabled the nested-reduce fusion), and the heuristic walkers / single-output classifiers / runtime peepholes all skipped Mutate.
- After this PR, `mutate(...)` matches the bare operator at every shape.
- Worst-case fix: P126 4-deep cuboid counter at 20000 elements went from **186s → 0.8s** (230×) with `mutate(.[\$layer] += 1)` at the leaf.

Refs #666 (mutate marker), follow-up to #697 (deep nested-reduce fusion).

## Behavior change
None — same outputs, same trace, faster.

## Test plan
- [x] `cargo test --release` (full suite, all pass)
- [x] New regression tests in `tests/regression.test`: depth-3 nested reduce with `mutate(...)` at leaf, and depth-3 with skip-if wrapping the `mutate(...)` leaf
- [x] New bench entry `p126-shape w/ mutate` in `bench/comprehensive.sh` to lock in the parity
- [x] Manual A/B with `--force-jit`: P126/P135/P124/P150 user-reported shapes all show parity (0–1% noise)
- [x] P126 20000 4-deep correctness check — unmarked and marked both produce `5081`

## Detailed cause analysis

### 1. `is_scalar(Mutate)` returned false (src/jit.rs)
`flatten_gen`'s Reduce arm does `if !is_scalar(update) { return false; }`. For `Reduce { update: LetBinding{ body: Mutate{...} } }`, `is_scalar` cascaded from the Mutate arm's `_ => false` default and the whole reduce JIT-bailed to interpreter. This was the headline regression: marked was slower than unmarked because marked ran in eval and unmarked ran in JIT.

### 2. `flatten_scalar` had no Mutate arm
Once `is_scalar(Mutate)` returned true (fix above), the default arm emitted `Null` for top-level `mutate(.a = 10)`. Added the Assign/Update-equivalent emits.

### 3. `detect_inplace_{update,assign}_in_branch` skipped Mutate (src/jit.rs)
Nested-reduce fusion (#647 / #697) peels `if cond then . else BODY end` via these helpers. The bare `Update` / `Assign` form was matched, but the `Mutate` wrapper was rejected → fusion bailed → the 4-deep P126 shape paid an O(N) clone per outer iteration. 20000-element variant: 0.8s → 186s.

### 4. eval `Mutate` arm cloned sub-expressions per call (src/eval.rs)
Constructed a fresh `Expr::Update` / `Expr::Assign` from `path_expr.clone()` and `value_expr.clone()` on every invocation. Extracted the Update/Assign bodies into `eval_update_body` / `eval_assign_body` helpers and dispatched directly. Also peels through the Reduce-update peephole that strips `. |= f` → `f`.

### 5. Heuristic walkers / single-output detectors (src/interpreter.rs)
`has_loop_constructs`, `has_any_runtime_loop_construct`, `uses_inputs`, `ast_node_count`, `is_single_output`, `expr_is_single_output` — all forgot Mutate. The CLI's JIT-vs-interpreter heuristic (`bin/jq-jit.rs`) consults these, so mutate-only programs could be misclassified.

## Benchmarks (--force-jit, default mode, mac local)

| Shape | Elements | unmarked | marked (before) | marked (after) |
|---|---|---|---|---|
| P126 4-deep cuboid counter | 20000 | 0.79s | 186.40s (**240×**) | 0.80s |
| P126 4-deep cuboid counter | 5000  | 0.11s | 3.60s (**33×**)    | 0.11s |
| P135 depth-2 array += | 5000×100×1000 | 13–18ms | (slower per user report) | 11–15ms |
| P124 flat reduce, array = inside if | 100001 | 18ms | (slower per user report) | 18ms |
| P150 nested reduce + object update | 500×500×100 | 169ms | (slower per user report) | 170ms |