### PR TITLE
perf(jit): fuse pipe-chain of in-place ops on same acc

### DIFF
--- a/bench/comprehensive.sh
+++ b/bench/comprehensive.sh
@@ -343,6 +343,13 @@ bench_gen "p126-shape nested reduce"   5000      '[range(0; .)] | reduce range(1
 # `detect_inplace_update_in_branch` (no Mutate arm), turning the 4-deep
 # 20000-element variant from ~0.8s into ~180s (#666 follow-up).
 bench_gen "p126-shape w/ mutate"        5000      '[range(0; .)] | reduce range(1; 30) as $a (.; reduce range($a; 60) as $b (.; if 2*$a*$b >= length then . else (((length/2 - $a*$b) / ($a+$b)) | floor) as $c_max | reduce range($b; $c_max+1) as $c (.; (2*($a*$b + $b*$c + $c*$a)) as $base | if $base >= length then . else ($a+$b+$c) as $s | reduce range(1; 30) as $n (.; ($base + 4*$s*($n-1) + 4*($n-1)*($n-2)) as $layer | if $layer >= length then . else mutate(.[$layer] += 1) end) end) end)) | add'
+# Anchors `NestedInplaceAction::Sequence` (#666 follow-up): a 2-field
+# object accumulator updated by two serial `mutate(...)` calls in pipe.
+# Without Sequence fusion the second mutate Cloned the (already updated)
+# acc and went through a full setpath deep-clone of the object per
+# iteration — ~1.9× slower than the equivalent `{s: $ns, m: ..}`
+# reconstruct form on the same input. P150 shape (minimum-sum-subarray).
+bench_gen "p150-shape serial mutate"    100000    'reduce range(0; .) as $k ({s: 0, m: 999999999}; (.s + $k) as $ns | mutate(.s = $ns) | if $ns < .m then mutate(.m = $ns) else . end) | .m'
 
 echo ""
 echo "--- String-heavy generators ---"

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -1940,27 +1940,24 @@ impl Flattener {
                             this.emit(JitOp::Drop { slot: acc });
                         });
                     }
-                } else if let Some(action @ NestedInplaceAction::InnerReduce { .. })
-                    = detect_inplace_action(update)
-                {
-                    // Fused nested reduce: the outer update body is one or
-                    // more inner `reduce SRC as $m (.; ...)` layers
-                    // bottoming out in a path-update operator (optionally
-                    // wrapped in `if cond then … else . end` at any
-                    // layer). Without this path, each inner reduce gets
-                    // its own acc_index var seeded by `Clone(input_slot)`,
-                    // so during inner iteration the array has refcount
-                    // ≥ 2 (outer's local slot + inner's var) and the first
-                    // PathInsert deep-clones the whole array — paid on
-                    // every outer iteration. For an N-element sieve over
-                    // N outer iterations that's O(N²) copies (#647,
-                    // 8–22× slowdown). Here we TakeVar the outer acc
-                    // into a slot, hold it uniquely, and run the entire
-                    // nest's in-place updates directly on that slot — so
-                    // PathInsert / SetPathMut always sees refcount 1.
-                    // `emit_inplace_action` recurses through `InnerReduce`
-                    // layers so the fusion is depth-unbounded (#666,
-                    // P126/P135 4-deep nested counters).
+                } else if let Some(action) = detect_inplace_action(update).filter(|a|
+                    matches!(a, NestedInplaceAction::InnerReduce { .. } | NestedInplaceAction::Sequence { .. })
+                ) {
+                    // Fused compound update on the outer acc: the body is
+                    // either an inner reduce nest (`InnerReduce`, #647 /
+                    // #666) or a pipe chain of in-place ops (`Sequence`,
+                    // #666 follow-up — `mutate(.s = ..) | if cond then
+                    // mutate(.m = ..) else . end` against a record-shaped
+                    // acc). The leaf Update/Assign variants are handled by
+                    // `flatten_gen_with_reduce` via inplace_info /
+                    // assign_info — only the compound shapes need this
+                    // path. Without it, each inner reduce or pipe leg
+                    // would seed its own slot from the acc and pay a deep
+                    // clone of the container per iteration. Here we
+                    // TakeVar the outer acc into a slot, hold it uniquely,
+                    // and run the entire body's in-place ops directly on
+                    // that slot — every leaf PathInsert / SetPathMut sees
+                    // refcount 1.
                     self.flatten_gen_with_each_output(source, input_slot, &|this, elem| {
                         this.emit(JitOp::SetVar { var_index: *var_index, src: elem });
                         let acc = this.alloc_slot();
@@ -2530,9 +2527,9 @@ impl Flattener {
                 // 4-deep shape (#666) bypasses emit_inplace_action entirely
                 // and falls into the generic per-iter Clone path inside
                 // flatten_gen_with_reduce.
-                if let Some(action @ NestedInplaceAction::InnerReduce { .. })
-                    = detect_inplace_action(update)
-                {
+                if let Some(action) = detect_inplace_action(update).filter(|a|
+                    matches!(a, NestedInplaceAction::InnerReduce { .. } | NestedInplaceAction::Sequence { .. })
+                ) {
                     let var_idx = *var_index;
                     let acc_idx = *acc_index;
                     self.flatten_gen_with_each_output(source, input_slot, &|this, elem| {
@@ -5558,6 +5555,25 @@ impl Flattener {
                     self.emit(JitOp::MoveToVar { var_index: vi, src: old });
                 }
             }
+            NestedInplaceAction::Sequence { let_bindings, actions } => {
+                // Same save/set/restore pattern as InnerReduce — the
+                // bindings scope across every child action so they're set
+                // once on the way in and restored once on the way out.
+                let mut saved_lets = Vec::new();
+                for &(vi, value_expr) in let_bindings {
+                    let old = self.alloc_slot();
+                    self.emit(JitOp::GetVar { dst: old, var_index: vi });
+                    let val = self.flatten_scalar(value_expr, acc);
+                    self.emit(JitOp::MoveToVar { var_index: vi, src: val });
+                    saved_lets.push((vi, old));
+                }
+                for child in actions {
+                    self.emit_inplace_action(acc, child);
+                }
+                for (vi, old) in saved_lets.into_iter().rev() {
+                    self.emit(JitOp::MoveToVar { var_index: vi, src: old });
+                }
+            }
         }
     }
 }
@@ -5933,6 +5949,21 @@ enum NestedInplaceAction<'a> {
         /// the fusion can span any nesting depth.
         action: Box<NestedInplaceAction<'a>>,
     },
+    /// `Pipe(left, right)` chain of in-place ops on the same acc slot. e.g.
+    /// `(.s + $k) as $ns | mutate(.s = $ns) | mutate(.m = $ns)` runs both
+    /// `mutate` calls against the same in-place acc. Without this the reduce
+    /// body would fall to the generic emit (`flatten_scalar(update, acc)`),
+    /// which compiles each Mutate as a `Clone(acc) + setpath` pair — that
+    /// bumps the inner Rc refcount and forces a deep clone of the
+    /// accumulator container per mutate per iteration. The P150 shape
+    /// (#666 follow-up) is `mutate(.s = ..) | if cond then mutate(.m = ..)
+    /// else . end` against a 2-field object accumulator; without Sequence
+    /// fusion it was ~1.9× slower than the unmarked `{s: .., m: ..}`
+    /// object-construct shape on the same input.
+    Sequence {
+        let_bindings: Vec<(u16, &'a Expr)>,
+        actions: Vec<NestedInplaceAction<'a>>,
+    },
 }
 
 /// Detect what (if anything) the body of an outer reduce can do in place
@@ -5951,11 +5982,57 @@ fn detect_inplace_action(expr: &Expr) -> Option<NestedInplaceAction<'_>> {
     if let Some(info) = detect_inplace_assign(expr) {
         return Some(NestedInplaceAction::Assign(info));
     }
+    // Pipe-chain of in-place ops, optionally wrapped in LetBindings.
+    // Sits between the leaf attempts and `detect_inner_reduce_chain` so
+    // that a pure `Pipe(Mutate, Mutate)` body is classified as a Sequence
+    // before falling into the reduce-chain peel (which would then fail).
+    if let Some(seq) = detect_inplace_sequence(expr, Vec::new()) {
+        return Some(seq);
+    }
     // Inner reduce with arbitrary mix of LetBinding / skip-if wrappers
     // around it. The leaf case above takes precedence so paths that
     // could be classified either way (e.g. a LetBinding chain that
     // bottoms out in `.[$x] += 1`) go through the leaf emit.
     detect_inner_reduce_chain(expr, Vec::new())
+}
+
+/// Peel `(value) as $x | REST` LetBinding wrappers around a `Pipe(left,
+/// right)` chain whose halves each detect as in-place actions. Returns a
+/// `Sequence` carrying the let-bindings to set before the chain runs.
+/// Nested Pipes flatten — `a | b | c` is `Pipe(Pipe(a,b), c)` and yields
+/// `Sequence([a_action, b_action, c_action])`.
+fn detect_inplace_sequence<'a>(
+    expr: &'a Expr,
+    mut let_bindings: Vec<(u16, &'a Expr)>,
+) -> Option<NestedInplaceAction<'a>> {
+    if let Expr::LetBinding { var_index, value, body } = expr {
+        if !is_scalar(value) { return None; }
+        let_bindings.push((*var_index, value.as_ref()));
+        return detect_inplace_sequence(body, let_bindings);
+    }
+    if let Expr::Pipe { left, right } = expr {
+        let left_action = detect_inplace_action(left)?;
+        let right_action = detect_inplace_action(right)?;
+        let mut actions = Vec::new();
+        // Flatten nested Sequences with empty let_bindings — they can
+        // merge into the parent. A child Sequence with its own
+        // let_bindings keeps its boundary (the inner lets are scoped to
+        // that subsequence and must be saved/restored separately).
+        match left_action {
+            NestedInplaceAction::Sequence { let_bindings: lb, actions: a } if lb.is_empty() => {
+                actions.extend(a);
+            }
+            other => actions.push(other),
+        }
+        match right_action {
+            NestedInplaceAction::Sequence { let_bindings: lb, actions: a } if lb.is_empty() => {
+                actions.extend(a);
+            }
+            other => actions.push(other),
+        }
+        return Some(NestedInplaceAction::Sequence { let_bindings, actions });
+    }
+    None
 }
 
 /// Peel layers of `(value) as $x | REST`, `if cond then . else REST end`

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -10345,6 +10345,19 @@ reduce range(3) as $a (.; if $a == 1 then . else reduce range(2) as $b (.; mutat
 [0,0,0,0,0,0]
 [1,1,0,0,1,1]
 
+# Sequence fusion: `(.s + $k) as $ns | mutate(.s = $ns) | mutate(.m = $ns)`
+# is a pipe-chain of in-place ops. Without `NestedInplaceAction::Sequence`
+# (#666 follow-up) the reduce body fell back to `flatten_scalar(update,
+# acc)` which compiles each Mutate as a `Clone(acc) + setpath` pair;
+# refcount > 1 inside setpath forced a deep clone of the object accumulator
+# per mutate per iteration. P150 (minimum-sum-subarray with record-shaped
+# acc) hit this — the unmarked `{s: .., m: ..}` reconstruct shape was
+# ~1.9× faster than the serial-mutate form. With Sequence fusion the
+# second mutate sees the same in-place acc the first one updated.
+reduce range(0; 5) as $k ({s: 0, m: 999}; (.s + $k) as $ns | mutate(.s = $ns) | if $ns < .m then mutate(.m = $ns) else . end)
+null
+{"s":10,"m":0}
+
 # Issue #698: FieldCmpNum fast path used to return 0 (false) for null
 # base / absent key / explicit null at the key, breaking jq's
 # null-vs-number ordering (null < every number). Surfaced by


### PR DESCRIPTION
## Summary
- Closes the residual P150 1.43× gap left after #699 — `mutate(.s = ..) | if cond then mutate(.m = ..) else . end` on a 2-field object acc was still slower than the equivalent `{s: .., m: ..}` reconstruct shape because the in-place fusion couldn't see across a `Pipe` of mutates.
- Adds `NestedInplaceAction::Sequence` so the JIT recognizes a pipe-chain of in-place ops with shared let-bindings and emits them against the same in-place acc slot.

Refs #666 (mutate marker), follow-up to #699.

## Cause
For `(value) as $x | mutate(.a = expr) | mutate(.b = expr)` inside a `reduce`, the reduce body is `LetBinding($x, value, Pipe(Mutate, Mutate))`. The existing `detect_inplace_action` only matched a leaf in-place op or an inner reduce — `Pipe` returned `None` and the reduce body went through the generic emit:

```rust
let acc = ...; GetVar(acc_index);
let new_acc = flatten_scalar(update, acc);
MoveToVar(acc_index, new_acc);
```

`flatten_scalar` then compiled each `Mutate` as `Clone(input) + setpath`. The `Clone` bumped the inner Rc refcount to 2, so `setpath` performed a deep clone of the object container instead of `Rc::make_mut` in place. Each iteration paid two deep clones of the accumulator.

## Fix
- New `NestedInplaceAction::Sequence { let_bindings, actions }` variant.
- `detect_inplace_sequence` peels outer `as $x` LetBinding chain, expects a `Pipe(left, right)`, recurses on both halves via `detect_inplace_action`, and returns a flattened `Sequence`. Nested Pipes collapse: `a | b | c` → `Sequence([a, b, c])`.
- `emit_inplace_action::Sequence` saves/restores let-bindings around the chain and emits each child against the same `acc` slot.
- Both `flatten_scalar`'s and `flatten_gen`'s Reduce arms now route `Sequence` through the in-place fast path alongside `InnerReduce`.

The leaf (`Update`/`Assign`) and `InnerReduce` cases keep precedence — Sequence only fires when the body is genuinely a chain.

## Benchmarks
Inner reduce of 100K iterations × outer 500 iterations on a 2-field object accumulator (`{s, m}`):

| Body | Time |
|---|---|
| `{s: $ns, m: ..}` reconstruct (unmarked) | 4.5s |
| `mutate(.s = ..) \| if cond then mutate(.m = ..) else . end` — **before** | 8.6s (1.9× slower) |
| `mutate(.s = ..) \| if cond then mutate(.m = ..) else . end` — **after** | 4.0s (slightly faster than reconstruct) |

Other regressed-then-fixed shapes (P126/P135/P124 from #699) stay at parity — Sequence sits between the leaf attempts and `detect_inner_reduce_chain`, so reduce-only bodies still take the existing InnerReduce path.

## Test plan
- [x] `cargo test --release` (full suite — all pass)
- [x] New regression test: `(.s + $k) as $ns | mutate(.s = $ns) | if $ns < .m then mutate(.m = $ns) else . end` pinned to its expected output
- [x] New bench entry `p150-shape serial mutate` in `bench/comprehensive.sh` to lock in the parity
- [x] Existing user-reported shapes (P126 20000, P135, P124, P150) re-checked with `--force-jit` — all at parity