### PR TITLE
release v1.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jq-jit"
-version = "1.7.1"
+version = "1.8.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jq-jit"
-version = "1.7.1"
+version = "1.8.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A JIT-compiling implementation of jq using Cranelift"

--- a/docs/benchmark-history.md
+++ b/docs/benchmark-history.md
@@ -6,265 +6,268 @@ Recent slice (last 5 columns). Full history lives in
 
 ```text
 --- NDJSON workloads (2M objects) ---
-  Benchmark                    v1.5.6  v1.6.0  v1.6.1  v1.7.0  v1.7.1
+  Benchmark                    v1.6.0  v1.6.1  v1.7.0  v1.7.1  v1.8.0
   ---                          ------  ------  ------  ------  ------
-  empty                        0.017s  0.017s  0.018s  0.017s  0.017s
-  identity -c                  0.087s  0.088s  0.087s  0.086s  0.084s
-  identity (pretty)            0.105s  0.106s  0.107s  0.106s  0.102s
-  field access .name           0.095s  0.096s  0.097s  0.093s  0.090s
-  nested .x,.y,.name           0.150s  0.155s  0.150s  0.147s  0.146s
-  arithmetic .x + .y           0.083s  0.086s  0.084s  0.083s  0.082s
-  select .x > 1500000          0.082s  0.083s  0.087s  0.084s  0.080s
-  string concat                0.093s  0.092s  0.095s  0.092s  0.092s
-  object construct             0.111s  0.115s  0.116s  0.114s  0.110s
-  array construct              0.103s  0.107s  0.106s  0.105s  0.105s
-  .[]                          0.101s  0.105s  0.104s  0.102s  0.101s
-  to_entries                   0.159s  0.159s  0.159s  0.163s  0.154s
-  keys                         0.109s  0.105s  0.107s  0.105s  0.100s
-  keys_unsorted                0.095s  0.095s  0.097s  0.094s  0.092s
-  length                       0.085s  0.087s  0.088s  0.084s  0.087s
-  has("x")                     0.034s  0.039s  0.039s  0.037s  0.036s
-  type                         0.022s  0.023s  0.023s  0.023s  0.022s
-  del(.name)                   0.104s  0.103s  0.107s  0.101s  0.099s
-  @csv                         0.123s  0.124s  0.120s  0.118s  0.117s
-  split/join                   0.089s  0.090s  0.094s  0.090s  0.089s
-  select|field                 0.095s  0.101s  0.099s  0.097s  0.094s
-  select|remap                 0.095s  0.098s  0.100s  0.099s  0.097s
-  computed remap               0.191s  0.190s  0.192s  0.191s  0.187s
-  [.x,.y]|add                  0.082s  0.084s  0.084s  0.083s  0.083s
-  [.x,.y]|avg                  0.106s  0.109s  0.111s  0.106s  0.106s
-  map(*2)|add                  0.103s  0.106s  0.107s  0.104s  0.102s
-  keys|length                  0.251s  0.253s  0.259s  0.255s  0.251s
-  .+{z=0}                      0.146s  0.150s  0.150s  0.146s  0.145s
-  split|first                  0.090s  0.091s  0.092s  0.089s  0.088s
-  slice[0..5]                  0.092s  0.093s  0.095s  0.094s  0.094s
-  dynkey {(.name)}             0.102s  0.106s  0.108s  0.104s  0.106s
-  .x += 1                      0.125s  0.129s  0.128s  0.121s  0.122s
-  {a}+{b} merge                0.135s  0.132s  0.133s  0.130s  0.129s
-  .x*2+1                       0.060s  0.060s  0.061s  0.060s  0.059s
-  .x+.y*2                      0.096s  0.100s  0.099s  0.100s  0.096s
-  .x > .y                      0.077s  0.079s  0.078s  0.077s  0.076s
-  to_entries|len               0.400s  0.400s  0.405s  0.397s  0.397s
-  .x|.+1 (pipe)                0.058s  0.058s  0.059s  0.059s  0.056s
-  .x|.*2|.+1                   0.059s  0.060s  0.060s  0.060s  0.058s
-  .name|.+"_x"                 0.092s  0.094s  0.097s  0.094s  0.092s
-  .x>N | not                   0.049s  0.049s  0.051s  0.049s  0.048s
-  and (2 cmp)                  0.080s  0.085s  0.082s  0.080s  0.080s
-  if-then-else                 0.052s  0.051s  0.053s  0.052s  0.051s
-  sel(and)|field               0.077s  0.080s  0.079s  0.076s  0.076s
-  sel(and)|remap               0.077s  0.079s  0.079s  0.077s  0.077s
-  arith|cmp                    0.053s  0.054s  0.056s  0.054s  0.053s
-  if cmp .field                0.114s  0.113s  0.118s  0.113s  0.110s
-  split|length                 0.090s  0.089s  0.093s  0.089s  0.088s
-  [x,y]|min                    0.090s  0.092s  0.092s  0.090s  0.089s
-  [x,y]|max                    0.092s  0.096s  0.097s  0.095s  0.092s
-  [x,y]|sort|.[0]              0.090s  0.093s  0.092s  0.089s  0.088s
-  .name|len>5                  0.092s  0.093s  0.094s  0.090s  0.089s
-  sel(len>5)|.x                0.111s  0.113s  0.111s  0.107s  0.107s
-  if .x>.y .name               0.089s  0.093s  0.092s  0.093s  0.088s
-  sel(.x>.y)|.name             0.072s  0.075s  0.074s  0.071s  0.070s
-  .x*2|tostring                0.056s  0.057s  0.058s  0.057s  0.055s
-  .x*.x+1                      0.066s  0.066s  0.067s  0.067s  0.064s
-  {k=.name,v=tostr}            0.144s  0.151s  0.147s  0.144s  0.145s
-  str add chain                0.385s  0.388s  0.388s  0.385s  0.378s
-  if>.y .name|empty            0.073s  0.077s  0.073s  0.073s  0.072s
-  if .x%2==0                   0.054s  0.055s  0.054s  0.055s  0.054s
-  if .x*2+1>1M                 0.054s  0.055s  0.055s  0.056s  0.054s
-  sel(.x%2==0)|.name           0.083s  0.083s  0.084s  0.084s  0.081s
-  sel(.x*2+1>1M)               0.159s  0.160s  0.157s  0.159s  0.154s
-  .x|@json                     0.048s  0.048s  0.049s  0.047s  0.047s
-  .x|@text                     0.047s  0.048s  0.049s  0.048s  0.047s
-  .name|@json                  0.103s  0.103s  0.102s  0.101s  0.101s
-  sel|[arr]                    0.143s  0.147s  0.143s  0.149s  0.144s
-  sel(and)|[arr]               0.077s  0.081s  0.077s  0.079s  0.076s
-  if>.y [arr]                  0.173s  0.178s  0.175s  0.179s  0.174s
-  if sw then .f                0.139s  0.143s  0.143s  0.139s  0.135s
-  dynkey {(.n)=.x*2}           0.114s  0.115s  0.117s  0.115s  0.112s
-  sel(and)|.x*.y               0.076s  0.079s  0.077s  0.077s  0.078s
-  sel>N|str chain              0.151s  0.156s  0.152s  0.155s  0.153s
-  .f+"_"+arith_ts              0.132s  0.136s  0.134s  0.133s  0.132s
-  sel(sw)|str ch               0.307s  0.304s  0.308s  0.307s  0.298s
-  split|rev|join               0.114s  0.118s  0.117s  0.117s  0.112s
-  dynkey+static                0.331s  0.338s  0.340s  0.338s  0.332s
-  if>.y str chain              0.165s  0.166s  0.167s  0.171s  0.168s
-  remap+str chain              0.148s  0.159s  0.156s  0.156s  0.154s
-  sel(len>8)                   0.165s  0.161s  0.163s  0.162s  0.159s
-  up|split|join                0.097s  0.098s  0.098s  0.095s  0.100s
-  .name|index                  0.121s  0.120s  0.121s  0.118s  0.117s
-  .name|index+1                0.123s  0.124s  0.126s  0.122s  0.122s
-  .name|rindex                 0.127s  0.130s  0.131s  0.127s  0.125s
-  .name|indices                0.146s  0.159s  0.161s  0.155s  0.149s
-  [x,y]|sort                   0.152s  0.156s  0.154s  0.153s  0.154s
-  .name|scan                   0.208s  0.209s  0.214s  0.207s  0.213s
-  .name|gsub                   0.168s  0.168s  0.170s  0.167s  0.166s
-  walk(if num .+1)             0.143s  0.142s  0.140s  0.141s  0.137s
-  tojson                       0.104s  0.106s  0.106s  0.104s  0.105s
-  {name,x}                     0.133s  0.130s  0.129s  0.128s  0.128s
-  .z//.name                    0.157s  0.157s  0.158s  0.154s  0.155s
-  .x|=test(re)                 0.180s  0.171s  0.176s  0.172s  0.170s
-  ./sep|first                  0.182s  0.190s  0.185s  0.182s  0.180s
-  .y=(.x*2)                    0.178s  0.181s  0.180s  0.174s  0.175s
-  .y=(.x+.y)                   0.233s  0.238s  0.234s  0.228s  0.226s
-  objects                      0.138s  0.134s  0.138s  0.134s  0.137s
-  .tag|=if..then N             0.614s  0.617s  0.611s  0.627s  0.614s
-  .x=(.x+1)                    0.128s  0.129s  0.127s  0.124s  0.126s
-  sel>N|.y+=1                  0.121s  0.124s  0.122s  0.122s  0.120s
-  sel(and)|.x+=1               0.111s  0.111s  0.111s  0.109s  0.109s
-  sel(sw)|.x+=1                0.164s  0.165s  0.163s  0.159s  0.156s
-  match(re)                    0.369s  0.364s  0.367s  0.362s  0.368s
-  capture(re)                  0.296s  0.297s  0.299s  0.302s  0.299s
-  first(.name,.x)              0.097s  0.098s  0.097s  0.094s  0.095s
-  if .x==null                  0.046s  0.048s  0.047s  0.046s  0.046s
-  we(sw(.key))                 0.110s  0.110s  0.105s  0.108s  0.107s
-  sel(sw or ew)                0.205s  0.202s  0.207s  0.205s  0.199s
-  path(.name,.x)               0.274s  0.276s  0.278s  0.278s  0.271s
-  sel(str+num+num)             0.152s  0.152s  0.153s  0.150s  0.151s
-  nested if|field              0.076s  0.081s  0.077s  0.077s  0.077s
-  .f|floor|.*2                 0.061s  0.061s  0.061s  0.060s  0.061s
-  split|len>1                  0.114s  0.118s  0.119s  0.115s  0.113s
-  .name|len|.*2                0.103s  0.104s  0.103s  0.103s  0.100s
-  if len>5 .x .y               0.113s  0.118s  0.113s  0.113s  0.115s
-  sel(len>5)|remap             0.207s  0.207s  0.202s  0.201s  0.199s
-  .x|tostr|len                 0.059s  0.062s  0.060s  0.059s  0.058s
-  if .x>.y .x .y               0.093s  0.097s  0.094s  0.094s  0.094s
-  split|last|tonum             0.096s  0.096s  0.097s  0.096s  0.095s
-  split|rev|.[0]               0.090s  0.096s  0.091s  0.091s  0.090s
-  split|.[0]+.[1]              0.114s  0.113s  0.115s  0.113s  0.112s
-  .[]|strings                  0.104s  0.106s  0.106s  0.105s  0.104s
-  .[]|numbers                  0.124s  0.129s  0.125s  0.124s  0.124s
-  [x,y]|any(>1M)               0.082s  0.084s  0.082s  0.082s  0.083s
-  sel(dc|sw)                   0.097s  0.098s  0.101s  0.098s  0.098s
-  [[x,y],[n]]|flat             0.460s  0.460s  0.462s  0.464s  0.456s
-  .x|floor|.*2                 0.061s  0.061s  0.060s  0.061s  0.061s
-  tojson|fromjson              0.085s  0.087s  0.084s  0.082s  0.084s
-  [.x]|add                     0.060s  0.060s  0.060s  0.059s  0.059s
-  if>N {o}+.                   0.135s  0.136s  0.135s  0.138s  0.136s
-  if>N .+{o}                   0.138s  0.135s  0.135s  0.136s  0.132s
-  if .n=="s" .+{o}             0.161s  0.158s  0.161s  0.157s  0.159s
-  sel(.n>"s")                  0.089s  0.089s  0.090s  0.091s  0.087s
-  [x,y,z]|min                  0.309s  0.308s  0.311s  0.307s  0.312s
-  if .n|len>5 l s              0.100s  0.100s  0.101s  0.100s  0.099s
-  if .x|flr>N b s              0.056s  0.056s  0.055s  0.055s  0.054s
-  if .n|test l e               0.106s  0.105s  0.105s  0.105s  0.104s
-  if .n|sw l e                 0.084s  0.083s  0.085s  0.082s  0.084s
-  if .n|ew l e                 0.084s  0.084s  0.086s  0.085s  0.083s
-  .n|len|tostr                 0.092s  0.092s  0.091s  0.090s  0.092s
+  empty                        0.017s  0.018s  0.017s  0.017s  0.017s
+  identity -c                  0.088s  0.087s  0.086s  0.084s  0.084s
+  identity (pretty)            0.106s  0.107s  0.106s  0.102s  0.099s
+  field access .name           0.096s  0.097s  0.093s  0.090s  0.089s
+  nested .x,.y,.name           0.155s  0.150s  0.147s  0.146s  0.149s
+  arithmetic .x + .y           0.086s  0.084s  0.083s  0.082s  0.079s
+  select .x > 1500000          0.083s  0.087s  0.084s  0.080s  0.077s
+  string concat                0.092s  0.095s  0.092s  0.092s  0.088s
+  object construct             0.115s  0.116s  0.114s  0.110s  0.109s
+  array construct              0.107s  0.106s  0.105s  0.105s  0.100s
+  .[]                          0.105s  0.104s  0.102s  0.101s  0.098s
+  to_entries                   0.159s  0.159s  0.163s  0.154s  0.150s
+  keys                         0.105s  0.107s  0.105s  0.100s  0.098s
+  keys_unsorted                0.095s  0.097s  0.094s  0.092s  0.090s
+  length                       0.087s  0.088s  0.084s  0.087s  0.084s
+  has("x")                     0.039s  0.039s  0.037s  0.036s  0.035s
+  type                         0.023s  0.023s  0.023s  0.022s  0.021s
+  del(.name)                   0.103s  0.107s  0.101s  0.099s  0.098s
+  @csv                         0.124s  0.120s  0.118s  0.117s  0.119s
+  split/join                   0.090s  0.094s  0.090s  0.089s  0.086s
+  select|field                 0.101s  0.099s  0.097s  0.094s  0.093s
+  select|remap                 0.098s  0.100s  0.099s  0.097s  0.093s
+  computed remap               0.190s  0.192s  0.191s  0.187s  0.186s
+  [.x,.y]|add                  0.084s  0.084s  0.083s  0.083s  0.081s
+  [.x,.y]|avg                  0.109s  0.111s  0.106s  0.106s  0.105s
+  map(*2)|add                  0.106s  0.107s  0.104s  0.102s  0.099s
+  keys|length                  0.253s  0.259s  0.255s  0.251s  0.249s
+  .+{z=0}                      0.150s  0.150s  0.146s  0.145s  0.142s
+  split|first                  0.091s  0.092s  0.089s  0.088s  0.086s
+  slice[0..5]                  0.093s  0.095s  0.094s  0.094s  0.088s
+  dynkey {(.name)}             0.106s  0.108s  0.104s  0.106s  0.100s
+  .x += 1                      0.129s  0.128s  0.121s  0.122s  0.124s
+  {a}+{b} merge                0.132s  0.133s  0.130s  0.129s  0.128s
+  .x*2+1                       0.060s  0.061s  0.060s  0.059s  0.057s
+  .x+.y*2                      0.100s  0.099s  0.100s  0.096s  0.094s
+  .x > .y                      0.079s  0.078s  0.077s  0.076s  0.074s
+  to_entries|len               0.400s  0.405s  0.397s  0.397s  0.389s
+  .x|.+1 (pipe)                0.058s  0.059s  0.059s  0.056s  0.055s
+  .x|.*2|.+1                   0.060s  0.060s  0.060s  0.058s  0.056s
+  .name|.+"_x"                 0.094s  0.097s  0.094s  0.092s  0.088s
+  .x>N | not                   0.049s  0.051s  0.049s  0.048s  0.047s
+  and (2 cmp)                  0.085s  0.082s  0.080s  0.080s  0.078s
+  if-then-else                 0.051s  0.053s  0.052s  0.051s  0.049s
+  sel(and)|field               0.080s  0.079s  0.076s  0.076s  0.073s
+  sel(and)|remap               0.079s  0.079s  0.077s  0.077s  0.074s
+  arith|cmp                    0.054s  0.056s  0.054s  0.053s  0.051s
+  if cmp .field                0.113s  0.118s  0.113s  0.110s  0.108s
+  split|length                 0.089s  0.093s  0.089s  0.088s  0.085s
+  [x,y]|min                    0.092s  0.092s  0.090s  0.089s  0.087s
+  [x,y]|max                    0.096s  0.097s  0.095s  0.092s  0.090s
+  [x,y]|sort|.[0]              0.093s  0.092s  0.089s  0.088s  0.085s
+  .name|len>5                  0.093s  0.094s  0.090s  0.089s  0.088s
+  sel(len>5)|.x                0.113s  0.111s  0.107s  0.107s  0.105s
+  if .x>.y .name               0.093s  0.092s  0.093s  0.088s  0.088s
+  sel(.x>.y)|.name             0.075s  0.074s  0.071s  0.070s  0.067s
+  .x*2|tostring                0.057s  0.058s  0.057s  0.055s  0.053s
+  .x*.x+1                      0.066s  0.067s  0.067s  0.064s  0.063s
+  {k=.name,v=tostr}            0.151s  0.147s  0.144s  0.145s  0.138s
+  str add chain                0.388s  0.388s  0.385s  0.378s  0.372s
+  if>.y .name|empty            0.077s  0.073s  0.073s  0.072s  0.070s
+  if .x%2==0                   0.055s  0.054s  0.055s  0.054s  0.052s
+  if .x*2+1>1M                 0.055s  0.055s  0.056s  0.054s  0.052s
+  sel(.x%2==0)|.name           0.083s  0.084s  0.084s  0.081s  0.080s
+  sel(.x*2+1>1M)               0.160s  0.157s  0.159s  0.154s  0.151s
+  .x|@json                     0.048s  0.049s  0.047s  0.047s  0.046s
+  .x|@text                     0.048s  0.049s  0.048s  0.047s  0.045s
+  .name|@json                  0.103s  0.102s  0.101s  0.101s  0.099s
+  sel|[arr]                    0.147s  0.143s  0.149s  0.144s  0.140s
+  sel(and)|[arr]               0.081s  0.077s  0.079s  0.076s  0.076s
+  if>.y [arr]                  0.178s  0.175s  0.179s  0.174s  0.178s
+  if sw then .f                0.143s  0.143s  0.139s  0.135s  0.132s
+  dynkey {(.n)=.x*2}           0.115s  0.117s  0.115s  0.112s  0.111s
+  sel(and)|.x*.y               0.079s  0.077s  0.077s  0.078s  0.074s
+  sel>N|str chain              0.156s  0.152s  0.155s  0.153s  0.151s
+  .f+"_"+arith_ts              0.136s  0.134s  0.133s  0.132s  0.130s
+  sel(sw)|str ch               0.304s  0.308s  0.307s  0.298s  0.301s
+  split|rev|join               0.118s  0.117s  0.117s  0.112s  0.111s
+  dynkey+static                0.338s  0.340s  0.338s  0.332s  0.332s
+  if>.y str chain              0.166s  0.167s  0.171s  0.168s  0.167s
+  remap+str chain              0.159s  0.156s  0.156s  0.154s  0.145s
+  sel(len>8)                   0.161s  0.163s  0.162s  0.159s  0.154s
+  up|split|join                0.098s  0.098s  0.095s  0.100s  0.095s
+  .name|index                  0.120s  0.121s  0.118s  0.117s  0.114s
+  .name|index+1                0.124s  0.126s  0.122s  0.122s  0.117s
+  .name|rindex                 0.130s  0.131s  0.127s  0.125s  0.122s
+  .name|indices                0.159s  0.161s  0.155s  0.149s  0.145s
+  [x,y]|sort                   0.156s  0.154s  0.153s  0.154s  0.152s
+  .name|scan                   0.209s  0.214s  0.207s  0.213s  0.208s
+  .name|gsub                   0.168s  0.170s  0.167s  0.166s  0.162s
+  walk(if num .+1)             0.142s  0.140s  0.141s  0.137s  0.136s
+  tojson                       0.106s  0.106s  0.104s  0.105s  0.100s
+  {name,x}                     0.130s  0.129s  0.128s  0.128s  0.123s
+  .z//.name                    0.157s  0.158s  0.154s  0.155s  0.146s
+  .x|=test(re)                 0.171s  0.176s  0.172s  0.170s  0.165s
+  ./sep|first                  0.190s  0.185s  0.182s  0.180s  0.173s
+  .y=(.x*2)                    0.181s  0.180s  0.174s  0.175s  0.172s
+  .y=(.x+.y)                   0.238s  0.234s  0.228s  0.226s  0.224s
+  objects                      0.134s  0.138s  0.134s  0.137s  0.130s
+  .tag|=if..then N             0.617s  0.611s  0.627s  0.614s  0.590s
+  .x=(.x+1)                    0.129s  0.127s  0.124s  0.126s  0.123s
+  sel>N|.y+=1                  0.124s  0.122s  0.122s  0.120s  0.119s
+  sel(and)|.x+=1               0.111s  0.111s  0.109s  0.109s  0.106s
+  sel(sw)|.x+=1                0.165s  0.163s  0.159s  0.156s  0.156s
+  match(re)                    0.364s  0.367s  0.362s  0.368s  0.355s
+  capture(re)                  0.297s  0.299s  0.302s  0.299s  0.294s
+  first(.name,.x)              0.098s  0.097s  0.094s  0.095s  0.092s
+  if .x==null                  0.048s  0.047s  0.046s  0.046s  0.045s
+  we(sw(.key))                 0.110s  0.105s  0.108s  0.107s  0.104s
+  sel(sw or ew)                0.202s  0.207s  0.205s  0.199s  0.198s
+  path(.name,.x)               0.276s  0.278s  0.278s  0.271s  0.264s
+  sel(str+num+num)             0.152s  0.153s  0.150s  0.151s  0.145s
+  nested if|field              0.081s  0.077s  0.077s  0.077s  0.074s
+  .f|floor|.*2                 0.061s  0.061s  0.060s  0.061s  0.058s
+  split|len>1                  0.118s  0.119s  0.115s  0.113s  0.110s
+  .name|len|.*2                0.104s  0.103s  0.103s  0.100s  0.097s
+  if len>5 .x .y               0.118s  0.113s  0.113s  0.115s  0.110s
+  sel(len>5)|remap             0.207s  0.202s  0.201s  0.199s  0.198s
+  .x|tostr|len                 0.062s  0.060s  0.059s  0.058s  0.057s
+  if .x>.y .x .y               0.097s  0.094s  0.094s  0.094s  0.091s
+  split|last|tonum             0.096s  0.097s  0.096s  0.095s  0.092s
+  split|rev|.[0]               0.096s  0.091s  0.091s  0.090s  0.089s
+  split|.[0]+.[1]              0.113s  0.115s  0.113s  0.112s  0.109s
+  .[]|strings                  0.106s  0.106s  0.105s  0.104s  0.106s
+  .[]|numbers                  0.129s  0.125s  0.124s  0.124s  0.125s
+  [x,y]|any(>1M)               0.084s  0.082s  0.082s  0.083s  0.079s
+  sel(dc|sw)                   0.098s  0.101s  0.098s  0.098s  0.094s
+  [[x,y],[n]]|flat             0.460s  0.462s  0.464s  0.456s  0.450s
+  .x|floor|.*2                 0.061s  0.060s  0.061s  0.061s  0.059s
+  tojson|fromjson              0.087s  0.084s  0.082s  0.084s  0.080s
+  [.x]|add                     0.060s  0.060s  0.059s  0.059s  0.057s
+  if>N {o}+.                   0.136s  0.135s  0.138s  0.136s  0.127s
+  if>N .+{o}                   0.135s  0.135s  0.136s  0.132s  0.131s
+  if .n=="s" .+{o}             0.158s  0.161s  0.157s  0.159s  0.154s
+  sel(.n>"s")                  0.089s  0.090s  0.091s  0.087s  0.085s
+  [x,y,z]|min                  0.308s  0.311s  0.307s  0.312s  0.305s
+  if .n|len>5 l s              0.100s  0.101s  0.100s  0.099s  0.095s
+  if .x|flr>N b s              0.056s  0.055s  0.055s  0.054s  0.053s
+  if .n|test l e               0.105s  0.105s  0.105s  0.104s  0.102s
+  if .n|sw l e                 0.083s  0.085s  0.082s  0.084s  0.080s
+  if .n|ew l e                 0.084s  0.086s  0.085s  0.083s  0.080s
+  .n|len|tostr                 0.092s  0.091s  0.090s  0.092s  0.085s
 
 --- String operations (2M objects) ---
-  Benchmark                    v1.5.6  v1.6.0  v1.6.1  v1.7.0  v1.7.1
+  Benchmark                    v1.6.0  v1.6.1  v1.7.0  v1.7.1  v1.8.0
   ---                          ------  ------  ------  ------  ------
-  ascii_downcase               0.105s  0.105s  0.106s  0.104s  0.104s
-  ascii_upcase                 0.103s  0.104s  0.106s  0.103s  0.102s
-  ltrimstr                     0.095s  0.096s  0.099s  0.097s  0.096s
-  rtrimstr                     0.098s  0.098s  0.099s  0.097s  0.097s
-  split                        0.162s  0.170s  0.165s  0.162s  0.164s
-  case+split                   0.115s  0.118s  0.116s  0.121s  0.116s
-  join                         0.091s  0.096s  0.093s  0.093s  0.094s
-  startswith                   0.095s  0.098s  0.098s  0.095s  0.094s
-  endswith                     0.096s  0.098s  0.098s  0.096s  0.097s
-  tostring                     0.063s  0.063s  0.063s  0.063s  0.062s
-  tonumber                     0.110s  0.112s  0.111s  0.110s  0.109s
-  string interpolation         0.118s  0.120s  0.116s  0.118s  0.119s
+  ascii_downcase               0.105s  0.106s  0.104s  0.104s  0.100s
+  ascii_upcase                 0.104s  0.106s  0.103s  0.102s  0.099s
+  ltrimstr                     0.096s  0.099s  0.097s  0.096s  0.093s
+  rtrimstr                     0.098s  0.099s  0.097s  0.097s  0.095s
+  split                        0.170s  0.165s  0.162s  0.164s  0.156s
+  case+split                   0.118s  0.116s  0.121s  0.116s  0.113s
+  join                         0.096s  0.093s  0.093s  0.094s  0.091s
+  startswith                   0.098s  0.098s  0.095s  0.094s  0.090s
+  endswith                     0.098s  0.098s  0.096s  0.097s  0.091s
+  tostring                     0.063s  0.063s  0.063s  0.062s  0.060s
+  tonumber                     0.112s  0.111s  0.110s  0.109s  0.108s
+  string interpolation         0.120s  0.116s  0.118s  0.119s  0.114s
 
 --- String ops (200K objects) ---
-  Benchmark                    v1.5.6  v1.6.0  v1.6.1  v1.7.0  v1.7.1
+  Benchmark                    v1.6.0  v1.6.1  v1.7.0  v1.7.1  v1.8.0
   ---                          ------  ------  ------  ------  ------
-  test (regex)                 0.015s  0.015s  0.015s  0.014s  0.014s
-  match (regex)                0.033s  0.032s  0.033s  0.032s  0.033s
-  @base64                      0.012s  0.012s  0.012s  0.012s  0.012s
-  @uri                         0.012s  0.012s  0.013s  0.012s  0.012s
-  @html                        0.012s  0.012s  0.013s  0.012s  0.012s
-  @csv (array)                 0.015s  0.016s  0.016s  0.016s  0.016s
-  @tsv (array)                 0.015s  0.015s  0.015s  0.015s  0.015s
-  gsub                         0.019s  0.019s  0.019s  0.019s  0.019s
-  case+gsub                    0.181s  0.181s  0.181s  0.180s  0.176s
-  case+test                    0.119s  0.116s  0.124s  0.120s  0.118s
-  ltrim+tonum+arith            0.111s  0.113s  0.113s  0.111s  0.111s
+  test (regex)                 0.015s  0.015s  0.014s  0.014s  0.014s
+  match (regex)                0.032s  0.033s  0.032s  0.033s  0.033s
+  @base64                      0.012s  0.012s  0.012s  0.012s  0.011s
+  @uri                         0.012s  0.013s  0.012s  0.012s  0.011s
+  @html                        0.012s  0.013s  0.012s  0.012s  0.011s
+  @csv (array)                 0.016s  0.016s  0.016s  0.016s  0.015s
+  @tsv (array)                 0.015s  0.015s  0.015s  0.015s  0.014s
+  gsub                         0.019s  0.019s  0.019s  0.019s  0.018s
+  case+gsub                    0.181s  0.181s  0.180s  0.176s  0.177s
+  case+test                    0.116s  0.124s  0.120s  0.118s  0.114s
+  ltrim+tonum+arith            0.113s  0.113s  0.111s  0.111s  0.107s
 
 --- Numeric & math (2M objects) ---
-  Benchmark                    v1.5.6  v1.6.0  v1.6.1  v1.7.0  v1.7.1
+  Benchmark                    v1.6.0  v1.6.1  v1.7.0  v1.7.1  v1.8.0
   ---                          ------  ------  ------  ------  ------
-  floor                        0.057s  0.059s  0.056s  0.057s  0.056s
-  sqrt                         0.079s  0.078s  0.079s  0.079s  0.078s
-  modulo                       0.057s  0.057s  0.057s  0.059s  0.057s
-  if-elif-else                 0.121s  0.124s  0.125s  0.123s  0.123s
-  select|del                   0.092s  0.090s  0.090s  0.091s  0.091s
-  select|merge                 0.120s  0.121s  0.118s  0.121s  0.118s
-  select(test)|merge           0.022s  0.021s  0.022s  0.021s  0.021s
+  floor                        0.059s  0.056s  0.057s  0.056s  0.054s
+  sqrt                         0.078s  0.079s  0.079s  0.078s  0.077s
+  modulo                       0.057s  0.057s  0.059s  0.057s  0.055s
+  if-elif-else                 0.124s  0.125s  0.123s  0.123s  0.123s
+  select|del                   0.090s  0.090s  0.091s  0.091s  0.087s
+  select|merge                 0.121s  0.118s  0.121s  0.118s  0.114s
+  select(test)|merge           0.021s  0.022s  0.021s  0.021s  0.020s
 
 --- Array generators ---
-  Benchmark                    v1.5.6  v1.6.0  v1.6.1  v1.7.0  v1.7.1
+  Benchmark                    v1.6.0  v1.6.1  v1.7.0  v1.7.1  v1.8.0
   ---                          ------  ------  ------  ------  ------
-  range(2M) | length           0.011s  0.012s  0.012s  0.012s  0.011s
-  reverse(2M)                  0.018s  0.018s  0.018s  0.018s  0.018s
-  sort(2M)                     0.023s  0.023s  0.023s  0.023s  0.023s
-  unique(1M)                   0.030s  0.031s  0.030s  0.030s  0.030s
-  flatten(500K)                0.010s  0.011s  0.011s  0.011s  0.011s
-  min, max(2M)                 0.018s  0.022s  0.021s  0.019s  0.020s
-  add numbers(2M)              0.013s  0.013s  0.013s  0.013s  0.013s
-  any/all(2M)                  0.028s  0.029s  0.028s  0.029s  0.028s
-  limit(10; range(10M))        0.002s  0.003s  0.002s  0.003s  0.002s
-  first(range(10M))            0.002s  0.003s  0.002s  0.003s  0.002s
-  last(range(2M))              0.002s  0.003s  0.002s  0.003s  0.002s
-  indices(1M)                  0.016s  0.017s  0.017s  0.017s  0.017s
+  range(2M) | length           0.012s  0.012s  0.012s  0.011s  0.011s
+  reverse(2M)                  0.018s  0.018s  0.018s  0.018s  0.017s
+  sort(2M)                     0.023s  0.023s  0.023s  0.023s  0.022s
+  unique(1M)                   0.031s  0.030s  0.030s  0.030s  0.029s
+  flatten(500K)                0.011s  0.011s  0.011s  0.011s  0.010s
+  min, max(2M)                 0.022s  0.021s  0.019s  0.020s  0.017s
+  add numbers(2M)              0.013s  0.013s  0.013s  0.013s  0.012s
+  any/all(2M)                  0.029s  0.028s  0.029s  0.028s  0.028s
+  limit(10; range(10M))        0.003s  0.002s  0.003s  0.002s  0.002s
+  first(range(10M))            0.003s  0.002s  0.003s  0.002s  0.002s
+  last(range(2M))              0.003s  0.002s  0.003s  0.002s  0.002s
+  indices(1M)                  0.017s  0.017s  0.017s  0.017s  0.016s
 
 --- Reduce & foreach ---
-  Benchmark                    v1.5.6  v1.6.0  v1.6.1  v1.7.0  v1.7.1
+  Benchmark                    v1.6.0  v1.6.1  v1.7.0  v1.7.1  v1.8.0
   ---                          ------  ------  ------  ------  ------
   reduce (sum)                 0.009s  0.009s  0.009s  0.009s  0.009s
   reduce (array build)         0.004s  0.004s  0.004s  0.004s  0.004s
-  reduce (obj build)           0.009s  0.010s  0.010s  0.010s  0.009s
-  reduce (setpath)             0.016s  0.017s  0.016s  0.016s  0.016s
-  foreach (running sum)        0.010s  0.010s  0.010s  0.010s  0.010s
-  foreach + emit               0.010s  0.011s  0.011s  0.010s  0.010s
-  reduce (sum-of-squares)      0.033s  0.036s  0.034s  0.034s  0.033s
-  reduce (conditional)         0.035s  0.037s  0.036s  0.035s  0.035s
-  reduce (product)             0.034s  0.036s  0.035s  0.034s  0.034s
-  foreach (conditional)        0.010s  0.011s  0.010s  0.010s  0.010s
-  until (100M)                 0.301s  0.307s  0.303s  0.305s  0.303s
-  reduce (harmonic)            0.033s  0.035s  0.033s  0.033s  0.033s
-  reduce (floor pipe)          0.032s  0.035s  0.034s  0.033s  0.033s
-  reduce (sqrt pipe)           0.032s  0.035s  0.033s  0.033s  0.033s
-  reduce (sin+cos)             0.052s  0.052s  0.052s  0.052s  0.052s
+  reduce (obj build)           0.010s  0.010s  0.010s  0.009s  0.009s
+  reduce (setpath)             0.017s  0.016s  0.016s  0.016s  0.016s
+  foreach (running sum)        0.010s  0.010s  0.010s  0.010s  0.009s
+  foreach + emit               0.011s  0.011s  0.010s  0.010s  0.010s
+  reduce (sum-of-squares)      0.036s  0.034s  0.034s  0.033s  0.032s
+  reduce (conditional)         0.037s  0.036s  0.035s  0.035s  0.033s
+  reduce (product)             0.036s  0.035s  0.034s  0.034s  0.035s
+  foreach (conditional)        0.011s  0.010s  0.010s  0.010s  0.010s
+  until (100M)                 0.307s  0.303s  0.305s  0.303s  0.301s
+  reduce (harmonic)            0.035s  0.033s  0.033s  0.033s  0.032s
+  reduce (floor pipe)          0.035s  0.034s  0.033s  0.033s  0.032s
+  reduce (sqrt pipe)           0.035s  0.033s  0.033s  0.033s  0.032s
+  reduce (sin+cos)             0.052s  0.052s  0.052s  0.052s  0.051s
 
 --- Object operations ---
-  Benchmark                    v1.5.6  v1.6.0  v1.6.1  v1.7.0  v1.7.1
+  Benchmark                    v1.6.0  v1.6.1  v1.7.0  v1.7.1  v1.8.0
   ---                          ------  ------  ------  ------  ------
   large obj construct          0.004s  0.004s  0.004s  0.004s  0.004s
-  large obj keys               0.011s  0.012s  0.011s  0.011s  0.011s
+  large obj keys               0.012s  0.011s  0.011s  0.011s  0.011s
   large obj to_entries         0.012s  0.012s  0.012s  0.012s  0.012s
-  with_entries                 0.009s  0.009s  0.009s  0.009s  0.009s
+  with_entries                 0.009s  0.009s  0.009s  0.009s  0.008s
 
 --- Assignment operators ---
-  Benchmark                    v1.5.6  v1.6.0  v1.6.1  v1.7.0  v1.7.1
+  Benchmark                    v1.6.0  v1.6.1  v1.7.0  v1.7.1  v1.8.0
   ---                          ------  ------  ------  ------  ------
   .[] |= f (100K)              0.005s  0.005s  0.005s  0.005s  0.005s
-  .[] += 1 (100K)              0.005s  0.006s  0.005s  0.005s  0.006s
+  .[] += 1 (100K)              0.006s  0.005s  0.005s  0.006s  0.005s
   .[k] = v reduce(50K)         0.008s  0.008s  0.008s  0.008s  0.008s
+  p126-shape nested reduce     -       -       -       -       0.103s
+  p126-shape w/ mutate         -       -       -       -       0.105s
+  p150-shape serial mutate     -       -       -       -       0.010s
 
 --- String-heavy generators ---
-  Benchmark                    v1.5.6  v1.6.0  v1.6.1  v1.7.0  v1.7.1
+  Benchmark                    v1.6.0  v1.6.1  v1.7.0  v1.7.1  v1.8.0
   ---                          ------  ------  ------  ------  ------
-  gsub(100K)                   0.027s  0.027s  0.027s  0.027s  0.026s
-  join large(100K)             0.006s  0.006s  0.005s  0.005s  0.006s
-  explode/implode(100K)        0.028s  0.028s  0.028s  0.027s  0.028s
-  reduce str concat(100K)      0.008s  0.008s  0.008s  0.008s  0.008s
+  gsub(100K)                   0.027s  0.027s  0.027s  0.026s  0.026s
+  join large(100K)             0.006s  0.005s  0.005s  0.006s  0.005s
+  explode/implode(100K)        0.028s  0.028s  0.027s  0.028s  0.027s
+  reduce str concat(100K)      0.008s  0.008s  0.008s  0.008s  0.007s
 
 --- Try-catch & alternative ---
-  Benchmark                    v1.5.6  v1.6.0  v1.6.1  v1.7.0  v1.7.1
+  Benchmark                    v1.6.0  v1.6.1  v1.7.0  v1.7.1  v1.8.0
   ---                          ------  ------  ------  ------  ------
-  alternative //               0.032s  0.035s  0.035s  0.035s  0.035s
-  try-catch                    0.023s  0.024s  0.024s  0.024s  0.024s
+  alternative //               0.035s  0.035s  0.035s  0.035s  0.034s
+  try-catch                    0.024s  0.024s  0.024s  0.024s  0.023s
   label-break                  0.004s  0.004s  0.004s  0.004s  0.004s
 
 --- Type conversion ---
-  Benchmark                    v1.5.6  v1.6.0  v1.6.1  v1.7.0  v1.7.1
+  Benchmark                    v1.6.0  v1.6.1  v1.7.0  v1.7.1  v1.8.0
   ---                          ------  ------  ------  ------  ------
-  tojson/fromjson(100K)        0.022s  0.023s  0.022s  0.022s  0.022s
-  null propagation(2M)         0.090s  0.093s  0.091s  0.091s  0.093s
+  tojson/fromjson(100K)        0.023s  0.022s  0.022s  0.022s  0.022s
+  null propagation(2M)         0.093s  0.091s  0.091s  0.093s  0.090s
 
 --- jaq-derived ---
-  Benchmark                    v1.5.6  v1.6.0  v1.6.1  v1.7.0  v1.7.1
+  Benchmark                    v1.6.0  v1.6.1  v1.7.0  v1.7.1  v1.8.0
   ---                          ------  ------  ------  ------  ------
   jaq: reverse                 -       -       -       -       -
   jaq: sort                    -       -       -       -       -
@@ -291,9 +294,9 @@ Recent slice (last 5 columns). Full history lives in
   jaq: str-slice               -       -       -       -       -
 
 --- Memoization (jqx) ---
-  Benchmark                    v1.5.6  v1.6.0  v1.6.1  v1.7.0  v1.7.1
+  Benchmark                    v1.6.0  v1.6.1  v1.7.0  v1.7.1  v1.8.0
   ---                          ------  ------  ------  ------  ------
-  memo fib (1K)                -       0.004s  0.003s  0.003s  0.003s
-  memo collatz sum (10K)       -       0.017s  0.017s  0.016s  0.016s
-  memo by .id (100K, 1K keys)  -       0.021s  0.020s  0.020s  0.020s
+  memo fib (1K)                0.004s  0.003s  0.003s  0.003s  0.003s
+  memo collatz sum (10K)       0.017s  0.017s  0.016s  0.016s  0.016s
+  memo by .id (100K, 1K keys)  0.021s  0.020s  0.020s  0.020s  0.020s
 ```

--- a/docs/benchmark-history.tsv
+++ b/docs/benchmark-history.tsv
@@ -4914,3 +4914,223 @@ Type conversion	null propagation(2M)	v1.7.1	0.093
 Memoization (jqx)	memo fib (1K)	v1.7.1	0.003
 Memoization (jqx)	memo collatz sum (10K)	v1.7.1	0.016
 Memoization (jqx)	memo by .id (100K, 1K keys)	v1.7.1	0.020
+NDJSON workloads (2M objects)	empty	v1.8.0	0.017
+NDJSON workloads (2M objects)	identity -c	v1.8.0	0.084
+NDJSON workloads (2M objects)	identity (pretty)	v1.8.0	0.099
+NDJSON workloads (2M objects)	field access .name	v1.8.0	0.089
+NDJSON workloads (2M objects)	nested .x,.y,.name	v1.8.0	0.149
+NDJSON workloads (2M objects)	arithmetic .x + .y	v1.8.0	0.079
+NDJSON workloads (2M objects)	select .x > 1500000	v1.8.0	0.077
+NDJSON workloads (2M objects)	string concat	v1.8.0	0.088
+NDJSON workloads (2M objects)	object construct	v1.8.0	0.109
+NDJSON workloads (2M objects)	array construct	v1.8.0	0.100
+NDJSON workloads (2M objects)	.[]	v1.8.0	0.098
+NDJSON workloads (2M objects)	to_entries	v1.8.0	0.150
+NDJSON workloads (2M objects)	keys	v1.8.0	0.098
+NDJSON workloads (2M objects)	keys_unsorted	v1.8.0	0.090
+NDJSON workloads (2M objects)	length	v1.8.0	0.084
+NDJSON workloads (2M objects)	has("x")	v1.8.0	0.035
+NDJSON workloads (2M objects)	type	v1.8.0	0.021
+NDJSON workloads (2M objects)	del(.name)	v1.8.0	0.098
+NDJSON workloads (2M objects)	@csv	v1.8.0	0.119
+NDJSON workloads (2M objects)	split/join	v1.8.0	0.086
+NDJSON workloads (2M objects)	select|field	v1.8.0	0.093
+NDJSON workloads (2M objects)	select|remap	v1.8.0	0.093
+NDJSON workloads (2M objects)	computed remap	v1.8.0	0.186
+NDJSON workloads (2M objects)	[.x,.y]|add	v1.8.0	0.081
+NDJSON workloads (2M objects)	[.x,.y]|avg	v1.8.0	0.105
+NDJSON workloads (2M objects)	map(*2)|add	v1.8.0	0.099
+NDJSON workloads (2M objects)	keys|length	v1.8.0	0.249
+NDJSON workloads (2M objects)	.+{z=0}	v1.8.0	0.142
+NDJSON workloads (2M objects)	split|first	v1.8.0	0.086
+NDJSON workloads (2M objects)	slice[0..5]	v1.8.0	0.088
+NDJSON workloads (2M objects)	dynkey {(.name)}	v1.8.0	0.100
+NDJSON workloads (2M objects)	.x += 1	v1.8.0	0.124
+NDJSON workloads (2M objects)	{a}+{b} merge	v1.8.0	0.128
+NDJSON workloads (2M objects)	.x*2+1	v1.8.0	0.057
+NDJSON workloads (2M objects)	.x+.y*2	v1.8.0	0.094
+NDJSON workloads (2M objects)	.x > .y	v1.8.0	0.074
+NDJSON workloads (2M objects)	to_entries|len	v1.8.0	0.389
+NDJSON workloads (2M objects)	.x|.+1 (pipe)	v1.8.0	0.055
+NDJSON workloads (2M objects)	.x|.*2|.+1	v1.8.0	0.056
+NDJSON workloads (2M objects)	.name|.+"_x"	v1.8.0	0.088
+NDJSON workloads (2M objects)	.x>N | not	v1.8.0	0.047
+NDJSON workloads (2M objects)	and (2 cmp)	v1.8.0	0.078
+NDJSON workloads (2M objects)	if-then-else	v1.8.0	0.049
+NDJSON workloads (2M objects)	sel(and)|field	v1.8.0	0.073
+NDJSON workloads (2M objects)	sel(and)|remap	v1.8.0	0.074
+NDJSON workloads (2M objects)	arith|cmp	v1.8.0	0.051
+NDJSON workloads (2M objects)	if cmp .field	v1.8.0	0.108
+NDJSON workloads (2M objects)	split|length	v1.8.0	0.085
+NDJSON workloads (2M objects)	[x,y]|min	v1.8.0	0.087
+NDJSON workloads (2M objects)	[x,y]|max	v1.8.0	0.090
+NDJSON workloads (2M objects)	[x,y]|sort|.[0]	v1.8.0	0.085
+NDJSON workloads (2M objects)	.name|len>5	v1.8.0	0.088
+NDJSON workloads (2M objects)	sel(len>5)|.x	v1.8.0	0.105
+NDJSON workloads (2M objects)	if .x>.y .name	v1.8.0	0.088
+NDJSON workloads (2M objects)	sel(.x>.y)|.name	v1.8.0	0.067
+NDJSON workloads (2M objects)	.x*2|tostring	v1.8.0	0.053
+NDJSON workloads (2M objects)	.x*.x+1	v1.8.0	0.063
+NDJSON workloads (2M objects)	{k=.name,v=tostr}	v1.8.0	0.138
+NDJSON workloads (2M objects)	str add chain	v1.8.0	0.372
+NDJSON workloads (2M objects)	if>.y .name|empty	v1.8.0	0.070
+NDJSON workloads (2M objects)	if .x%2==0	v1.8.0	0.052
+NDJSON workloads (2M objects)	if .x*2+1>1M	v1.8.0	0.052
+NDJSON workloads (2M objects)	sel(.x%2==0)|.name	v1.8.0	0.080
+NDJSON workloads (2M objects)	sel(.x*2+1>1M)	v1.8.0	0.151
+NDJSON workloads (2M objects)	.x|@json	v1.8.0	0.046
+NDJSON workloads (2M objects)	.x|@text	v1.8.0	0.045
+NDJSON workloads (2M objects)	.name|@json	v1.8.0	0.099
+NDJSON workloads (2M objects)	sel|[arr]	v1.8.0	0.140
+NDJSON workloads (2M objects)	sel(and)|[arr]	v1.8.0	0.076
+NDJSON workloads (2M objects)	if>.y [arr]	v1.8.0	0.178
+NDJSON workloads (2M objects)	if sw then .f	v1.8.0	0.132
+NDJSON workloads (2M objects)	dynkey {(.n)=.x*2}	v1.8.0	0.111
+NDJSON workloads (2M objects)	sel(and)|.x*.y	v1.8.0	0.074
+NDJSON workloads (2M objects)	sel>N|str chain	v1.8.0	0.151
+NDJSON workloads (2M objects)	.f+"_"+arith_ts	v1.8.0	0.130
+NDJSON workloads (2M objects)	sel(sw)|str ch	v1.8.0	0.301
+NDJSON workloads (2M objects)	split|rev|join	v1.8.0	0.111
+NDJSON workloads (2M objects)	dynkey+static	v1.8.0	0.332
+NDJSON workloads (2M objects)	if>.y str chain	v1.8.0	0.167
+NDJSON workloads (2M objects)	remap+str chain	v1.8.0	0.145
+NDJSON workloads (2M objects)	sel(len>8)	v1.8.0	0.154
+NDJSON workloads (2M objects)	up|split|join	v1.8.0	0.095
+NDJSON workloads (2M objects)	.name|index	v1.8.0	0.114
+NDJSON workloads (2M objects)	.name|index+1	v1.8.0	0.117
+NDJSON workloads (2M objects)	.name|rindex	v1.8.0	0.122
+NDJSON workloads (2M objects)	.name|indices	v1.8.0	0.145
+NDJSON workloads (2M objects)	[x,y]|sort	v1.8.0	0.152
+NDJSON workloads (2M objects)	.name|scan	v1.8.0	0.208
+NDJSON workloads (2M objects)	.name|gsub	v1.8.0	0.162
+NDJSON workloads (2M objects)	walk(if num .+1)	v1.8.0	0.136
+NDJSON workloads (2M objects)	tojson	v1.8.0	0.100
+NDJSON workloads (2M objects)	{name,x}	v1.8.0	0.123
+NDJSON workloads (2M objects)	.z//.name	v1.8.0	0.146
+NDJSON workloads (2M objects)	.x|=test(re)	v1.8.0	0.165
+NDJSON workloads (2M objects)	./sep|first	v1.8.0	0.173
+NDJSON workloads (2M objects)	.y=(.x*2)	v1.8.0	0.172
+NDJSON workloads (2M objects)	.y=(.x+.y)	v1.8.0	0.224
+NDJSON workloads (2M objects)	objects	v1.8.0	0.130
+NDJSON workloads (2M objects)	.tag|=if..then N	v1.8.0	0.590
+NDJSON workloads (2M objects)	.x=(.x+1)	v1.8.0	0.123
+NDJSON workloads (2M objects)	sel>N|.y+=1	v1.8.0	0.119
+NDJSON workloads (2M objects)	sel(and)|.x+=1	v1.8.0	0.106
+NDJSON workloads (2M objects)	sel(sw)|.x+=1	v1.8.0	0.156
+NDJSON workloads (2M objects)	match(re)	v1.8.0	0.355
+NDJSON workloads (2M objects)	capture(re)	v1.8.0	0.294
+NDJSON workloads (2M objects)	first(.name,.x)	v1.8.0	0.092
+NDJSON workloads (2M objects)	if .x==null	v1.8.0	0.045
+NDJSON workloads (2M objects)	we(sw(.key))	v1.8.0	0.104
+NDJSON workloads (2M objects)	sel(sw or ew)	v1.8.0	0.198
+NDJSON workloads (2M objects)	path(.name,.x)	v1.8.0	0.264
+NDJSON workloads (2M objects)	sel(str+num+num)	v1.8.0	0.145
+NDJSON workloads (2M objects)	nested if|field	v1.8.0	0.074
+NDJSON workloads (2M objects)	.f|floor|.*2	v1.8.0	0.058
+NDJSON workloads (2M objects)	split|len>1	v1.8.0	0.110
+NDJSON workloads (2M objects)	.name|len|.*2	v1.8.0	0.097
+NDJSON workloads (2M objects)	if len>5 .x .y	v1.8.0	0.110
+NDJSON workloads (2M objects)	sel(len>5)|remap	v1.8.0	0.198
+NDJSON workloads (2M objects)	.x|tostr|len	v1.8.0	0.057
+NDJSON workloads (2M objects)	if .x>.y .x .y	v1.8.0	0.091
+NDJSON workloads (2M objects)	split|last|tonum	v1.8.0	0.092
+NDJSON workloads (2M objects)	split|rev|.[0]	v1.8.0	0.089
+NDJSON workloads (2M objects)	split|.[0]+.[1]	v1.8.0	0.109
+NDJSON workloads (2M objects)	.[]|strings	v1.8.0	0.106
+NDJSON workloads (2M objects)	.[]|numbers	v1.8.0	0.125
+NDJSON workloads (2M objects)	[x,y]|any(>1M)	v1.8.0	0.079
+NDJSON workloads (2M objects)	sel(dc|sw)	v1.8.0	0.094
+NDJSON workloads (2M objects)	[[x,y],[n]]|flat	v1.8.0	0.450
+NDJSON workloads (2M objects)	.x|floor|.*2	v1.8.0	0.059
+NDJSON workloads (2M objects)	tojson|fromjson	v1.8.0	0.080
+NDJSON workloads (2M objects)	[.x]|add	v1.8.0	0.057
+NDJSON workloads (2M objects)	if>N {o}+.	v1.8.0	0.127
+NDJSON workloads (2M objects)	if>N .+{o}	v1.8.0	0.131
+NDJSON workloads (2M objects)	if .n=="s" .+{o}	v1.8.0	0.154
+NDJSON workloads (2M objects)	sel(.n>"s")	v1.8.0	0.085
+NDJSON workloads (2M objects)	[x,y,z]|min	v1.8.0	0.305
+NDJSON workloads (2M objects)	if .n|len>5 l s	v1.8.0	0.095
+NDJSON workloads (2M objects)	if .x|flr>N b s	v1.8.0	0.053
+NDJSON workloads (2M objects)	if .n|test l e	v1.8.0	0.102
+NDJSON workloads (2M objects)	if .n|sw l e	v1.8.0	0.080
+NDJSON workloads (2M objects)	if .n|ew l e	v1.8.0	0.080
+NDJSON workloads (2M objects)	.n|len|tostr	v1.8.0	0.085
+String operations (2M objects)	ascii_downcase	v1.8.0	0.100
+String operations (2M objects)	ascii_upcase	v1.8.0	0.099
+String operations (2M objects)	ltrimstr	v1.8.0	0.093
+String operations (2M objects)	rtrimstr	v1.8.0	0.095
+String operations (2M objects)	split	v1.8.0	0.156
+String operations (2M objects)	case+split	v1.8.0	0.113
+String operations (2M objects)	join	v1.8.0	0.091
+String operations (2M objects)	startswith	v1.8.0	0.090
+String operations (2M objects)	endswith	v1.8.0	0.091
+String operations (2M objects)	tostring	v1.8.0	0.060
+String operations (2M objects)	tonumber	v1.8.0	0.108
+String operations (2M objects)	string interpolation	v1.8.0	0.114
+String ops (200K objects)	test (regex)	v1.8.0	0.014
+String ops (200K objects)	match (regex)	v1.8.0	0.033
+String ops (200K objects)	@base64	v1.8.0	0.011
+String ops (200K objects)	@uri	v1.8.0	0.011
+String ops (200K objects)	@html	v1.8.0	0.011
+String ops (200K objects)	@csv (array)	v1.8.0	0.015
+String ops (200K objects)	@tsv (array)	v1.8.0	0.014
+String ops (200K objects)	gsub	v1.8.0	0.018
+String ops (200K objects)	case+gsub	v1.8.0	0.177
+String ops (200K objects)	case+test	v1.8.0	0.114
+String ops (200K objects)	ltrim+tonum+arith	v1.8.0	0.107
+Numeric & math (2M objects)	floor	v1.8.0	0.054
+Numeric & math (2M objects)	sqrt	v1.8.0	0.077
+Numeric & math (2M objects)	modulo	v1.8.0	0.055
+Numeric & math (2M objects)	if-elif-else	v1.8.0	0.123
+Numeric & math (2M objects)	select|del	v1.8.0	0.087
+Numeric & math (2M objects)	select|merge	v1.8.0	0.114
+Numeric & math (2M objects)	select(test)|merge	v1.8.0	0.020
+Array generators	range(2M) | length	v1.8.0	0.011
+Array generators	reverse(2M)	v1.8.0	0.017
+Array generators	sort(2M)	v1.8.0	0.022
+Array generators	unique(1M)	v1.8.0	0.029
+Array generators	flatten(500K)	v1.8.0	0.010
+Array generators	min, max(2M)	v1.8.0	0.017
+Array generators	add numbers(2M)	v1.8.0	0.012
+Array generators	any/all(2M)	v1.8.0	0.028
+Array generators	limit(10; range(10M))	v1.8.0	0.002
+Array generators	first(range(10M))	v1.8.0	0.002
+Array generators	last(range(2M))	v1.8.0	0.002
+Array generators	indices(1M)	v1.8.0	0.016
+Reduce & foreach	reduce (sum)	v1.8.0	0.009
+Reduce & foreach	reduce (array build)	v1.8.0	0.004
+Reduce & foreach	reduce (obj build)	v1.8.0	0.009
+Reduce & foreach	reduce (setpath)	v1.8.0	0.016
+Reduce & foreach	foreach (running sum)	v1.8.0	0.009
+Reduce & foreach	foreach + emit	v1.8.0	0.010
+Reduce & foreach	reduce (sum-of-squares)	v1.8.0	0.032
+Reduce & foreach	reduce (conditional)	v1.8.0	0.033
+Reduce & foreach	reduce (product)	v1.8.0	0.035
+Reduce & foreach	foreach (conditional)	v1.8.0	0.010
+Reduce & foreach	until (100M)	v1.8.0	0.301
+Reduce & foreach	reduce (harmonic)	v1.8.0	0.032
+Reduce & foreach	reduce (floor pipe)	v1.8.0	0.032
+Reduce & foreach	reduce (sqrt pipe)	v1.8.0	0.032
+Reduce & foreach	reduce (sin+cos)	v1.8.0	0.051
+Object operations	large obj construct	v1.8.0	0.004
+Object operations	large obj keys	v1.8.0	0.011
+Object operations	large obj to_entries	v1.8.0	0.012
+Object operations	with_entries	v1.8.0	0.008
+Assignment operators	.[] |= f (100K)	v1.8.0	0.005
+Assignment operators	.[] += 1 (100K)	v1.8.0	0.005
+Assignment operators	.[k] = v reduce(50K)	v1.8.0	0.008
+Assignment operators	p126-shape nested reduce	v1.8.0	0.103
+Assignment operators	p126-shape w/ mutate	v1.8.0	0.105
+Assignment operators	p150-shape serial mutate	v1.8.0	0.010
+String-heavy generators	gsub(100K)	v1.8.0	0.026
+String-heavy generators	join large(100K)	v1.8.0	0.005
+String-heavy generators	explode/implode(100K)	v1.8.0	0.027
+String-heavy generators	reduce str concat(100K)	v1.8.0	0.007
+Try-catch & alternative	alternative //	v1.8.0	0.034
+Try-catch & alternative	try-catch	v1.8.0	0.023
+Try-catch & alternative	label-break	v1.8.0	0.004
+Type conversion	tojson/fromjson(100K)	v1.8.0	0.022
+Type conversion	null propagation(2M)	v1.8.0	0.090
+Memoization (jqx)	memo fib (1K)	v1.8.0	0.003
+Memoization (jqx)	memo collatz sum (10K)	v1.8.0	0.016
+Memoization (jqx)	memo by .id (100K, 1K keys)	v1.8.0	0.020


### PR DESCRIPTION
## Summary

Release v1.8.0 — `mutate(...)` jqx extension + nested-reduce / pipe-chain in-place fusion across the JIT.

Highlights since v1.7.1:

- `feat(jq)`: `mutate(...)` builtin as in-place path-update marker (#696)
- `perf(jit)`: nested-reduce in-place fusion across arbitrary depth (#697)
- `fix(jit)`: `FieldCmpNum` returns null-vs-num correctly on null base / absent key (#697)
- `perf(jit)`: `mutate(...)` transparent to in-place fusion (is_scalar, flatten_scalar, branch peelers, walkers) (#699)
- `perf(jit)`: `NestedInplaceAction::Sequence` — pipe-chain of in-place ops on the same accumulator (#700)

## Bench delta (v1.7.1 → v1.8.0)

- 205 / 220 benches comparable (8 new since v1.7.1)
- **0** benches ≥ 1.05× slower (no regression)
- 27 benches ≥ 1.05× faster, 6 ≥ 1.10× faster
- Median ratio 0.972× across the comparable set
- New `p126-shape w/ mutate` (0.105s) matches unmarked baseline (0.103s) — mutate marker is fully transparent

History columns appended for v1.8.0 in `docs/benchmark-history.{tsv,md}`.

## Test plan

- [x] `cargo build --release` clean (0 warnings)
- [x] `cargo test --release` all passing (424 unit + property + equiv + self-diff)
- [x] `bench/comprehensive.sh` no regression > 5%
- [ ] Auto-merge → tag v1.8.0 → release.yml publishes binaries + Homebrew tap bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)