### PR TITLE
test(metamorphic): persist proptest failure seeds for reproducible repros

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,12 @@ jobs:
 
       - name: Run tests
         run: cargo test --release
+
+      - name: Upload proptest regressions
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: proptest-regressions-${{ matrix.os }}
+          path: tests/proptest-regressions/
+          if-no-files-found: ignore
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+proptest-regressions/

--- a/tests/metamorphic.rs
+++ b/tests/metamorphic.rs
@@ -73,7 +73,7 @@ mod common;
 use std::time::Duration;
 
 use proptest::prelude::*;
-use proptest::test_runner::{TestCaseError, TestRunner};
+use proptest::test_runner::{FileFailurePersistence, TestCaseError, TestRunner};
 
 use common::diff_harness::{jq_jit_path, run_filter};
 use common::filter_strategy::{
@@ -255,9 +255,16 @@ fn proptest_timeout() -> Duration {
 }
 
 fn proptest_config() -> ProptestConfig {
+    // `Direct` over `SourceParallel`: proptest's `SourceParallel` walks up
+    // looking for a sibling `lib.rs`/`main.rs`, and silently falls back to
+    // a flat `<source>.<sibling>` file when the crate uses the `src/lib.rs`
+    // layout (as this one does). Hardcoding the path keeps the regressions
+    // file in a predictable location for the CI artifact upload.
     ProptestConfig {
         cases: proptest_cases(),
-        failure_persistence: None,
+        failure_persistence: Some(Box::new(FileFailurePersistence::Direct(
+            "tests/proptest-regressions/metamorphic.txt",
+        ))),
         max_shrink_time: 15_000,
         ..ProptestConfig::default()
     }


### PR DESCRIPTION
## Summary

- Switch `tests/metamorphic.rs` proptest config from `failure_persistence: None` to `Direct("tests/proptest-regressions/metamorphic.txt")` so each failed seed is persisted to a stable, predictable location.
- Upload `tests/proptest-regressions/` as a CI build artifact on test failure (matrix-scoped: `proptest-regressions-{os}`, 30-day retention) so the seed survives past the live workflow run.
- `.gitignore` the regressions dir — kept as CI artifacts only, not committed.

## Why `Direct` over `SourceParallel`

Issue #706 originally proposed `SourceParallel("proptest-regressions")` (proptest's stated default). But proptest's `SourceParallel` walks up looking for a sibling `lib.rs` / `main.rs`, and silently falls back to a flat `<source>.<sibling>` filename when the crate uses the `src/lib.rs` layout (as this one does). On `jq-jit` that fallback produced `tests/metamorphic.proptest-regressions` instead of the AC-expected `tests/proptest-regressions/metamorphic.txt`. `Direct` is the simplest way to pin the path; the inline comment explains this for future readers.

## Test plan

- [x] Local smoke test: forced-failure proptest with the same config writes to `tests/proptest-regressions/<name>.txt` (verified, file removed before commit)
- [x] `cargo test --release` — full suite passes locally
- [ ] CI green on this PR (no metamorphic failure expected; artifact upload is gated on `if: failure()` so won't fire here)
- [ ] On the next real metamorphic failure: confirm artifact appears in Actions UI, download, and re-run locally for deterministic repro

Closes #706.

🤖 Generated with [Claude Code](https://claude.com/claude-code)