### PR TITLE
ci: pin Windows runner to windows-2025

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-2025]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
             target: linux-x86_64
           - os: macos-latest
             target: macos-arm64
-          - os: windows-latest
+          - os: windows-2025
             target: windows-x86_64
     runs-on: ${{ matrix.os }}
     steps:
@@ -51,7 +51,7 @@ jobs:
         run: cargo test --release
 
       - name: Package (tar.gz)
-        if: matrix.os != 'windows-latest'
+        if: matrix.os != 'windows-2025'
         shell: bash
         run: |
           staging="jq-jit-${{ matrix.target }}"
@@ -61,7 +61,7 @@ jobs:
           tar czf "${staging}.tar.gz" -C "$staging" .
 
       - name: Package (zip)
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2025'
         shell: bash
         run: |
           staging="jq-jit-${{ matrix.target }}"


### PR DESCRIPTION
## Summary

- `windows-latest` will silently redirect to `windows-2025-vs2026` (VS2026) on **2026-06-15**.
- Pin to the current label (`windows-2025`, VS2022) in both CI and release workflows so release artifacts produced on or after the migration day are unaffected by the toolchain swap.
- Updates matrix entries in `ci.yml` and `release.yml`, plus the two `matrix.os == 'windows-latest'` conditionals in `release.yml`.

Closes #704

## Test plan

- [ ] CI green on the pinned `windows-2025` image
- [ ] (Manual, before next release) verify the release workflow still builds the Windows artifact on the pinned image

🤖 Generated with [Claude Code](https://claude.com/claude-code)