### PR TITLE
fix: limit/nth honor jq's rounding for fractional arguments (#719)

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -2937,13 +2937,20 @@ pub fn eval(
                 // float-formatted counts (#539).
                 match &cv {
                     Value::Num(n, _) => {
-                        let limit = *n as i64;
-                        if limit == 0 { return Ok(true); }
-                        if limit < 0 {
+                        let n = *n;
+                        // jq emits while a 1-based counter stays below `n` and
+                        // breaks once it reaches `n` — i.e. ceil(n) items for
+                        // positive n. Comparing the integer counter against the
+                        // raw f64 (instead of truncating `n` to an integer)
+                        // matches jq for fractional counts: `*n as i64` floored,
+                        // dropping the ceil item (#719). The JIT path already
+                        // does this float compare (jit.rs emit_yield); this
+                        // aligns the eval/interpreter path with it and with jq.
+                        if n < 0.0 {
                             bail!("__jqerror__:\"limit doesn't support negative count\"");
                         }
-                        let limit = limit as usize;
-                        let mut emitted = 0;
+                        if n == 0.0 { return Ok(true); } // 0.0 and -0.0 → empty
+                        let mut emitted: i64 = 0;
                         let mut stopped_by_outer = false;
                         let result = eval(generator, input.clone(), env, &mut |val| {
                             emitted += 1;
@@ -2951,7 +2958,7 @@ pub fn eval(
                             if !cont {
                                 stopped_by_outer = true;
                                 Ok(false)
-                            } else if emitted >= limit {
+                            } else if emitted as f64 >= n {
                                 Ok(false)
                             } else {
                                 Ok(true)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3626,9 +3626,19 @@ impl Parser {
                     }),
                     else_branch: Box::new(first_match),
                 };
+                // jq's nth(n; g) floors the index: nth(0.5) == nth(0), and a
+                // non-numeric index raises (floor errors on non-numbers). The
+                // foreach counter is integer-valued, so binding the raw float
+                // made `counter == $n` never match for fractional n (silently
+                // empty) and let a string index fall through to empty instead
+                // of erroring (#719). Flooring at the binding fixes both and
+                // leaves integer / negative indices unchanged.
                 Ok(Expr::LetBinding {
                     var_index: n_var,
-                    value: Box::new(n_expr),
+                    value: Box::new(Expr::UnaryOp {
+                        op: UnaryOp::Floor,
+                        operand: Box::new(n_expr),
+                    }),
                     body: Box::new(body),
                 })
             }

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -3663,3 +3663,20 @@ tojson
 
 tojson
 {"a": 1.5e-10, "b": 1e1000}
+
+# ---------- Issue #719: fractional limit/nth count rounding ----------
+
+[limit(1.5; 1,2,3)]
+null
+
+[limit(0.5; range(10))]
+null
+
+[limit(2.9; .[])]
+[10,20,30,40,50]
+
+nth(0.5; 10,20,30)
+null
+
+nth(2.9; 10,20,30,40)
+null

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -10374,3 +10374,54 @@ null
 .a |= {a: (if (.a <= 0) then 99 else empty end)}
 {}
 {"a":{"a":99}}
+
+# Issue #719: limit with a fractional count emits ceil(n) items, not floor(n).
+# eval floored via `*n as i64`; jq breaks when a 1-based counter reaches n.
+[limit(1.5; 1,2,3)]
+null
+[1,2]
+
+# Issue #719: fractional count below 1 still keeps the first item.
+[limit(0.5; 1,2,3)]
+null
+[1]
+
+# Issue #719: 2.9 rounds up to 3 items.
+[limit(2.9; 1,2,3)]
+null
+[1,2,3]
+
+# Issue #719: integer count is unchanged (n items).
+[limit(2.0; 1,2,3)]
+null
+[1,2]
+
+# Issue #719: -0.0 == 0 yields empty (not the negative-count error).
+[limit(-0.0; 1,2,3)]
+null
+[]
+
+# Issue #719: fractional limit over an input array generator.
+[limit(2.5; .[])]
+[10,20,30,40]
+[10,20,30]
+
+# Issue #719: fractional count sourced from input.
+[limit(.n; range(10))]
+{"n":2.7}
+[0,1,2]
+
+# Issue #719: nth floors a fractional index (nth(0.5) == nth(0)).
+nth(0.5; 10,20,30,40)
+null
+10
+
+# Issue #719: nth floors 1.5 to index 1.
+nth(1.5; 10,20,30,40)
+null
+20
+
+# Issue #719: nth floors 2.9 to index 2.
+nth(2.9; 10,20,30,40)
+null
+30


### PR DESCRIPTION
## Summary

`limit` and `nth` diverged from jq on fractional arguments.

- **`limit`** truncated its count with `*n as i64` (floor) in the eval/interpreter path, while the JIT path already compared a 1-based integer counter against the raw `f64` (ceil, matching jq). This aligns the eval path with the JIT path and jq: emit while the counter stays below `n` and stop once it reaches `n` → `ceil(n)` items for positive `n`. Also fixes `limit(-0.0)` (empty) and a negative fractional count like `limit(-0.5; …)` (errors like jq, instead of truncating to `0` and silently returning empty).
- **`nth`** desugared to a `foreach` whose integer counter was compared `== $n`; for a fractional index the equality never held (silently empty), and a non-numeric index fell through to empty instead of erroring. jq floors the index, so `n` is now floored at the binding: `nth(0.5) == nth(0)`, and a non-numeric index errors (parity with jq). Integer and negative indices are unchanged.

## Repro (before → after)

```
$ echo null | jq-jit -c '[limit(1.5; 1,2,3)]'   # was [1]   → now [1,2]   (jq: [1,2])
$ echo null | jq-jit -c '[limit(0.5; 1,2,3)]'    # was []    → now [1]     (jq: [1])
$ echo null | jq-jit -c '[limit(2.9; 1,2,3)]'    # was [1,2] → now [1,2,3] (jq: [1,2,3])
$ jq-jit -nc 'nth(0.5; 10,20,30)'                # was empty → now 10      (jq: 10)
$ jq-jit -nc 'nth("x"; 9)'                        # was empty → now errors  (jq: errors)
```

## How it was found

A metamorphic invocation-mode sweep — same `(filter, input)` across stdin / `-n` / forced-interpreter, where any disagreement is a bug by construction — flagged this as the single largest self-inconsistency cluster (it surfaced through dozens of generator/consumer shapes). The apparent "stdin vs `-n`" split was incidental; the real axis was engine (eval floored, JIT ceiled).

## Tests & bench

- `cargo build --release`: zero warnings.
- `cargo test --release`: official 509/509, regression 1997→2007/2007, all other binaries green. Added 10 regression cases (`tests/regression.test`) and 5 differential probes (`tests/differential/corpus.test`).
- `bench/comprehensive.sh`: `limit(10; range(10M))`, `first(range(10M))`, `last(range(2M))` all unchanged (0.002s); `split|first` / `./sep|first` within ~2% of the v1.8.0 baseline (measurement noise).

Closes #719