### PR TITLE
fix: strftime tz specifiers no longer panic on broken-down time (#710)

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -3504,7 +3504,7 @@ fn rt_strftime(v: &Value, fmt: &Value) -> Result<Value> {
 /// regression tests (`#113`) only exercise `%Y` for these edge cases, so
 /// the clamp doesn't shift any tested output.
 fn format_broken(t: &BrokenTime, fmt: &str) -> String {
-    use chrono::NaiveDate;
+    use chrono::{NaiveDate, TimeZone, Utc};
     let mon = (t.mon.clamp(0, 11) + 1) as u32;
     let mday = t.mday.clamp(1, 31) as u32;
     let hour = t.hour.clamp(0, 23) as u32;
@@ -3514,10 +3514,16 @@ fn format_broken(t: &BrokenTime, fmt: &str) -> String {
         .or_else(|| NaiveDate::from_ymd_opt(t.year, mon, 1))
         .or_else(|| NaiveDate::from_ymd_opt(t.year, 1, 1))
         .unwrap_or_else(|| NaiveDate::from_ymd_opt(1900, 1, 1).unwrap());
-    let dt = date
+    let ndt = date
         .and_hms_opt(hour, min, sec)
         .unwrap_or_else(|| date.and_hms_opt(0, 0, 0).unwrap());
-    dt.format(fmt).to_string()
+    // A broken-down time array carries no timezone offset, so jq treats it as
+    // UTC. Format through a UTC `DateTime` rather than the naive value: the
+    // naive `Display` impl returns `Err` for tz specifiers (`%z`/`%Z`), which
+    // `to_string()` turns into a process-aborting panic (#710). With UTC
+    // attached, `%z` renders `+0000` and `%Z` renders `UTC`, matching jq; all
+    // non-tz specifiers format identically to the naive path.
+    Utc.from_utc_datetime(&ndt).format(fmt).to_string()
 }
 
 fn rt_strptime(v: &Value, fmt: &Value) -> Result<Value> {

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -10425,3 +10425,18 @@ null
 nth(2.9; 10,20,30,40)
 null
 30
+
+# Issue #710: strftime %z on broken-down array renders UTC offset, no panic.
+strftime("%z")
+[2023,10,14,22,13,20,2,317]
+"+0000"
+
+# Issue #710: strftime %Z on broken-down array renders UTC, no panic.
+strftime("%Z")
+[2023,10,14,22,13,20,2,317]
+"UTC"
+
+# Issue #710: gmtime | strftime %z stays UTC, no panic.
+gmtime|strftime("%z")
+1697321600
+"+0000"


### PR DESCRIPTION
## Summary

`strftime("%z")` and `strftime("%Z")` aborted the process (SIGABRT) when given a broken-down time array:

```
$ echo '[2023,10,14,22,13,20,2,317]' | jq-jit -c 'strftime("%z")'
thread '<unnamed>' panicked at .../string.rs:2889:
a Display implementation returned an error unexpectedly: Error
```

`format_broken` formatted through a naive `NaiveDateTime`, whose `Display` impl returns `Err` for timezone specifiers; `to_string()` converts that into a panic.

## Fix

A broken-down time array carries no offset, so jq treats it as UTC. Format through a UTC `DateTime` instead of the naive value:

- `%z` → `"+0000"`, `%Z` → `"UTC"` (matches jq's broken-down-time semantics)
- all non-tz specifiers render identically to before

## Tests

- 3 regression cases in `tests/regression.test` (`%z`, `%Z`, `gmtime|strftime("%z")`)
- `cargo build --release` zero warnings, `cargo test --release` all green

Closes #710

🤖 Generated with [Claude Code](https://claude.com/claude-code)