### PR TITLE
fix: forward path tracking through first/limit/nth/label/reduce (#711)

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -4696,6 +4696,16 @@ fn is_valid_slice_object(v: &Value) -> bool {
     valid("start") && valid("end")
 }
 
+thread_local! {
+    // Active path-mode `foreach` element bindings: (element-var index, source
+    // path). When a bare `$x` reference to a registered element var is
+    // evaluated in path mode — as the `nth(n; g)` desugar's extract does — it
+    // forwards the element's source path instead of being rejected as a value.
+    // Outside a path-mode `foreach`, the stack is empty and variables behave
+    // as ordinary (non-path) values. See #711.
+    static FOREACH_PATH_BIND: RefCell<Vec<(u16, Value)>> = const { RefCell::new(Vec::new()) };
+}
+
 fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) -> GenResult) -> GenResult {
     match expr {
         Expr::Input => cb(Value::Arr(Rc::new(vec![]))),
@@ -4972,6 +4982,188 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
             if !cont { return Ok(false); }
             if any_truthy { return Ok(true); }
             eval_path(fallback, input, env, cb)
+        }
+        Expr::LoadVar { var_index } => {
+            // Inside a path-mode `foreach` (the `nth(n; g)` desugar), a bare
+            // reference to the element variable forwards that element's source
+            // path. Outside that context a variable is an ordinary value, so a
+            // `null`/`true`/`false` that equals the input is the identity path
+            // and anything else is an invalid path expression (mirrors the
+            // catch-all). See #711.
+            if let Some(p) = FOREACH_PATH_BIND.with(|s| {
+                s.borrow().iter().rev().find(|(idx, _)| idx == var_index).map(|(_, p)| p.clone())
+            }) {
+                return cb(p);
+            }
+            let v = env.borrow().get_var(*var_index);
+            if matches!(&v, Value::Null | Value::True | Value::False) && v == input {
+                return cb(Value::Arr(Rc::new(vec![])));
+            }
+            bail!("__pathexpr_result__:{}", crate::value::value_to_json(&v));
+        }
+        Expr::Label { var_index, body } => {
+            // Forward the body's paths; a matching `break` ends the label
+            // cleanly (mirrors the value-mode handler). #711.
+            let label_id = {
+                let mut e = env.borrow_mut();
+                let id = e.next_label;
+                e.next_label = id + 1;
+                e.set_var(*var_index, Value::number(id as f64));
+                id
+            };
+            match eval_path(body, input, env, cb) {
+                Err(e) => {
+                    if let Some(be) = e.downcast_ref::<BreakError>() {
+                        if be.0 == label_id { return Ok(true); }
+                    }
+                    Err(e)
+                }
+                other => other,
+            }
+        }
+        Expr::Break { var_index, .. } => {
+            let label = env.borrow().get_var(*var_index);
+            if let Value::Num(n, NumRepr(None)) = &label {
+                return Err(BreakError(*n as u64).into());
+            }
+            bail!("break: invalid label")
+        }
+        Expr::Limit { count, generator } => {
+            // Forward the generator's paths, stopping after the same count as
+            // value context (ceil(n) for positive n). Covers `first(p)` =
+            // `limit(1; p)` and the `nth` desugar's `limit(1; foreach …)`. #711.
+            let mut stopped_by_outer = false;
+            let result = eval(count, input.clone(), env, &mut |cv| {
+                let n = match &cv {
+                    Value::Num(n, _) => *n,
+                    Value::Null | Value::True | Value::False => {
+                        bail!("__jqerror__:\"limit doesn't support negative count\"");
+                    }
+                    other => {
+                        let msg = format!(
+                            "{} and number (1) cannot be subtracted",
+                            crate::runtime::errdesc_pub(other),
+                        );
+                        bail!(
+                            "__jqerror__:{}",
+                            crate::value::value_to_json_precise(&Value::from_string(msg)),
+                        );
+                    }
+                };
+                if n < 0.0 {
+                    bail!("__jqerror__:\"limit doesn't support negative count\"");
+                }
+                if n == 0.0 { return Ok(true); }
+                let mut emitted: i64 = 0;
+                let inner = eval_path(generator, input.clone(), env, &mut |p| {
+                    emitted += 1;
+                    let cont = cb(p)?;
+                    if !cont {
+                        stopped_by_outer = true;
+                        Ok(false)
+                    } else if emitted as f64 >= n {
+                        Ok(false)
+                    } else {
+                        Ok(true)
+                    }
+                })?;
+                Ok(inner && !stopped_by_outer)
+            });
+            match result {
+                Ok(_) if stopped_by_outer => Ok(false),
+                other => other,
+            }
+        }
+        Expr::Foreach { source, init, var_index, acc_index, update, extract } => {
+            // Forward the path of selected source elements. The source is
+            // evaluated in PATH mode so each element's path is available; the
+            // element var is bound to the element VALUE (for use in
+            // update/cond) and registered in FOREACH_PATH_BIND so a bare `$x`
+            // in the extract forwards the element path — this is what makes the
+            // `nth(n; g)` desugar path-transparent. #711.
+            let vi = *var_index;
+            let ai = *acc_index;
+            { let mut e = env.borrow_mut(); e.ensure_var(vi); e.ensure_var(ai); }
+            eval(init, input.clone(), env, &mut |init_val| {
+                let mut acc = init_val;
+                eval_path(source, input.clone(), env, &mut |src_path| {
+                    let elem_val = crate::runtime::rt_getpath(&input, &src_path).unwrap_or(Value::Null);
+                    let acc_val = std::mem::replace(&mut acc, Value::Null);
+                    let (old_var, old_acc) = {
+                        let mut e = env.borrow_mut();
+                        let ov = std::mem::replace(&mut e.vars[vi as usize], elem_val);
+                        let oa = std::mem::replace(&mut e.vars[ai as usize], acc_val.clone());
+                        (ov, oa)
+                    };
+                    let mut stopped = false;
+                    let update_result = eval(update, acc_val, env, &mut |new_acc| {
+                        acc = new_acc.clone();
+                        env.borrow_mut().vars[ai as usize] = new_acc.clone();
+                        let cont = if let Some(extract_expr) = extract {
+                            FOREACH_PATH_BIND.with(|s| s.borrow_mut().push((vi, src_path.clone())));
+                            let r = eval_path(extract_expr, new_acc.clone(), env, cb);
+                            FOREACH_PATH_BIND.with(|s| { s.borrow_mut().pop(); });
+                            r?
+                        } else {
+                            // No extract: foreach yields the accumulator value,
+                            // which is not a path.
+                            bail!("__pathexpr_result__:{}", crate::value::value_to_json(&new_acc));
+                        };
+                        if !cont { stopped = true; }
+                        Ok(cont)
+                    });
+                    {
+                        let mut e = env.borrow_mut();
+                        e.vars[ai as usize] = old_acc;
+                        e.vars[vi as usize] = old_var;
+                    }
+                    update_result?;
+                    Ok(!stopped)
+                })
+            })
+        }
+        Expr::Reduce { source, init, var_index, acc_index, update } => {
+            // The accumulator threads as a PATH: INIT seeds the path(s) and
+            // each source element runs UPDATE in path mode relative to the
+            // current accumulator path. With an empty source the INIT path is
+            // forwarded unchanged: `path(reduce empty as $x (.a; .))` → ["a"].
+            // #711.
+            let vi = *var_index;
+            let ai = *acc_index;
+            { let mut e = env.borrow_mut(); e.ensure_var(vi); e.ensure_var(ai); }
+            let mut acc_paths: Vec<Value> = Vec::new();
+            eval_path(init, input.clone(), env, &mut |p| { acc_paths.push(p); Ok(true) })?;
+            let mut source_vals: Vec<Value> = Vec::new();
+            eval(source, input.clone(), env, &mut |v| { source_vals.push(v); Ok(true) })?;
+            for sv in source_vals {
+                let (old_var, old_acc) = {
+                    let mut e = env.borrow_mut();
+                    let ov = std::mem::replace(&mut e.vars[vi as usize], sv);
+                    (ov, e.vars[ai as usize].clone())
+                };
+                let mut next: Vec<Value> = Vec::new();
+                for ap in &acc_paths {
+                    let base_val = crate::runtime::rt_getpath(&input, ap).unwrap_or(Value::Null);
+                    env.borrow_mut().vars[ai as usize] = base_val.clone();
+                    let ap_vec: Vec<Value> = match ap { Value::Arr(a) => a.as_ref().clone(), _ => vec![] };
+                    eval_path(update, base_val, env, &mut |rp| {
+                        let mut p = ap_vec.clone();
+                        if let Value::Arr(rpa) = &rp { p.extend(rpa.iter().cloned()); }
+                        next.push(Value::Arr(Rc::new(p)));
+                        Ok(true)
+                    })?;
+                }
+                {
+                    let mut e = env.borrow_mut();
+                    e.vars[ai as usize] = old_acc;
+                    e.vars[vi as usize] = old_var;
+                }
+                acc_paths = next;
+            }
+            for p in acc_paths {
+                if !cb(p)? { return Ok(false); }
+            }
+            Ok(true)
         }
         _ => {
             // Non-path-safe expression: evaluate, then accept the value as

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -3504,7 +3504,7 @@ fn rt_strftime(v: &Value, fmt: &Value) -> Result<Value> {
 /// regression tests (`#113`) only exercise `%Y` for these edge cases, so
 /// the clamp doesn't shift any tested output.
 fn format_broken(t: &BrokenTime, fmt: &str) -> String {
-    use chrono::NaiveDate;
+    use chrono::{NaiveDate, TimeZone, Utc};
     let mon = (t.mon.clamp(0, 11) + 1) as u32;
     let mday = t.mday.clamp(1, 31) as u32;
     let hour = t.hour.clamp(0, 23) as u32;
@@ -3514,10 +3514,16 @@ fn format_broken(t: &BrokenTime, fmt: &str) -> String {
         .or_else(|| NaiveDate::from_ymd_opt(t.year, mon, 1))
         .or_else(|| NaiveDate::from_ymd_opt(t.year, 1, 1))
         .unwrap_or_else(|| NaiveDate::from_ymd_opt(1900, 1, 1).unwrap());
-    let dt = date
+    let ndt = date
         .and_hms_opt(hour, min, sec)
         .unwrap_or_else(|| date.and_hms_opt(0, 0, 0).unwrap());
-    dt.format(fmt).to_string()
+    // A broken-down time array carries no timezone offset, so jq treats it as
+    // UTC. Format through a UTC `DateTime` rather than the naive value: the
+    // naive `Display` impl returns `Err` for tz specifiers (`%z`/`%Z`), which
+    // `to_string()` turns into a process-aborting panic (#710). With UTC
+    // attached, `%z` renders `+0000` and `%Z` renders `UTC`, matching jq; all
+    // non-tz specifiers format identically to the naive path.
+    Utc.from_utc_datetime(&ndt).format(fmt).to_string()
 }
 
 fn rt_strptime(v: &Value, fmt: &Value) -> Result<Value> {

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -10425,3 +10425,18 @@ null
 nth(2.9; 10,20,30,40)
 null
 30
+
+# Issue #710: strftime %z on broken-down array renders UTC offset, no panic.
+strftime("%z")
+[2023,10,14,22,13,20,2,317]
+"+0000"
+
+# Issue #710: strftime %Z on broken-down array renders UTC, no panic.
+strftime("%Z")
+[2023,10,14,22,13,20,2,317]
+"UTC"
+
+# Issue #710: gmtime | strftime %z stays UTC, no panic.
+gmtime|strftime("%z")
+1697321600
+"+0000"

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -10440,3 +10440,53 @@ strftime("%Z")
 gmtime|strftime("%z")
 1697321600
 "+0000"
+
+# Issue #711: first(p) in assignment LHS forwards the path.
+first(.[]) = 0
+[1,2,3]
+[0,2,3]
+
+# Issue #711: limit(n; p) in assignment LHS forwards the path.
+limit(1; .[]) = 9
+[1,2]
+[9,2]
+
+# Issue #711: first over a nested path forwards the deep path.
+first(.a.b) = 0
+{"a":{"b":1}}
+{"a":{"b":0}}
+
+# Issue #711: path(first(p)) yields the first element's path.
+path(first(.[]))
+[1]
+[0]
+
+# Issue #711: path through label forwards the inner path.
+path(label $out | .a)
+{"a":1}
+["a"]
+
+# Issue #711: reduce with empty source forwards the INIT path.
+path(reduce empty as $x (.a; .))
+{"a":1}
+["a"]
+
+# Issue #711: path(nth(i; p)) yields the i-th element's path.
+path(nth(2; .[]))
+[10,20,30,40]
+[2]
+
+# Issue #711: nth floors a fractional index in path context.
+path(nth(1.7; .[]))
+[10,20,30]
+[1]
+
+# Issue #711: nth past the end yields no path (assignment is a no-op).
+nth(5; .[]) = 99
+[10,20,30]
+[10,20,30]
+
+# Issue #711: nth in assignment LHS forwards the path.
+nth(1; .[]) = 99
+[10,20,30]
+[10,99,30]


### PR DESCRIPTION
## Summary

Path-expression tracking was lost when a path flowed through `first` / `limit` / `nth` / `label` / a `reduce` INIT. These constructs fell into the `eval_path` catch-all, which evaluates the body for a *value* and then rejects it as an invalid path:

```
$ echo '[1,2,3]' | jq-jit -c 'first(.[]) = 0'
jq: error (at <stdin>:1): Invalid path expression with result 1   # jq: [0,2,3]
```

## Fix

Added path-mode handlers to `eval_path`:

- **`Limit`** — forwards the generator's paths, stopping after the same count as value context (`ceil(n)`). Covers `first(p)` = `limit(1; p)`.
- **`Label` / `Break`** — `Label` forwards the body's paths and absorbs a matching `break`; `Break` raises the label as in value mode.
- **`Foreach`** — evaluates its source in path mode and registers the element var so a bare `$x` in the extract forwards the element's path. This makes the `nth(n; g)` desugar path-transparent (floored index; no path past the end).
- **`Reduce`** — threads the accumulator as a path: INIT seeds it, each source element runs UPDATE in path mode; an empty source forwards the INIT path unchanged.

Both engines route `path()` and assignment LHS through `eval_path` (the JIT delegates via `__path__` / `__assign__` / `__update__`), so the fix applies uniformly to interpreter and JIT and keeps the self-diff tests consistent.

## Verification

All issue repros now match jq (path forwarding, fractional/out-of-bounds nth, assignment LHS):

```
path(first(.[]))        -> [0]
path(nth(1.7; .[]))     -> [1]
nth(5; .[]) = 99        -> [10,20,30]   (no path → no-op)
path(reduce empty as $x (.a; .)) -> ["a"]
```

Var-in-path that *should* error still errors (`[1] as $x | path($x)`).

## Tests

- 10 regression cases in `tests/regression.test`
- `cargo build --release` zero warnings; `cargo test --release` all green (official + regression + jit/interpreter self-diff)
- `bench/comprehensive.sh`: no regression (hot `limit`/`first`/`range` value paths untouched)

Closes #711

🤖 Generated with [Claude Code](https://claude.com/claude-code)