### PR TITLE
fix: recurse(empty) emits the input instead of null (#713)

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -2131,7 +2131,12 @@ fn contains_input(expr: &crate::ir::Expr) -> bool {
         Expr::Mutate { path_expr, value_expr, .. } => contains_input(path_expr) || contains_input(value_expr),
         // GetPath/SetPath/DelPaths/PathExpr implicitly operate on the current input
         Expr::GetPath { .. } | Expr::SetPath { .. } | Expr::DelPaths { .. } | Expr::PathExpr { .. } => true,
-        Expr::Recurse { input_expr: e } => contains_input(e),
+        // `recurse(f)` always emits the input value first (`def recurse(f):
+        // ., (f | recurse(f))`), so it is input-dependent regardless of `f`.
+        // Classifying by the body alone wrongly marked `recurse(empty)` (and
+        // any input-free `f`) as input-free, evaluating it against `null` and
+        // emitting `null` instead of the input (#713).
+        Expr::Recurse { .. } => true,
         // debug/stderr pass through the current input
         Expr::Debug { .. } | Expr::Stderr { .. } => true,
         Expr::Label { body, .. } => contains_input(body),

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -10510,3 +10510,13 @@ reduce .[] as [$a] ?// {a:$a} ?// $a (0; .+$a)
 reduce .[] as {$x} ?// $x (0; .+$x)
 [{"x":5},7]
 12
+
+# Issue #713: recurse(empty) emits the input, not null.
+recurse(empty)
+5
+5
+
+# Issue #713: recurse(empty) collected is the singleton input.
+[recurse(empty)]
+{"a":1}
+[{"a":1}]


### PR DESCRIPTION
## Summary

```
$ echo 5 | jq-jit -c 'recurse(empty)'
null          # jq: 5
```

`contains_input` classified `Recurse` by its body (`contains_input(input_expr)`). For `recurse(empty)` the body has no `Expr::Input`, so the whole expression was treated as input-free, evaluated against `null`, and emitted `null`.

## Fix

`recurse(f)` always emits the input value first (`def recurse(f): ., (f | recurse(f))`), so it is input-dependent regardless of `f`. `contains_input` now returns `true` for any `Recurse`. The 0-arg `recurse` and `recurse(.[]?)` already returned `true` via their input-referencing bodies, so only input-free-body cases change.

## Tests

- 2 regression cases (`recurse(empty)` on `5` → `5`; `[recurse(empty)]` → `[{...}]`)
- `cargo build --release` zero warnings; `cargo test --release` all green
- `bench/comprehensive.sh`: unchanged (benchmarked recurse/walk have input-dependent bodies, already classified input-dependent)

Closes #713

🤖 Generated with [Claude Code](https://claude.com/claude-code)