### PR TITLE
fix: capture enclosing filter parameters in nested defs (#714)

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -397,6 +397,108 @@ fn subst_inner(
     }
 }
 
+/// Append `extra` arguments to every `FuncCall` that targets `target` within
+/// `expr`, recursively. Used by the parser to forward a lambda-lifted nested
+/// def's hidden capture parameters through the def's own recursive self-calls,
+/// which were emitted (as zero-arg calls) before the captures were known.
+/// Exhaustive (no catch-all) so a new `Expr` variant forces review. See #714.
+pub(crate) fn append_call_args(expr: &Expr, target: usize, extra: &[Expr]) -> Expr {
+    macro_rules! r { ($e:expr) => { append_call_args($e, target, extra) } }
+    macro_rules! rb { ($e:expr) => { Box::new(r!($e)) } }
+    match expr {
+        Expr::FuncCall { func_id, args } => {
+            let mut new_args: Vec<Expr> = args.iter().map(|a| r!(a)).collect();
+            if *func_id == target {
+                new_args.extend(extra.iter().cloned());
+            }
+            Expr::FuncCall { func_id: *func_id, args: new_args }
+        }
+        Expr::Pipe { left, right } => Expr::Pipe { left: rb!(left), right: rb!(right) },
+        Expr::Comma { left, right } => Expr::Comma { left: rb!(left), right: rb!(right) },
+        Expr::BinOp { op, lhs, rhs } => Expr::BinOp { op: *op, lhs: rb!(lhs), rhs: rb!(rhs) },
+        Expr::UnaryOp { op, operand } => Expr::UnaryOp { op: *op, operand: rb!(operand) },
+        Expr::Index { expr: e, key } => Expr::Index { expr: rb!(e), key: rb!(key) },
+        Expr::IndexOpt { expr: e, key } => Expr::IndexOpt { expr: rb!(e), key: rb!(key) },
+        Expr::Each { input_expr } => Expr::Each { input_expr: rb!(input_expr) },
+        Expr::EachOpt { input_expr } => Expr::EachOpt { input_expr: rb!(input_expr) },
+        Expr::IfThenElse { cond, then_branch, else_branch } => Expr::IfThenElse {
+            cond: rb!(cond), then_branch: rb!(then_branch), else_branch: rb!(else_branch),
+        },
+        Expr::LetBinding { var_index, value, body } => Expr::LetBinding {
+            var_index: *var_index, value: rb!(value), body: rb!(body),
+        },
+        Expr::TryCatch { try_expr, catch_expr } => Expr::TryCatch { try_expr: rb!(try_expr), catch_expr: rb!(catch_expr) },
+        Expr::Collect { generator } => Expr::Collect { generator: rb!(generator) },
+        Expr::Negate { operand } => Expr::Negate { operand: rb!(operand) },
+        Expr::Alternative { primary, fallback } => Expr::Alternative { primary: rb!(primary), fallback: rb!(fallback) },
+        Expr::Reduce { source, init, var_index, acc_index, update } => Expr::Reduce {
+            source: rb!(source), init: rb!(init), var_index: *var_index, acc_index: *acc_index, update: rb!(update),
+        },
+        Expr::Foreach { source, init, var_index, acc_index, update, extract } => Expr::Foreach {
+            source: rb!(source), init: rb!(init), var_index: *var_index, acc_index: *acc_index,
+            update: rb!(update), extract: extract.as_ref().map(|e| rb!(e)),
+        },
+        Expr::ObjectConstruct { pairs } => Expr::ObjectConstruct {
+            pairs: pairs.iter().map(|(k, v)| (r!(k), r!(v))).collect(),
+        },
+        Expr::Recurse { input_expr } => Expr::Recurse { input_expr: rb!(input_expr) },
+        Expr::Range { from, to, step } => Expr::Range {
+            from: rb!(from), to: rb!(to), step: step.as_ref().map(|s| rb!(s)),
+        },
+        Expr::Update { path_expr, update_expr } => Expr::Update { path_expr: rb!(path_expr), update_expr: rb!(update_expr) },
+        Expr::Assign { path_expr, value_expr } => Expr::Assign { path_expr: rb!(path_expr), value_expr: rb!(value_expr) },
+        Expr::Mutate { path_expr, value_expr, kind } => Expr::Mutate {
+            path_expr: rb!(path_expr), value_expr: rb!(value_expr), kind: *kind,
+        },
+        Expr::PathExpr { expr: e } => Expr::PathExpr { expr: rb!(e) },
+        Expr::SetPath { path, value } => Expr::SetPath { path: rb!(path), value: rb!(value) },
+        Expr::GetPath { path } => Expr::GetPath { path: rb!(path) },
+        Expr::DelPaths { paths } => Expr::DelPaths { paths: rb!(paths) },
+        Expr::StringInterpolation { parts } => Expr::StringInterpolation {
+            parts: parts.iter().map(|p| match p {
+                StringPart::Literal(s) => StringPart::Literal(s.clone()),
+                StringPart::Expr(e) => StringPart::Expr(r!(e)),
+            }).collect(),
+        },
+        Expr::Limit { count, generator } => Expr::Limit { count: rb!(count), generator: rb!(generator) },
+        Expr::While { cond, update } => Expr::While { cond: rb!(cond), update: rb!(update) },
+        Expr::Until { cond, update } => Expr::Until { cond: rb!(cond), update: rb!(update) },
+        Expr::Repeat { update } => Expr::Repeat { update: rb!(update) },
+        Expr::AllShort { generator, predicate } => Expr::AllShort { generator: rb!(generator), predicate: rb!(predicate) },
+        Expr::AnyShort { generator, predicate } => Expr::AnyShort { generator: rb!(generator), predicate: rb!(predicate) },
+        Expr::Label { var_index, body } => Expr::Label { var_index: *var_index, body: rb!(body) },
+        Expr::Break { var_index, value } => Expr::Break { var_index: *var_index, value: rb!(value) },
+        Expr::Error { msg } => Expr::Error { msg: msg.as_ref().map(|m| rb!(m)) },
+        Expr::Format { name, expr: e } => Expr::Format { name: name.clone(), expr: rb!(e) },
+        Expr::ClosureOp { op, input_expr, key_expr } => Expr::ClosureOp {
+            op: *op, input_expr: rb!(input_expr), key_expr: rb!(key_expr),
+        },
+        Expr::CallBuiltin { name, args } => Expr::CallBuiltin {
+            name: name.clone(), args: args.iter().map(|a| r!(a)).collect(),
+        },
+        Expr::Slice { expr: e, from, to } => Expr::Slice {
+            expr: rb!(e), from: from.as_ref().map(|f| rb!(f)), to: to.as_ref().map(|t| rb!(t)),
+        },
+        Expr::Debug { expr: e } => Expr::Debug { expr: rb!(e) },
+        Expr::Stderr { expr: e } => Expr::Stderr { expr: rb!(e) },
+        Expr::RegexTest { input_expr, re, flags } => Expr::RegexTest { input_expr: rb!(input_expr), re: rb!(re), flags: rb!(flags) },
+        Expr::RegexMatch { input_expr, re, flags } => Expr::RegexMatch { input_expr: rb!(input_expr), re: rb!(re), flags: rb!(flags) },
+        Expr::RegexCapture { input_expr, re, flags } => Expr::RegexCapture { input_expr: rb!(input_expr), re: rb!(re), flags: rb!(flags) },
+        Expr::RegexScan { input_expr, re, flags } => Expr::RegexScan { input_expr: rb!(input_expr), re: rb!(re), flags: rb!(flags) },
+        Expr::RegexSub { input_expr, re, tostr, flags } => Expr::RegexSub { input_expr: rb!(input_expr), re: rb!(re), tostr: rb!(tostr), flags: rb!(flags) },
+        Expr::RegexGsub { input_expr, re, tostr, flags } => Expr::RegexGsub { input_expr: rb!(input_expr), re: rb!(re), tostr: rb!(tostr), flags: rb!(flags) },
+        Expr::AlternativeDestructure { alternatives } => Expr::AlternativeDestructure {
+            alternatives: alternatives.iter().map(|a| r!(a)).collect(),
+        },
+        Expr::Memoize { slot_id, key, body } => Expr::Memoize {
+            slot_id: *slot_id, key: key.as_ref().map(|k| rb!(k)), body: rb!(body),
+        },
+        Expr::LoadVar { .. } | Expr::Input | Expr::Empty | Expr::Not | Expr::Env
+        | Expr::Builtins | Expr::ReadInput | Expr::ReadInputs | Expr::ModuleMeta
+        | Expr::GenLabel | Expr::Literal(_) | Expr::Loc { .. } => expr.clone(),
+    }
+}
+
 /// COW substitution: returns None if no param vars were found (no changes needed).
 /// Avoids deep-cloning unchanged subtrees.
 fn subst_cow(expr: &Expr, pv: &[u16], args: &[Expr]) -> Option<Expr> {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -19,6 +19,12 @@ struct Scope {
     next_var: u16,
     /// Compiled function bodies.
     compiled_funcs: Vec<CompiledFunc>,
+    /// Captured outer filter-parameter slots per func_id. A nested `def` that
+    /// references an enclosing def's filter parameter is lambda-lifted: the
+    /// captured slot becomes a hidden trailing parameter, and every call site
+    /// forwards `LoadVar{captured_slot}`. Parse-time only — `eval` just sees
+    /// the extra args/param_vars. See #714.
+    func_captures: std::collections::HashMap<usize, Vec<u16>>,
     /// Next available memoize slot id. Each lexical occurrence of `memoize(...)`
     /// gets a unique slot; the Env allocates one cache map per slot.
     next_memo_slot: u32,
@@ -31,6 +37,7 @@ impl Scope {
             funcs: Vec::new(),
             next_var: 0,
             compiled_funcs: Vec::new(),
+            func_captures: std::collections::HashMap::new(),
             next_memo_slot: 0,
         }
     }
@@ -92,6 +99,29 @@ impl Scope {
         self.funcs.iter().rev()
             .find(|(n, _, na)| n == name && *na == nargs)
             .map(|(_, id, _)| *id)
+    }
+
+    /// Record the captured outer filter-param slots for a lambda-lifted func.
+    fn set_func_captures(&mut self, func_id: usize, captures: Vec<u16>) {
+        if !captures.is_empty() {
+            self.func_captures.insert(func_id, captures);
+        }
+    }
+
+    /// Trailing capture args (`LoadVar{slot}` per captured slot) a call to
+    /// `func_id` must forward, in declared order. Empty for ordinary funcs.
+    fn func_capture_args(&self, func_id: usize) -> Vec<Expr> {
+        self.func_captures.get(&func_id)
+            .map(|caps| caps.iter().map(|&v| Expr::LoadVar { var_index: v }).collect())
+            .unwrap_or_default()
+    }
+
+    /// Build a `FuncCall`, appending any lambda-lifted capture args after the
+    /// caller-supplied `args` (#714). Use at every call-emission site so
+    /// captures are forwarded uniformly.
+    fn make_funccall(&self, func_id: usize, mut args: Vec<Expr>) -> Expr {
+        args.extend(self.func_capture_args(func_id));
+        Expr::FuncCall { func_id, args }
     }
 
     fn save_func_scope(&self) -> usize {
@@ -905,6 +935,46 @@ impl Parser {
                 value: Box::new(Expr::LoadVar { var_index: filter_var }),
                 body: Box::new(body),
             };
+        }
+
+        // Lambda-lift captured enclosing filter parameters (#714). A filter
+        // parameter is passed by beta-substitution into the def's body, but a
+        // *nested* def's body lives in a separate func slot the outer
+        // substitution never reaches — so a nested reference to an enclosing
+        // filter param would resolve to an unbound slot (`null`). Promote each
+        // captured enclosing filter param to a hidden trailing parameter:
+        // rewrite the body to read the hidden slot, forward it through the
+        // def's own recursive self-calls, and record it so every call site
+        // (handled in the call-emission paths) passes the captured slot along.
+        // Value params and let-bindings already work via the env, so only
+        // `\x00fparam:`-prefixed (filter) params from the enclosing scope need
+        // this.
+        let mut captured: Vec<u16> = Vec::new();
+        for (vname, vidx) in self.scope.vars[..saved_vars].iter() {
+            if vname.starts_with('\x00')
+                && vname.starts_with("\x00fparam:")
+                && !param_vars.contains(vidx)
+                && !captured.contains(vidx)
+                && crate::eval::expr_uses_var(&body, *vidx)
+            {
+                captured.push(*vidx);
+            }
+        }
+        let mut param_vars = param_vars;
+        if !captured.is_empty() {
+            let hidden: Vec<u16> = captured.iter()
+                .map(|c| self.scope.alloc_var(&format!("\x00fparam:cap:{}", c)))
+                .collect();
+            let hidden_loadvars: Vec<Expr> = hidden.iter()
+                .map(|&h| Expr::LoadVar { var_index: h })
+                .collect();
+            // References to the captured params become the hidden params.
+            body = crate::eval::substitute_params(&body, &captured, &hidden_loadvars);
+            // Forward the hidden params through the def's recursive self-calls
+            // (emitted as plain calls before the captures were known).
+            body = crate::eval::append_call_args(&body, func_id, &hidden_loadvars);
+            param_vars.extend(hidden);
+            self.scope.set_func_captures(func_id, captured);
         }
 
         // Update the function body (replacing placeholder)
@@ -2966,7 +3036,7 @@ impl Parser {
     fn compile_builtin_noargs(&self, name: &str) -> Result<Expr> {
         // User-defined 0-arg functions shadow same-named builtins.
         if let Some(func_id) = self.scope.lookup_func(name, 0) {
-            return Ok(Expr::FuncCall { func_id, args: vec![] });
+            return Ok(self.scope.make_funccall(func_id, vec![]));
         }
         match name {
             "not" => Ok(Expr::Not),
@@ -3187,7 +3257,8 @@ impl Parser {
             _ => {
                 // Check user-defined functions
                 if let Some(func_id) = self.scope.lookup_func(name, 0) {
-                    Ok(Expr::FuncCall { func_id, args: vec![] })
+                    // Forward any lambda-lifted capture params (#714).
+                    Ok(self.scope.make_funccall(func_id, vec![]))
                 } else {
                     // Check for filter parameter reference (bare identifier like `x` in `def f(x):`)
                     let fparam_name = format!("\x00fparam:{}", name);
@@ -3208,7 +3279,8 @@ impl Parser {
     fn compile_funcall(&mut self, name: &str, args: Vec<Expr>) -> Result<Expr> {
         // User-defined functions shadow builtins (matches jq semantics).
         if let Some(func_id) = self.scope.lookup_func(name, args.len()) {
-            return Ok(Expr::FuncCall { func_id, args });
+            // Append any lambda-lifted capture params after the user args (#714).
+            return Ok(self.scope.make_funccall(func_id, args));
         }
         match (name, args.len()) {
             // Standard library functions
@@ -4112,7 +4184,7 @@ impl Parser {
             _ => {
                 // Check user-defined functions
                 if let Some(func_id) = self.scope.lookup_func(name, args.len()) {
-                    Ok(Expr::FuncCall { func_id, args })
+                    Ok(self.scope.make_funccall(func_id, args))
                 } else {
                     bail!("unknown function '{}' with {} args", name, args.len())
                 }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -10520,3 +10520,28 @@ recurse(empty)
 [recurse(empty)]
 {"a":1}
 [{"a":1}]
+
+# Issue #714: nested zero-arg def captures the outer def's filter parameter.
+def g(f): def w: f; w; g(10)
+5
+10
+
+# Issue #714: captured filter param sees the caller's input.
+def g(f): def w: f; w; g(.+1)
+5
+6
+
+# Issue #714: nested def using map(f) captures f (walk pattern).
+def outer(f): def m: map(f); m; outer(.+1)
+[1,2,3]
+[2,3,4]
+
+# Issue #714: doubly-nested def captures the outer filter param.
+def g(f): def w: def u: f; u; w; g(10)
+5
+10
+
+# Issue #714: recursive nested def with captured filter param (user-defined walk).
+def mywalk(f): def w: if type=="object" then map_values(w) elif type=="array" then map(w) else . end | f; w; mywalk(if type=="number" then .+1 else . end)
+{"a":[1,2],"b":3}
+{"a":[2,3],"b":4}


### PR DESCRIPTION
## Summary

A filter parameter of an outer `def` was dropped when referenced from a nested `def` — the inner function saw `null`:

```
$ echo 5 | jq-jit -c 'def g(f): def w: f; w; g(10)'
null          # jq: 10
```

This also broke user-defined `walk`-style recursion (`def outer(f): def m: map(f); m`).

## Cause

Filter params are passed by **beta-substitution** into a def's body. A *nested* def's body lives in a separate func slot that the outer substitution never reaches, so a nested reference to an enclosing filter param resolved to an unbound slot. (Value params `$x` and let-bindings already work — they bind through the env.)

## Fix — lambda lifting

Each captured enclosing filter param is promoted to a hidden trailing parameter of the nested def:

- detect captured `\x00fparam:` slots referenced in the body but not the def's own params;
- rewrite the body to read fresh hidden slots, and forward them through the def's **own recursive self-calls** via `append_call_args` (exhaustive match — a new `Expr` variant forces review);
- record the captures so every call-emission site appends them as trailing args (`Scope::make_funccall`, used at all four call sites).

The hidden slots ride the existing substitution machinery, so the outer call's argument flows transparently into the nested body — including through recursion.

## Verification

Matches jq for: 0-arg / n-arg nested capture, doubly-nested, `map(f)`, multi-capture, capture inside reduce/foreach/path/try/if, mixed value+filter params, and **recursive nested capture (user-defined `walk`)**. Non-capturing defs and ordinary recursion (`fib`) are unchanged.

## Tests

- 5 regression cases in `tests/regression.test`
- `cargo build --release` zero warnings; `cargo test --release` all green (official + regression + jit/interpreter self-diff + metamorphic)
- `bench/comprehensive.sh`: no regression (lifting is parse-time; non-capturing calls have zero runtime overhead)

Closes #714

🤖 Generated with [Claude Code](https://claude.com/claude-code)