### PR TITLE
fix: make break catchable by try/catch and ? (#715)

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -118,6 +118,16 @@ impl std::fmt::Display for BreakError {
 }
 impl std::error::Error for BreakError {}
 
+/// The value a `try ... catch` / `?` receives when it catches a `break`
+/// signal. jq surfaces the break as `{"__jq": <label id>}`; matching the
+/// shape lets `catch`/`?` handle it like any other error. Only the shape is
+/// guaranteed — the id is an internal counter and need not match jq's. #715.
+fn break_catch_value(label_id: u64) -> Value {
+    let mut obj = crate::value::new_objmap();
+    obj.insert("__jq".into(), Value::number(label_id as f64));
+    Value::object_from_map(obj)
+}
+
 /// Cached output sequence for a single memoize call site.
 ///
 /// The vast majority of memoize use cases — fib, Collatz, totient, etc. —
@@ -2149,7 +2159,14 @@ pub fn eval(
                 Ok(cont) => Ok(cont),
                 Err(e) if cb_error.get() => Err(e),
                 Err(e) => {
-                    if e.downcast_ref::<BreakError>().is_some() { return Err(e); }
+                    // jq makes `break` a catchable signal: a `try`/`?` in the
+                    // unwind path catches it (surfacing `{"__jq": id}`) and
+                    // execution continues — only an uncaught break reaches its
+                    // label. A break that came from the downstream callback is
+                    // excluded above by `cb_error`. See #715.
+                    if let Some(be) = e.downcast_ref::<BreakError>() {
+                        return eval(catch_expr, break_catch_value(be.0), env, cb);
+                    }
                     let msg = format!("{}", e);
                     // halt / halt_error are non-recoverable: jq lets them
                     // propagate past `try ... catch` so the process exits with
@@ -5019,7 +5036,11 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
             match result {
                 Ok(cont) => Ok(cont),
                 Err(e) => {
-                    if e.downcast_ref::<BreakError>().is_some() { return Err(e); }
+                    // A caught `break` surfaces as `{"__jq": id}`, mirroring the
+                    // value-mode handler (#715).
+                    if let Some(be) = e.downcast_ref::<BreakError>() {
+                        return eval(catch_expr, break_catch_value(be.0), env, cb);
+                    }
                     let msg = format!("{}", e);
                     // halt / halt_error are non-recoverable: jq lets them
                     // propagate past `try ... catch` so the process exits with

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -10545,3 +10545,38 @@ def g(f): def w: def u: f; u; w; g(10)
 def mywalk(f): def w: if type=="object" then map_values(w) elif type=="array" then map(w) else . end | f; w; mywalk(if type=="number" then .+1 else . end)
 {"a":[1,2],"b":3}
 {"a":[2,3],"b":4}
+
+# Issue #715: try catches break, surfacing a value (constant catch).
+label $out | try break $out catch "c"
+null
+"c"
+
+# Issue #715: postfix ? swallows break and execution continues.
+[label $out | (break $out)?, 1]
+null
+[1]
+
+# Issue #715: a try inside the label catches break; the loop continues.
+[label $out | range(5) | try (if .==2 then break $out else . end) catch "x"]
+null
+[0,1,"x",3,4]
+
+# Issue #715: emitted values before the break survive; the break is caught.
+[label $out | try (1, break $out, 2) catch "c"]
+null
+[1,"c"]
+
+# Issue #715: a caught break is an object (shape {"__jq": id}).
+[label $out | try break $out catch (type, has("__jq"))]
+null
+["object",true]
+
+# Issue #715: // does NOT catch break (it reaches the label).
+[label $out | (break $out) // "alt"]
+null
+[]
+
+# Issue #715: an uncaught break still terminates the label normally.
+[label $o | range(5) | if .==2 then break $o else . end]
+null
+[0,1]


### PR DESCRIPTION
## Summary

jq treats `break $label` as a **catchable** control signal — a `try`/`?` in the unwind path catches it and execution continues; only an uncaught break reaches its label. jq-jit re-raised the break past the handler:

```
$ echo null | jq-jit -c 'label $out | try break $out catch "c"'
(no output)                      # jq: "c"
$ echo null | jq-jit -c 'label $out | (break $out)?, 1'
(no output)                      # jq: 1
```

## Fix

In both the value-mode and path-mode `TryCatch` handlers, catch a `BreakError` instead of re-raising it, running the catch with input `{"__jq": id}` (shape matches jq; the id is an internal counter).

The value-mode handler already excludes breaks that originate **downstream** of the `try` (via its `cb_error` flag), so only a break raised inside the `try` body is caught — matching jq, including the "try inside a label catches the break and the loop continues" case:

```
[label $out | range(5) | try (if .==2 then break $out else . end) catch "x"]
  →  [0,1,"x",3,4]
```

`//`, the top-level break safety nets, and the `label`/`break` handlers are untouched, so `//` still does **not** catch break and uncaught breaks still terminate their label. The JIT lowers `label`/`break` filters through the interpreter, so JIT and interpreter stay consistent (self-diff green).

## Tests

- 7 regression cases (catch constant / `?` swallow / loop-continue / pre-break values / caught-object shape / `//` non-catch / uncaught-break)
- `cargo build --release` zero warnings; `cargo test --release` all green (official + regression + self-diff)
- `bench/comprehensive.sh`: try-catch / label-break unchanged

Closes #715

🤖 Generated with [Claude Code](https://claude.com/claude-code)