### PR TITLE
fix: treat assignment forms as input-dependent in fast path

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -2127,8 +2127,14 @@ fn contains_input(expr: &crate::ir::Expr) -> bool {
         Expr::Range { from, to, step } => contains_input(from) || contains_input(to) || step.as_ref().map_or(false, |s| contains_input(s)),
         Expr::Limit { count, generator } => contains_input(count) || contains_input(generator),
         Expr::Error { msg } => msg.as_ref().map_or(false, |m| contains_input(m)),
-        Expr::Update { path_expr, update_expr } | Expr::Assign { path_expr, value_expr: update_expr } => contains_input(path_expr) || contains_input(update_expr),
-        Expr::Mutate { path_expr, value_expr, .. } => contains_input(path_expr) || contains_input(value_expr),
+        // Assignment forms (`p = v`, `p |= f`, `p += v`, …) always read the
+        // current input as the document being updated and return it (possibly
+        // modified), regardless of whether the path/value sub-exprs mention
+        // `.`. Classifying e.g. `empty = 9` by its sub-exprs marked it
+        // input-free, so the fast path evaluated it against `null` and emitted
+        // `null` instead of echoing the input unchanged (#716). Same family as
+        // the SetPath/GetPath/PathExpr arm below and eval.rs's #556 fix.
+        Expr::Update { .. } | Expr::Assign { .. } | Expr::Mutate { .. } => true,
         // GetPath/SetPath/DelPaths/PathExpr implicitly operate on the current input
         Expr::GetPath { .. } | Expr::SetPath { .. } | Expr::DelPaths { .. } | Expr::PathExpr { .. } => true,
         // `recurse(f)` always emits the input value first (`def recurse(f):

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -10580,3 +10580,13 @@ null
 [label $o | range(5) | if .==2 then break $o else . end]
 null
 [0,1]
+
+# Issue #716: assignment with an empty LHS path echoes the input unchanged.
+empty = 9
+{"a":1}
+{"a":1}
+
+# Issue #716: empty-path update (|=) likewise returns the input, not null.
+empty |= 9
+{"a":1}
+{"a":1}


### PR DESCRIPTION
## Problem

`empty = 9` (and any assignment whose path/value sub-expressions don't reference `.`) returned `null` instead of echoing the input document unchanged:

```
$ echo '{"a":1}' | jq-jit -c 'empty = 9'
null            # jq: {"a":1}
$ echo '{"a":1}' | jq-jit -c 'empty |= 9'
null            # jq: {"a":1}
```

## Root cause

`detect_input_free_output`'s `contains_input` helper classified `Update`/`Assign`/`Mutate` by their path/value sub-expressions. With both sub-exprs input-free, the assignment was deemed input-free, evaluated against `null`, and emitted `null`.

But assignment **always** reads the current input as the document being updated and returns it (possibly modified) — independent of whether the path/value mention `.`. This is the same reasoning behind the adjacent `SetPath`/`GetPath`/`PathExpr` arm (already `=> true`) and the `eval.rs` `expr_uses_outer_input` #556 fix.

## Fix

Mark `Update`/`Assign`/`Mutate` input-dependent so they fall through to the real evaluator instead of the input-free precompute fast path.

## Verification

- `empty = 9`, `empty |= 9`, `empty += 1`, `.a = empty`, `(.x | select(false)) = 5` now all match jq 1.8.1.
- Regression tests added to `tests/regression.test`.
- Full suite green (official 509 + regression); benchmark shows no regression vs `docs/benchmark-history.md`.

Closes #716

🤖 Generated with [Claude Code](https://claude.com/claude-code)