### PR TITLE
fix: iterate setpath value/path generators instead of last-value

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -2840,9 +2840,15 @@ pub fn eval(
         }
 
         Expr::SetPath { path, value } => {
-            if !expr_uses_outer_input(path) && !expr_uses_outer_input(value) {
-                // path and value don't reference `.` — avoid cloning input so
-                // Rc refcount stays 1 and rt_setpath_mut can mutate in-place.
+            if !expr_uses_outer_input(path) && !expr_uses_outer_input(value)
+                && path.is_single_output() && value.is_single_output() {
+                // path and value don't reference `.` and each yields exactly one
+                // output — avoid cloning input so Rc refcount stays 1 and
+                // rt_setpath_mut can mutate in-place. Multi-output or `empty`
+                // generators must take the iterating branch below: `setpath(p; g)`
+                // emits one result per `g` value (and nothing for `empty`); the
+                // last-value-wins shortcut here collapsed `(1,2)` to `2` and
+                // turned `empty` into `null` (#717).
                 let pv = {
                     let mut r = Value::Null;
                     eval(path, Value::Null, env, &mut |v| { r = v; Ok(true) })?;
@@ -2861,8 +2867,11 @@ pub fn eval(
                     cb(crate::runtime::rt_setpath(&base, &pv, &val)?)
                 }
             } else {
-                eval(path, input.clone(), env, &mut |pv| {
-                    eval(value, input.clone(), env, &mut |v| {
+                // jq iterates the value generator in the outer loop and the
+                // path generator in the inner loop: `setpath((["a"],["b"]); (1,2))`
+                // yields a/1, b/1, a/2, b/2. Match that nesting order.
+                eval(value, input.clone(), env, &mut |v| {
+                    eval(path, input.clone(), env, &mut |pv| {
                         cb(crate::runtime::rt_setpath(&input, &pv, &v)?)
                     })
                 })

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -10590,3 +10590,18 @@ empty = 9
 empty |= 9
 {"a":1}
 {"a":1}
+
+# Issue #717: setpath iterates its value generator (one output per value).
+[setpath([]; (1,2))]
+null
+[1,2]
+
+# Issue #717: setpath with an empty value generator emits nothing.
+[setpath(["a"]; empty)]
+{}
+[]
+
+# Issue #717: value is the outer loop, path the inner loop.
+[setpath((["a"],["b"]); (1,2))]
+{}
+[{"a":1},{"b":1},{"a":2},{"b":2}]


### PR DESCRIPTION
## Problem

`setpath`'s in-place fast path collapsed a multi-output value generator to its last output and turned an `empty` value into `null`:

```
$ echo null | jq-jit -c 'setpath([]; (1,2))'
2               # jq: 1 / 2
$ echo '{}' | jq-jit -c 'setpath(["a"]; empty)'
{"a":null}      # jq: (no output)
```

## Root cause

The `Expr::SetPath` fast path (taken when neither argument references `.`) evaluated both path and value with a last-value-wins closure `|v| { r = v; Ok(true) }`, keeping only the final generator output (or `null` for `empty`).

## Fix

- Restrict the in-place fast path to statically single-output path **and** value expressions (`is_single_output`). Multi-output or `empty` arguments fall through to the iterating branch.
- Fix the iterating branch's loop nesting to match jq: **value in the outer loop, path in the inner loop**, so `setpath((["a"],["b"]); (1,2))` yields `a/1, b/1, a/2, b/2`.

## Verification

Matches jq 1.8.1 for: `setpath([]; (1,2))`, `setpath(["a"]; empty)`, `setpath(["a"]; 5)`, multi×multi (`(["a"],["b"]); (1,2)`), 3×2 / 2×3 cardinalities, `range(3)`, and input-referencing values (`setpath(["x"]; (.x, .x+10))`).

- Regression tests added to `tests/regression.test`.
- Full suite green (official 509 + regression); benchmark shows no regression vs `docs/benchmark-history.md`.

Closes #717

🤖 Generated with [Claude Code](https://claude.com/claude-code)