### PR TITLE
fix: flatten fully for a fractional depth instead of flooring

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -69,7 +69,13 @@ pub fn call_builtin(name: &str, args: &[Value]) -> Result<Value> {
             match &args[1] {
                 Value::Num(n, _) => {
                     if *n < 0.0 { bail!("flatten depth must not be negative"); }
-                    rt_flatten(&args[0], Some(*n as usize))
+                    // An integer depth flattens that many levels, but a fractional
+                    // depth flattens *fully* (every remaining level) rather than
+                    // flooring: jq's stdlib reduce never reaches a clean stop at a
+                    // non-integer `$d`, so it keeps recursing. `flatten(0.5)` on
+                    // `[[1]]` → `[1]`, not `[[1]]`. #720 (cf. #537 non-numeric).
+                    let depth = if *n == n.floor() { Some(*n as usize) } else { None };
+                    rt_flatten(&args[0], depth)
                 }
                 Value::Null | Value::True | Value::False => {
                     bail!("flatten depth must not be negative");

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -10625,3 +10625,18 @@ null
 [reduce .x as $i ((0,100); . + $i)]
 {"x":5}
 [5,100]
+
+# Issue #720: a fractional flatten depth flattens fully, not floored.
+flatten(0.5)
+[[1]]
+[1]
+
+# Issue #720: fractional depth flattens every remaining level.
+flatten(1.5)
+[[[[1]]]]
+[1]
+
+# Issue #720: an integer depth still flattens exactly that many levels.
+flatten(1)
+[[[1]]]
+[[1]]


### PR DESCRIPTION
## Problem

`flatten($d)` cast the depth to `usize`, flooring a fractional depth and flattening fewer levels (or none) than jq:

```
$ echo '[[1]]' | jq-jit -c 'flatten(0.5)'
[[1]]           # jq: [1]
```

## Root cause

`runtime.rs`'s `flatten` dispatch did `rt_flatten(&args[0], Some(*n as usize))`, truncating `0.5` → `0` (no flatten).

## Fix

jq's stdlib `flatten` recurses while `$d > 0`, subtracting 1 per level; a non-integer depth never lands on a clean stop, so it keeps recursing and flattens **every remaining level**. Map an integer depth to that many levels (unchanged) and any fractional depth to a full flatten (`None`).

## Verification (matches jq 1.8.1 across all cases tested)

| filter | input | output |
|---|---|---|
| `flatten(0.5)` | `[[1]]` | `[1]` |
| `flatten(1.5)` | `[[[[1]]]]` | `[1]` |
| `flatten(1)` | `[[[1]]]` | `[[1]]` (unchanged) |
| `flatten(-0.5)` | any | error "flatten depth must not be negative" (unchanged) |

Exhaustively diffed against jq over depths `{-1,-0.5,0,0.1,0.5,0.9,1,1.1,1.5,2,2.5,3,1e9}` × several inputs: 0 divergences. Distinct from #537 (non-numeric depth).

- Regression tests added to `tests/regression.test`.
- Full suite green (official 509 + regression); `flatten(500K)` benchmark matches `docs/benchmark-history.md`.

Closes #720

🤖 Generated with [Claude Code](https://claude.com/claude-code)