### PR TITLE
fix: match jq dtoa fixed-vs-scientific choice for large doubles

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -5539,21 +5539,35 @@ pub fn push_jq_number_str(buf: &mut String, n: f64) {
         }
     }
 
-    // Use Rust's shortest-representation (like jq's jvp_dtoa)
+    // jq's dtoa chooses fixed vs scientific from the *shortest* decimal: it
+    // emits exponential form iff `decpt <= -4 || decpt > sigdigits + 15`,
+    // where `decpt` is the decimal-point position (1 past the leading digit's
+    // place) and `sigdigits` is the count of significant digits. Rust's
+    // `Display` never uses scientific notation, so `s` is always the
+    // fixed-point form jq's dtoa would print.
     let s = format!("{}", n);
     let abs = n.abs();
 
-    // For very small numbers (abs < 1e-4), always use scientific notation (matching %g)
+    // Small side: `decpt <= -4` is exactly `abs < 1e-4` for finite nonzero
+    // values, so this matches jq without parsing the digits.
     if abs != 0.0 && abs < 1e-4 {
         buf.push_str(&format_as_scientific_lowercase(n));
         return;
     }
 
-    // For large numbers: compare fixed vs scientific length, prefer shorter
+    // Large side: below 1e16 jq is always fixed-point (`decpt <= 16 <=
+    // sigdigits + 15`); at or above 1e16 apply `decpt > sigdigits + 15`. This
+    // keeps large high-precision values like `1.2345678e22` fixed
+    // (`12345678000000000000000`) while `1e22` — fewer significant digits —
+    // stays scientific (`1e+22`). A magnitude-only threshold mis-classified
+    // high-precision large values. #721 (cf. #143/#236/#415).
     if abs >= 1e16 {
-        let sci = format_as_scientific_lowercase(n);
-        if sci.len() < s.len() {
-            buf.push_str(&sci);
+        let exp_str = format!("{:e}", n); // shortest sci form, e.g. "1.2345678e22"
+        let (mantissa, exp) = exp_str.split_once('e').expect("LowerExp always emits 'e'");
+        let exp: i32 = exp.parse().expect("LowerExp exponent is an integer");
+        let sigdigits = mantissa.bytes().filter(u8::is_ascii_digit).count() as i32;
+        if exp + 1 > sigdigits + 15 {
+            buf.push_str(&format_as_scientific_lowercase(n));
             return;
         }
     }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -10640,3 +10640,18 @@ flatten(1.5)
 flatten(1)
 [[[1]]]
 [[1]]
+
+# Issue #721: a large high-precision finite double prints in fixed-point.
+.+0
+1.2345678e22
+12345678000000000000000
+
+# Issue #721: a low-precision large double still prints in scientific form.
+.+0
+1e22
+1e+22
+
+# Issue #721: a value just under 1e16 prints fixed.
+.+0
+123456789012345680
+123456789012345680


### PR DESCRIPTION
## Problem

A large but finite double printed in scientific notation where jq uses fixed-point:

```
$ echo '1.2345678e22' | jq-jit -c '.+0'
1.2345678e+22   # jq: 12345678000000000000000
```

(`.+0` forces a fresh f64 so the value goes through f64 formatting rather than literal-repr preservation.)

## Root cause

`push_jq_number_str` chose scientific form for `abs >= 1e16` by comparing string lengths — a magnitude-only heuristic that ignores significant-digit count.

## Fix

jq's dtoa chooses the form from the **shortest** decimal: scientific iff `decpt <= -4 || decpt > sigdigits + 15`, where `decpt` is the decimal-point position and `sigdigits` the significant-digit count.

- Small side (`decpt <= -4`) is exactly `abs < 1e-4` — already handled.
- Large side: apply `decpt > sigdigits + 15`. So `1.2345678e22` (8 sig digits, `decpt 23`, `23 ≯ 23`) stays fixed-point, while `1e22` (1 sig digit, `23 > 16`) stays scientific.

Below 1e16 the result is always fixed-point, so the common path keeps its single `format!` — no perf cost.

## Verification

- Repro fixed; `1e22`, `1e16`, `1e-5`, `123456789012345680`, etc. unchanged.
- Fuzzed 223 mantissa×exponent combinations (exponents −310…308) against jq 1.8.1: **0 divergences**.
- Regression tests added. Full suite green; float/number-heavy benchmarks match `docs/benchmark-history.md`.

Distinct from #143 (E-form normalization) and #236/#415 (literal preservation through tojson).

Closes #721

🤖 Generated with [Claude Code](https://claude.com/claude-code)