### PR TITLE
fix: map jq `m` regex flag to dotall (Oniguruma), not `s`

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2993,9 +2993,15 @@ fn apply_regex_flags(pattern: &str, flags: &Value) -> Result<(String, bool)> {
     let mut global = false;
     for ch in flags_str.chars() {
         match ch {
-            'i' | 'x' | 's' => inline.push(ch),
+            'i' | 'x' => inline.push(ch),
+            // In jq's engine (Oniguruma) `m` is dotall — `.` matches newline —
+            // which the underlying regex spells `s`. jq's own `s` (single-line
+            // anchors) is already this engine's default, so it needs no inline
+            // flag. The two were mapped PCRE-style (`s` = dotall), i.e. swapped.
+            // `"a\nb" | test("a.b";"m")` must be true, `…;"s"` false. #723.
+            'm' => inline.push('s'),
             'g' => global = true,
-            // l, m, n, p have no inline equivalent in onig — accepted but ignored.
+            // l, n, p (and jq's `s`) have no inline equivalent here — accepted, ignored.
             _ => {}
         }
     }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -2780,8 +2780,9 @@ true
 {"x":"a\nb"}
 false
 
-# Escape-bearing string with newline-spanning regex: relies on decoded value
-.x | test("a.b"; "s")
+# Escape-bearing string with newline-spanning regex: relies on decoded value.
+# `m` is jq's dotall flag (Oniguruma); `.` matches the decoded newline. #723.
+.x | test("a.b"; "m")
 {"x":"a\nb"}
 true
 
@@ -10670,3 +10671,18 @@ flatten(1)
 del(.[1.5:3.5])
 [1,2,3,4,5]
 [1,5]
+
+# Issue #723: jq `m` flag is dotall (Oniguruma) — `.` matches a newline.
+"a\nb" | test("a.b";"m")
+null
+true
+
+# Issue #723: jq `s` flag is single-line anchors, not dotall.
+"a\nb" | test("a.b";"s")
+null
+false
+
+# Issue #723: dotall `m` lets a match span the newline.
+"a\nb" | [match("a.b";"m").string]
+null
+["a\nb"]


### PR DESCRIPTION
## Problem

The regex flag mapping followed the PCRE convention (`s` = dotall) but jq's engine is Oniguruma, where **`m` is dotall** and `s` selects single-line anchors:

```
$ jq-jit -nc '"a\nb" | test("a.b";"m")'   # false   (jq: true)
$ jq-jit -nc '"a\nb" | test("a.b";"s")'   # true    (jq: false)
```

## Fix

In `apply_regex_flags`, map jq `m` → the underlying engine's dotall inline flag (`s`). jq's own `s` (single-line anchors) is already this engine's default, so it needs no inline flag. `i`/`x` are unchanged. Affects all regex builtins (`test`/`match`/`capture`/`scan`/`splits`/`sub`/`gsub`).

## Verification

55 clean cases across `test`/`match`/`scan`/`sub`/`gsub`/`splits`/`capture` with flags `{"", m, s, ms, i, mi, sx}` and anchor checks: **0 divergences** from jq 1.8.1. Anchoring is unaffected (jq `s` = engine default).

- An existing regression test encoded the old swapped behavior (`test("a.b";"s")` expecting a newline-spanning match); updated to `"m"`, preserving its decoded-value-dotall intent.
- New regression tests added. Full suite green; regex benchmarks within run-to-run noise of `docs/benchmark-history.md` (the change is compile-time flag parsing, not in the match loop).

Closes #723

🤖 Generated with [Claude Code](https://claude.com/claude-code)