### PR TITLE
fix(datetime): render %Z as zone abbreviation in strflocaltime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,6 +456,7 @@ dependencies = [
  "cranelift-native",
  "csv",
  "itoa",
+ "libc",
  "libm",
  "memchr",
  "memmap2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ ryu = "1"
 stacker = "0.1"
 csv = "1"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
+libc = "0.2"
 
 [dev-dependencies]
 proptest = { version = "1", default-features = false, features = ["std", "bit-set"] }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -3629,6 +3629,85 @@ fn civil_wday(year: i32, mon0: i32, mday: i32) -> i32 {
         .unwrap_or(6)
 }
 
+/// Rewrite a strftime format string, replacing each `%Z` specifier with the
+/// literal `abbrev`, escaping any `%` in `abbrev` so chrono treats it as text.
+/// `%%` (a literal percent) is passed through untouched.
+fn splice_local_zone(fmt: &str, abbrev: &str) -> String {
+    let mut out = String::with_capacity(fmt.len());
+    let mut chars = fmt.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '%' {
+            match chars.peek() {
+                Some('Z') => {
+                    chars.next();
+                    for ac in abbrev.chars() {
+                        if ac == '%' {
+                            out.push('%');
+                        }
+                        out.push(ac);
+                    }
+                }
+                Some('%') => {
+                    chars.next();
+                    out.push('%');
+                    out.push('%');
+                }
+                _ => out.push('%'),
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+/// Return the local timezone abbreviation for `epoch` (e.g. `JST`, `UTC`) via
+/// libc, matching jq's `strftime("%Z")`. chrono cannot supply zone names, so we
+/// fill a `tm` with `localtime_r`/`localtime_s` and let libc `strftime` render
+/// `%Z`. Returns `None` on conversion failure; an empty zone name yields
+/// `Some("")`.
+#[cfg(any(unix, windows))]
+fn local_tz_abbrev(epoch: i64) -> Option<String> {
+    use std::ffi::CStr;
+    unsafe {
+        let t = epoch as libc::time_t;
+        let mut tmv: libc::tm = std::mem::zeroed();
+        #[cfg(unix)]
+        {
+            if libc::localtime_r(&t, &mut tmv).is_null() {
+                return None;
+            }
+        }
+        #[cfg(windows)]
+        {
+            if libc::localtime_s(&mut tmv, &t) != 0 {
+                return None;
+            }
+        }
+        let mut buf = [0u8; 64];
+        let n = libc::strftime(
+            buf.as_mut_ptr() as *mut libc::c_char,
+            buf.len(),
+            c"%Z".as_ptr(),
+            &tmv,
+        );
+        // `strftime` returns 0 both on overflow and on a legitimately empty
+        // result; 64 bytes never overflows for a zone name, so treat 0 as "".
+        if n == 0 {
+            return Some(String::new());
+        }
+        CStr::from_ptr(buf.as_ptr() as *const libc::c_char)
+            .to_str()
+            .ok()
+            .map(|s| s.to_string())
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+fn local_tz_abbrev(_epoch: i64) -> Option<String> {
+    None
+}
+
 fn rt_strflocaltime_impl(input: &Value, fmt: &Value) -> Result<Value> {
     let fmt_str = match fmt {
         Value::Str(s) => s.clone(),
@@ -3649,7 +3728,18 @@ fn rt_strflocaltime_impl(input: &Value, fmt: &Value) -> Result<Value> {
             let dt = chrono::DateTime::<chrono::Utc>::from_timestamp(secs, 0)
                 .ok_or_else(|| anyhow::anyhow!("strflocaltime: epoch out of range"))?
                 .with_timezone(&chrono::Local);
-            Ok(Value::from_str(&dt.format(fmt_str.as_str()).to_string()))
+            // chrono renders `%Z` as the numeric offset (e.g. `+09:00`) because
+            // it has no IANA zone database. jq delegates to libc `strftime`,
+            // which emits the zone abbreviation (`JST`, `UTC`, ...). Splice the
+            // libc-provided abbreviation into the format string before chrono
+            // formats it, so every other specifier keeps chrono's behaviour.
+            if fmt_str.contains("%Z") {
+                let abbrev = local_tz_abbrev(secs).unwrap_or_default();
+                let fmt_final = splice_local_zone(fmt_str.as_str(), abbrev.as_str());
+                Ok(Value::from_str(&dt.format(fmt_final.as_str()).to_string()))
+            } else {
+                Ok(Value::from_str(&dt.format(fmt_str.as_str()).to_string()))
+            }
         }
         _ => bail!("strflocaltime/1 requires parsed datetime inputs"),
     }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -31,6 +31,16 @@ unsafe extern "C" {
     fn fmin(x: f64, y: f64) -> f64;
     fn fmod(x: f64, y: f64) -> f64;
     fn nextafter(x: f64, y: f64) -> f64;
+    // Standard C `strftime`, used to render `%Z` as the zone abbreviation in
+    // strflocaltime (#725). The `libc` crate omits this binding on the Windows
+    // MSVC target, so declare it ourselves; it exists in every CRT (glibc,
+    // Apple libc, Windows UCRT).
+    fn strftime(
+        s: *mut libc::c_char,
+        maxsize: usize,
+        format: *const libc::c_char,
+        timeptr: *const libc::tm,
+    ) -> usize;
 }
 
 /// Dispatch a builtin call by name.
@@ -3685,10 +3695,10 @@ fn local_tz_abbrev(epoch: i64) -> Option<String> {
             }
         }
         let mut buf = [0u8; 64];
-        let n = libc::strftime(
+        let n = strftime(
             buf.as_mut_ptr() as *mut libc::c_char,
             buf.len(),
-            c"%Z".as_ptr(),
+            c"%Z".as_ptr() as *const libc::c_char,
             &tmv,
         );
         // `strftime` returns 0 both on overflow and on a legitimately empty

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -1384,6 +1384,14 @@ strftime("%Y")
 # for #113 is covered by the `[]` and `[1900]` cases above, both of
 # which format a zeroed tm_year and are platform-independent.)
 
+# Issue #725: %Z renders the zone abbreviation, not a numeric offset. A
+# broken-down-time array carries no offset so jq treats it as UTC; the
+# localtime variant (strflocaltime on an epoch number) is TZ-dependent and
+# verified manually (TZ=Asia/Tokyo -> "JST", TZ=UTC -> "UTC").
+strftime("%Z")
+[0,0,0,1,0,124,1,0]
+"UTC"
+
 # Issue #114: halt short-circuits but emits already-yielded values
 2, halt, 3
 1

--- a/tests/selfdiff_jit_interp.rs
+++ b/tests/selfdiff_jit_interp.rs
@@ -153,7 +153,7 @@ fn normalize(output: &str) -> String {
 ///   without also flipping `have_decnum` to `true` breaks the upstream
 ///   `tests/official/jq.test` decnum consistency check (#443). Tracked
 ///   in #415.
-const KNOWN_DIVERGENCES: &[usize] = &[2197, 2202, 2207, 2333, 2338];
+const KNOWN_DIVERGENCES: &[usize] = &[2205, 2210, 2215, 2341, 2346];
 
 #[test]
 fn jit_vs_interpreter_self_diff() {

--- a/tests/selfdiff_layers.rs
+++ b/tests/selfdiff_layers.rs
@@ -206,7 +206,7 @@ fn normalize(output: &str) -> String {
 /// (`tests/selfdiff_jit_interp.rs`). The 4-way harness inherits these so
 /// known upstream-tracked divergences do not double-fail. Keep in sync
 /// with `selfdiff_jit_interp.rs::KNOWN_DIVERGENCES`.
-const KNOWN_DIVERGENCES: &[usize] = &[2197, 2202, 2207, 2333, 2338];
+const KNOWN_DIVERGENCES: &[usize] = &[2205, 2210, 2215, 2341, 2346];
 
 #[test]
 fn layer_pinned_self_diff() {


### PR DESCRIPTION
## Summary

`strflocaltime("%Z")` on an epoch number rendered the numeric UTC offset (e.g. `+09:00`) instead of the timezone abbreviation (`JST`, `UTC`, ...). The number branch formats through `chrono::Local`, but chrono has no IANA zone database and renders `%Z` as the offset.

## Fix

Delegate `%Z` rendering to libc `strftime`, matching jq:

- Fill a `tm` via `localtime_r` (unix) / `localtime_s` (windows) for the epoch, render `%Z` to get the zone abbreviation.
- Splice the abbreviation into the format string as a literal before chrono formats the rest (`%%` preserved; any `%` in the abbrev escaped). Every other specifier keeps chrono's existing behaviour.
- The broken-down-time **array** branch is unchanged — it has no offset and is correctly treated as UTC (`%Z` → `UTC`).

`libc` is added as a direct dependency (already present transitively via chrono), consistent with the existing libc FFI used for math-function ULP parity. Works on Win/Mac/Linux.

## Verification

```
$ echo 1700000000 | TZ=UTC        ./jq-jit -c 'strflocaltime("%Z")'   # "UTC"  (was "+00:00")
$ echo 1700000000 | TZ=Asia/Tokyo ./jq-jit -c 'strflocaltime("%Z")'   # "JST"  (was "+09:00")
```

Matched against jq 1.8.1 across `TZ=UTC / Asia/Tokyo / America/New_York / Europe/London`, plus `%%`, `%z %Z`, and DST (`EST` in November) cases.

The regression test pins the deterministic array path (`%Z` → `UTC`); the localtime path is TZ-dependent and verified manually.

## Note

The added regression group shifts the corpus by 8 lines, so the `KNOWN_DIVERGENCES` line-number allowlists in both self-diff harnesses (tracking the pre-existing #415 `tojson`-overflow interpreter divergence) are bumped to match. No behavioural change to that allowlist.

Closes #725

🤖 Generated with [Claude Code](https://claude.com/claude-code)