### PR TITLE
fix(parser): reject constant non-string object keys at compile time

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2640,6 +2640,19 @@ impl Parser {
                 self.advance();
                 let key_expr = self.parse_pipe()?;
                 self.expect(&Token::RParen)?;
+                // A constant non-string key is a compile-time error in jq, so it
+                // cannot be caught by `try`/`?` (#726). Fold the key the way jq's
+                // compiler does and reject a non-string result here, before the
+                // program runs. Runtime-computed keys (`{(.k):2}`) fold to None
+                // and keep their runtime error.
+                if let Some(v) = crate::runtime::const_fold(&key_expr) {
+                    if !matches!(v, crate::value::Value::Str(_)) {
+                        bail!(
+                            "Cannot use {} as object key",
+                            crate::runtime::errdesc_pub(&v)
+                        );
+                    }
+                }
                 self.expect(&Token::Colon)?;
                 let val = self.parse_pipe_nocomma()?;
                 Ok((key_expr, val))

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -677,6 +677,87 @@ pub fn call_builtin(name: &str, args: &[Value]) -> Result<Value> {
 /// Long values are truncated with "..." appended.
 pub fn errdesc_pub(v: &Value) -> String { errdesc(v) }
 
+/// Constant-fold an object-key expression the way jq's compiler does, so a
+/// constant non-string key can be rejected at compile time (#726). jq folds
+/// exactly literals and binary arithmetic/comparison operators whose operands
+/// both fold; it does NOT fold `and`/`or`, the alternative `//`, unary
+/// operators, pipes, commas, indexing, `if`, variables, or anything
+/// input-dependent (those defer to runtime — e.g. `{(-1):2}` and `{(1|.+1):2}`
+/// are runtime errors in jq, not compile errors). A fold whose operation would
+/// error (e.g. `1 + "a"`) returns `None` so the runtime error surfaces
+/// normally. Returns the folded value, or `None` when the expression is not a
+/// compile-time constant under jq's rules.
+pub fn const_fold(expr: &crate::ir::Expr) -> Option<Value> {
+    use crate::ir::{BinOp, Expr, Literal};
+    use std::cmp::Ordering;
+    let bool_val = |b: bool| if b { Value::True } else { Value::False };
+    match expr {
+        Expr::Literal(lit) => Some(match lit {
+            Literal::Null => Value::Null,
+            Literal::True => Value::True,
+            Literal::False => Value::False,
+            Literal::Num(n, repr) => Value::number_opt(*n, repr.clone()),
+            Literal::Str(s) => Value::from_str(s),
+        }),
+        Expr::BinOp { op, lhs, rhs } => {
+            let a = const_fold(lhs)?;
+            let b = const_fold(rhs)?;
+            match op {
+                BinOp::Add => rt_add(&a, &b).ok(),
+                BinOp::Sub => rt_sub(&a, &b).ok(),
+                BinOp::Mul => rt_mul(&a, &b).ok(),
+                BinOp::Div => rt_div(&a, &b).ok(),
+                BinOp::Mod => rt_mod(&a, &b).ok(),
+                BinOp::Eq => Some(bool_val(compare_values(&a, &b) == Ordering::Equal)),
+                BinOp::Ne => Some(bool_val(compare_values(&a, &b) != Ordering::Equal)),
+                BinOp::Lt => Some(bool_val(compare_values(&a, &b) == Ordering::Less)),
+                BinOp::Le => Some(bool_val(compare_values(&a, &b) != Ordering::Greater)),
+                BinOp::Gt => Some(bool_val(compare_values(&a, &b) == Ordering::Greater)),
+                BinOp::Ge => Some(bool_val(compare_values(&a, &b) != Ordering::Less)),
+                // jq compiles `and`/`or` to short-circuiting branches, not a
+                // foldable binary op, so they defer to runtime.
+                BinOp::And | BinOp::Or => None,
+            }
+        }
+        // Array literal: jq folds `[...]` to a constant array when every
+        // element folds (`[]`, `[1,2]`, `[1+1]`, `[1,[2]]`), and defers when
+        // any element is input-dependent or a call (`[.]`, `[range(3)]`).
+        Expr::Collect { generator } => {
+            Some(Value::Arr(std::rc::Rc::new(const_fold_seq(generator)?)))
+        }
+        // Object literal: jq folds `{...}` to a constant object when every key
+        // folds to a string and every value folds (`{}`, `{a:1}`, `{"a":1}`).
+        Expr::ObjectConstruct { pairs } => {
+            let mut obj = new_objmap();
+            for (k, v) in pairs {
+                let key = match const_fold(k)? {
+                    Value::Str(s) => s,
+                    _ => return None,
+                };
+                obj.insert(key, const_fold(v)?);
+            }
+            Some(Value::object_from_map(obj))
+        }
+        _ => None,
+    }
+}
+
+/// Fold a generator expression into a constant sequence of values, for the
+/// array-literal case of [`const_fold`]. Returns `None` if any element is not
+/// a compile-time constant.
+fn const_fold_seq(expr: &crate::ir::Expr) -> Option<Vec<Value>> {
+    use crate::ir::Expr;
+    match expr {
+        Expr::Empty => Some(Vec::new()),
+        Expr::Comma { left, right } => {
+            let mut items = const_fold_seq(left)?;
+            items.extend(const_fold_seq(right)?);
+            Some(items)
+        }
+        other => Some(vec![const_fold(other)?]),
+    }
+}
+
 fn errdesc(v: &Value) -> String {
     // For numbers, prefer the canonical form of the original repr (so
     // `1.0` stays `"1.0"`, `1e30` becomes `"1E+30"` matching jq's decnum

--- a/tests/compile_const_object_key.rs
+++ b/tests/compile_const_object_key.rs
@@ -1,0 +1,95 @@
+//! Issue #726: a constant non-string object key is a *compile-time* error in
+//! jq (rejected before any input is read), so it cannot be intercepted by
+//! `try`/`?`. jq folds the key the way its compiler does — literals, binary
+//! arithmetic/comparison operators, and constant array/object literals — and
+//! rejects a non-string result at compile time. Runtime-computed keys
+//! (`{(.k):2}`), unary operators (`{(-1):2}`), pipes, `and`/`or`, and anything
+//! input- or variable-dependent keep their *runtime* error and parse fine.
+//!
+//! `regression.test` cannot cover this: its harness skips programs that exit 3
+//! (compile error). So assert directly against `Filter::with_options`, which
+//! is what surfaces the compile error in the CLI (`jq: error: ...`, exit 3).
+
+use jq_jit::interpreter::Filter;
+
+fn compile_err(program: &str) -> String {
+    match Filter::with_options(program, &[], false) {
+        Ok(_) => panic!("expected compile error for `{program}`, but it parsed"),
+        Err(e) => e.to_string(),
+    }
+}
+
+fn parses(program: &str) {
+    if let Err(e) = Filter::with_options(program, &[], false) {
+        panic!("expected `{program}` to parse (defer to runtime), got compile error: {e}");
+    }
+}
+
+#[test]
+fn scalar_constant_non_string_keys_are_compile_errors() {
+    assert!(compile_err("{(1):2}").contains("Cannot use number (1) as object key"));
+    assert!(compile_err("{(null):2}").contains("Cannot use null (null) as object key"));
+    assert!(compile_err("{(true):2}").contains("Cannot use boolean (true) as object key"));
+    assert!(compile_err("{(false):2}").contains("Cannot use boolean (false) as object key"));
+}
+
+#[test]
+fn constant_key_compile_error_is_not_catchable() {
+    // The whole point of #726: `try`/`?` must not be able to swallow it,
+    // because the error happens before the program runs.
+    compile_err(r#"try {(1):2} catch "c""#);
+    compile_err("{(1):2}?");
+}
+
+#[test]
+fn folded_binop_constant_keys_are_compile_errors() {
+    // jq constant-folds arithmetic and comparison operators over literals.
+    assert!(compile_err("{(1+1):2}").contains("Cannot use number (2) as object key"));
+    assert!(compile_err("{(2*3):2}").contains("Cannot use number (6) as object key"));
+    assert!(compile_err("{(3-1):2}").contains("Cannot use number (2) as object key"));
+    assert!(compile_err("{(6/2):2}").contains("Cannot use number (3) as object key"));
+    assert!(compile_err("{(7%3):2}").contains("Cannot use number (1) as object key"));
+    assert!(compile_err("{(1+2*3):2}").contains("Cannot use number (7) as object key"));
+    assert!(compile_err("{(1==1):2}").contains("Cannot use boolean (true) as object key"));
+    assert!(compile_err("{(1<2):2}").contains("Cannot use boolean (true) as object key"));
+    assert!(compile_err("{(1>=2):2}").contains("Cannot use boolean (false) as object key"));
+}
+
+#[test]
+fn composite_constant_literal_keys_are_compile_errors() {
+    assert!(compile_err("{([]):2}").contains("Cannot use array ([]) as object key"));
+    assert!(compile_err("{([1,2]):2}").contains("Cannot use array ([1,2]) as object key"));
+    assert!(compile_err("{([1+1]):2}").contains("Cannot use array ([2]) as object key"));
+    assert!(compile_err("{({}):2}").contains("Cannot use object ({}) as object key"));
+    assert!(compile_err("{({a:1}):2}").contains("as object key"));
+}
+
+#[test]
+fn unused_def_with_constant_key_is_a_compile_error() {
+    // jq validates constant keys regardless of reachability.
+    compile_err("def f: {(1):2}; 1");
+}
+
+#[test]
+fn string_constant_keys_parse() {
+    parses(r#"{("a"):2}"#);
+    parses(r#"{("a"+"b"):1}"#); // folds to a string -> allowed
+    parses(r#"{("a"|ascii_upcase):1}"#);
+}
+
+#[test]
+fn runtime_computed_keys_defer_to_runtime() {
+    // These are *runtime* errors in jq (catchable), so they must parse.
+    parses("{(.k):2}");
+    parses("{(-1):2}"); // unary negate is not folded by jq
+    parses("{(1|.+1):2}");
+    parses("{(1,2):3}");
+    parses("{(if true then 1 else 2 end):2}");
+    parses("{(true and false):2}");
+    parses("{(true or false):2}");
+    parses("{(null//5):2}");
+    parses("1 as $x | {($x):2}");
+    parses("{([range(3)]):2}");
+    parses("{([.]):2}");
+    parses("{([1,.]):2}");
+}


### PR DESCRIPTION
## Summary

A constant non-string object key (`{(1):2}`, `{(null):2}`, `{([]):2}`) is a **compile-time** error in jq — rejected before any input is read, so `try`/`?` cannot intercept it. jq-jit deferred the check to runtime, which let `try {(1):2} catch "c"` swallow it and return `"c"`.

## Fix

Fold the computed key the way jq's compiler does and reject a non-string result during parsing, so the error surfaces as a compile error (exit 3, uncatchable). The fold matches jq's exact set:

- literals;
- binary arithmetic/comparison operators over folded operands (`+ - * / % == != < <= > >=`), including nesting (`1+2*3`);
- constant array/object literals whose **every** element folds (`[]`, `[1,2]`, `[1+1]`, `{}`, `{a:1}`).

Everything else defers to runtime exactly as jq does — `and`/`or`, the alternative `//`, unary negate (`{(-1):2}`), pipes, `if`, indexing, variables, function calls (`[range(3)]`), and any input-dependent element (`[.]`, `[1,.]`). A fold that would itself error (`1 + "a"`) defers too. Keys folding to a string (`{("a"+"b"):1}`) stay valid.

## Verification

```
$ echo null | ./jq-jit -c 'try {(1):2} catch "c"'
jq: error: Cannot use number (1) as object key      # exit 3, was "c"
```

Checked against jq 1.8.1 across the full compile / runtime / ok boundary (scalars, folded binops, composites, and every deferred form). `regression.test` can't cover this — its harness skips programs that exit 3 — so coverage lives in a dedicated `tests/compile_const_object_key.rs` (7 tests).

Follow-up to #52. Closes #726

🤖 Generated with [Claude Code](https://claude.com/claude-code)