### PR TITLE
fix(number): parse 16+ digit integers as f64 instead of rejecting them

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -1151,7 +1151,15 @@ pub fn parse_json_num(b: &[u8]) -> Option<f64> {
         return num_str.parse::<f64>().ok();
     }
     if k != b.len() { return None; } // trailing garbage
-    if (k - start) > 15 { return None; }
+    if (k - start) > 15 {
+        // Integers with more than 15 digits overflow / lose precision in the
+        // i64 accumulator above. They are still valid JSON numbers, so parse
+        // them through f64 (jq-jit's number model) rather than rejecting them
+        // as non-numeric — returning None here made comparison fast paths drop
+        // rows for operands > 2^53 (#730).
+        let num_str = unsafe { std::str::from_utf8_unchecked(b) };
+        return num_str.parse::<f64>().ok();
+    }
     Some(if neg { -(n as f64) } else { n as f64 })
 }
 

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -10789,3 +10789,24 @@ del(.c)
 if .b>0 then {y:.c} else 0 end
 {"b":1,"c":1e10}
 {"y":1E+10}
+
+# Issue #730: collect/select comparison fast path keeps rows with operands
+# > 2^53 (parse_json_num no longer rejects 16+ digit integers)
+[.[]|select(.>9007199254740993)]
+[9007199254740992,9007199254740994]
+[9007199254740994]
+
+# Issue #730: large element passes a small-threshold comparison (was dropped)
+[.[]|select(.>5)]
+[9007199254740994,3]
+[9007199254740994]
+
+# Issue #730: >= against a 16-digit threshold keeps the matching element
+[.[]|select(.>=9007199254740994)]
+[9007199254740993,9007199254740994]
+[9007199254740994]
+
+# Issue #730: scalar comparison against a 16-digit field value
+.x>5
+{"x":9007199254740994}
+true


### PR DESCRIPTION
## Summary

`parse_json_num` returned `None` for integer literals with more than 15 digits (the i64 accumulator loses precision past that), so the raw-byte comparison fast paths treated a value like `9007199254740994` as non-numeric and **silently dropped the row** — even for a small threshold such as `select(. > 5)`. The interpreter (which parses through f64) keeps those rows, so the fast path diverged from it and from jq.

```
$ echo '[9007199254740992,9007199254740994]' | ./jq-jit -c '[.[]|select(.>9007199254740993)]'
[9007199254740994]      # was []
$ echo '[9007199254740994,3]' | ./jq-jit -c '[.[]|select(.>5)]'
[9007199254740994]      # was []
```

## Fix

Fall back to the same f64 string-parse the function already uses for `.`/`e`/`E` numbers when the integer exceeds 15 digits. This makes every `parse_json_num`-based fast path (`detect_collect_each_select_cmp` and its `select(. cmp N)` siblings, field comparisons, arithmetic) agree with the interpreter for operands beyond 2^53.

## Notes

- The hot path for ≤15-digit numbers is unchanged — common numeric workloads are unaffected (verified: identical user-CPU before/after).
- This aligns the fast path with jq-jit's **f64 number model**. Decimal resolution beyond 2^53 (e.g. distinguishing `9007199254740993` from `9007199254740992`) is a separate, pre-existing limitation of that model **shared by the interpreter**, out of scope here. Every affected fast path now matches the interpreter exactly.

## Tests

Full suite green (official jq.test + selfdiff + fuzzers + regression). 4 regression cases added.

Closes #730

🤖 Generated with [Claude Code](https://claude.com/claude-code)