### PR TITLE
fix(jit): return [] for split on empty input string

### DIFF
--- a/src/jit.rs
+++ b/src/jit.rs
@@ -7899,7 +7899,10 @@ extern "C" fn jit_rt_call_builtin(dst: *mut Value, name_ptr: *const u8, name_len
         // Fast path: split(sep) — avoid call_builtin dispatch
         if name == "split" && args.len() == 2 {
             if let (Value::Str(s), Value::Str(p)) = (&args[0], &args[1]) {
-                let parts: Vec<Value> = if p.is_empty() {
+                let parts: Vec<Value> = if s.is_empty() {
+                    // jq: "" | split(sep) => [] for any sep (matches rt_split)
+                    Vec::new()
+                } else if p.is_empty() {
                     if s.is_ascii() {
                         (0..s.len()).map(|i| Value::from_str(&s.as_str()[i..i+1])).collect()
                     } else {

--- a/tests/split_empty_input_null.rs
+++ b/tests/split_empty_input_null.rs
@@ -1,0 +1,51 @@
+//! Issue #731: `"" | split(sep)` must return `[]` (an empty array) for an
+//! empty input string, matching jq, even when the program runs through the
+//! JIT codepath reached by `-n` (null input).
+//!
+//! The interpreter's `rt_split` already special-cases the empty input string,
+//! and so does jq itself. The JIT fast path for single-arg `split` did not:
+//! Rust's `"".split(",")` yields one empty segment (`[""]`), so the JIT path
+//! emitted `[""]` while every other path returned `[]`.
+//!
+//! `regression.test` cannot cover this: its harness always feeds input on
+//! stdin (no `-n`), which routes through the interpreter/eval path and never
+//! reaches the JIT `split` fast path. So shell out with `-n` directly.
+
+use std::process::Command;
+
+fn run_null_input(filter: &str) -> String {
+    let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
+    let out = Command::new(jq_jit)
+        .arg("-nc")
+        .arg(filter)
+        .output()
+        .expect("failed to spawn jq-jit");
+    assert!(
+        out.status.success(),
+        "jq-jit -nc {filter:?} exited with {:?}\nstderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8(out.stdout)
+        .expect("non-utf8 stdout")
+        .trim_end()
+        .to_string()
+}
+
+#[test]
+fn empty_input_string_splits_to_empty_array_on_null_input() {
+    // The core bug: empty string with a non-empty separator -> [].
+    assert_eq!(run_null_input(r#""" | split(",")"#), "[]");
+    assert_eq!(run_null_input(r#""" | split(",x,")"#), "[]");
+    // Empty separator on empty string is also [] (already correct, pinned here).
+    assert_eq!(run_null_input(r#""" | split("")"#), "[]");
+}
+
+#[test]
+fn non_empty_input_string_split_unaffected_on_null_input() {
+    // Guard against over-eager emptying: non-empty inputs keep their segments.
+    assert_eq!(run_null_input(r#""abc" | split(",")"#), r#"["abc"]"#);
+    assert_eq!(run_null_input(r#""a,b,c" | split(",")"#), r#"["a","b","c"]"#);
+    assert_eq!(run_null_input(r#""a,," | split(",")"#), r#"["a","",""]"#);
+    assert_eq!(run_null_input(r#""abc" | split("")"#), r#"["a","b","c"]"#);
+}


### PR DESCRIPTION
## Summary

`"" | split(sep)` returned `[""]` instead of `[]` when jq-jit ran via the `-n` (null-input) JIT codepath. The interpreter and stdin paths were already correct.

## Root cause

The JIT fast path for single-arg `split(sep)` in `src/jit.rs` used `s.split(p).collect()` directly. Rust's `"".split(",")` yields one empty segment (`[""]`), but jq — and jq-jit's own interpreter `rt_split` — return `[]` for an empty input string with any separator. The JIT path was missing the `s.is_empty()` special case that `rt_split` already has.

## Fix

Add the `s.is_empty() => []` branch to the JIT `split` fast path, matching `rt_split`.

## Tests

`regression.test` can't cover this: its harness always feeds input on stdin (no `-n`), which routes through the eval/interpreter path and never reaches the JIT `split` fast path. Added a dedicated `-n` integration test `tests/split_empty_input_null.rs` (mirroring #726's approach), covering empty/non-empty separators and guarding non-empty inputs against over-eager emptying.

- `cargo build --release` — zero warnings
- `cargo test --release` — all suites pass

Closes #731

🤖 Generated with [Claude Code](https://claude.com/claude-code)