### PR TITLE
fix(jit): stream global match/capture results per value

### DIFF
--- a/src/jit.rs
+++ b/src/jit.rs
@@ -1004,6 +1004,54 @@ impl Flattener {
         }
     }
 
+    /// Yield a value that may be a stream packed in an array.
+    ///
+    /// `match`/`capture` with the `g` (global) flag return a `Value::Arr` of
+    /// all match objects, which jq streams one-per-value; a non-global match
+    /// returns a single match *object* (never an array). Dispatch on the
+    /// runtime kind so the JIT generator path streams the global array while
+    /// still yielding the single-match object verbatim (#748).
+    fn emit_yield_each_if_array(&mut self, slot: SlotId) {
+        let kind_var = self.alloc_var();
+        let arr_lbl = self.alloc_label();
+        let single_lbl = self.alloc_label();
+        let done_lbl = self.alloc_label();
+        self.emit(JitOp::GetKind { dst_var: kind_var, src: slot });
+        // Array -> stream each; object/other -> yield the value once.
+        self.emit(JitOp::BranchKind {
+            kind_var,
+            arr_label: arr_lbl,
+            obj_label: single_lbl,
+            other_label: single_lbl,
+        });
+        // Array: yield each element.
+        self.emit(JitOp::Label { id: arr_lbl });
+        {
+            let idx = self.alloc_var();
+            let len = self.alloc_var();
+            let head = self.alloc_label();
+            let body = self.alloc_label();
+            let end = self.alloc_label();
+            self.emit(JitOp::GetLen { dst_var: len, src: slot });
+            self.emit(JitOp::InitVar { var: idx });
+            self.emit(JitOp::Label { id: head });
+            self.emit(JitOp::LoopCheck { idx_var: idx, len_var: len, body_label: body, done_label: end });
+            self.emit(JitOp::Label { id: body });
+            let elem = self.alloc_slot();
+            self.emit(JitOp::ArrayGet { dst: elem, arr: slot, idx_var: idx });
+            self.emit_yield(elem);
+            self.emit(JitOp::Drop { slot: elem });
+            self.emit(JitOp::IncVar { var: idx });
+            self.emit(JitOp::Jump { label: head });
+            self.emit(JitOp::Label { id: end });
+        }
+        self.emit(JitOp::Jump { label: done_lbl });
+        // Single object (non-global match): yield once.
+        self.emit(JitOp::Label { id: single_lbl });
+        self.emit_yield(slot);
+        self.emit(JitOp::Label { id: done_lbl });
+    }
+
     fn emit_literal(&mut self, dst: SlotId, lit: &Literal) {
         match lit {
             Literal::Null => self.emit(JitOp::Null { dst }),
@@ -2649,8 +2697,11 @@ impl Flattener {
                 self.flatten_gen_try_catch(try_expr, catch_expr, input_slot)
             }
 
-            // RegexMatch/RegexCapture: 0-or-1 output generator
-            // match("re") yields one object or empty (non-match throws error → empty)
+            // RegexMatch/RegexCapture: 0-or-N output generator.
+            // Non-global `match("re")` yields one object or empty (non-match
+            // throws error → empty). Global `match("re";"g")` returns a
+            // `Value::Arr` of all matches that jq streams one-per-value (#748),
+            // so emit_yield_each_if_array dispatches on the runtime result kind.
             Expr::RegexMatch { input_expr, re, flags } | Expr::RegexCapture { input_expr, re, flags } => {
                 let is_capture = matches!(expr, Expr::RegexCapture { .. });
                 if !is_scalar(input_expr) || !is_scalar(re) || !is_scalar(flags) { return false; }
@@ -2668,7 +2719,7 @@ impl Flattener {
                 self.try_depth += 1;
                 self.emit(JitOp::TryCatchBegin);
                 self.emit(JitOp::CallBuiltin { dst: out, name: builtin_name.to_string(), args: vec![inp, re_val, flags_val] });
-                self.emit_yield(out);
+                self.emit_yield_each_if_array(out);
                 self.emit(JitOp::Drop { slot: out });
                 self.emit(JitOp::TryCatchEnd);
                 self.try_depth -= 1;

--- a/tests/regex_global_match_stream.rs
+++ b/tests/regex_global_match_stream.rs
@@ -1,0 +1,87 @@
+//! Issue #748: `match`/`capture` with the `g` (global) flag must emit one
+//! match per value as a *stream*, matching jq, rather than a single array
+//! containing all matches. `scan`/`splits`/`gsub` already behave correctly.
+//!
+//! This was a JIT-only divergence reached on the `-n` (null-input) codepath:
+//! the interpreter's regex path already streamed the global array via the
+//! callback, but the JIT generator flattener emitted the whole array slot once.
+//! A non-global match yields a single match *object* (never an array), so the
+//! fix dispatches on the runtime result kind: array -> stream each element,
+//! object/other -> yield once.
+//!
+//! `regression.test` cannot cover this: its harness always feeds input on
+//! stdin (no `-n`), which routes through the eval/interpreter path and never
+//! reaches the JIT regex generator path. So shell out with `-n` directly.
+
+use std::process::Command;
+
+/// Run `jq-jit -nc <filter>` and return stdout, one output value per line,
+/// joined with '|' so a streamed result is distinguishable from a single array.
+fn run_null_input(filter: &str) -> String {
+    let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
+    let out = Command::new(jq_jit)
+        .arg("-nc")
+        .arg(filter)
+        .output()
+        .expect("failed to spawn jq-jit");
+    assert!(
+        out.status.success(),
+        "jq-jit -nc {filter:?} exited with {:?}\nstderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8(out.stdout)
+        .expect("non-utf8 stdout")
+        .trim_end()
+        .replace('\n', "|")
+}
+
+#[test]
+fn global_match_streams_one_object_per_match() {
+    // The core bug: `g` flag must stream, not pack into a single array.
+    assert_eq!(
+        run_null_input(r#""aXbXc" | match("X";"g")"#),
+        r#"{"offset":1,"length":1,"string":"X","captures":[]}|{"offset":3,"length":1,"string":"X","captures":[]}"#
+    );
+    // Collecting the stream yields one element per match.
+    assert_eq!(run_null_input(r#"[ "aXbXc" | match("X";"g") ] | length"#), "2");
+    assert_eq!(run_null_input(r#"[ "aXbXcXd" | match("X";"g") ] | length"#), "3");
+}
+
+#[test]
+fn global_capture_streams_one_object_per_match() {
+    assert_eq!(
+        run_null_input(r#""aXbYc" | capture("(?<c>[A-Z])";"g")"#),
+        r#"{"c":"X"}|{"c":"Y"}"#
+    );
+    assert_eq!(
+        run_null_input(r#"[ "aXbYc" | capture("(?<c>[A-Z])";"g") ]"#),
+        r#"[{"c":"X"},{"c":"Y"}]"#
+    );
+}
+
+#[test]
+fn array_form_regex_with_global_flag_streams() {
+    // The `g` flag can also ride inside the `[regex, flags]` array argument
+    // (flags == null but the array carries "g"). Must still stream.
+    assert_eq!(run_null_input(r#"[ "aXbXcXd" | match(["X","g"]) ] | length"#), "3");
+}
+
+#[test]
+fn non_global_match_yields_single_object() {
+    // Without `g`, match/capture yield exactly one object (a stream of 1),
+    // never wrapped in an array.
+    assert_eq!(
+        run_null_input(r#""aXbXc" | match("X")"#),
+        r#"{"offset":1,"length":1,"string":"X","captures":[]}"#
+    );
+    assert_eq!(run_null_input(r#"[ "aXbXc" | match("X") ] | length"#), "1");
+    assert_eq!(run_null_input(r#""aXbYc" | capture("(?<c>[A-Z])")"#), r#"{"c":"X"}"#);
+}
+
+#[test]
+fn no_match_global_is_empty_stream() {
+    // No matches -> empty stream (collects to []), not an error or [null].
+    assert_eq!(run_null_input(r#"[ "abc" | match("X";"g") ] | length"#), "0");
+    assert_eq!(run_null_input(r#"[ "abc" | capture("(?<c>[A-Z])";"g") ] | length"#), "0");
+}


### PR DESCRIPTION
## Summary

`match(re; "g")` and `capture(re; "g")` returned a single array of all matches instead of streaming one match object per value, on the JIT (`-n` / null-input) codepath. `scan`/`splits`/`gsub` were already correct.

```
$ ./target/release/jq-jit -nc '[ "aXbXc" | match("X";"g") ] | length'
1   # jq: 2
$ ./target/release/jq-jit -nc '"aXbYc" | capture("(?<c>[A-Z])";"g")'
[{"c":"X"},{"c":"Y"}]   # jq: stream of {"c":"X"} then {"c":"Y"}
```

## Root cause

The interpreter's regex path already streamed the global result array via its callback. The JIT generator flattener for `RegexMatch`/`RegexCapture` emitted the whole array slot once (`emit_yield(out)`), so the global array surfaced as a single value.

## Fix

A non-global match yields a single match **object** (never an array), while a global match yields an **array**. Added `emit_yield_each_if_array`, which dispatches on the runtime result kind:

- array → stream each element
- object/other → yield once

Dispatching on the runtime type (rather than at compile time) handles all three ways the `g` flag can appear uniformly: the literal-flag form `match(re; "g")`, the array-form `match(["X","g"])` (flags embedded in the regex argument, with `flags == null`), and runtime-computed flags.

## Tests

`regression.test` can't cover this: its harness always feeds input on stdin (no `-n`), routing through the eval path and never reaching the JIT regex generator. Added a dedicated `-n` integration test `tests/regex_global_match_stream.rs` covering global streaming, non-global single, no-match empty stream, and the array-form `match(["X","g"])`.

- `cargo build --release` — zero warnings
- `cargo test --release` — all suites pass

Closes #748

🤖 Generated with [Claude Code](https://claude.com/claude-code)