### PR TITLE
fix(jit): raise index error from fused if-condition fast paths

### DIFF
--- a/src/jit.rs
+++ b/src/jit.rs
@@ -370,9 +370,14 @@ enum JitOp {
     // Control flow
     IfTruthy { src: SlotId, then_label: LabelId, else_label: LabelId },
     /// Combined field access + truthiness check: avoids clone+drop of the field value.
-    FieldIsTruthy { base: SlotId, field: String, then_label: LabelId, else_label: LabelId },
-    /// Combined field access + numeric comparison + branch: avoids creating intermediate Values.
-    FieldCmpNum { base: SlotId, field: String, value: f64, op: i32, then_label: LabelId, else_label: LabelId },
+    /// Writes 1/0 into `dst_var`. Sets the pending JIT error for a non-indexable
+    /// base (`.field` on a non-object/non-null) — the caller must follow with
+    /// `JumpIfError` before branching on the result (#751).
+    FieldIsTruthy { base: SlotId, field: String, dst_var: u32 },
+    /// Combined field access + numeric comparison: avoids creating intermediate
+    /// Values. Writes 1/0 into `dst_var`. Sets the pending JIT error for a
+    /// non-indexable base — caller must follow with `JumpIfError` (#751).
+    FieldCmpNum { base: SlotId, field: String, value: f64, op: i32, dst_var: u32 },
     /// Branch on type tag comparison: loads tag byte from src and compares against expected.
     /// tags is a bitmask of matching tag values (bit 0 = Null, 1 = False, 2 = True, 3 = Num, etc.)
     TypeCmpBranch { src: SlotId, tags: u8, then_label: LabelId, else_label: LabelId },
@@ -2388,6 +2393,13 @@ impl Flattener {
                     let then_lbl = self.alloc_label();
                     let else_lbl = self.alloc_label();
                     let done_lbl = self.alloc_label();
+                    // The fused `.field` ops (FieldCmpNum/FieldIsTruthy) write a
+                    // 0/1 result into a var and set the pending JIT error for a
+                    // non-indexable base; `field_cond_var` records the var so we
+                    // can emit `JumpIfError` + `BranchOnVar` after, surfacing
+                    // jq's "Cannot index ..." error instead of silently taking
+                    // the else branch (#751).
+                    let mut field_cond_var: Option<u32> = None;
                     // Optimization: if cond is .field OP num on input, use combined FieldCmpNum
                     let used_fused = if let Expr::BinOp { op, lhs, rhs } = cond.as_ref() {
                         if matches!(op, BinOp::Eq | BinOp::Ne | BinOp::Lt | BinOp::Gt | BinOp::Le | BinOp::Ge) {
@@ -2419,7 +2431,9 @@ impl Flattener {
                                 } else { None }
                             });
                             if let Some((field, value, op_code)) = field_num {
-                                self.emit(JitOp::FieldCmpNum { base: input_slot, field, value, op: op_code, then_label: then_lbl, else_label: else_lbl });
+                                let v = self.alloc_var();
+                                self.emit(JitOp::FieldCmpNum { base: input_slot, field, value, op: op_code, dst_var: v });
+                                field_cond_var = Some(v);
                                 true
                             } else { false }
                         } else { false }
@@ -2428,7 +2442,9 @@ impl Flattener {
                     let used_fused = used_fused || if let Expr::Index { expr: base, key } | Expr::IndexOpt { expr: base, key } = cond.as_ref() {
                         if matches!(base.as_ref(), Expr::Input) {
                             if let Expr::Literal(Literal::Str(field)) = key.as_ref() {
-                                self.emit(JitOp::FieldIsTruthy { base: input_slot, field: field.clone(), then_label: then_lbl, else_label: else_lbl });
+                                let v = self.alloc_var();
+                                self.emit(JitOp::FieldIsTruthy { base: input_slot, field: field.clone(), dst_var: v });
+                                field_cond_var = Some(v);
                                 true
                             } else { false }
                         } else { false }
@@ -2457,6 +2473,17 @@ impl Flattener {
                             } else { false }
                         } else { false }
                     } else { false };
+                    // A fused `.field` op wrote its 0/1 result into a var and may
+                    // have set the pending error (non-indexable base). Bail to
+                    // the error block before branching, then branch on the var.
+                    let err_lbl = if let Some(v) = field_cond_var {
+                        let el = self.alloc_label();
+                        self.emit(JitOp::JumpIfError { label: el });
+                        self.emit(JitOp::BranchOnVar { var: v, nonzero_label: then_lbl, zero_label: else_lbl });
+                        Some(el)
+                    } else {
+                        None
+                    };
                     if !used_fused {
                         let cond_val = self.flatten_scalar(cond, input_slot);
                         self.emit(JitOp::IfTruthy { src: cond_val, then_label: then_lbl, else_label: else_lbl });
@@ -2469,6 +2496,18 @@ impl Flattener {
 
                     self.emit(JitOp::Label { id: else_lbl });
                     self.flatten_gen(else_branch, input_slot);
+                    // Error block for the fused `.field` cond (#751): the runtime
+                    // op already set the pending error; propagate it (to the
+                    // enclosing try/catch, else out of the JIT fn).
+                    if let Some(el) = err_lbl {
+                        self.emit(JitOp::Jump { label: done_lbl });
+                        self.emit(JitOp::Label { id: el });
+                        if let Some((catch_label, error_slot)) = self.try_catch_target {
+                            self.emit(JitOp::CheckError { error_dst: error_slot, catch_label });
+                        } else {
+                            self.emit(JitOp::ReturnError);
+                        }
+                    }
                     self.emit(JitOp::Label { id: done_lbl });
                     true
                 } else {
@@ -6324,7 +6363,16 @@ extern "C" fn jit_rt_field_is_truthy(base: *const Value, key_ptr: *const u8, key
                     None => 0,
                 }
             }
-            _ => 0,
+            // `.field` on null is null → falsy, no error.
+            Value::Null => 0,
+            // `.field` on any other type is a runtime error in jq (#751). Set
+            // the pending error; the caller checks the error flag via
+            // JumpIfError and bails before branching on the (meaningless) 0.
+            _ => {
+                let key = std::str::from_utf8_unchecked(std::slice::from_raw_parts(key_ptr, key_len));
+                set_jit_error(format!("Cannot index {} with string \"{}\"", (*base).type_name(), key));
+                0
+            }
         }
     }
 }
@@ -6344,11 +6392,13 @@ extern "C" fn jit_rt_field_cmp_num(base: *const Value, key_ptr: *const u8, key_l
             Value::Obj(ObjInner(o)) => o.get(key),
             Value::Null => None,
             // `.field` on a non-object/non-null base is a runtime error in
-            // jq. Surfacing that error from this fast path would need a
-            // bail channel the op doesn't have, so keep the existing
-            // permissive behavior (treat as false) and let the generic
-            // path handle programs that depend on the error.
-            _ => return 0,
+            // jq (#751). Set the pending error; the caller checks the error
+            // flag via JumpIfError and bails before branching on the
+            // (meaningless) 0 this returns.
+            _ => {
+                set_jit_error(format!("Cannot index {} with string \"{}\"", (*base).type_name(), key));
+                return 0;
+            }
         };
         match field_val {
             Some(Value::Num(lhs, _)) => {
@@ -6400,7 +6450,8 @@ extern "C" fn jit_rt_field_binop_field(
                 }
             }
             _ => {
-                set_jit_error(format!("Cannot index {} with string", (*base).type_name()));
+                let ka_str = std::str::from_utf8_unchecked(std::slice::from_raw_parts(ka_ptr, ka_len));
+                set_jit_error(format!("Cannot index {} with string \"{}\"", (*base).type_name(), ka_str));
                 std::ptr::write(dst, Value::Null);
                 return GEN_ERROR;
             }
@@ -6463,7 +6514,8 @@ extern "C" fn jit_rt_field_binop_const(
                 }
             }
             _ => {
-                set_jit_error(format!("Cannot index {} with string", (*base).type_name()));
+                let key = std::str::from_utf8_unchecked(std::slice::from_raw_parts(key_ptr, key_len));
+                set_jit_error(format!("Cannot index {} with string \"{}\"", (*base).type_name(), key));
                 std::ptr::write(dst, Value::Null);
                 return GEN_ERROR;
             }
@@ -9687,7 +9739,7 @@ impl JitCompiler {
                         b.ins().brif(is_truthy, label_blocks[*then_label as usize], &[], label_blocks[*else_label as usize], &[]);
                         terminated = true;
                     }
-                    JitOp::FieldIsTruthy { base, field, then_label, else_label } => {
+                    JitOp::FieldIsTruthy { base, field, dst_var } => {
                         let ba = slot_addr(&mut b, *base);
                         let leaked = Box::leak(field.clone().into_boxed_str());
                         self._string_constants.push(leaked);
@@ -9695,12 +9747,12 @@ impl JitCompiler {
                         let kl = b.ins().iconst(ptr_ty, leaked.len() as i64);
                         let call = b.ins().call(rt["field_is_truthy"], &[ba, kp, kl]);
                         let truthy = b.inst_results(call)[0];
-                        let zero = b.ins().iconst(ptr_ty, 0);
-                        let is_t = b.ins().icmp(cranelift_codegen::ir::condcodes::IntCC::NotEqual, truthy, zero);
-                        b.ins().brif(is_t, label_blocks[*then_label as usize], &[], label_blocks[*else_label as usize], &[]);
-                        terminated = true;
+                        // Store 0/1 into the var; a non-indexable base sets the
+                        // pending error, which the following JumpIfError catches
+                        // before this result is branched on (#751).
+                        b.def_var(vars[*dst_var as usize], truthy);
                     }
-                    JitOp::FieldCmpNum { base, field, value, op, then_label, else_label } => {
+                    JitOp::FieldCmpNum { base, field, value, op, dst_var } => {
                         let ba = slot_addr(&mut b, *base);
                         let leaked = Box::leak(field.clone().into_boxed_str());
                         self._string_constants.push(leaked);
@@ -9710,10 +9762,9 @@ impl JitCompiler {
                         let op_i32 = b.ins().iconst(types::I32, *op as i64);
                         let call = b.ins().call(rt["field_cmp_num"], &[ba, kp, kl, rhs_f64, op_i32]);
                         let result = b.inst_results(call)[0];
-                        let zero = b.ins().iconst(ptr_ty, 0);
-                        let is_t = b.ins().icmp(cranelift_codegen::ir::condcodes::IntCC::NotEqual, result, zero);
-                        b.ins().brif(is_t, label_blocks[*then_label as usize], &[], label_blocks[*else_label as usize], &[]);
-                        terminated = true;
+                        // Store 0/1 into the var; a non-indexable base sets the
+                        // pending error (#751), caught by the following JumpIfError.
+                        b.def_var(vars[*dst_var as usize], result);
                     }
                     JitOp::TypeCmpBranch { src, tags, then_label, else_label } => {
                         // Load tag byte (offset 0) from Value at slot

--- a/tests/update_cond_index_error.rs
+++ b/tests/update_cond_index_error.rs
@@ -1,0 +1,128 @@
+//! Issue #751: an arithmetic update (`+=`) whose RHS is `if COND then GEN
+//! else SCALAR end` (with a *generator* then-branch) must evaluate `COND`
+//! with the same error semantics as every other path. A condition that
+//! indexes a non-object/non-null value — e.g. `.a` on a boolean — raises
+//! `Cannot index <type> with string "<field>"`, and `?`-less callers surface
+//! it.
+//!
+//! The JIT compiled the if-condition through the fused `FieldCmpNum` /
+//! `FieldIsTruthy` ops, which silently returned `false` for a non-indexable
+//! base instead of erroring, so the `else` branch was taken and the error
+//! vanished — but only on the `+=` codepath (a scalar then-branch kept the
+//! `map` value scalar and took the erroring path). The fused ops now set the
+//! pending error and the if-codegen bails via `JumpIfError`.
+//!
+//! `regression.test` cannot cover this: an erroring filter produces empty
+//! stdout, and an empty expected line is the suite's group delimiter. So
+//! assert against stderr / exit status directly.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+struct Run {
+    code: i32,
+    stdout: String,
+    stderr: String,
+}
+
+fn run(filter: &str, input: &str) -> Run {
+    let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
+    let mut child = Command::new(jq_jit)
+        .arg("-c")
+        .arg(filter)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn jq-jit");
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(format!("{input}\n").as_bytes())
+        .unwrap();
+    let out = child.wait_with_output().unwrap();
+    Run {
+        code: out.status.code().unwrap_or(-1),
+        stdout: String::from_utf8_lossy(&out.stdout).trim_end().to_string(),
+        stderr: String::from_utf8_lossy(&out.stderr).trim_end().to_string(),
+    }
+}
+
+#[test]
+fn plus_assign_generator_then_propagates_cond_index_error() {
+    // The core bug: the `+=` RHS must raise, not silently take `else`.
+    for filter in [
+        r#".x += map(if (.a > 0) then values else 0 end)"#,
+        r#".x += map(if .a then values else 0 end)"#,
+        r#".x += map(if (.a|. > 0) then values else 0 end)"#,
+        r#".x += map(if (.a == 1) then values else 0 end)"#,
+    ] {
+        let r = run(filter, r#"{"a":false}"#);
+        assert_ne!(r.code, 0, "expected error for `{filter}`, got stdout {:?}", r.stdout);
+        assert!(r.stdout.is_empty(), "expected no output for `{filter}`, got {:?}", r.stdout);
+        assert!(
+            r.stderr.contains(r#"Cannot index boolean with string "a""#),
+            "wrong error for `{filter}`: {:?}",
+            r.stderr
+        );
+    }
+}
+
+#[test]
+fn error_message_includes_field_name() {
+    // Secondary fix: the JIT field-access error text used to be truncated
+    // ("... with string" with no field name).
+    let r = run(r#".x += map(if (.a > 0) then 1 else 0 end)"#, r#"{"a":false}"#);
+    assert!(
+        r.stderr.contains(r#"Cannot index boolean with string "a""#),
+        "truncated/wrong error: {:?}",
+        r.stderr
+    );
+    // Number base reports its own type.
+    let r = run(r#".x += map(if (.a > 0) then values else 0 end)"#, r#"{"a":7}"#);
+    assert!(
+        r.stderr.contains(r#"Cannot index number with string "a""#),
+        "wrong type in error: {:?}",
+        r.stderr
+    );
+}
+
+#[test]
+fn cond_index_error_is_catchable() {
+    // `try`/`?` must still be able to swallow it — the error is a normal
+    // runtime error, not a compile error.
+    let r = run(
+        r#".x += [.[] | try (if (.a > 0) then values else 0 end) catch "caught"]"#,
+        r#"{"a":false}"#,
+    );
+    assert_eq!(r.code, 0, "try/catch should succeed: {:?}", r.stderr);
+    assert_eq!(r.stdout, r#"{"a":false,"x":["caught"]}"#);
+
+    let r = run(
+        r#".x += [.[] | (if (.a > 0) then values else 0 end)?]"#,
+        r#"{"a":false}"#,
+    );
+    assert_eq!(r.code, 0, "? should suppress: {:?}", r.stderr);
+    assert_eq!(r.stdout, r#"{"a":false,"x":[]}"#);
+}
+
+#[test]
+fn fused_cond_fast_path_unaffected_on_valid_input() {
+    // The fused FieldCmpNum/FieldIsTruthy fast paths must stay correct for
+    // object/null bases (no spurious errors).
+    let cases = [
+        // jq truthiness: 0 is truthy, so {"a":0} → "T"; missing field → null → "F".
+        (r#"map(if .a then "T" else "F" end)"#, r#"[{"a":1},{"a":0},{"b":2}]"#, r#"["T","T","F"]"#),
+        (r#"[.[] | if .a >= 0 then .a else empty end]"#, r#"[{"a":5},{"a":-3}]"#, "[5]"),
+        (r#"if .a > 0 then "y" else "n" end"#, r#"{"a":3}"#, r#""y""#),
+        (r#"if .a > 0 then "y" else "n" end"#, r#"{"b":1}"#, r#""n""#),
+        (r#"if .a > 0 then "y" else "n" end"#, "null", r#""n""#),
+        (r#".x += map(if (.a > 0) then [.a] else [] end)"#, r#"{"k":{"a":5}}"#, r#"{"k":{"a":5},"x":[[5]]}"#),
+    ];
+    for (filter, input, expected) in cases {
+        let r = run(filter, input);
+        assert_eq!(r.code, 0, "`{filter}` on `{input}` errored: {:?}", r.stderr);
+        assert_eq!(r.stdout, expected, "`{filter}` on `{input}`");
+    }
+}


### PR DESCRIPTION
## Summary

An arithmetic update (`+=`) whose RHS is `if COND then GEN else SCALAR end` — with a **generator** then-branch — silently swallowed `COND`'s index error and took the `else` branch, where jq raises an error.

```
$ echo '{"a":false}' | ./target/release/jq-jit -c '.x += map(if (.a > 0) then values else 0 end)'
{"a":false,"x":[0]}
$ echo '{"a":false}' | jq -c '.x += map(if (.a > 0) then values else 0 end)'
jq: error (at <stdin>:1): Cannot index boolean with string "a"
```

## Root cause

The JIT compiled the if-condition (`.field OP num` / `.field`) through the fused `FieldCmpNum` / `FieldIsTruthy` runtime ops. These **intentionally** returned `false` for a non-indexable base (`.field` on a non-object/non-null), relying on error-dependent programs routing to the interpreter. But the `+=` path with a generator then-branch keeps the `map` value non-scalar → it JIT-compiles via `flatten_gen_let_binding` and never falls back, so the `Cannot index ...` error vanished. (A *scalar* then-branch keeps the value scalar and took the erroring path, which is why the bug needed both `+=` **and** a generator then-branch.)

## Fix

Give the two fused ops a proper error bail channel:

- `jit_rt_field_cmp_num` / `jit_rt_field_is_truthy` now `set_jit_error("Cannot index <type> with string \"<field>\"")` for a non-indexable base (null stays a no-error `null` field).
- The ops are emitted as value-producing (write 0/1 into a var) instead of branching; the if-codegen follows with `JumpIfError` + `BranchOnVar`, so a pending error short-circuits before the branch.

Deciding at runtime keeps the hot object/null fast paths untouched (the `FieldCmpNum` micro-benchmark is unchanged: 0.13s = 0.13s). The error is a normal runtime error, so `try`/`?` still catch it.

Also fixes a related **truncated message**: `field_binop_field` / `field_binop_const` reported `Cannot index <type> with string` without the field name — now `... with string "<field>"`, matching the interpreter.

## Tests

`regression.test` can't express an erroring filter (empty stdout = the suite's blank-line group delimiter), so added a dedicated test `tests/update_cond_index_error.rs` covering: the `+=` generator-then error (4 cond shapes), the field-name in the message, `try`/`?` catchability, and the fused fast paths staying correct on valid object/null inputs.

- `cargo build --release` — zero warnings
- `cargo test --release` — all suites pass (incl. `selfdiff_jit_interp`, confirming JIT ≡ interpreter)

Closes #751

🤖 Generated with [Claude Code](https://claude.com/claude-code)