### PR TITLE
release v1.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jq-jit"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jq-jit"
-version = "1.8.0"
+version = "1.8.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A JIT-compiling implementation of jq using Cranelift"

--- a/docs/benchmark-history.md
+++ b/docs/benchmark-history.md
@@ -6,268 +6,268 @@ Recent slice (last 5 columns). Full history lives in
 
 ```text
 --- NDJSON workloads (2M objects) ---
-  Benchmark                    v1.6.0  v1.6.1  v1.7.0  v1.7.1  v1.8.0
+  Benchmark                    v1.6.1  v1.7.0  v1.7.1  v1.8.0  v1.8.1
   ---                          ------  ------  ------  ------  ------
-  empty                        0.017s  0.018s  0.017s  0.017s  0.017s
-  identity -c                  0.088s  0.087s  0.086s  0.084s  0.084s
-  identity (pretty)            0.106s  0.107s  0.106s  0.102s  0.099s
-  field access .name           0.096s  0.097s  0.093s  0.090s  0.089s
-  nested .x,.y,.name           0.155s  0.150s  0.147s  0.146s  0.149s
-  arithmetic .x + .y           0.086s  0.084s  0.083s  0.082s  0.079s
-  select .x > 1500000          0.083s  0.087s  0.084s  0.080s  0.077s
-  string concat                0.092s  0.095s  0.092s  0.092s  0.088s
-  object construct             0.115s  0.116s  0.114s  0.110s  0.109s
-  array construct              0.107s  0.106s  0.105s  0.105s  0.100s
-  .[]                          0.105s  0.104s  0.102s  0.101s  0.098s
-  to_entries                   0.159s  0.159s  0.163s  0.154s  0.150s
-  keys                         0.105s  0.107s  0.105s  0.100s  0.098s
-  keys_unsorted                0.095s  0.097s  0.094s  0.092s  0.090s
-  length                       0.087s  0.088s  0.084s  0.087s  0.084s
-  has("x")                     0.039s  0.039s  0.037s  0.036s  0.035s
-  type                         0.023s  0.023s  0.023s  0.022s  0.021s
-  del(.name)                   0.103s  0.107s  0.101s  0.099s  0.098s
-  @csv                         0.124s  0.120s  0.118s  0.117s  0.119s
-  split/join                   0.090s  0.094s  0.090s  0.089s  0.086s
-  select|field                 0.101s  0.099s  0.097s  0.094s  0.093s
-  select|remap                 0.098s  0.100s  0.099s  0.097s  0.093s
-  computed remap               0.190s  0.192s  0.191s  0.187s  0.186s
-  [.x,.y]|add                  0.084s  0.084s  0.083s  0.083s  0.081s
-  [.x,.y]|avg                  0.109s  0.111s  0.106s  0.106s  0.105s
-  map(*2)|add                  0.106s  0.107s  0.104s  0.102s  0.099s
-  keys|length                  0.253s  0.259s  0.255s  0.251s  0.249s
-  .+{z=0}                      0.150s  0.150s  0.146s  0.145s  0.142s
-  split|first                  0.091s  0.092s  0.089s  0.088s  0.086s
-  slice[0..5]                  0.093s  0.095s  0.094s  0.094s  0.088s
-  dynkey {(.name)}             0.106s  0.108s  0.104s  0.106s  0.100s
-  .x += 1                      0.129s  0.128s  0.121s  0.122s  0.124s
-  {a}+{b} merge                0.132s  0.133s  0.130s  0.129s  0.128s
-  .x*2+1                       0.060s  0.061s  0.060s  0.059s  0.057s
-  .x+.y*2                      0.100s  0.099s  0.100s  0.096s  0.094s
-  .x > .y                      0.079s  0.078s  0.077s  0.076s  0.074s
-  to_entries|len               0.400s  0.405s  0.397s  0.397s  0.389s
-  .x|.+1 (pipe)                0.058s  0.059s  0.059s  0.056s  0.055s
-  .x|.*2|.+1                   0.060s  0.060s  0.060s  0.058s  0.056s
-  .name|.+"_x"                 0.094s  0.097s  0.094s  0.092s  0.088s
-  .x>N | not                   0.049s  0.051s  0.049s  0.048s  0.047s
-  and (2 cmp)                  0.085s  0.082s  0.080s  0.080s  0.078s
-  if-then-else                 0.051s  0.053s  0.052s  0.051s  0.049s
-  sel(and)|field               0.080s  0.079s  0.076s  0.076s  0.073s
-  sel(and)|remap               0.079s  0.079s  0.077s  0.077s  0.074s
-  arith|cmp                    0.054s  0.056s  0.054s  0.053s  0.051s
-  if cmp .field                0.113s  0.118s  0.113s  0.110s  0.108s
-  split|length                 0.089s  0.093s  0.089s  0.088s  0.085s
-  [x,y]|min                    0.092s  0.092s  0.090s  0.089s  0.087s
-  [x,y]|max                    0.096s  0.097s  0.095s  0.092s  0.090s
-  [x,y]|sort|.[0]              0.093s  0.092s  0.089s  0.088s  0.085s
-  .name|len>5                  0.093s  0.094s  0.090s  0.089s  0.088s
-  sel(len>5)|.x                0.113s  0.111s  0.107s  0.107s  0.105s
-  if .x>.y .name               0.093s  0.092s  0.093s  0.088s  0.088s
-  sel(.x>.y)|.name             0.075s  0.074s  0.071s  0.070s  0.067s
-  .x*2|tostring                0.057s  0.058s  0.057s  0.055s  0.053s
-  .x*.x+1                      0.066s  0.067s  0.067s  0.064s  0.063s
-  {k=.name,v=tostr}            0.151s  0.147s  0.144s  0.145s  0.138s
-  str add chain                0.388s  0.388s  0.385s  0.378s  0.372s
-  if>.y .name|empty            0.077s  0.073s  0.073s  0.072s  0.070s
-  if .x%2==0                   0.055s  0.054s  0.055s  0.054s  0.052s
-  if .x*2+1>1M                 0.055s  0.055s  0.056s  0.054s  0.052s
-  sel(.x%2==0)|.name           0.083s  0.084s  0.084s  0.081s  0.080s
-  sel(.x*2+1>1M)               0.160s  0.157s  0.159s  0.154s  0.151s
-  .x|@json                     0.048s  0.049s  0.047s  0.047s  0.046s
-  .x|@text                     0.048s  0.049s  0.048s  0.047s  0.045s
-  .name|@json                  0.103s  0.102s  0.101s  0.101s  0.099s
-  sel|[arr]                    0.147s  0.143s  0.149s  0.144s  0.140s
-  sel(and)|[arr]               0.081s  0.077s  0.079s  0.076s  0.076s
-  if>.y [arr]                  0.178s  0.175s  0.179s  0.174s  0.178s
-  if sw then .f                0.143s  0.143s  0.139s  0.135s  0.132s
-  dynkey {(.n)=.x*2}           0.115s  0.117s  0.115s  0.112s  0.111s
-  sel(and)|.x*.y               0.079s  0.077s  0.077s  0.078s  0.074s
-  sel>N|str chain              0.156s  0.152s  0.155s  0.153s  0.151s
-  .f+"_"+arith_ts              0.136s  0.134s  0.133s  0.132s  0.130s
-  sel(sw)|str ch               0.304s  0.308s  0.307s  0.298s  0.301s
-  split|rev|join               0.118s  0.117s  0.117s  0.112s  0.111s
-  dynkey+static                0.338s  0.340s  0.338s  0.332s  0.332s
-  if>.y str chain              0.166s  0.167s  0.171s  0.168s  0.167s
-  remap+str chain              0.159s  0.156s  0.156s  0.154s  0.145s
-  sel(len>8)                   0.161s  0.163s  0.162s  0.159s  0.154s
-  up|split|join                0.098s  0.098s  0.095s  0.100s  0.095s
-  .name|index                  0.120s  0.121s  0.118s  0.117s  0.114s
-  .name|index+1                0.124s  0.126s  0.122s  0.122s  0.117s
-  .name|rindex                 0.130s  0.131s  0.127s  0.125s  0.122s
-  .name|indices                0.159s  0.161s  0.155s  0.149s  0.145s
-  [x,y]|sort                   0.156s  0.154s  0.153s  0.154s  0.152s
-  .name|scan                   0.209s  0.214s  0.207s  0.213s  0.208s
-  .name|gsub                   0.168s  0.170s  0.167s  0.166s  0.162s
-  walk(if num .+1)             0.142s  0.140s  0.141s  0.137s  0.136s
-  tojson                       0.106s  0.106s  0.104s  0.105s  0.100s
-  {name,x}                     0.130s  0.129s  0.128s  0.128s  0.123s
-  .z//.name                    0.157s  0.158s  0.154s  0.155s  0.146s
-  .x|=test(re)                 0.171s  0.176s  0.172s  0.170s  0.165s
-  ./sep|first                  0.190s  0.185s  0.182s  0.180s  0.173s
-  .y=(.x*2)                    0.181s  0.180s  0.174s  0.175s  0.172s
-  .y=(.x+.y)                   0.238s  0.234s  0.228s  0.226s  0.224s
-  objects                      0.134s  0.138s  0.134s  0.137s  0.130s
-  .tag|=if..then N             0.617s  0.611s  0.627s  0.614s  0.590s
-  .x=(.x+1)                    0.129s  0.127s  0.124s  0.126s  0.123s
-  sel>N|.y+=1                  0.124s  0.122s  0.122s  0.120s  0.119s
-  sel(and)|.x+=1               0.111s  0.111s  0.109s  0.109s  0.106s
-  sel(sw)|.x+=1                0.165s  0.163s  0.159s  0.156s  0.156s
-  match(re)                    0.364s  0.367s  0.362s  0.368s  0.355s
-  capture(re)                  0.297s  0.299s  0.302s  0.299s  0.294s
-  first(.name,.x)              0.098s  0.097s  0.094s  0.095s  0.092s
-  if .x==null                  0.048s  0.047s  0.046s  0.046s  0.045s
-  we(sw(.key))                 0.110s  0.105s  0.108s  0.107s  0.104s
-  sel(sw or ew)                0.202s  0.207s  0.205s  0.199s  0.198s
-  path(.name,.x)               0.276s  0.278s  0.278s  0.271s  0.264s
-  sel(str+num+num)             0.152s  0.153s  0.150s  0.151s  0.145s
-  nested if|field              0.081s  0.077s  0.077s  0.077s  0.074s
-  .f|floor|.*2                 0.061s  0.061s  0.060s  0.061s  0.058s
-  split|len>1                  0.118s  0.119s  0.115s  0.113s  0.110s
-  .name|len|.*2                0.104s  0.103s  0.103s  0.100s  0.097s
-  if len>5 .x .y               0.118s  0.113s  0.113s  0.115s  0.110s
-  sel(len>5)|remap             0.207s  0.202s  0.201s  0.199s  0.198s
-  .x|tostr|len                 0.062s  0.060s  0.059s  0.058s  0.057s
-  if .x>.y .x .y               0.097s  0.094s  0.094s  0.094s  0.091s
-  split|last|tonum             0.096s  0.097s  0.096s  0.095s  0.092s
-  split|rev|.[0]               0.096s  0.091s  0.091s  0.090s  0.089s
-  split|.[0]+.[1]              0.113s  0.115s  0.113s  0.112s  0.109s
-  .[]|strings                  0.106s  0.106s  0.105s  0.104s  0.106s
-  .[]|numbers                  0.129s  0.125s  0.124s  0.124s  0.125s
-  [x,y]|any(>1M)               0.084s  0.082s  0.082s  0.083s  0.079s
-  sel(dc|sw)                   0.098s  0.101s  0.098s  0.098s  0.094s
-  [[x,y],[n]]|flat             0.460s  0.462s  0.464s  0.456s  0.450s
-  .x|floor|.*2                 0.061s  0.060s  0.061s  0.061s  0.059s
-  tojson|fromjson              0.087s  0.084s  0.082s  0.084s  0.080s
-  [.x]|add                     0.060s  0.060s  0.059s  0.059s  0.057s
-  if>N {o}+.                   0.136s  0.135s  0.138s  0.136s  0.127s
-  if>N .+{o}                   0.135s  0.135s  0.136s  0.132s  0.131s
-  if .n=="s" .+{o}             0.158s  0.161s  0.157s  0.159s  0.154s
-  sel(.n>"s")                  0.089s  0.090s  0.091s  0.087s  0.085s
-  [x,y,z]|min                  0.308s  0.311s  0.307s  0.312s  0.305s
-  if .n|len>5 l s              0.100s  0.101s  0.100s  0.099s  0.095s
-  if .x|flr>N b s              0.056s  0.055s  0.055s  0.054s  0.053s
-  if .n|test l e               0.105s  0.105s  0.105s  0.104s  0.102s
-  if .n|sw l e                 0.083s  0.085s  0.082s  0.084s  0.080s
-  if .n|ew l e                 0.084s  0.086s  0.085s  0.083s  0.080s
-  .n|len|tostr                 0.092s  0.091s  0.090s  0.092s  0.085s
+  empty                        0.018s  0.017s  0.017s  0.017s  0.017s
+  identity -c                  0.087s  0.086s  0.084s  0.084s  0.083s
+  identity (pretty)            0.107s  0.106s  0.102s  0.099s  0.103s
+  field access .name           0.097s  0.093s  0.090s  0.089s  0.103s
+  nested .x,.y,.name           0.150s  0.147s  0.146s  0.149s  0.171s
+  arithmetic .x + .y           0.084s  0.083s  0.082s  0.079s  0.083s
+  select .x > 1500000          0.087s  0.084s  0.080s  0.077s  0.082s
+  string concat                0.095s  0.092s  0.092s  0.088s  0.090s
+  object construct             0.116s  0.114s  0.110s  0.109s  0.124s
+  array construct              0.106s  0.105s  0.105s  0.100s  0.123s
+  .[]                          0.104s  0.102s  0.101s  0.098s  0.111s
+  to_entries                   0.159s  0.163s  0.154s  0.150s  0.169s
+  keys                         0.107s  0.105s  0.100s  0.098s  0.101s
+  keys_unsorted                0.097s  0.094s  0.092s  0.090s  0.094s
+  length                       0.088s  0.084s  0.087s  0.084s  0.086s
+  has("x")                     0.039s  0.037s  0.036s  0.035s  0.038s
+  type                         0.023s  0.023s  0.022s  0.021s  0.022s
+  del(.name)                   0.107s  0.101s  0.099s  0.098s  0.113s
+  @csv                         0.120s  0.118s  0.117s  0.119s  0.125s
+  split/join                   0.094s  0.090s  0.089s  0.086s  0.089s
+  select|field                 0.099s  0.097s  0.094s  0.093s  0.098s
+  select|remap                 0.100s  0.099s  0.097s  0.093s  0.097s
+  computed remap               0.192s  0.191s  0.187s  0.186s  0.206s
+  [.x,.y]|add                  0.084s  0.083s  0.083s  0.081s  0.082s
+  [.x,.y]|avg                  0.111s  0.106s  0.106s  0.105s  0.105s
+  map(*2)|add                  0.107s  0.104s  0.102s  0.099s  0.104s
+  keys|length                  0.259s  0.255s  0.251s  0.249s  0.252s
+  .+{z=0}                      0.150s  0.146s  0.145s  0.142s  0.147s
+  split|first                  0.092s  0.089s  0.088s  0.086s  0.087s
+  slice[0..5]                  0.095s  0.094s  0.094s  0.088s  0.091s
+  dynkey {(.name)}             0.108s  0.104s  0.106s  0.100s  0.114s
+  .x += 1                      0.128s  0.121s  0.122s  0.124s  0.127s
+  {a}+{b} merge                0.133s  0.130s  0.129s  0.128s  0.148s
+  .x*2+1                       0.061s  0.060s  0.059s  0.057s  0.059s
+  .x+.y*2                      0.099s  0.100s  0.096s  0.094s  0.095s
+  .x > .y                      0.078s  0.077s  0.076s  0.074s  0.078s
+  to_entries|len               0.405s  0.397s  0.397s  0.389s  0.393s
+  .x|.+1 (pipe)                0.059s  0.059s  0.056s  0.055s  0.057s
+  .x|.*2|.+1                   0.060s  0.060s  0.058s  0.056s  0.059s
+  .name|.+"_x"                 0.097s  0.094s  0.092s  0.088s  0.092s
+  .x>N | not                   0.051s  0.049s  0.048s  0.047s  0.050s
+  and (2 cmp)                  0.082s  0.080s  0.080s  0.078s  0.081s
+  if-then-else                 0.053s  0.052s  0.051s  0.049s  0.052s
+  sel(and)|field               0.079s  0.076s  0.076s  0.073s  0.077s
+  sel(and)|remap               0.079s  0.077s  0.077s  0.074s  0.078s
+  arith|cmp                    0.056s  0.054s  0.053s  0.051s  0.053s
+  if cmp .field                0.118s  0.113s  0.110s  0.108s  0.113s
+  split|length                 0.093s  0.089s  0.088s  0.085s  0.087s
+  [x,y]|min                    0.092s  0.090s  0.089s  0.087s  0.090s
+  [x,y]|max                    0.097s  0.095s  0.092s  0.090s  0.094s
+  [x,y]|sort|.[0]              0.092s  0.089s  0.088s  0.085s  0.089s
+  .name|len>5                  0.094s  0.090s  0.089s  0.088s  0.091s
+  sel(len>5)|.x                0.111s  0.107s  0.107s  0.105s  0.106s
+  if .x>.y .name               0.092s  0.093s  0.088s  0.088s  0.089s
+  sel(.x>.y)|.name             0.074s  0.071s  0.070s  0.067s  0.071s
+  .x*2|tostring                0.058s  0.057s  0.055s  0.053s  0.056s
+  .x*.x+1                      0.067s  0.067s  0.064s  0.063s  0.066s
+  {k=.name,v=tostr}            0.147s  0.144s  0.145s  0.138s  0.157s
+  str add chain                0.388s  0.385s  0.378s  0.372s  0.380s
+  if>.y .name|empty            0.073s  0.073s  0.072s  0.070s  0.073s
+  if .x%2==0                   0.054s  0.055s  0.054s  0.052s  0.054s
+  if .x*2+1>1M                 0.055s  0.056s  0.054s  0.052s  0.054s
+  sel(.x%2==0)|.name           0.084s  0.084s  0.081s  0.080s  0.084s
+  sel(.x*2+1>1M)               0.157s  0.159s  0.154s  0.151s  0.157s
+  .x|@json                     0.049s  0.047s  0.047s  0.046s  0.048s
+  .x|@text                     0.049s  0.048s  0.047s  0.045s  0.048s
+  .name|@json                  0.102s  0.101s  0.101s  0.099s  0.102s
+  sel|[arr]                    0.143s  0.149s  0.144s  0.140s  0.160s
+  sel(and)|[arr]               0.077s  0.079s  0.076s  0.076s  0.079s
+  if>.y [arr]                  0.175s  0.179s  0.174s  0.178s  0.198s
+  if sw then .f                0.143s  0.139s  0.135s  0.132s  0.139s
+  dynkey {(.n)=.x*2}           0.117s  0.115s  0.112s  0.111s  0.116s
+  sel(and)|.x*.y               0.077s  0.077s  0.078s  0.074s  0.079s
+  sel>N|str chain              0.152s  0.155s  0.153s  0.151s  0.153s
+  .f+"_"+arith_ts              0.134s  0.133s  0.132s  0.130s  0.133s
+  sel(sw)|str ch               0.308s  0.307s  0.298s  0.301s  0.303s
+  split|rev|join               0.117s  0.117s  0.112s  0.111s  0.112s
+  dynkey+static                0.340s  0.338s  0.332s  0.332s  0.339s
+  if>.y str chain              0.167s  0.171s  0.168s  0.167s  0.170s
+  remap+str chain              0.156s  0.156s  0.154s  0.145s  0.160s
+  sel(len>8)                   0.163s  0.162s  0.159s  0.154s  0.159s
+  up|split|join                0.098s  0.095s  0.100s  0.095s  0.096s
+  .name|index                  0.121s  0.118s  0.117s  0.114s  0.121s
+  .name|index+1                0.126s  0.122s  0.122s  0.117s  0.122s
+  .name|rindex                 0.131s  0.127s  0.125s  0.122s  0.124s
+  .name|indices                0.161s  0.155s  0.149s  0.145s  0.159s
+  [x,y]|sort                   0.154s  0.153s  0.154s  0.152s  0.168s
+  .name|scan                   0.214s  0.207s  0.213s  0.208s  0.206s
+  .name|gsub                   0.170s  0.167s  0.166s  0.162s  0.168s
+  walk(if num .+1)             0.140s  0.141s  0.137s  0.136s  0.137s
+  tojson                       0.106s  0.104s  0.105s  0.100s  0.107s
+  {name,x}                     0.129s  0.128s  0.128s  0.123s  0.150s
+  .z//.name                    0.158s  0.154s  0.155s  0.146s  0.164s
+  .x|=test(re)                 0.176s  0.172s  0.170s  0.165s  0.170s
+  ./sep|first                  0.185s  0.182s  0.180s  0.173s  0.179s
+  .y=(.x*2)                    0.180s  0.174s  0.175s  0.172s  0.176s
+  .y=(.x+.y)                   0.234s  0.228s  0.226s  0.224s  0.232s
+  objects                      0.138s  0.134s  0.137s  0.130s  0.125s
+  .tag|=if..then N             0.611s  0.627s  0.614s  0.590s  0.607s
+  .x=(.x+1)                    0.127s  0.124s  0.126s  0.123s  0.128s
+  sel>N|.y+=1                  0.122s  0.122s  0.120s  0.119s  0.122s
+  sel(and)|.x+=1               0.111s  0.109s  0.109s  0.106s  0.106s
+  sel(sw)|.x+=1                0.163s  0.159s  0.156s  0.156s  0.164s
+  match(re)                    0.367s  0.362s  0.368s  0.355s  0.363s
+  capture(re)                  0.299s  0.302s  0.299s  0.294s  0.299s
+  first(.name,.x)              0.097s  0.094s  0.095s  0.092s  0.106s
+  if .x==null                  0.047s  0.046s  0.046s  0.045s  0.047s
+  we(sw(.key))                 0.105s  0.108s  0.107s  0.104s  0.109s
+  sel(sw or ew)                0.207s  0.205s  0.199s  0.198s  0.206s
+  path(.name,.x)               0.278s  0.278s  0.271s  0.264s  0.273s
+  sel(str+num+num)             0.153s  0.150s  0.151s  0.145s  0.150s
+  nested if|field              0.077s  0.077s  0.077s  0.074s  0.078s
+  .f|floor|.*2                 0.061s  0.060s  0.061s  0.058s  0.062s
+  split|len>1                  0.119s  0.115s  0.113s  0.110s  0.117s
+  .name|len|.*2                0.103s  0.103s  0.100s  0.097s  0.101s
+  if len>5 .x .y               0.113s  0.113s  0.115s  0.110s  0.112s
+  sel(len>5)|remap             0.202s  0.201s  0.199s  0.198s  0.199s
+  .x|tostr|len                 0.060s  0.059s  0.058s  0.057s  0.060s
+  if .x>.y .x .y               0.094s  0.094s  0.094s  0.091s  0.093s
+  split|last|tonum             0.097s  0.096s  0.095s  0.092s  0.097s
+  split|rev|.[0]               0.091s  0.091s  0.090s  0.089s  0.092s
+  split|.[0]+.[1]              0.115s  0.113s  0.112s  0.109s  0.112s
+  .[]|strings                  0.106s  0.105s  0.104s  0.106s  0.108s
+  .[]|numbers                  0.125s  0.124s  0.124s  0.125s  0.126s
+  [x,y]|any(>1M)               0.082s  0.082s  0.083s  0.079s  0.082s
+  sel(dc|sw)                   0.101s  0.098s  0.098s  0.094s  0.099s
+  [[x,y],[n]]|flat             0.462s  0.464s  0.456s  0.450s  0.459s
+  .x|floor|.*2                 0.060s  0.061s  0.061s  0.059s  0.062s
+  tojson|fromjson              0.084s  0.082s  0.084s  0.080s  0.086s
+  [.x]|add                     0.060s  0.059s  0.059s  0.057s  0.064s
+  if>N {o}+.                   0.135s  0.138s  0.136s  0.127s  0.137s
+  if>N .+{o}                   0.135s  0.136s  0.132s  0.131s  0.132s
+  if .n=="s" .+{o}             0.161s  0.157s  0.159s  0.154s  0.162s
+  sel(.n>"s")                  0.090s  0.091s  0.087s  0.085s  0.088s
+  [x,y,z]|min                  0.311s  0.307s  0.312s  0.305s  0.313s
+  if .n|len>5 l s              0.101s  0.100s  0.099s  0.095s  0.100s
+  if .x|flr>N b s              0.055s  0.055s  0.054s  0.053s  0.055s
+  if .n|test l e               0.105s  0.105s  0.104s  0.102s  0.109s
+  if .n|sw l e                 0.085s  0.082s  0.084s  0.080s  0.085s
+  if .n|ew l e                 0.086s  0.085s  0.083s  0.080s  0.084s
+  .n|len|tostr                 0.091s  0.090s  0.092s  0.085s  0.090s
 
 --- String operations (2M objects) ---
-  Benchmark                    v1.6.0  v1.6.1  v1.7.0  v1.7.1  v1.8.0
+  Benchmark                    v1.6.1  v1.7.0  v1.7.1  v1.8.0  v1.8.1
   ---                          ------  ------  ------  ------  ------
-  ascii_downcase               0.105s  0.106s  0.104s  0.104s  0.100s
-  ascii_upcase                 0.104s  0.106s  0.103s  0.102s  0.099s
-  ltrimstr                     0.096s  0.099s  0.097s  0.096s  0.093s
-  rtrimstr                     0.098s  0.099s  0.097s  0.097s  0.095s
-  split                        0.170s  0.165s  0.162s  0.164s  0.156s
-  case+split                   0.118s  0.116s  0.121s  0.116s  0.113s
-  join                         0.096s  0.093s  0.093s  0.094s  0.091s
-  startswith                   0.098s  0.098s  0.095s  0.094s  0.090s
-  endswith                     0.098s  0.098s  0.096s  0.097s  0.091s
-  tostring                     0.063s  0.063s  0.063s  0.062s  0.060s
-  tonumber                     0.112s  0.111s  0.110s  0.109s  0.108s
-  string interpolation         0.120s  0.116s  0.118s  0.119s  0.114s
+  ascii_downcase               0.106s  0.104s  0.104s  0.100s  0.104s
+  ascii_upcase                 0.106s  0.103s  0.102s  0.099s  0.101s
+  ltrimstr                     0.099s  0.097s  0.096s  0.093s  0.096s
+  rtrimstr                     0.099s  0.097s  0.097s  0.095s  0.099s
+  split                        0.165s  0.162s  0.164s  0.156s  0.166s
+  case+split                   0.116s  0.121s  0.116s  0.113s  0.117s
+  join                         0.093s  0.093s  0.094s  0.091s  0.092s
+  startswith                   0.098s  0.095s  0.094s  0.090s  0.096s
+  endswith                     0.098s  0.096s  0.097s  0.091s  0.096s
+  tostring                     0.063s  0.063s  0.062s  0.060s  0.073s
+  tonumber                     0.111s  0.110s  0.109s  0.108s  0.108s
+  string interpolation         0.116s  0.118s  0.119s  0.114s  0.120s
 
 --- String ops (200K objects) ---
-  Benchmark                    v1.6.0  v1.6.1  v1.7.0  v1.7.1  v1.8.0
+  Benchmark                    v1.6.1  v1.7.0  v1.7.1  v1.8.0  v1.8.1
   ---                          ------  ------  ------  ------  ------
-  test (regex)                 0.015s  0.015s  0.014s  0.014s  0.014s
-  match (regex)                0.032s  0.033s  0.032s  0.033s  0.033s
-  @base64                      0.012s  0.012s  0.012s  0.012s  0.011s
-  @uri                         0.012s  0.013s  0.012s  0.012s  0.011s
-  @html                        0.012s  0.013s  0.012s  0.012s  0.011s
-  @csv (array)                 0.016s  0.016s  0.016s  0.016s  0.015s
-  @tsv (array)                 0.015s  0.015s  0.015s  0.015s  0.014s
-  gsub                         0.019s  0.019s  0.019s  0.019s  0.018s
-  case+gsub                    0.181s  0.181s  0.180s  0.176s  0.177s
-  case+test                    0.116s  0.124s  0.120s  0.118s  0.114s
-  ltrim+tonum+arith            0.113s  0.113s  0.111s  0.111s  0.107s
+  test (regex)                 0.015s  0.014s  0.014s  0.014s  0.014s
+  match (regex)                0.033s  0.032s  0.033s  0.033s  0.032s
+  @base64                      0.012s  0.012s  0.012s  0.011s  0.012s
+  @uri                         0.013s  0.012s  0.012s  0.011s  0.012s
+  @html                        0.013s  0.012s  0.012s  0.011s  0.012s
+  @csv (array)                 0.016s  0.016s  0.016s  0.015s  0.016s
+  @tsv (array)                 0.015s  0.015s  0.015s  0.014s  0.015s
+  gsub                         0.019s  0.019s  0.019s  0.018s  0.019s
+  case+gsub                    0.181s  0.180s  0.176s  0.177s  0.182s
+  case+test                    0.124s  0.120s  0.118s  0.114s  0.122s
+  ltrim+tonum+arith            0.113s  0.111s  0.111s  0.107s  0.111s
 
 --- Numeric & math (2M objects) ---
-  Benchmark                    v1.6.0  v1.6.1  v1.7.0  v1.7.1  v1.8.0
+  Benchmark                    v1.6.1  v1.7.0  v1.7.1  v1.8.0  v1.8.1
   ---                          ------  ------  ------  ------  ------
-  floor                        0.059s  0.056s  0.057s  0.056s  0.054s
-  sqrt                         0.078s  0.079s  0.079s  0.078s  0.077s
-  modulo                       0.057s  0.057s  0.059s  0.057s  0.055s
-  if-elif-else                 0.124s  0.125s  0.123s  0.123s  0.123s
-  select|del                   0.090s  0.090s  0.091s  0.091s  0.087s
-  select|merge                 0.121s  0.118s  0.121s  0.118s  0.114s
-  select(test)|merge           0.021s  0.022s  0.021s  0.021s  0.020s
+  floor                        0.056s  0.057s  0.056s  0.054s  0.057s
+  sqrt                         0.079s  0.079s  0.078s  0.077s  0.080s
+  modulo                       0.057s  0.059s  0.057s  0.055s  0.059s
+  if-elif-else                 0.125s  0.123s  0.123s  0.123s  0.126s
+  select|del                   0.090s  0.091s  0.091s  0.087s  0.097s
+  select|merge                 0.118s  0.121s  0.118s  0.114s  0.119s
+  select(test)|merge           0.022s  0.021s  0.021s  0.020s  0.022s
 
 --- Array generators ---
-  Benchmark                    v1.6.0  v1.6.1  v1.7.0  v1.7.1  v1.8.0
+  Benchmark                    v1.6.1  v1.7.0  v1.7.1  v1.8.0  v1.8.1
   ---                          ------  ------  ------  ------  ------
-  range(2M) | length           0.012s  0.012s  0.012s  0.011s  0.011s
-  reverse(2M)                  0.018s  0.018s  0.018s  0.018s  0.017s
-  sort(2M)                     0.023s  0.023s  0.023s  0.023s  0.022s
-  unique(1M)                   0.031s  0.030s  0.030s  0.030s  0.029s
-  flatten(500K)                0.011s  0.011s  0.011s  0.011s  0.010s
-  min, max(2M)                 0.022s  0.021s  0.019s  0.020s  0.017s
-  add numbers(2M)              0.013s  0.013s  0.013s  0.013s  0.012s
-  any/all(2M)                  0.029s  0.028s  0.029s  0.028s  0.028s
-  limit(10; range(10M))        0.003s  0.002s  0.003s  0.002s  0.002s
-  first(range(10M))            0.003s  0.002s  0.003s  0.002s  0.002s
-  last(range(2M))              0.003s  0.002s  0.003s  0.002s  0.002s
-  indices(1M)                  0.017s  0.017s  0.017s  0.017s  0.016s
+  range(2M) | length           0.012s  0.012s  0.011s  0.011s  0.012s
+  reverse(2M)                  0.018s  0.018s  0.018s  0.017s  0.018s
+  sort(2M)                     0.023s  0.023s  0.023s  0.022s  0.024s
+  unique(1M)                   0.030s  0.030s  0.030s  0.029s  0.031s
+  flatten(500K)                0.011s  0.011s  0.011s  0.010s  0.011s
+  min, max(2M)                 0.021s  0.019s  0.020s  0.017s  0.020s
+  add numbers(2M)              0.013s  0.013s  0.013s  0.012s  0.013s
+  any/all(2M)                  0.028s  0.029s  0.028s  0.028s  0.028s
+  limit(10; range(10M))        0.002s  0.003s  0.002s  0.002s  0.002s
+  first(range(10M))            0.002s  0.003s  0.002s  0.002s  0.002s
+  last(range(2M))              0.002s  0.003s  0.002s  0.002s  0.002s
+  indices(1M)                  0.017s  0.017s  0.017s  0.016s  0.016s
 
 --- Reduce & foreach ---
-  Benchmark                    v1.6.0  v1.6.1  v1.7.0  v1.7.1  v1.8.0
+  Benchmark                    v1.6.1  v1.7.0  v1.7.1  v1.8.0  v1.8.1
   ---                          ------  ------  ------  ------  ------
   reduce (sum)                 0.009s  0.009s  0.009s  0.009s  0.009s
   reduce (array build)         0.004s  0.004s  0.004s  0.004s  0.004s
-  reduce (obj build)           0.010s  0.010s  0.010s  0.009s  0.009s
-  reduce (setpath)             0.017s  0.016s  0.016s  0.016s  0.016s
-  foreach (running sum)        0.010s  0.010s  0.010s  0.010s  0.009s
-  foreach + emit               0.011s  0.011s  0.010s  0.010s  0.010s
-  reduce (sum-of-squares)      0.036s  0.034s  0.034s  0.033s  0.032s
-  reduce (conditional)         0.037s  0.036s  0.035s  0.035s  0.033s
-  reduce (product)             0.036s  0.035s  0.034s  0.034s  0.035s
-  foreach (conditional)        0.011s  0.010s  0.010s  0.010s  0.010s
-  until (100M)                 0.307s  0.303s  0.305s  0.303s  0.301s
-  reduce (harmonic)            0.035s  0.033s  0.033s  0.033s  0.032s
-  reduce (floor pipe)          0.035s  0.034s  0.033s  0.033s  0.032s
-  reduce (sqrt pipe)           0.035s  0.033s  0.033s  0.033s  0.032s
-  reduce (sin+cos)             0.052s  0.052s  0.052s  0.052s  0.051s
+  reduce (obj build)           0.010s  0.010s  0.009s  0.009s  0.010s
+  reduce (setpath)             0.016s  0.016s  0.016s  0.016s  0.017s
+  foreach (running sum)        0.010s  0.010s  0.010s  0.009s  0.010s
+  foreach + emit               0.011s  0.010s  0.010s  0.010s  0.010s
+  reduce (sum-of-squares)      0.034s  0.034s  0.033s  0.032s  0.033s
+  reduce (conditional)         0.036s  0.035s  0.035s  0.033s  0.035s
+  reduce (product)             0.035s  0.034s  0.034s  0.035s  0.034s
+  foreach (conditional)        0.010s  0.010s  0.010s  0.010s  0.010s
+  until (100M)                 0.303s  0.305s  0.303s  0.301s  0.301s
+  reduce (harmonic)            0.033s  0.033s  0.033s  0.032s  0.032s
+  reduce (floor pipe)          0.034s  0.033s  0.033s  0.032s  0.033s
+  reduce (sqrt pipe)           0.033s  0.033s  0.033s  0.032s  0.033s
+  reduce (sin+cos)             0.052s  0.052s  0.052s  0.051s  0.052s
 
 --- Object operations ---
-  Benchmark                    v1.6.0  v1.6.1  v1.7.0  v1.7.1  v1.8.0
+  Benchmark                    v1.6.1  v1.7.0  v1.7.1  v1.8.0  v1.8.1
   ---                          ------  ------  ------  ------  ------
   large obj construct          0.004s  0.004s  0.004s  0.004s  0.004s
-  large obj keys               0.012s  0.011s  0.011s  0.011s  0.011s
+  large obj keys               0.011s  0.011s  0.011s  0.011s  0.011s
   large obj to_entries         0.012s  0.012s  0.012s  0.012s  0.012s
-  with_entries                 0.009s  0.009s  0.009s  0.009s  0.008s
+  with_entries                 0.009s  0.009s  0.009s  0.008s  0.009s
 
 --- Assignment operators ---
-  Benchmark                    v1.6.0  v1.6.1  v1.7.0  v1.7.1  v1.8.0
+  Benchmark                    v1.6.1  v1.7.0  v1.7.1  v1.8.0  v1.8.1
   ---                          ------  ------  ------  ------  ------
   .[] |= f (100K)              0.005s  0.005s  0.005s  0.005s  0.005s
-  .[] += 1 (100K)              0.006s  0.005s  0.005s  0.006s  0.005s
+  .[] += 1 (100K)              0.005s  0.005s  0.006s  0.005s  0.005s
   .[k] = v reduce(50K)         0.008s  0.008s  0.008s  0.008s  0.008s
-  p126-shape nested reduce     -       -       -       -       0.103s
-  p126-shape w/ mutate         -       -       -       -       0.105s
-  p150-shape serial mutate     -       -       -       -       0.010s
+  p126-shape nested reduce     -       -       -       0.103s  0.110s
+  p126-shape w/ mutate         -       -       -       0.105s  0.112s
+  p150-shape serial mutate     -       -       -       0.010s  0.012s
 
 --- String-heavy generators ---
-  Benchmark                    v1.6.0  v1.6.1  v1.7.0  v1.7.1  v1.8.0
+  Benchmark                    v1.6.1  v1.7.0  v1.7.1  v1.8.0  v1.8.1
   ---                          ------  ------  ------  ------  ------
-  gsub(100K)                   0.027s  0.027s  0.027s  0.026s  0.026s
-  join large(100K)             0.006s  0.005s  0.005s  0.006s  0.005s
-  explode/implode(100K)        0.028s  0.028s  0.027s  0.028s  0.027s
-  reduce str concat(100K)      0.008s  0.008s  0.008s  0.008s  0.007s
+  gsub(100K)                   0.027s  0.027s  0.026s  0.026s  0.027s
+  join large(100K)             0.005s  0.005s  0.006s  0.005s  0.006s
+  explode/implode(100K)        0.028s  0.027s  0.028s  0.027s  0.028s
+  reduce str concat(100K)      0.008s  0.008s  0.008s  0.007s  0.008s
 
 --- Try-catch & alternative ---
-  Benchmark                    v1.6.0  v1.6.1  v1.7.0  v1.7.1  v1.8.0
+  Benchmark                    v1.6.1  v1.7.0  v1.7.1  v1.8.0  v1.8.1
   ---                          ------  ------  ------  ------  ------
-  alternative //               0.035s  0.035s  0.035s  0.035s  0.034s
-  try-catch                    0.024s  0.024s  0.024s  0.024s  0.023s
+  alternative //               0.035s  0.035s  0.035s  0.034s  0.035s
+  try-catch                    0.024s  0.024s  0.024s  0.023s  0.023s
   label-break                  0.004s  0.004s  0.004s  0.004s  0.004s
 
 --- Type conversion ---
-  Benchmark                    v1.6.0  v1.6.1  v1.7.0  v1.7.1  v1.8.0
+  Benchmark                    v1.6.1  v1.7.0  v1.7.1  v1.8.0  v1.8.1
   ---                          ------  ------  ------  ------  ------
-  tojson/fromjson(100K)        0.023s  0.022s  0.022s  0.022s  0.022s
-  null propagation(2M)         0.093s  0.091s  0.091s  0.093s  0.090s
+  tojson/fromjson(100K)        0.022s  0.022s  0.022s  0.022s  0.022s
+  null propagation(2M)         0.091s  0.091s  0.093s  0.090s  0.092s
 
 --- jaq-derived ---
-  Benchmark                    v1.6.0  v1.6.1  v1.7.0  v1.7.1  v1.8.0
+  Benchmark                    v1.6.1  v1.7.0  v1.7.1  v1.8.0  v1.8.1
   ---                          ------  ------  ------  ------  ------
   jaq: reverse                 -       -       -       -       -
   jaq: sort                    -       -       -       -       -
@@ -294,9 +294,9 @@ Recent slice (last 5 columns). Full history lives in
   jaq: str-slice               -       -       -       -       -
 
 --- Memoization (jqx) ---
-  Benchmark                    v1.6.0  v1.6.1  v1.7.0  v1.7.1  v1.8.0
+  Benchmark                    v1.6.1  v1.7.0  v1.7.1  v1.8.0  v1.8.1
   ---                          ------  ------  ------  ------  ------
-  memo fib (1K)                0.004s  0.003s  0.003s  0.003s  0.003s
-  memo collatz sum (10K)       0.017s  0.017s  0.016s  0.016s  0.016s
-  memo by .id (100K, 1K keys)  0.021s  0.020s  0.020s  0.020s  0.020s
+  memo fib (1K)                0.003s  0.003s  0.003s  0.003s  0.003s
+  memo collatz sum (10K)       0.017s  0.016s  0.016s  0.016s  0.017s
+  memo by .id (100K, 1K keys)  0.020s  0.020s  0.020s  0.020s  0.020s
 ```

--- a/docs/benchmark-history.tsv
+++ b/docs/benchmark-history.tsv
@@ -5134,3 +5134,223 @@ Type conversion	null propagation(2M)	v1.8.0	0.090
 Memoization (jqx)	memo fib (1K)	v1.8.0	0.003
 Memoization (jqx)	memo collatz sum (10K)	v1.8.0	0.016
 Memoization (jqx)	memo by .id (100K, 1K keys)	v1.8.0	0.020
+NDJSON workloads (2M objects)	empty	v1.8.1	0.017
+NDJSON workloads (2M objects)	identity -c	v1.8.1	0.083
+NDJSON workloads (2M objects)	identity (pretty)	v1.8.1	0.103
+NDJSON workloads (2M objects)	field access .name	v1.8.1	0.103
+NDJSON workloads (2M objects)	nested .x,.y,.name	v1.8.1	0.171
+NDJSON workloads (2M objects)	arithmetic .x + .y	v1.8.1	0.083
+NDJSON workloads (2M objects)	select .x > 1500000	v1.8.1	0.082
+NDJSON workloads (2M objects)	string concat	v1.8.1	0.090
+NDJSON workloads (2M objects)	object construct	v1.8.1	0.124
+NDJSON workloads (2M objects)	array construct	v1.8.1	0.123
+NDJSON workloads (2M objects)	.[]	v1.8.1	0.111
+NDJSON workloads (2M objects)	to_entries	v1.8.1	0.169
+NDJSON workloads (2M objects)	keys	v1.8.1	0.101
+NDJSON workloads (2M objects)	keys_unsorted	v1.8.1	0.094
+NDJSON workloads (2M objects)	length	v1.8.1	0.086
+NDJSON workloads (2M objects)	has("x")	v1.8.1	0.038
+NDJSON workloads (2M objects)	type	v1.8.1	0.022
+NDJSON workloads (2M objects)	del(.name)	v1.8.1	0.113
+NDJSON workloads (2M objects)	@csv	v1.8.1	0.125
+NDJSON workloads (2M objects)	split/join	v1.8.1	0.089
+NDJSON workloads (2M objects)	select|field	v1.8.1	0.098
+NDJSON workloads (2M objects)	select|remap	v1.8.1	0.097
+NDJSON workloads (2M objects)	computed remap	v1.8.1	0.206
+NDJSON workloads (2M objects)	[.x,.y]|add	v1.8.1	0.082
+NDJSON workloads (2M objects)	[.x,.y]|avg	v1.8.1	0.105
+NDJSON workloads (2M objects)	map(*2)|add	v1.8.1	0.104
+NDJSON workloads (2M objects)	keys|length	v1.8.1	0.252
+NDJSON workloads (2M objects)	.+{z=0}	v1.8.1	0.147
+NDJSON workloads (2M objects)	split|first	v1.8.1	0.087
+NDJSON workloads (2M objects)	slice[0..5]	v1.8.1	0.091
+NDJSON workloads (2M objects)	dynkey {(.name)}	v1.8.1	0.114
+NDJSON workloads (2M objects)	.x += 1	v1.8.1	0.127
+NDJSON workloads (2M objects)	{a}+{b} merge	v1.8.1	0.148
+NDJSON workloads (2M objects)	.x*2+1	v1.8.1	0.059
+NDJSON workloads (2M objects)	.x+.y*2	v1.8.1	0.095
+NDJSON workloads (2M objects)	.x > .y	v1.8.1	0.078
+NDJSON workloads (2M objects)	to_entries|len	v1.8.1	0.393
+NDJSON workloads (2M objects)	.x|.+1 (pipe)	v1.8.1	0.057
+NDJSON workloads (2M objects)	.x|.*2|.+1	v1.8.1	0.059
+NDJSON workloads (2M objects)	.name|.+"_x"	v1.8.1	0.092
+NDJSON workloads (2M objects)	.x>N | not	v1.8.1	0.050
+NDJSON workloads (2M objects)	and (2 cmp)	v1.8.1	0.081
+NDJSON workloads (2M objects)	if-then-else	v1.8.1	0.052
+NDJSON workloads (2M objects)	sel(and)|field	v1.8.1	0.077
+NDJSON workloads (2M objects)	sel(and)|remap	v1.8.1	0.078
+NDJSON workloads (2M objects)	arith|cmp	v1.8.1	0.053
+NDJSON workloads (2M objects)	if cmp .field	v1.8.1	0.113
+NDJSON workloads (2M objects)	split|length	v1.8.1	0.087
+NDJSON workloads (2M objects)	[x,y]|min	v1.8.1	0.090
+NDJSON workloads (2M objects)	[x,y]|max	v1.8.1	0.094
+NDJSON workloads (2M objects)	[x,y]|sort|.[0]	v1.8.1	0.089
+NDJSON workloads (2M objects)	.name|len>5	v1.8.1	0.091
+NDJSON workloads (2M objects)	sel(len>5)|.x	v1.8.1	0.106
+NDJSON workloads (2M objects)	if .x>.y .name	v1.8.1	0.089
+NDJSON workloads (2M objects)	sel(.x>.y)|.name	v1.8.1	0.071
+NDJSON workloads (2M objects)	.x*2|tostring	v1.8.1	0.056
+NDJSON workloads (2M objects)	.x*.x+1	v1.8.1	0.066
+NDJSON workloads (2M objects)	{k=.name,v=tostr}	v1.8.1	0.157
+NDJSON workloads (2M objects)	str add chain	v1.8.1	0.380
+NDJSON workloads (2M objects)	if>.y .name|empty	v1.8.1	0.073
+NDJSON workloads (2M objects)	if .x%2==0	v1.8.1	0.054
+NDJSON workloads (2M objects)	if .x*2+1>1M	v1.8.1	0.054
+NDJSON workloads (2M objects)	sel(.x%2==0)|.name	v1.8.1	0.084
+NDJSON workloads (2M objects)	sel(.x*2+1>1M)	v1.8.1	0.157
+NDJSON workloads (2M objects)	.x|@json	v1.8.1	0.048
+NDJSON workloads (2M objects)	.x|@text	v1.8.1	0.048
+NDJSON workloads (2M objects)	.name|@json	v1.8.1	0.102
+NDJSON workloads (2M objects)	sel|[arr]	v1.8.1	0.160
+NDJSON workloads (2M objects)	sel(and)|[arr]	v1.8.1	0.079
+NDJSON workloads (2M objects)	if>.y [arr]	v1.8.1	0.198
+NDJSON workloads (2M objects)	if sw then .f	v1.8.1	0.139
+NDJSON workloads (2M objects)	dynkey {(.n)=.x*2}	v1.8.1	0.116
+NDJSON workloads (2M objects)	sel(and)|.x*.y	v1.8.1	0.079
+NDJSON workloads (2M objects)	sel>N|str chain	v1.8.1	0.153
+NDJSON workloads (2M objects)	.f+"_"+arith_ts	v1.8.1	0.133
+NDJSON workloads (2M objects)	sel(sw)|str ch	v1.8.1	0.303
+NDJSON workloads (2M objects)	split|rev|join	v1.8.1	0.112
+NDJSON workloads (2M objects)	dynkey+static	v1.8.1	0.339
+NDJSON workloads (2M objects)	if>.y str chain	v1.8.1	0.170
+NDJSON workloads (2M objects)	remap+str chain	v1.8.1	0.160
+NDJSON workloads (2M objects)	sel(len>8)	v1.8.1	0.159
+NDJSON workloads (2M objects)	up|split|join	v1.8.1	0.096
+NDJSON workloads (2M objects)	.name|index	v1.8.1	0.121
+NDJSON workloads (2M objects)	.name|index+1	v1.8.1	0.122
+NDJSON workloads (2M objects)	.name|rindex	v1.8.1	0.124
+NDJSON workloads (2M objects)	.name|indices	v1.8.1	0.159
+NDJSON workloads (2M objects)	[x,y]|sort	v1.8.1	0.168
+NDJSON workloads (2M objects)	.name|scan	v1.8.1	0.206
+NDJSON workloads (2M objects)	.name|gsub	v1.8.1	0.168
+NDJSON workloads (2M objects)	walk(if num .+1)	v1.8.1	0.137
+NDJSON workloads (2M objects)	tojson	v1.8.1	0.107
+NDJSON workloads (2M objects)	{name,x}	v1.8.1	0.150
+NDJSON workloads (2M objects)	.z//.name	v1.8.1	0.164
+NDJSON workloads (2M objects)	.x|=test(re)	v1.8.1	0.170
+NDJSON workloads (2M objects)	./sep|first	v1.8.1	0.179
+NDJSON workloads (2M objects)	.y=(.x*2)	v1.8.1	0.176
+NDJSON workloads (2M objects)	.y=(.x+.y)	v1.8.1	0.232
+NDJSON workloads (2M objects)	objects	v1.8.1	0.125
+NDJSON workloads (2M objects)	.tag|=if..then N	v1.8.1	0.607
+NDJSON workloads (2M objects)	.x=(.x+1)	v1.8.1	0.128
+NDJSON workloads (2M objects)	sel>N|.y+=1	v1.8.1	0.122
+NDJSON workloads (2M objects)	sel(and)|.x+=1	v1.8.1	0.106
+NDJSON workloads (2M objects)	sel(sw)|.x+=1	v1.8.1	0.164
+NDJSON workloads (2M objects)	match(re)	v1.8.1	0.363
+NDJSON workloads (2M objects)	capture(re)	v1.8.1	0.299
+NDJSON workloads (2M objects)	first(.name,.x)	v1.8.1	0.106
+NDJSON workloads (2M objects)	if .x==null	v1.8.1	0.047
+NDJSON workloads (2M objects)	we(sw(.key))	v1.8.1	0.109
+NDJSON workloads (2M objects)	sel(sw or ew)	v1.8.1	0.206
+NDJSON workloads (2M objects)	path(.name,.x)	v1.8.1	0.273
+NDJSON workloads (2M objects)	sel(str+num+num)	v1.8.1	0.150
+NDJSON workloads (2M objects)	nested if|field	v1.8.1	0.078
+NDJSON workloads (2M objects)	.f|floor|.*2	v1.8.1	0.062
+NDJSON workloads (2M objects)	split|len>1	v1.8.1	0.117
+NDJSON workloads (2M objects)	.name|len|.*2	v1.8.1	0.101
+NDJSON workloads (2M objects)	if len>5 .x .y	v1.8.1	0.112
+NDJSON workloads (2M objects)	sel(len>5)|remap	v1.8.1	0.199
+NDJSON workloads (2M objects)	.x|tostr|len	v1.8.1	0.060
+NDJSON workloads (2M objects)	if .x>.y .x .y	v1.8.1	0.093
+NDJSON workloads (2M objects)	split|last|tonum	v1.8.1	0.097
+NDJSON workloads (2M objects)	split|rev|.[0]	v1.8.1	0.092
+NDJSON workloads (2M objects)	split|.[0]+.[1]	v1.8.1	0.112
+NDJSON workloads (2M objects)	.[]|strings	v1.8.1	0.108
+NDJSON workloads (2M objects)	.[]|numbers	v1.8.1	0.126
+NDJSON workloads (2M objects)	[x,y]|any(>1M)	v1.8.1	0.082
+NDJSON workloads (2M objects)	sel(dc|sw)	v1.8.1	0.099
+NDJSON workloads (2M objects)	[[x,y],[n]]|flat	v1.8.1	0.459
+NDJSON workloads (2M objects)	.x|floor|.*2	v1.8.1	0.062
+NDJSON workloads (2M objects)	tojson|fromjson	v1.8.1	0.086
+NDJSON workloads (2M objects)	[.x]|add	v1.8.1	0.064
+NDJSON workloads (2M objects)	if>N {o}+.	v1.8.1	0.137
+NDJSON workloads (2M objects)	if>N .+{o}	v1.8.1	0.132
+NDJSON workloads (2M objects)	if .n=="s" .+{o}	v1.8.1	0.162
+NDJSON workloads (2M objects)	sel(.n>"s")	v1.8.1	0.088
+NDJSON workloads (2M objects)	[x,y,z]|min	v1.8.1	0.313
+NDJSON workloads (2M objects)	if .n|len>5 l s	v1.8.1	0.100
+NDJSON workloads (2M objects)	if .x|flr>N b s	v1.8.1	0.055
+NDJSON workloads (2M objects)	if .n|test l e	v1.8.1	0.109
+NDJSON workloads (2M objects)	if .n|sw l e	v1.8.1	0.085
+NDJSON workloads (2M objects)	if .n|ew l e	v1.8.1	0.084
+NDJSON workloads (2M objects)	.n|len|tostr	v1.8.1	0.090
+String operations (2M objects)	ascii_downcase	v1.8.1	0.104
+String operations (2M objects)	ascii_upcase	v1.8.1	0.101
+String operations (2M objects)	ltrimstr	v1.8.1	0.096
+String operations (2M objects)	rtrimstr	v1.8.1	0.099
+String operations (2M objects)	split	v1.8.1	0.166
+String operations (2M objects)	case+split	v1.8.1	0.117
+String operations (2M objects)	join	v1.8.1	0.092
+String operations (2M objects)	startswith	v1.8.1	0.096
+String operations (2M objects)	endswith	v1.8.1	0.096
+String operations (2M objects)	tostring	v1.8.1	0.073
+String operations (2M objects)	tonumber	v1.8.1	0.108
+String operations (2M objects)	string interpolation	v1.8.1	0.120
+String ops (200K objects)	test (regex)	v1.8.1	0.014
+String ops (200K objects)	match (regex)	v1.8.1	0.032
+String ops (200K objects)	@base64	v1.8.1	0.012
+String ops (200K objects)	@uri	v1.8.1	0.012
+String ops (200K objects)	@html	v1.8.1	0.012
+String ops (200K objects)	@csv (array)	v1.8.1	0.016
+String ops (200K objects)	@tsv (array)	v1.8.1	0.015
+String ops (200K objects)	gsub	v1.8.1	0.019
+String ops (200K objects)	case+gsub	v1.8.1	0.182
+String ops (200K objects)	case+test	v1.8.1	0.122
+String ops (200K objects)	ltrim+tonum+arith	v1.8.1	0.111
+Numeric & math (2M objects)	floor	v1.8.1	0.057
+Numeric & math (2M objects)	sqrt	v1.8.1	0.080
+Numeric & math (2M objects)	modulo	v1.8.1	0.059
+Numeric & math (2M objects)	if-elif-else	v1.8.1	0.126
+Numeric & math (2M objects)	select|del	v1.8.1	0.097
+Numeric & math (2M objects)	select|merge	v1.8.1	0.119
+Numeric & math (2M objects)	select(test)|merge	v1.8.1	0.022
+Array generators	range(2M) | length	v1.8.1	0.012
+Array generators	reverse(2M)	v1.8.1	0.018
+Array generators	sort(2M)	v1.8.1	0.024
+Array generators	unique(1M)	v1.8.1	0.031
+Array generators	flatten(500K)	v1.8.1	0.011
+Array generators	min, max(2M)	v1.8.1	0.020
+Array generators	add numbers(2M)	v1.8.1	0.013
+Array generators	any/all(2M)	v1.8.1	0.028
+Array generators	limit(10; range(10M))	v1.8.1	0.002
+Array generators	first(range(10M))	v1.8.1	0.002
+Array generators	last(range(2M))	v1.8.1	0.002
+Array generators	indices(1M)	v1.8.1	0.016
+Reduce & foreach	reduce (sum)	v1.8.1	0.009
+Reduce & foreach	reduce (array build)	v1.8.1	0.004
+Reduce & foreach	reduce (obj build)	v1.8.1	0.010
+Reduce & foreach	reduce (setpath)	v1.8.1	0.017
+Reduce & foreach	foreach (running sum)	v1.8.1	0.010
+Reduce & foreach	foreach + emit	v1.8.1	0.010
+Reduce & foreach	reduce (sum-of-squares)	v1.8.1	0.033
+Reduce & foreach	reduce (conditional)	v1.8.1	0.035
+Reduce & foreach	reduce (product)	v1.8.1	0.034
+Reduce & foreach	foreach (conditional)	v1.8.1	0.010
+Reduce & foreach	until (100M)	v1.8.1	0.301
+Reduce & foreach	reduce (harmonic)	v1.8.1	0.032
+Reduce & foreach	reduce (floor pipe)	v1.8.1	0.033
+Reduce & foreach	reduce (sqrt pipe)	v1.8.1	0.033
+Reduce & foreach	reduce (sin+cos)	v1.8.1	0.052
+Object operations	large obj construct	v1.8.1	0.004
+Object operations	large obj keys	v1.8.1	0.011
+Object operations	large obj to_entries	v1.8.1	0.012
+Object operations	with_entries	v1.8.1	0.009
+Assignment operators	.[] |= f (100K)	v1.8.1	0.005
+Assignment operators	.[] += 1 (100K)	v1.8.1	0.005
+Assignment operators	.[k] = v reduce(50K)	v1.8.1	0.008
+Assignment operators	p126-shape nested reduce	v1.8.1	0.110
+Assignment operators	p126-shape w/ mutate	v1.8.1	0.112
+Assignment operators	p150-shape serial mutate	v1.8.1	0.012
+String-heavy generators	gsub(100K)	v1.8.1	0.027
+String-heavy generators	join large(100K)	v1.8.1	0.006
+String-heavy generators	explode/implode(100K)	v1.8.1	0.028
+String-heavy generators	reduce str concat(100K)	v1.8.1	0.008
+Try-catch & alternative	alternative //	v1.8.1	0.035
+Try-catch & alternative	try-catch	v1.8.1	0.023
+Try-catch & alternative	label-break	v1.8.1	0.004
+Type conversion	tojson/fromjson(100K)	v1.8.1	0.022
+Type conversion	null propagation(2M)	v1.8.1	0.092
+Memoization (jqx)	memo fib (1K)	v1.8.1	0.003
+Memoization (jqx)	memo collatz sum (10K)	v1.8.1	0.017
+Memoization (jqx)	memo by .id (100K, 1K keys)	v1.8.1	0.020

--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -5108,13 +5108,11 @@ fn real_main() {
                     let mut ranges_buf = vec![(0usize, 0usize); field_refs.len()];
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        // A non-canonical number in the value (or key) must be
-                        // re-rendered through Value; bail to the generic path
-                        // rather than echo the source lexeme (#729).
-                        if raw_contains_non_canonical_number(raw) {
-                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                        } else if json_object_get_fields_raw_buf(raw, 0, &field_refs, &mut ranges_buf) {
+                        // The key is a string (emitted verbatim) and the value
+                        // goes through `emit_resolved_value`, which canonicalises
+                        // any non-canonical number repr itself (#729) — so no
+                        // whole-record pre-scan is needed here.
+                        if json_object_get_fields_raw_buf(raw, 0, &field_refs, &mut ranges_buf) {
                             let (ks, ke) = ranges_buf[key_idx];
                             let key_val = &raw[ks..ke];
                             // Key must be a string
@@ -14068,11 +14066,11 @@ fn real_main() {
                 let mut ranges_buf = vec![(0usize, 0usize); field_refs.len()];
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    // Canonicalise non-canonical numbers via the generic path (#729).
-                    if raw_contains_non_canonical_number(raw) {
-                        let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
-                        process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
-                    } else if json_object_get_fields_raw_buf(raw, 0, &field_refs, &mut ranges_buf) {
+                    // The key is a string (emitted verbatim) and the value goes
+                    // through `emit_resolved_value`, which canonicalises any
+                    // non-canonical number repr itself (#729) — so no whole-record
+                    // pre-scan is needed here.
+                    if json_object_get_fields_raw_buf(raw, 0, &field_refs, &mut ranges_buf) {
                         let (ks, ke) = ranges_buf[key_idx];
                         let key_val = &raw[ks..ke];
                         if key_val.len() >= 2 && key_val[0] == b'"' {

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -2670,20 +2670,35 @@ pub fn apply_field_unary_num_raw(
         UnaryOp::ToString => {
             // Only the numeric-field shape stays in the fast path; strings,
             // arrays, etc. need the generic path's `tostring` semantics.
-            // A non-canonical number must keep jq's canonical repr through
-            // tostring (`2e3` -> `"2E+3"`, not `"2000"`), which is lost once
-            // parsed to f64 — bail to the generic path for those (#729).
+            // Locate the field once and reuse its byte range for both the
+            // canonical-repr check and the parse — `json_object_get_field_raw`
+            // shares `json_object_get_num`'s last-wins dedup, so a second
+            // object walk just to parse would be pure overhead (#729 perf).
             match json_object_get_field_raw(raw, 0, field) {
-                Some((vs, ve)) if raw_contains_non_canonical_number(&raw[vs..ve]) => {
-                    return RawApplyOutcome::Bail;
-                }
-                _ => {}
-            }
-            match json_object_get_num(raw, 0, field) {
-                Some(n) => {
-                    buf.push(b'"');
-                    push_jq_number_bytes(buf, n);
-                    buf.extend_from_slice(b"\"\n");
+                Some((vs, ve)) => {
+                    let val = &raw[vs..ve];
+                    // A non-canonical number must keep jq's canonical repr
+                    // through tostring (`2e3` -> `"2E+3"`, not `"2000"`),
+                    // which is lost once parsed to f64 — bail for those (#729).
+                    if raw_contains_non_canonical_number(val) {
+                        return RawApplyOutcome::Bail;
+                    }
+                    // Mirror `json_object_get_num`: a 16+ digit integer is not
+                    // kept in the fast path (it needs the generic f64 route).
+                    // The canonical check above guarantees no `.`/`e`/`E`, so a
+                    // numeric value here is a plain integer and its digit count
+                    // is its width.
+                    if val.iter().filter(|c| c.is_ascii_digit()).count() > 15 {
+                        return RawApplyOutcome::Bail;
+                    }
+                    match parse_json_num(val) {
+                        Some(n) => {
+                            buf.push(b'"');
+                            push_jq_number_bytes(buf, n);
+                            buf.extend_from_slice(b"\"\n");
+                        }
+                        None => return RawApplyOutcome::Bail,
+                    }
                 }
                 None => return RawApplyOutcome::Bail,
             }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -10810,3 +10810,28 @@ if .b>0 then {y:.c} else 0 end
 .x>5
 {"x":9007199254740994}
 true
+
+# Issue #729 perf: dynamic-key object still canonicalizes the value (single-walk emit, no whole-record pre-scan)
+{(.name):.x}
+{"name":"k","x":2e3}
+{"k":2E+3}
+
+# Issue #729 perf: dynamic-key object with computed value stays canonical
+{(.name):(.x*2)}
+{"name":"k","x":21}
+{"k":42}
+
+# Issue #729 perf: dynamic-key object passes a clean 16-digit integer through verbatim
+{(.name):.x}
+{"name":"k","x":1234567890123456}
+{"k":1234567890123456}
+
+# Issue #729 perf: tostring fast path keeps a clean integer in-path
+.x|tostring
+{"x":12345}
+"12345"
+
+# Issue #729 perf: tostring bails a 16-digit integer to the generic path (matches json_object_get_num guard)
+.x|tostring
+{"x":1234567890123456}
+"1234567890123456"


### PR DESCRIPTION
## Summary

Release v1.8.1. Bundles a perf fix for a regression surfaced by the
release benchmark, plus the version bump and benchmark-history columns.

## Perf fix (e66d253)

#753 (the #729 canonical-number-repr fix) added two avoidable costs to
hot raw-byte paths — a doubled object walk in field-`tostring` and a
redundant whole-record pre-scan in the dynamic-key object fast paths —
regressing `.x | tostring` and `{(.name): .x}` ~1.5x on the 2M-object
NDJSON suite. Both are restored to a single object walk while preserving
#729 canonicalization and #615 surrogate handling. dynkey fully
recovers; tostring drops ~1.5x → ~1.2x. New regression cases lock in the
canonical output through the optimized paths.

## Benchmark

History columns appended for v1.8.1. Gate vs v1.8.0: **max ratio 1.23,
zero benchmarks above the 1.30 stop threshold.** The acute tostring/dynkey
outliers are fixed; a broad ~10–20% NDJSON value-passthrough tax remains
as the intrinsic cost of #729 canonicalization (every emitted value now
runs a canonical/surrogate check instead of a verbatim copy). Tracked for
follow-up optimization in #758.

🤖 Generated with [Claude Code](https://claude.com/claude-code)