### PR TITLE
fix(eval): treat while/until update as a generator

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1728,6 +1728,91 @@ fn eval_assign_body(
     })
 }
 
+/// `while(cond; update)` with full generator semantics.
+///
+/// jq desugars it to `def _while: if cond then ., (update | _while) else empty
+/// end; _while;`. The update is therefore a *generator*: each value it yields is
+/// an independent successor that re-enters the loop. The common case (update
+/// yields exactly one value) stays a tight tail-iteration; an empty update
+/// terminates the chain (#760), and a multi-valued update fans out (#767).
+fn eval_while_gen(
+    cond: &Expr, update: &Expr, always_true: bool, mut current: Value,
+    env: &EnvRef, cb: &mut dyn FnMut(Value) -> GenResult,
+) -> GenResult {
+    loop {
+        if !always_true {
+            let is_true = if let Ok(v) = eval_one(cond, &current, env) {
+                v.is_truthy()
+            } else {
+                let mut t = false;
+                eval(cond, current.clone(), env, &mut |v| { t = v.is_truthy(); Ok(true) })?;
+                t
+            };
+            if !is_true { return Ok(true); }
+        }
+        if !cb(current.clone())? { return Ok(false); }
+        // Advance through `update`, honouring its generator semantics.
+        if let Ok(next) = eval_one(update, &current, env) {
+            current = next; // single value → tail-iterate (hot path)
+            continue;
+        }
+        let mut succ: Vec<Value> = Vec::new();
+        eval(update, current.clone(), env, &mut |v| { succ.push(v); Ok(true) })?;
+        match succ.len() {
+            0 => return Ok(true),                  // empty update → no successor (#760)
+            1 => current = succ.pop().unwrap(),    // single value → tail-iterate
+            _ => {                                 // multi-valued → fan out (#767)
+                for u in succ {
+                    if !eval_while_gen(cond, update, always_true, u, env, cb)? {
+                        return Ok(false);
+                    }
+                }
+                return Ok(true);
+            }
+        }
+    }
+}
+
+/// `until(cond; update)` with full generator semantics.
+///
+/// jq desugars it to `def _until: if cond then . else (update | _until) end;
+/// _until;`. As with `while`, the update is a generator: an empty update yields
+/// no successor (so the loop terminates emitting nothing) and a multi-valued
+/// update fans out, each value re-entering the loop.
+fn eval_until_gen(
+    cond: &Expr, update: &Expr, mut current: Value,
+    env: &EnvRef, cb: &mut dyn FnMut(Value) -> GenResult,
+) -> GenResult {
+    loop {
+        let is_true = if let Ok(v) = eval_one(cond, &current, env) {
+            v.is_truthy()
+        } else {
+            let mut t = false;
+            eval(cond, current.clone(), env, &mut |v| { t = v.is_truthy(); Ok(true) })?;
+            t
+        };
+        if is_true { return cb(current); }
+        if let Ok(next) = eval_one(update, &current, env) {
+            current = next; // single value → tail-iterate (hot path)
+            continue;
+        }
+        let mut succ: Vec<Value> = Vec::new();
+        eval(update, current.clone(), env, &mut |v| { succ.push(v); Ok(true) })?;
+        match succ.len() {
+            0 => return Ok(true),                  // empty update → no successor
+            1 => current = succ.pop().unwrap(),    // single value → tail-iterate
+            _ => {                                 // multi-valued → fan out
+                for u in succ {
+                    if !eval_until_gen(cond, update, u, env, cb)? {
+                        return Ok(false);
+                    }
+                }
+                return Ok(true);
+            }
+        }
+    }
+}
+
 pub fn eval(
     expr: &Expr, input: Value, env: &EnvRef,
     cb: &mut dyn FnMut(Value) -> GenResult,
@@ -1945,9 +2030,25 @@ pub fn eval(
                         } else if let Ok(next) = eval_one(update, &current, env) {
                             current = next;
                         } else {
-                            let mut next = Value::Null;
-                            eval(update, current, env, &mut |v| { next = v; Ok(true) })?;
-                            current = next;
+                            // `update` is a generator here: 0, 1, or many successors.
+                            let mut succ: Vec<Value> = Vec::new();
+                            eval(update, current.clone(), env, &mut |v| { succ.push(v); Ok(true) })?;
+                            match succ.len() {
+                                0 => break,                        // empty update terminates (#760)
+                                1 => current = succ.pop().unwrap(),
+                                _ => {
+                                    // Multi-valued update (#767): each successor spawns an
+                                    // independent continuation of `while(cond; update)`, whose
+                                    // values flow through the piped `right`. Delegate to the
+                                    // generator helper so the linear fast path stays untouched.
+                                    for u in succ {
+                                        let go = eval_while_gen(cond, update, always_true, u, env,
+                                            &mut |wv| eval(right, wv, env, cb))?;
+                                        if !go { return Ok(false); }
+                                    }
+                                    break;
+                                }
+                            }
                         }
                     }
                     Ok(true)
@@ -3169,50 +3270,11 @@ pub fn eval(
 
         Expr::While { cond, update } => {
             let always_true = matches!(cond.as_ref(), Expr::Literal(Literal::True));
-            let mut current = input;
-            loop {
-                if !always_true {
-                    let is_true = if let Ok(v) = eval_one(cond, &current, env) {
-                        v.is_truthy()
-                    } else {
-                        let mut t = false;
-                        eval(cond, current.clone(), env, &mut |v| { t = v.is_truthy(); Ok(true) })?;
-                        t
-                    };
-                    if !is_true { break; }
-                }
-                if !cb(current.clone())? { return Ok(false); }
-                if let Ok(next) = eval_one(update, &current, env) {
-                    current = next;
-                } else {
-                    let mut next = Value::Null;
-                    eval(update, current, env, &mut |v| { next = v; Ok(true) })?;
-                    current = next;
-                }
-            }
-            Ok(true)
+            eval_while_gen(cond, update, always_true, input, env, cb)
         }
 
         Expr::Until { cond, update } => {
-            let mut current = input;
-            loop {
-                let is_true = if let Ok(v) = eval_one(cond, &current, env) {
-                    v.is_truthy()
-                } else {
-                    let mut t = false;
-                    eval(cond, current.clone(), env, &mut |v| { t = v.is_truthy(); Ok(true) })?;
-                    t
-                };
-                if is_true { break; }
-                if let Ok(next) = eval_one(update, &current, env) {
-                    current = next;
-                } else {
-                    let mut next = Value::Null;
-                    eval(update, current, env, &mut |v| { next = v; Ok(true) })?;
-                    current = next;
-                }
-            }
-            cb(current)
+            eval_until_gen(cond, update, input, env, cb)
         }
 
         Expr::Repeat { update } => {

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -3680,3 +3680,20 @@ null
 
 nth(2.9; 10,20,30,40)
 null
+
+# ---------- Issue #760/#767: while/until update is a generator ----------
+
+while(.<3; empty)
+0
+
+[while(.<3; empty) | .+1]
+0
+
+[until(.>3; empty)]
+0
+
+[limit(8; while(.<3; .+1, .+2))]
+0
+
+[limit(8; until(.>=3; .+1, .+2))]
+0

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -10835,3 +10835,33 @@ true
 .x|tostring
 {"x":1234567890123456}
 "1234567890123456"
+
+# Issue #760 eval: while(cond; empty) terminates after emitting the input once
+while(.<3; empty)
+0
+0
+
+# Issue #760 eval: while(cond; empty) piped continuation also terminates
+[while(.<3; empty) | .+1]
+0
+[1]
+
+# Issue #760 eval: until(cond; empty) with a false cond emits nothing and terminates
+[until(.>3; empty)]
+0
+[]
+
+# Issue #767 eval: while folds a multi-valued update into independent successors
+[limit(8; while(.<3; .+1, .+2))]
+0
+[0,1,2,2]
+
+# Issue #767 eval: until fans out a multi-valued update into independent successors
+[limit(8; until(.>=3; .+1, .+2))]
+0
+[3,4,3,3,4]
+
+# Issue #767 eval: piped while with a multi-valued update threads each successor through the continuation
+[while(.<3; .+1, .+10) | .]
+0
+[0,1,2]


### PR DESCRIPTION
## Summary

`while(cond; update)` and `until(cond; update)` desugar to a recursive `def` where `update` is a **generator** — each value it yields is an independent successor that re-enters the loop. The eval handlers folded `update` to a single value, producing two related divergences:

- **#760** — `while(.<3; empty)` looped forever emitting `null` (an empty update yielded a stray `Value::Null` instead of terminating).
- **#767** — a multi-valued update (`while(.<3; .+1, .+2)`) collapsed to its last value instead of fanning out into independent successors.

## Fix

Both standalone handlers and the fused `while(...) | scalar` path now route through new `eval_while_gen` / `eval_until_gen` helpers that:

- **terminate** when the update yields nothing (empty update has no successor) — fixes #760
- **tail-iterate** on the single-value common case — no perf change; the hot scalar loop (`until(.<N; .+1)`) still runs the JIT f64 path, which is unaffected
- **fan out**, recursing per successor, when the update is multi-valued — fixes #767

## Verification

- `cargo build --release` — zero warnings
- `cargo test --release` — 509 official + 2089 regression, 0 failures (6 new regression groups, 5 new differential-corpus probes)
- `./bench/comprehensive.sh` — `until (100M)` 0.304s vs 0.301s baseline (within noise); the benchmarked scalar loop uses the JIT path, untouched here

```
$ echo 0 | jq-jit -c 'while(.<3; empty)'
0
$ echo 0 | jq-jit -c '[limit(8; while(.<3; .+1, .+2))]'
[0,1,2,2]
```

Closes #760
Closes #767

🤖 Generated with [Claude Code](https://claude.com/claude-code)