### PR TITLE
fix(datetime): apply %p and %C in strptime

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -3668,21 +3668,31 @@ fn parsed_to_broken(p: &chrono::format::Parsed) -> BrokenTime {
     let (year, mon0, mday, date_seen) = match full_date {
         Some(d) => (d.year(), d.month0() as i32, d.day() as i32, true),
         None => {
-            // `%y` sets only the mod-100 year; resolve the century with the
-            // POSIX pivot (00–68 → 2000s, 69–99 → 1900s) the way libc does.
+            // Resolve the year from `%Y` (`year`), `%C` (`year_div_100`), and
+            // `%y` (`year_mod_100`). `%C %y` combine to `C*100 + y2`; `%C` alone
+            // gives `C*100`; `%y` alone resolves the century with the POSIX pivot
+            // (00–68 → 2000s, 69–99 → 1900s) the way libc does. #762
             let year = p.year()
-                .or_else(|| p.year_mod_100().map(|y2| if y2 < 69 { 2000 + y2 } else { 1900 + y2 }))
+                .or_else(|| match (p.year_div_100(), p.year_mod_100()) {
+                    (Some(c), Some(y2)) => Some(c * 100 + y2),
+                    (Some(c), None) => Some(c * 100),
+                    (None, Some(y2)) => Some(if y2 < 69 { 2000 + y2 } else { 1900 + y2 }),
+                    (None, None) => None,
+                })
                 .unwrap_or(1900);
             let mon0 = p.month().map(|m| m as i32 - 1).unwrap_or(0);
             let mday = p.day().map(|d| d as i32).unwrap_or(0);
-            let seen = p.year().is_some() || p.year_mod_100().is_some()
+            let seen = p.year().is_some() || p.year_div_100().is_some() || p.year_mod_100().is_some()
                 || p.month().is_some() || p.day().is_some();
             (year, mon0, mday, seen)
         }
     };
+    // `%H`/`%I` set the 12-hour parts, `%p` the AM/PM half-day. jq fills each
+    // independently: `%p` alone (PM → 12, AM → 0) and `%I` alone (no `%p` → the
+    // literal 12-hour value) must still apply, not just the both-present case. #762
     let hour = match (p.hour_div_12(), p.hour_mod_12()) {
-        (Some(d), Some(m)) => (d * 12 + m) as i32,
-        _ => 0,
+        (None, None) => 0,
+        (d, m) => (d.unwrap_or(0) * 12 + m.unwrap_or(0)) as i32,
     };
     let min = p.minute().map(|m| m as i32).unwrap_or(0);
     let sec = p.second().map(|s| s as i32).unwrap_or(0);
@@ -3693,7 +3703,16 @@ fn parsed_to_broken(p: &chrono::format::Parsed) -> BrokenTime {
         // the normalized civil date (`mday` may be 0 = last day of the prior
         // month). `yday` is `days-before-month + mday - 1`, so a day-less parse
         // yields the `-1` jq emits for year/month-only formats.
-        (civil_wday(year, mon0, mday), days_before_month(mon0, year) + mday - 1)
+        let mut wday = civil_wday(year, mon0, mday);
+        // A day-less January (mon 0, mday 0) normalizes to Dec 31 of `year-1`,
+        // crossing the year boundary. jq's own day arithmetic miscounts that
+        // crossing by one day when `year` is a non-leap century, so e.g.
+        // `strptime("%C")` on "21" reports wday 3, not the civil 4. Reproduce
+        // the quirk for bit-exact parity (also affects `%Y`/`%y`). #762
+        if mon0 == 0 && mday == 0 && year % 100 == 0 && year % 400 != 0 {
+            wday = (wday + 6) % 7;
+        }
+        (wday, days_before_month(mon0, year) + mday - 1)
     } else {
         // No date field at all (time-only): jq leaves the tm_wday/tm_yday
         // sentinels, which surface as 6 / -1.

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -3714,3 +3714,13 @@ while(.<3; empty)
 
 del(.[(0,1):(3,4)])
 [1,2,3,4,5]
+
+# ---------- Issue #762: strptime %C century specifier ----------
+# jq delegates strptime to libc, so any partial parse (mday = 0) has a
+# platform-divergent wday/yday: glibc → 8/367, BSD → 6/-1, MSVC leaves yday
+# at the 367 sentinel even when the year is set. Only a FULL date (year +
+# month + day all resolved) yields a calendar wday/yday stable on all three,
+# so that is the only shape probed here.
+
+strptime("%C %y-%m-%d")
+"21 24-03-15"

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -10905,3 +10905,48 @@ del(.[(0,1):(3,4)])
 del(.a[(0,2):(1,4)])
 {"a":[10,20,30,40,50,60]}
 {"a":[50,60]}
+
+# Issue #762 datetime: strptime applies %p alone (PM sets hour 12)
+strptime("%p")
+"PM"
+[1900,0,0,12,0,0,6,-1]
+
+# Issue #762 datetime: strptime applies %p alone (AM keeps hour 0)
+strptime("%p")
+"AM"
+[1900,0,0,0,0,0,6,-1]
+
+# Issue #762 datetime: strptime combines %I and %p (5 PM -> 17)
+strptime("%I:%M %p")
+"05:30 PM"
+[1900,0,0,17,30,0,6,-1]
+
+# Issue #762 datetime: strptime 12 AM with %I/%p is midnight (hour 0)
+strptime("%I:%M %p")
+"12:00 AM"
+[1900,0,0,0,0,0,6,-1]
+
+# Issue #762 datetime: strptime applies %C alone (century 21 -> year 2100, jq's boundary wday)
+strptime("%C")
+"21"
+[2100,0,0,0,0,0,3,-1]
+
+# Issue #762 datetime: strptime applies %C with a leap century (no wday correction)
+strptime("%C")
+"20"
+[2000,0,0,0,0,0,5,-1]
+
+# Issue #762 datetime: strptime combines %C and %y (century + 2-digit year)
+strptime("%C %y")
+"20 05"
+[2005,0,0,0,0,0,5,-1]
+
+# Issue #762 datetime: strptime combines %p and %C across the format
+strptime("%p %C")
+"PM 21"
+[2100,0,0,12,0,0,3,-1]
+
+# Issue #762 datetime: strptime %C with a full date resolves the calendar wday
+strptime("%C %y-%m-%d")
+"21 24-03-15"
+[2124,2,15,0,0,0,3,74]


### PR DESCRIPTION
## Summary

`strptime` parsed the `%p` (AM/PM) and `%C` (century) specifiers but never folded them into the broken-down time, so the matching fields kept their 1900-epoch defaults.

```
$ echo '"21"' | jq-jit -c 'strptime("%C")'    # before: year stays 1900
[2100,0,0,0,0,0,3,-1]
```

## Fix (`parsed_to_broken`)

- **`%C` (century) → year.** `%C %y` combine to `C*100 + y2`; `%C` alone gives `C*100`; `%y` alone keeps the POSIX 00–68 / 69–99 pivot. `year_div_100` now also counts toward the "date seen" flag. **Platform-stable** — glibc and BSD libc both yield year 2100 for `%C` "21".
- **`%p` / `%I` → hour, independently** (not only when both are present).
- **Day-less weekday.** A day-less January normalizes to Dec 31 of `year-1`; the macOS reference jq miscounts that boundary by one day for a non-leap century, so its weekday is reproduced.

## Platform dependence (important)

jq delegates `strptime` to libc, so several fields differ between glibc (Linux CI) and BSD libc (macOS):

| field | BSD / macOS jq | glibc / Linux jq |
|---|---|---|
| `%p`-alone hour | 12 | 0 |
| day-less wday / yday | 6 / -1 | 8 / 367 |
| century-boundary wday | 3 (off-by-one) | 4 (civil) |

jq-jit targets the **macOS homebrew jq** reference per `docs/maintenance.md` (and already matched its 6/-1 day-less sentinels before this change). These platform-divergent shapes are kept **out of the differential corpus** (which runs against glibc jq in CI); only the year resolution and full-date weekdays — stable on both — are probed there. The regression suite pins jit's deterministic, macOS-parity output directly.

## Out of scope

Pre-existing, unrelated to `%p`/`%C`: chrono collapses `%I` "12"/"00" to `hour_mod_12 = 0`, so `strptime("%I")` on "12" still differs from jq's 12.

## Verification

- `cargo build --release` — zero warnings
- `cargo test --release` — 509 official + 2106 regression, 0 failures; `diff_corpus` green locally and (after dropping the platform-divergent probes) in CI
- 113-case local differential sweep over `%p`/`%C`/`%y`/`%Y`/`%I` and century boundaries matches the macOS reference
- No benchmark run: change is confined to the `strptime` datetime builtin, no shared hot-path code

Closes #762

🤖 Generated with [Claude Code](https://claude.com/claude-code)