### PR TITLE
fix(regex): honour the p flag and tolerate duplicated flags

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -3080,20 +3080,29 @@ fn apply_regex_flags(pattern: &str, flags: &Value) -> Result<(String, bool)> {
     if !flags_str.chars().all(|c| matches!(c, 'g' | 'i' | 'l' | 'm' | 'n' | 'p' | 's' | 'x')) {
         bail!("{} is not a valid modifier string", flags_str);
     }
+    // jq tolerates a repeated flag (e.g. "ii", "mp" both map to dotall), but the
+    // Rust engine rejects a duplicated inline flag like `(?ii)`/`(?ss)`. Collect
+    // each inline flag at most once. #764 / #774
     let mut inline = String::new();
     let mut global = false;
     for ch in flags_str.chars() {
-        match ch {
-            'i' | 'x' => inline.push(ch),
+        let inline_flag = match ch {
+            'i' | 'x' => Some(ch),
             // In jq's engine (Oniguruma) `m` is dotall — `.` matches newline —
             // which the underlying regex spells `s`. jq's own `s` (single-line
             // anchors) is already this engine's default, so it needs no inline
             // flag. The two were mapped PCRE-style (`s` = dotall), i.e. swapped.
             // `"a\nb" | test("a.b";"m")` must be true, `…;"s"` false. #723.
-            'm' => inline.push('s'),
-            'g' => global = true,
-            // l, n, p (and jq's `s`) have no inline equivalent here — accepted, ignored.
-            _ => {}
+            // jq's `p` enables both its `s` (single-line anchors) and `m`
+            // (dotall) modes. The single-line half is this engine's default, so
+            // `p` reduces to the same dotall as `m` — it must not be ignored. #764
+            'm' | 'p' => Some('s'),
+            'g' => { global = true; None }
+            // l, n (and jq's `s`) have no inline equivalent here — accepted, ignored.
+            _ => None,
+        };
+        if let Some(f) = inline_flag {
+            if !inline.contains(f) { inline.push(f); }
         }
     }
     let pat = if inline.is_empty() {

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -3724,3 +3724,17 @@ del(.[(0,1):(3,4)])
 
 strptime("%C %y-%m-%d")
 "21 24-03-15"
+
+# ---------- Issue #764/#774: regex p flag and duplicated flags ----------
+
+gsub(".";"X";"p")
+"\n"
+
+[match("a.b";"p").string]
+"a\nb"
+
+test("ab";"ii")
+"AB"
+
+test("a.b";"mp")
+"a\nb"

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -10975,3 +10975,33 @@ gmtime|strftime("100%% %x")
 gmtime|strftime("%D")
 1700000000
 "11/14/23"
+
+# Issue #764 regex: the p flag enables dotall so . matches a newline
+gsub(".";"X";"p")
+"\n"
+"X"
+
+# Issue #764 regex: p flag dotall lets . span a newline
+[match("a.b";"p").string]
+"a\nb"
+["a\nb"]
+
+# Issue #764 regex: p does not turn ^ into a per-line anchor (single-line anchors)
+test("^b";"p")
+"a\nb"
+false
+
+# Issue #764 regex: p combined with m (both dotall) is tolerated, not a duplicate-flag error
+test("a.b";"mp")
+"a\nb"
+true
+
+# Issue #774 regex: a duplicated valid flag (ii) is tolerated like jq
+test("ab";"ii")
+"AB"
+true
+
+# Issue #774 regex: repeated dotall flag (mm) is tolerated
+test("a.b";"mm")
+"a\nb"
+true


### PR DESCRIPTION
## Summary

Two related bugs in `apply_regex_flags`:

- **#764** — jq's `p` modifier was dropped on the floor, so `.` did not match a newline under `p`.
- **#774** — each occurrence of a flag emitted its own inline letter, so a repeated flag produced an invalid `(?ii)` / `(?ss)` that the Rust engine rejects, while jq tolerates it.

```
$ printf '"\n"' | jq-jit -c 'gsub(".";"X";"p")'     # before: "\n"
"X"
$ echo '"AB"' | jq-jit -c 'test("ab";"ii")'          # before: Invalid regex … duplicate flag
true
```

## Fix

- **`p`** enables jq's `s` (single-line anchors — already this engine's default) plus `m` (dotall), so it now maps to the same inline `s` as `m`: `.` matches a newline under `p`, while `^`/`$` stay string anchors (not per-line). Confirmed against jq: `test("^b";"p")` on `"a\nb"` is `false`.
- **Inline flags are de-duplicated**, so jq-tolerated repeats like `"ii"`, `"mm"`, and the `"mp"`/`"pm"` dotall pair no longer raise a duplicate-flag error. Invalid modifier letters are still rejected.

Both fixes are in the Rust regex layer (not libc), so the behavior is platform-independent and the new cases are also added to the differential corpus.

## Verification

- `cargo build --release` — zero warnings
- `cargo test --release` — 509 official + 2117 regression, 0 failures (6 new regression groups, 4 new differential-corpus probes); `diff_corpus` green
- No benchmark run: the change is confined to `apply_regex_flags` (regex compilation), no hot-path overlap

Closes #764
Closes #774

🤖 Generated with [Claude Code](https://claude.com/claude-code)