### PR TITLE
fix(parser): defer unbound-var errors to reachable defs only

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1075,6 +1075,111 @@ pub(crate) fn expr_uses_var(expr: &Expr, target: u16) -> bool {
     }
 }
 
+/// Push the `func_id` of every `FuncCall` that appears anywhere in `expr` onto
+/// `out` (one level deep — the caller follows callees transitively). Exhaustive
+/// over `Expr` so a call buried in any sub-expression is found, which is what
+/// makes the #765 reachability check sound. Mirrors `expr_uses_var`'s structure.
+pub(crate) fn collect_func_calls(expr: &Expr, out: &mut Vec<usize>) {
+    match expr {
+        Expr::Input | Expr::Empty | Expr::Not | Expr::Env | Expr::Builtins
+        | Expr::ReadInput | Expr::ReadInputs | Expr::ModuleMeta | Expr::GenLabel
+        | Expr::Literal(_) | Expr::Loc { .. } | Expr::LoadVar { .. } => {}
+        Expr::Pipe { left, right } | Expr::Comma { left, right }
+        | Expr::BinOp { lhs: left, rhs: right, .. }
+        | Expr::Alternative { primary: left, fallback: right }
+        | Expr::While { cond: left, update: right }
+        | Expr::Until { cond: left, update: right }
+        | Expr::Limit { count: left, generator: right }
+        | Expr::Index { expr: left, key: right }
+        | Expr::IndexOpt { expr: left, key: right }
+        | Expr::Update { path_expr: left, update_expr: right }
+        | Expr::Assign { path_expr: left, value_expr: right }
+        | Expr::SetPath { path: left, value: right }
+        | Expr::TryCatch { try_expr: left, catch_expr: right } => {
+            collect_func_calls(left, out);
+            collect_func_calls(right, out);
+        }
+        Expr::Mutate { path_expr, value_expr, .. } => {
+            collect_func_calls(path_expr, out);
+            collect_func_calls(value_expr, out);
+        }
+        Expr::IfThenElse { cond, then_branch, else_branch } => {
+            collect_func_calls(cond, out);
+            collect_func_calls(then_branch, out);
+            collect_func_calls(else_branch, out);
+        }
+        Expr::LetBinding { value, body, .. } => {
+            collect_func_calls(value, out);
+            collect_func_calls(body, out);
+        }
+        Expr::Each { input_expr } | Expr::EachOpt { input_expr }
+        | Expr::Recurse { input_expr } | Expr::Repeat { update: input_expr }
+        | Expr::Negate { operand: input_expr } | Expr::UnaryOp { operand: input_expr, .. }
+        | Expr::Collect { generator: input_expr }
+        | Expr::PathExpr { expr: input_expr } | Expr::GetPath { path: input_expr }
+        | Expr::DelPaths { paths: input_expr } | Expr::Debug { expr: input_expr }
+        | Expr::Stderr { expr: input_expr } | Expr::Format { expr: input_expr, .. } => {
+            collect_func_calls(input_expr, out);
+        }
+        Expr::Reduce { source, init, update, .. }
+        | Expr::Foreach { source, init, update, .. } => {
+            collect_func_calls(source, out);
+            collect_func_calls(init, out);
+            collect_func_calls(update, out);
+        }
+        Expr::Range { from, to, step } => {
+            collect_func_calls(from, out);
+            collect_func_calls(to, out);
+            if let Some(s) = step { collect_func_calls(s, out); }
+        }
+        Expr::FuncCall { func_id, args } => {
+            out.push(*func_id);
+            for a in args { collect_func_calls(a, out); }
+        }
+        Expr::CallBuiltin { args, .. } => { for a in args { collect_func_calls(a, out); } }
+        Expr::ObjectConstruct { pairs } => {
+            for (k, v) in pairs { collect_func_calls(k, out); collect_func_calls(v, out); }
+        }
+        Expr::StringInterpolation { parts } => {
+            for p in parts { if let StringPart::Expr(e) = p { collect_func_calls(e, out); } }
+        }
+        Expr::AllShort { generator, predicate } | Expr::AnyShort { generator, predicate } => {
+            collect_func_calls(generator, out);
+            collect_func_calls(predicate, out);
+        }
+        Expr::Label { body, .. } | Expr::Break { value: body, .. } => collect_func_calls(body, out),
+        Expr::Error { msg } => { if let Some(m) = msg { collect_func_calls(m, out); } }
+        Expr::ClosureOp { input_expr, key_expr, .. } => {
+            collect_func_calls(input_expr, out);
+            collect_func_calls(key_expr, out);
+        }
+        Expr::Slice { expr, from, to } => {
+            collect_func_calls(expr, out);
+            if let Some(f) = from { collect_func_calls(f, out); }
+            if let Some(t) = to { collect_func_calls(t, out); }
+        }
+        Expr::RegexTest { input_expr, re, flags } | Expr::RegexMatch { input_expr, re, flags }
+        | Expr::RegexCapture { input_expr, re, flags } | Expr::RegexScan { input_expr, re, flags } => {
+            collect_func_calls(input_expr, out);
+            collect_func_calls(re, out);
+            collect_func_calls(flags, out);
+        }
+        Expr::RegexSub { input_expr, re, tostr, flags } | Expr::RegexGsub { input_expr, re, tostr, flags } => {
+            collect_func_calls(input_expr, out);
+            collect_func_calls(re, out);
+            collect_func_calls(tostr, out);
+            collect_func_calls(flags, out);
+        }
+        Expr::AlternativeDestructure { alternatives } => {
+            for a in alternatives { collect_func_calls(a, out); }
+        }
+        Expr::Memoize { key, body, .. } => {
+            if let Some(k) = key { collect_func_calls(k, out); }
+            collect_func_calls(body, out);
+        }
+    }
+}
+
 /// Extract f64 from a leaf expression (LoadVar, Input, Literal) or simple
 /// numeric BinOp without cloning. Used by the zero-clone BinOp fast path.
 #[inline(always)]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -753,6 +753,16 @@ pub struct Parser {
     pos: usize,
     scope: Scope,
     lib_dirs: Vec<String>,
+    /// The `compiled_funcs` id of the function body currently being parsed, or
+    /// `None` at the top level. Used to attribute a deferred unbound-variable
+    /// reference to its enclosing def. #765
+    current_func: Option<usize>,
+    /// Unbound `$var` references parked instead of erroring eagerly, as
+    /// `(enclosing_func_id, name)`. After the whole program is parsed, only
+    /// those reachable from the top-level expression (top-level refs, plus refs
+    /// inside transitively-called defs) are errors — jq never compiles the body
+    /// of an uncalled def. #765
+    deferred_unbound: Vec<(Option<usize>, String)>,
 }
 
 /// Result of parsing: expression + compiled functions.
@@ -777,6 +787,8 @@ impl Parser {
             pos: 0,
             scope: Scope::new(),
             lib_dirs: lib_dirs.to_vec(),
+            current_func: None,
+            deferred_unbound: Vec::new(),
         };
 
         // Pre-register $ENV
@@ -786,11 +798,63 @@ impl Parser {
         if !parser.at_eof() {
             bail!("unexpected token {:?} at position {}", parser.current(), parser.pos);
         }
+        parser.check_unbound_reachability(&expr)?;
         Ok(ParseResult {
             expr,
             funcs: parser.scope.compiled_funcs,
             memo_slots: parser.scope.next_memo_slot,
         })
+    }
+
+    /// Record an unbound `$name` reference (attributed to the def currently
+    /// being parsed) and return a placeholder that errors with jq's message if
+    /// it is ever evaluated. The eager error is deferred so a never-called def
+    /// with a free variable does not abort compilation; the real decision is
+    /// made by `check_unbound_reachability`. #765
+    fn defer_unbound_var(&mut self, name: &str) -> Expr {
+        self.deferred_unbound.push((self.current_func, name.to_string()));
+        Expr::Error {
+            msg: Some(Box::new(Expr::Literal(Literal::Str(format!("${} is not defined", name))))),
+        }
+    }
+
+    /// Resolve `$name`, deferring the "not defined" error for an unbound
+    /// reference (see `defer_unbound_var`). #765
+    fn load_or_defer_var(&mut self, name: &str) -> Expr {
+        match self.scope.lookup_var(name) {
+            Some(idx) => Expr::LoadVar { var_index: idx },
+            None => self.defer_unbound_var(name),
+        }
+    }
+
+    /// Turn parked unbound `$var` references into errors, but only those that
+    /// are actually reachable: a top-level reference, or one inside a def that
+    /// the top-level program calls (transitively). jq never compiles the body
+    /// of an uncalled def, so a free variable there is not an error. #765
+    fn check_unbound_reachability(&self, program: &Expr) -> Result<()> {
+        if self.deferred_unbound.is_empty() {
+            return Ok(());
+        }
+        let mut reachable: std::collections::HashSet<usize> = std::collections::HashSet::new();
+        let mut stack: Vec<usize> = Vec::new();
+        crate::eval::collect_func_calls(program, &mut stack);
+        while let Some(fid) = stack.pop() {
+            if reachable.insert(fid) {
+                if let Some(f) = self.scope.compiled_funcs.get(fid) {
+                    crate::eval::collect_func_calls(&f.body, &mut stack);
+                }
+            }
+        }
+        for (fid, name) in &self.deferred_unbound {
+            let is_reachable = match fid {
+                None => true, // top-level reference
+                Some(id) => reachable.contains(id),
+            };
+            if is_reachable {
+                bail!("${} is not defined", name);
+            }
+        }
+        Ok(())
     }
 
     fn current(&self) -> &Token {
@@ -921,7 +985,13 @@ impl Parser {
         let func_id = self.scope.define_func(&name, params.len(), Expr::Empty, param_vars.clone());
 
         let saved_funcs = self.scope.save_func_scope();
+        // Attribute any unbound `$var` parked while parsing this body to this
+        // def, so the reachability check can ignore it if the def is never
+        // called (#765). Nested defs save/restore around their own bodies.
+        let saved_current_func = self.current_func;
+        self.current_func = Some(func_id);
         let mut body = self.parse_pipe()?;
+        self.current_func = saved_current_func;
         self.scope.restore_func_scope(saved_funcs);
         self.expect(&Token::Semicolon)?;
 
@@ -1178,6 +1248,8 @@ impl Parser {
             pos: 0,
             scope: mod_scope,
             lib_dirs: mod_lib_dirs,
+            current_func: None,
+            deferred_unbound: Vec::new(),
         };
 
         // Skip module statement
@@ -2493,10 +2565,7 @@ impl Parser {
                 } else if name == "ENV" {
                     Ok(Expr::Env)
                 } else {
-                    match self.scope.lookup_var(&name) {
-                        Some(idx) => Ok(Expr::LoadVar { var_index: idx }),
-                        None => bail!("${} is not defined", name),
-                    }
+                    Ok(self.load_or_defer_var(&name))
                 }
             }
 
@@ -2598,9 +2667,7 @@ impl Parser {
                 if self.eat(&Token::Colon) {
                     let val = self.parse_pipe_nocomma()?;
                     // $var: value — key is the variable's value converted to string
-                    let idx = self.scope.lookup_var(&name)
-                        .ok_or_else(|| anyhow::anyhow!("${} is not defined", name))?;
-                    let key_expr = Expr::LoadVar { var_index: idx };
+                    let key_expr = self.load_or_defer_var(&name);
                     Ok((key_expr, val))
                 } else {
                     // Shorthand: {$x} = {"x": $x}
@@ -2609,9 +2676,7 @@ impl Parser {
                     } else if name == "ENV" {
                         Expr::Env
                     } else {
-                        let idx = self.scope.lookup_var(&name)
-                            .ok_or_else(|| anyhow::anyhow!("${} is not defined", name))?;
-                        Expr::LoadVar { var_index: idx }
+                        self.load_or_defer_var(&name)
                     };
                     Ok((
                         Expr::Literal(Literal::Str(name)),

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -3738,3 +3738,17 @@ test("ab";"ii")
 
 test("a.b";"mp")
 "a\nb"
+
+# ---------- Issue #765: free var in an uncalled def is not eagerly rejected ----------
+
+def g: def f: $x; "inner"; g
+null
+
+def f: $x; def g: f; "z"
+null
+
+def f: .+$x; def g: 1; g
+null
+
+def f: {$x}; "ok"
+null

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -11005,3 +11005,33 @@ true
 test("a.b";"mm")
 "a\nb"
 true
+
+# Issue #765 eval: a free variable in an uncalled nested def does not error
+def g: def f: $x; "inner"; g
+null
+"inner"
+
+# Issue #765 eval: an uncalled def with a free variable is not compiled
+def f: $x; "inner"
+null
+"inner"
+
+# Issue #765 eval: a free variable reached only through an uncalled def is fine
+def f: $x; def g: f; "z"
+null
+"z"
+
+# Issue #765 eval: an unbound var in a def that is never called is ignored
+def f: .+$x; def g: 1; g
+null
+1
+
+# Issue #765 eval: a free variable in an uncalled def's object shorthand is fine
+def f: {$x}; "ok"
+null
+"ok"
+
+# Issue #765 eval: deeply nested uncalled def with a free variable is fine
+def outer: def inner: $z; inner; "ok"
+null
+"ok"


### PR DESCRIPTION
## Summary

A free `$var` inside a `def` body was rejected eagerly during parsing, so a never-called def with an unbound variable aborted compilation.

```
$ echo null | jq-jit -c 'def g: def f: $x; "inner"; g'   # before: $x is not defined
"inner"
```

jq never compiles the body of an uncalled def, so such a variable is only an error when its def is actually reached.

## Fix

Park each unresolved `$var` reference — attributed to the def being parsed (or the top level) — behind an error placeholder instead of bailing. After the whole program is parsed, walk the call graph from the top-level expression and raise `$x is not defined` only for references that are top-level or sit inside a transitively-called def.

This matches jq exactly across the tricky cases:

| program | jq / jq-jit |
|---|---|
| `def f: $x; "inner"` | `"inner"` (f uncalled) |
| `def f: $x; f` | error (f called) |
| `def f: $x; if false then f else "ok" end` | error (f reachable in a dead branch of the compiled tree) |
| `def f: $x; def g: f; "z"` | `"z"` (f reached only via uncalled g) |
| `if false then $x else 1 end` | error (top-level reference) |

Module bodies keep the placeholder as a runtime safety net rather than the compile-time check. Adds `collect_func_calls`, an exhaustive `Expr` walker mirroring `expr_uses_var`.

## Verification

- `cargo build --release` — zero warnings
- `cargo test --release` — 509 official + 2123 regression, 0 failures (6 new regression groups, 4 new differential-corpus probes); `diff_corpus` green
- 21-case manual matrix against jq 1.8.1 (value + error cases) all match
- No benchmark run: parsing-only change; the reachability scan early-returns when there are no unbound references, so valid programs are unaffected

Closes #765

🤖 Generated with [Claude Code](https://claude.com/claude-code)