### PR TITLE
fix(regex): sub/gsub emit one output per replacement-generator value

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3628,38 +3628,61 @@ pub fn eval(
                             crate::runtime::errdesc_pub(&rv),
                         ))?;
                         let segments = crate::runtime::sub_gsub_segments(input_str, re_str, &fv, is_global)?;
-                        let mut result = String::new();
+                        // jq treats the replacement as a generator and applies the
+                        // i-th value of every match in lockstep — NOT a Cartesian
+                        // product (#768). So the number of outputs is the largest
+                        // number of values any single match yields; a match whose
+                        // generator runs out at index i contributes nothing (drops
+                        // the match) for that output. When *every* match yields
+                        // nothing (or there are no matches at all), jq emits the
+                        // original string unchanged.
+                        let mut reps: Vec<Vec<Value>> = Vec::new();
                         for seg in &segments {
-                            result.push_str(&seg.literal);
                             if let Some(ref cap_obj) = seg.captures {
-                                let mut replacement = Value::Null;
-                                eval(tostr, cap_obj.clone(), env, &mut |tv| {
-                                    replacement = tv;
-                                    Ok(true)
-                                })?;
-                                // jq's sub/gsub concatenates the replacement
-                                // into the running string via `+`. String
-                                // works as expected; null is the additive
-                                // identity (drops the match); other types
-                                // surface jq's standard addition error
-                                // referencing the partial result built so
-                                // far (#545). The previous `.to_string()`
-                                // catch-all silently coerced non-strings.
-                                match &replacement {
-                                    Value::Str(s) => result.push_str(s),
-                                    Value::Null => {},
-                                    other => {
-                                        let partial = Value::from_string(result);
-                                        bail!(
-                                            "{} and {} cannot be added",
-                                            crate::runtime::errdesc_pub(&partial),
-                                            crate::runtime::errdesc_pub(other),
-                                        );
+                                let mut vals = Vec::new();
+                                eval(tostr, cap_obj.clone(), env, &mut |tv| { vals.push(tv); Ok(true) })?;
+                                reps.push(vals);
+                            }
+                        }
+                        let n = reps.iter().map(|v| v.len()).max().unwrap_or(0);
+                        if n == 0 {
+                            // No matches, or every replacement generator was empty:
+                            // the original string is preserved as a single output.
+                            return cb(s.clone());
+                        }
+                        for i in 0..n {
+                            let mut result = String::new();
+                            let mut cap_idx = 0;
+                            for seg in &segments {
+                                result.push_str(&seg.literal);
+                                if seg.captures.is_some() {
+                                    let rep = reps[cap_idx].get(i);
+                                    cap_idx += 1;
+                                    // jq concatenates the replacement via `+`: a
+                                    // string appends, null is the additive identity
+                                    // (drops the match), other types surface jq's
+                                    // standard addition error referencing the partial
+                                    // result built so far (#545). A missing value at
+                                    // this index likewise drops the match.
+                                    match rep {
+                                        Some(Value::Str(rs)) => result.push_str(rs),
+                                        Some(Value::Null) | None => {},
+                                        Some(other) => {
+                                            let partial = Value::from_string(result);
+                                            bail!(
+                                                "{} and {} cannot be added",
+                                                crate::runtime::errdesc_pub(&partial),
+                                                crate::runtime::errdesc_pub(other),
+                                            );
+                                        }
                                     }
                                 }
                             }
+                            if !cb(Value::from_string(result))? {
+                                return Ok(false);
+                            }
                         }
-                        cb(Value::from_string(result))
+                        Ok(true)
                     })
                 })
             })

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -3769,3 +3769,18 @@ null
 
 def x: 1; [x, (def f($x): x; f(5))]
 null
+
+[sub("a";"x","y")]
+"a"
+
+[gsub("a";"x","y")]
+"aa"
+
+sub("a";empty)
+"a"
+
+[gsub("(?<c>.)";.c,"Z")]
+"ab"
+
+[gsub("(?<c>.)";if .c=="a" then "x","y" else "z" end)]
+"ab"

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -11065,3 +11065,38 @@ null
 def x: 1; [x, (def f($x): x; f(5))]
 null
 [1,5]
+
+# Issue #768 regex: sub keeps every value of a multi-valued replacement generator
+[sub("a";"x","y")]
+"a"
+["x","y"]
+
+# Issue #768 regex: gsub applies the i-th replacement value to all matches in lockstep
+[gsub("a";"x","y")]
+"aa"
+["xx","yy"]
+
+# Issue #768 regex: an empty replacement generator preserves the original string (sub)
+sub("a";empty)
+"a"
+"a"
+
+# Issue #768 regex: an empty replacement generator preserves the original string (gsub)
+gsub("a";empty)
+"aa"
+"aa"
+
+# Issue #768 regex: per-match captures combine in lockstep
+[gsub("(?<c>.)";.c,"Z")]
+"ab"
+["ab","ZZ"]
+
+# Issue #768 regex: uneven generator lengths drop exhausted matches at higher indices
+[gsub("(?<c>.)";if .c=="a" then "x","y" else "z" end)]
+"ab"
+["xz","y"]
+
+# Issue #768 regex: a multi-valued sub feeds downstream folds value by value
+reduce sub("a";"x","y") as $s ("";.+$s)
+"a"
+"xy"


### PR DESCRIPTION
## Summary

`sub`/`gsub` treat the replacement as a **generator**. jq emits one output per value the generator yields, applying the i-th value of every match in **lockstep** (not a Cartesian product), and emits the **original** string unchanged when the generator is empty.

jq-jit folded the replacement to its last value:

```
$ echo '"a"' | jq-jit -c '[sub("a"; "x","y")]'   # was ["y"], now ["x","y"]
$ echo '"a"' | jq-jit -c '[gsub("a"; "x","y")]'  # was ["y"], now ["x","y"]
$ echo '"a"' | jq-jit -c 'sub("a"; empty)'       # was "",   now "a"
```

## Fix

Reworked the eval handler for `Expr::RegexSub`/`RegexGsub` to:
- collect each match's full replacement-value list, then
- build outputs in lockstep: output count = max values across matches; a match exhausted at index `i` drops (contributes nothing); `n == 0` (all-empty / no match) preserves the original string.

The `+`-concatenation semantics are preserved per value (string appends, null drops, other types raise the addition error against the partial result, #545). The JIT scalar path is gated on a literal-string replacement (`is_scalar`, single-valued), and `flatten_gen` falls back to eval for generator replacements, so only the eval path needed the change.

## Tests

7 regression cases (lockstep, empty-preserves-original, per-match captures, uneven generator lengths, downstream fold) + 5 differential corpus cases. Full suite green (official + regression + selfdiff + diff_corpus), zero warnings.

Closes #768

🤖 Generated with [Claude Code](https://claude.com/claude-code)