### PR TITLE
fix(eval): walk(f) backtracks a multi-valued f during recursion

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -6324,8 +6324,16 @@ fn eval_walk(f: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) -> 
     // Optimization: walk(if type == "T" then F else . end)
     // For values whose type != T, f is identity, so skip eval entirely.
     // Only call eval(F, ...) on matching-type leaf values.
+    // The in-place fast path folds the then-branch to a single value, so it is
+    // only valid when that branch yields exactly one output. A multi-valued
+    // branch (`.,.+1`, `.+(1,2)`, …) must backtrack: each leaf forks the
+    // surrounding reconstruction, which the generic `walk_value_cb` handles
+    // correctly (arrays collect every fork via `map`, objects keep the first
+    // via `map_values`, and the trailing `f` forks at every level). #769
     if let Some((type_name, then_body)) = detect_walk_type_guard(f) {
-        return walk_type_guarded(type_name, then_body, f, input, env, cb);
+        if then_body.is_single_output() {
+            return walk_type_guarded(type_name, then_body, f, input, env, cb);
+        }
     }
     walk_value_cb(f, input, env, cb)
 }

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -3784,3 +3784,15 @@ sub("a";empty)
 
 [gsub("(?<c>.)";if .c=="a" then "x","y" else "z" end)]
 "ab"
+
+[walk(if type=="number" then .,.+1 else . end)]
+[1]
+
+[walk(if type=="number" then .,.+1 else . end)]
+[1,2]
+
+walk(if type=="number" then .+(1,2) else . end)
+{"a":1}
+
+walk(if type=="number" then .,.+1 else . end)
+{"a":1,"b":[2,3]}

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -11100,3 +11100,33 @@ gsub("a";empty)
 reduce sub("a";"x","y") as $s ("";.+$s)
 "a"
 "xy"
+
+# Issue #769 walk: a multi-valued f forks the array reconstruction (Cartesian per leaf)
+[walk(if type=="number" then .,.+1 else . end)]
+[1]
+[[1,2]]
+
+# Issue #769 walk: lockstep flatten across multiple array elements
+[walk(if type=="number" then .,.+1 else . end)]
+[1,2]
+[[1,2,2,3]]
+
+# Issue #769 walk: a multi-valued binop on a leaf forks
+[walk(if type=="number" then .+(1,2) else . end)]
+[1]
+[[2,3]]
+
+# Issue #769 walk: objects keep the first fork per key (map_values semantics)
+walk(if type=="number" then .+(1,2) else . end)
+{"a":1}
+{"a":2}
+
+# Issue #769 walk: nested array under an object forks the inner array only
+walk(if type=="number" then .,.+1 else . end)
+{"a":1,"b":[2,3]}
+{"a":1,"b":[2,3,3,4]}
+
+# Issue #769 walk: single-valued branch still folds to one output
+walk(if type=="number" then .+1 else . end)
+{"a":1,"b":[2,3]}
+{"a":2,"b":[3,4]}


### PR DESCRIPTION
## Summary

`walk(f)` treats `f` as a generator. When `f` is multi-valued, each leaf forks the surrounding reconstruction — arrays collect every fork (jq's `map(w)`), objects keep the first fork per key (`map_values(w)`), and the trailing `f` forks at every level.

jq-jit's in-place fast path for `walk(if type=="T" then F else . end)` folded `F` to its last value:

```
$ echo '[1]' | jq-jit -c 'walk(if type=="number" then .,.+1 else . end)'   # was [2], now [1,2]
$ echo '[1]' | jq-jit -c 'walk(if type=="number" then .+(1,2) else . end)' # was [3], now [2,3]
```

## Fix

The generic `walk_value_cb` already implements the correct generator-aware semantics; only the in-place type-guard fast path folded. Gate that fast path on the then-branch being single-output (`Expr::is_single_output`) — a multi-valued branch now falls through to `walk_value_cb`. The raw-byte `detect_walk_num_op` path is already restricted to a literal numeric op (`. op N`), so it is single-valued and unaffected.

## Tests

6 regression cases (array fork, lockstep flatten across elements, multi-valued binop leaf, object keeps-first-per-key, nested array under object, single-valued branch still folds) + 4 differential corpus cases. Full suite green (official + regression + selfdiff + diff_corpus), zero warnings.

Closes #769

🤖 Generated with [Claude Code](https://claude.com/claude-code)