### PR TITLE
fix(output): normalize NaN in the tojson and @csv/@tsv encoders

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -4025,6 +4025,20 @@ pub fn push_tojson_raw(buf: &mut Vec<u8>, b: &[u8]) {
                     buf.extend_from_slice(num_bytes);
                 }
             }
+            b'a'..=b'z' | b'A'..=b'Z' => {
+                // Bare literal tokens (true/false/null/nan). An input-parsed
+                // NaN reaches this raw fast path without normalization; jq
+                // renders NaN as `null` in JSON, so the literal `nan` token
+                // would otherwise leak as invalid JSON. #771
+                let start = i;
+                while i < len && b[i].is_ascii_alphabetic() { i += 1; }
+                let tok = &b[start..i];
+                if tok.eq_ignore_ascii_case(b"nan") {
+                    buf.extend_from_slice(b"null");
+                } else {
+                    buf.extend_from_slice(tok);
+                }
+            }
             c => { buf.push(c); i += 1; }
         }
     }
@@ -5517,6 +5531,8 @@ pub fn format_jq_number(n: f64) -> String {
 /// through f64. Falls back to f64 dtoa otherwise. Used by @csv / @tsv
 /// formatters where jq preserves the literal shape (#475).
 pub fn push_value_num_repr_str(buf: &mut String, n: f64, repr: Option<&Rc<str>>) {
+    // jq renders a NaN cell as empty in CSV/TSV (not the JSON `null`). #771
+    if n.is_nan() { return; }
     if let Some(r) = repr.filter(|r| is_valid_json_number(r) && repr_is_exact_for_f64(r, n)) {
         if let Some(canonical) = normalize_jq_repr(r) {
             buf.push_str(&canonical);
@@ -5530,6 +5546,8 @@ pub fn push_value_num_repr_str(buf: &mut String, n: f64, repr: Option<&Rc<str>>)
 
 /// Same as [`push_value_num_repr_str`] but writes UTF-8 bytes to a `Vec<u8>`.
 pub fn push_value_num_repr_bytes(buf: &mut Vec<u8>, n: f64, repr: Option<&Rc<str>>) {
+    // jq renders a NaN cell as empty in CSV/TSV (not the JSON `null`). #771
+    if n.is_nan() { return; }
     if let Some(r) = repr.filter(|r| is_valid_json_number(r) && repr_is_exact_for_f64(r, n)) {
         if let Some(canonical) = normalize_jq_repr(r) {
             buf.extend_from_slice(canonical.as_bytes());

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -3814,3 +3814,18 @@ null
 
 [[1,2],[1]]|min_by(.[])
 null
+
+tojson
+nan
+
+tojson
+[nan,1,2.5]
+
+[1,nan,3]|@csv
+null
+
+[1,nan,3]|@tsv
+null
+
+["a",nan,1]|@csv
+null

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -11170,3 +11170,28 @@ null
 [[1,2],[1]]|group_by(.[])
 null
 [[[1]],[[1,2]]]
+
+# Issue #771 tojson: an input-parsed NaN normalizes to null (raw fast path)
+tojson
+nan
+"null"
+
+# Issue #771 tojson: NaN inside a nested input value normalizes to null
+tojson
+[1,nan,2]
+"[1,null,2]"
+
+# Issue #771 @csv: a NaN cell renders empty, not the JSON null
+[1,nan,3]|@csv
+null
+"1,,3"
+
+# Issue #771 @tsv: a NaN cell renders empty, not the JSON null
+[1,nan,3]|@tsv
+null
+"1\t\t3"
+
+# Issue #771 @csv: a lone NaN cell produces an empty row field
+[nan]|@csv
+null
+""


### PR DESCRIPTION
## Summary

NaN was not normalized in two raw output encoders. jq renders NaN as `null` in JSON and as an empty field in CSV/TSV; jq-jit leaked the bare token `nan` (invalid JSON) from `tojson`/`@json` and the literal `null` from `@csv`/`@tsv`.

```
$ printf 'nan'  | jq-jit -c 'tojson'           # was "nan",  now "null"
$ printf '[nan]'| jq-jit -c 'tojson'           # was "[nan]", now "[null]"
$ echo 'null'   | jq-jit -c '[1,nan,3]|@csv'   # was "1,null,3", now "1,,3"
```

## Fix

- **`tojson`/`@json` raw fast path** (`push_tojson_raw`): the top-level implicit-input path copied an input-parsed NaN token verbatim. Added a NaN→`null` rewrite for bare literal tokens. (Routing the value through any expression already normalized it, so only this raw path leaked.)
- **`@csv`/`@tsv`** (`push_value_num_repr_str`/`_bytes`, used only by these formatters): emit an empty cell for NaN instead of delegating to the JSON number writer. This covers all four CSV/TSV num-formatting sites (eval + JIT) and leaves JSON output untouched.

Infinity-token saturation in the raw path is out of scope (tracked under the overflow-saturation work, #415).

## Tests

5 regression cases + 5 differential corpus cases (input-parsed NaN through tojson, nested NaN, @csv/@tsv empty cells, lone NaN cell). NaN handling here is platform-independent, so it is corpus-safe. Full suite green (official + regression + selfdiff + diff_corpus), zero warnings.

Closes #771

🤖 Generated with [Claude Code](https://claude.com/claude-code)