### PR TITLE
fix(eval): validate getpath traversal in path position

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -5354,12 +5354,23 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
             Ok(true)
         }
         Expr::CallBuiltin { name, args } if name == "getpath" && args.len() == 1 => {
-            // In path context, getpath(p) = the path p itself
-            eval(&args[0], input, env, cb)
+            // In path context, getpath(p) yields the path p — but jq still
+            // traverses the input along p and raises a type error if an
+            // intermediate value cannot be indexed. `rt_getpath` performs that
+            // exact check (lenient on missing keys, strict on type mismatch), so
+            // validate before emitting the path. #775
+            eval(&args[0], input.clone(), env, &mut |pv| {
+                crate::runtime::rt_getpath(&input, &pv)?;
+                cb(pv)
+            })
         }
         Expr::GetPath { path } => {
-            // In path context, getpath(p) = the path p itself
-            eval(path, input, env, cb)
+            // In path context, getpath(p) = the path p itself, validated against
+            // the input the same way as the CallBuiltin form above. #775
+            eval(path, input.clone(), env, &mut |pv| {
+                crate::runtime::rt_getpath(&input, &pv)?;
+                cb(pv)
+            })
         }
         Expr::FuncCall { func_id, .. } => {
             let func = env.borrow().funcs.get(*func_id).cloned();

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -3829,3 +3829,15 @@ null
 
 ["a",nan,1]|@csv
 null
+
+path(getpath(["a","b"]))
+{"a":1}
+
+path(getpath([0]))
+"hello"
+
+path(getpath(["a","b"]))
+{"a":{"b":1}}
+
+path(getpath(["a","b"]))
+{"a":{}}

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -11226,3 +11226,21 @@ null
 strptime("%Y-%m-%d")
 "2024-01-15"
 [2024,0,15,0,0,0,1,14]
+
+# Issue #775 path: path(getpath(P)) errors when an intermediate value is not indexable
+path(getpath(["a","b"]))
+{"a":1}
+
+# Issue #775 path: indexing a string with a number errors in path position too
+path(getpath([0]))
+"hello"
+
+# Issue #775 path: a valid path traverses and returns the path array
+path(getpath(["a","b"]))
+{"a":{"b":1}}
+["a","b"]
+
+# Issue #775 path: a missing key is lenient (descends into null), not an error
+path(getpath(["a","b"]))
+{"a":{}}
+["a","b"]


### PR DESCRIPTION
## Summary

`path(getpath(P))` must traverse the input along `P` and raise a type error when an intermediate value cannot be indexed, just like the direct `path(.a.b)` form. The path-context handler returned the raw path array unchecked.

```
$ echo '{"a":1}' | jq-jit -c 'path(getpath(["a","b"]))'  # was ["a","b"], now errors
$ echo '"hello"' | jq-jit -c 'path(getpath([0]))'        # was [0], now errors
```

## Fix

Run the resolved path through `rt_getpath` (lenient on missing keys, strict on type mismatches — the same validation jq applies, and the one the value-context `getpath` already used) before emitting it. Missing keys still descend into null, and assignment forms (`getpath(P)=v` / `|=v`) were already correct and stay so.

## Tests

4 regression cases + 4 differential corpus cases (type-mismatch errors, valid traversal, lenient missing key). Platform-independent, so corpus-safe. Full suite green (official + regression + selfdiff + diff_corpus), zero warnings.

Closes #775

🤖 Generated with [Claude Code](https://claude.com/claude-code)