### PR TITLE
fix(parser): scope a label binding to its body so a sibling break resolves outward

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2529,9 +2529,16 @@ impl Parser {
                     Token::Variable(name) => {
                         // Register label-typed bindings under a sentinel prefix so they
                         // can only be referenced via `break $name`, never as a bare $name.
+                        // The binding is lexically scoped to the body: pop it afterwards
+                        // so a sibling `break $name` following an inner `label $name`
+                        // resolves to the still-live *outer* label rather than the
+                        // already-finished inner one (which `lookup_var` would otherwise
+                        // pick as the innermost match, dropping the whole output). #776
+                        let saved_vars = self.scope.vars.len();
                         let var_idx = self.scope.alloc_var(&format!("\x00label:{}", name));
                         self.expect(&Token::Pipe)?;
                         let body = self.parse_pipe()?;
+                        self.scope.vars.truncate(saved_vars);
                         Ok(Expr::Label {
                             var_index: var_idx,
                             body: Box::new(body),

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -3841,3 +3841,12 @@ path(getpath(["a","b"]))
 
 path(getpath(["a","b"]))
 {"a":{}}
+
+[label $out | ((label $out | 2), break $out)]
+null
+
+[label $x | (1,(label $x|(2,(label $x|3),break $x,4)),break $x,5)]
+null
+
+[label $x | (label $x | break $x), 99]
+null

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -11244,3 +11244,23 @@ path(getpath(["a","b"]))
 path(getpath(["a","b"]))
 {"a":{}}
 ["a","b"]
+
+# Issue #776 label: an outer break is not captured by a finished inner same-name label
+[label $out | ((label $out | 2), break $out)]
+null
+[2]
+
+# Issue #776 label: triply-nested same-name labels each break to their own scope
+[label $x | (1,(label $x|(2,(label $x|3),break $x,4)),break $x,5)]
+null
+[1,2,3]
+
+# Issue #776 label: an inner break targets the inner label, outer continues
+[label $x | (label $x | break $x), 99]
+null
+[99]
+
+# Issue #776 label: a same-name break inside reaches the nearest enclosing label
+[label $a | (1, (label $b | (2, break $a, 3)), 4)]
+null
+[1,2]


### PR DESCRIPTION
Closes #776

## Problem

A `break $x` targeting a label whose body had already finished could resolve to a *sibling* same-name label that was still open, or fail to walk outward to the correct enclosing label. The parser kept a label's variable binding in scope after `parse_pipe()` of its body returned, so a later sibling `label $x` / `break $x` saw the stale binding.

## Fix

In the `Label` parse path, snapshot `self.scope.vars.len()` before allocating the `\x00label:<name>` binding and `truncate` back to it after parsing the body. The binding is now scoped strictly to the label body, so a sibling `break` resolves to the nearest *enclosing* (not finished-sibling) label, matching jq.

## Tests

4 regression cases + 3 corpus cases covering: outer break not captured by a finished inner same-name label; triply-nested same-name labels each breaking to their own scope; inner break targeting the inner label with outer continuation; same-name break reaching the nearest enclosing label.

Zero-warning `cargo build --release`; full `cargo test --release` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)