### PR TITLE
fix(interpreter): don't evaluate user-func programs in the input-free fast path

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -2841,7 +2841,18 @@ impl Filter {
         if push_const_json(expr, &mut buf) {
             return Some(vec![buf]);
         }
-        // Evaluate with null input using eval
+        // This fast path evaluates `self.simplified` against a `null` input
+        // with an env that carries no user functions. That is only faithful
+        // when the program defines none: a `FuncCall` would otherwise hit an
+        // empty func table and raise "undefined function", which an enclosing
+        // `try`/`catch` silently turns into bogus output (#777 — e.g.
+        // `def f: label $o|break $o; try f catch "c"` wrongly yielded "c").
+        // Const-foldable input-free exprs are already returned above via
+        // `push_const_json`; anything left that references user defs must run
+        // on the authoritative input-carrying path instead, so bail.
+        if !self.parsed.1.is_empty() {
+            return None;
+        }
         let mut outputs = Vec::new();
         let env: crate::eval::EnvRef = std::rc::Rc::new(std::cell::RefCell::new(crate::eval::Env::new(vec![])));
         let result = crate::eval::eval(expr, crate::value::Value::Null, &env, &mut |v| {

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -3850,3 +3850,9 @@ null
 
 [label $x | (label $x | break $x), 99]
 null
+
+def f: label $o | break $o; try f catch "c"
+null
+
+def f: label $o | (10, break $o, 20); try (f, 99) catch "c"
+null

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -11264,3 +11264,13 @@ null
 [label $a | (1, (label $b | (2, break $a, 3)), 4)]
 null
 [1,2]
+
+# Issue #777 label: a self-contained break inside a def must not leak into an enclosing try/catch
+def f: label $o | break $o; try f catch "c"
+null
+
+# Issue #777 label: break in a def drops only the def's tail, sibling try branches survive
+def f: label $o | (10, break $o, 20); try (f, 99) catch "c"
+null
+10
+99


### PR DESCRIPTION
Closes #777

## Problem

`detect_input_free_output` evaluates the simplified expression once against a `null` input using an env that carries **no user functions**. When a program defines functions, a `FuncCall` hits the empty func table and raises "undefined function" — and an enclosing `try`/`catch` silently turns that error into bogus output:

```
$ echo null | jq    -c 'def f: label $o | break $o; try f catch "c"'   # (empty)
$ echo null | jq-jit -c 'def f: label $o | break $o; try f catch "c"'   # "c"   ✗

$ echo null | jq    -c 'def f: label $o | (10, break $o, 20); try (f, 99) catch "c"'   # 10 / 99
$ echo null | jq-jit -c 'def f: label $o | (10, break $o, 20); try (f, 99) catch "c"'  # "c"   ✗
```

The reporter framed it as a `label`/`break` leak across a def boundary, but the break unwind is correct — the real defect is the input-free fast path swallowing the (spurious) undefined-function error.

## Fix

Const-foldable input-free expressions are already returned earlier via `push_const_json`. Anything reaching the eval step that references user-defined functions cannot be faithfully evaluated by this no-funcs env, so bail whenever the program defines any functions and let the authoritative input-carrying path run.

This is strictly safer than the prior behavior: before this change every such program already errored inside the fast path (and only produced correct output by luck when no `try`/`catch` swallowed the error). Seeding the funcs instead was rejected because it would execute user code through the *simplified* IR, which can diverge from the authoritative `parsed` IR (it regressed official jq tests #149/#166/#167, all of which define helper functions).

## Tests

2 regression cases + 2 corpus cases covering both repros. Zero-warning `cargo build --release`; full `cargo test --release` green (official 509 + regression + selfdiff + diff_corpus).

🤖 Generated with [Claude Code](https://claude.com/claude-code)