### PR TITLE
fix(parser): track source lines so $__loc__ reports the real line

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -230,6 +230,15 @@ struct Lexer {
     chars: Vec<char>,
     pos: usize,
     tokens: Vec<Token>,
+    /// Source char offset where each token in `tokens` begins. Parallel to
+    /// `tokens`; backfilled per tokenize iteration so multi-token emitters
+    /// (string interpolation) share the start of their originating token.
+    /// Converted to 1-based line numbers in `token_lines` after tokenize so
+    /// `$__loc__` can report the actual source line (#778).
+    token_starts: Vec<usize>,
+    /// 1-based source line for each token in `tokens`, computed from
+    /// `token_starts` at the end of `tokenize`.
+    token_lines: Vec<usize>,
 }
 
 impl Lexer {
@@ -238,6 +247,8 @@ impl Lexer {
             chars: input.chars().collect(),
             pos: 0,
             tokens: Vec::new(),
+            token_starts: Vec::new(),
+            token_lines: Vec::new(),
         }
     }
 
@@ -246,6 +257,7 @@ impl Lexer {
             self.skip_whitespace_and_comments();
             if self.pos >= self.chars.len() { break; }
 
+            let tok_start = self.pos;
             let ch = self.chars[self.pos];
             match ch {
                 '|' => {
@@ -442,8 +454,31 @@ impl Lexer {
                     bail!("unexpected character '{}' at position {}", ch, self.pos);
                 }
             }
+            // Attribute every token emitted this iteration (one, or several for
+            // string interpolation) to the char offset where the iteration began.
+            while self.token_starts.len() < self.tokens.len() {
+                self.token_starts.push(tok_start);
+            }
         }
         self.tokens.push(Token::Eof);
+        while self.token_starts.len() < self.tokens.len() {
+            self.token_starts.push(self.chars.len());
+        }
+        // Convert char offsets to 1-based line numbers in a single forward pass
+        // (token_starts is non-decreasing across the main token stream).
+        self.token_lines.clear();
+        self.token_lines.reserve(self.token_starts.len());
+        let mut cursor = 0usize;
+        let mut line = 1usize;
+        for &start in &self.token_starts {
+            while cursor < start {
+                if self.chars[cursor] == '\n' {
+                    line += 1;
+                }
+                cursor += 1;
+            }
+            self.token_lines.push(line);
+        }
         Ok(self.tokens.clone())
     }
 
@@ -780,6 +815,11 @@ enum StringSegment {
 /// Parser state.
 pub struct Parser {
     tokens: Vec<Token>,
+    /// 1-based source line for each token in `tokens` (parallel vector).
+    /// Used to give `$__loc__` the actual source line (#778). May be empty
+    /// for parsers built without line info, in which case lookups fall back
+    /// to line 1.
+    token_lines: Vec<usize>,
     pos: usize,
     scope: Scope,
     lib_dirs: Vec<String>,
@@ -812,8 +852,10 @@ impl Parser {
     pub fn parse_with_libs(input: &str, lib_dirs: &[String]) -> Result<ParseResult> {
         let mut lexer = Lexer::new(input);
         let tokens = lexer.tokenize()?;
+        let token_lines = std::mem::take(&mut lexer.token_lines);
         let mut parser = Parser {
             tokens,
+            token_lines,
             pos: 0,
             scope: Scope::new(),
             lib_dirs: lib_dirs.to_vec(),
@@ -889,6 +931,12 @@ impl Parser {
 
     fn current(&self) -> &Token {
         self.tokens.get(self.pos).unwrap_or(&Token::Eof)
+    }
+
+    /// 1-based source line of the token at the current cursor, for `$__loc__`
+    /// (#778). Falls back to line 1 when line info is unavailable.
+    fn current_line(&self) -> usize {
+        self.token_lines.get(self.pos).copied().unwrap_or(1)
     }
 
     fn peek(&self) -> &Token {
@@ -1258,6 +1306,7 @@ impl Parser {
 
         let mut lexer = Lexer::new(&content);
         let tokens = lexer.tokenize()?;
+        let mod_token_lines = std::mem::take(&mut lexer.token_lines);
 
         // Add the module's directory to lib_dirs for resolving relative imports
         let mut mod_lib_dirs = self.lib_dirs.clone();
@@ -1275,6 +1324,7 @@ impl Parser {
         mod_scope.next_var = self.scope.next_var;
         let mut mod_parser = Parser {
             tokens,
+            token_lines: mod_token_lines,
             pos: 0,
             scope: mod_scope,
             lib_dirs: mod_lib_dirs,
@@ -2585,6 +2635,7 @@ impl Parser {
             }
 
             Token::Variable(name) => {
+                let loc_line = self.current_line();
                 self.advance();
                 // Check for $var::name (namespace access for data imports)
                 if self.at(&Token::Colon) && matches!(self.tokens.get(self.pos + 1), Some(Token::Colon)) {
@@ -2598,7 +2649,7 @@ impl Parser {
                     }
                 }
                 if name == "__loc__" {
-                    Ok(Expr::Loc { file: "<top-level>".to_string(), line: 1 })
+                    Ok(Expr::Loc { file: "<top-level>".to_string(), line: loc_line as i64 })
                 } else if name == "ENV" {
                     Ok(Expr::Env)
                 } else {
@@ -2700,6 +2751,7 @@ impl Parser {
                 }
             }
             Token::Variable(name) => {
+                let loc_line = self.current_line();
                 self.advance();
                 if self.eat(&Token::Colon) {
                     let val = self.parse_pipe_nocomma()?;
@@ -2709,7 +2761,7 @@ impl Parser {
                 } else {
                     // Shorthand: {$x} = {"x": $x}
                     let val_expr = if name == "__loc__" {
-                        Expr::Loc { file: "<top-level>".to_string(), line: 1 }
+                        Expr::Loc { file: "<top-level>".to_string(), line: loc_line as i64 }
                     } else if name == "ENV" {
                         Expr::Env
                     } else {

--- a/tests/loc_line_number.rs
+++ b/tests/loc_line_number.rs
@@ -1,0 +1,60 @@
+//! Issue #778: `$__loc__` must report the actual source line of the token,
+//! counting newlines in the program text — jq does, jq-jit previously always
+//! returned `line: 1` because the lexer never tracked the source line.
+//!
+//! `regression.test` / `corpus.test` cannot cover this: both harnesses are
+//! line-based (one line per filter), so a multi-line program can't be
+//! expressed. Shell out with multi-line program strings instead.
+
+use std::process::Command;
+
+fn run(filter: &str) -> String {
+    let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
+    let out = Command::new(jq_jit)
+        .arg("-nc")
+        .arg(filter)
+        .output()
+        .expect("failed to spawn jq-jit");
+    assert!(
+        out.status.success(),
+        "jq-jit -nc {filter:?} exited with {:?}\nstderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8(out.stdout)
+        .expect("non-utf8 stdout")
+        .trim_end()
+        .to_string()
+}
+
+#[test]
+fn loc_reports_line_one_at_program_start() {
+    assert_eq!(run("$__loc__"), r#"{"file":"<top-level>","line":1}"#);
+}
+
+#[test]
+fn loc_counts_leading_newlines() {
+    assert_eq!(run("\n$__loc__"), r#"{"file":"<top-level>","line":2}"#);
+    assert_eq!(run("\n\n\n$__loc__"), r#"{"file":"<top-level>","line":4}"#);
+}
+
+#[test]
+fn loc_counts_newlines_through_pipes() {
+    assert_eq!(run("1\n|2\n|$__loc__"), r#"{"file":"<top-level>","line":3}"#);
+}
+
+#[test]
+fn loc_counts_newlines_past_comments() {
+    assert_eq!(
+        run("1 |\n# comment\n$__loc__"),
+        r#"{"file":"<top-level>","line":3}"#
+    );
+}
+
+#[test]
+fn loc_in_object_shorthand_tracks_line() {
+    assert_eq!(
+        run("\n{x: $__loc__}"),
+        r#"{"x":{"file":"<top-level>","line":2}}"#
+    );
+}


### PR DESCRIPTION
Closes #778

## Problem

`$__loc__` always reported `line: 1`, regardless of the token's actual source line. jq counts the newlines preceding the token in the program text:

```
$ printf '\n$__loc__' | jq    -c          # {"file":"<top-level>","line":2}
$ printf '\n$__loc__' | jq-jit -c          # {"file":"<top-level>","line":1}  ✗
```

Both `Expr::Loc` construction sites in `src/parser.rs` hard-coded `line: 1` because the lexer never tracked where each token began.

## Fix

During tokenization, record each token's starting char offset (backfilled per iteration so multi-token emitters like string interpolation share the offset of their originating token), then convert offsets to 1-based line numbers in a single forward pass over the source. The parser carries this parallel `token_lines` vector and stamps the current token's line into `Expr::Loc` at both sites.

Now matches jq for: leading newlines, pipes spanning lines, comments, def bodies, object shorthand (`{$__loc__}`), and string interpolation (`"\($__loc__)"`).

## Tests

New `tests/loc_line_number.rs` integration test (5 cases). The line-based `regression.test`/`corpus.test` harnesses cannot express multi-line programs, so this shells out with multi-line program strings — same approach as `tests/split_empty_input_null.rs`.

Zero-warning `cargo build --release`; full `cargo test --release` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)