### PR TITLE
fix(runtime): index/rindex with an array argument do a subsequence search

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2251,21 +2251,19 @@ fn rt_str_index(v: &Value, target: &Value, is_rindex: bool) -> Result<Value> {
                 Ok(Value::Null)
             }
         }
-        (Value::Arr(a), _) => {
-            if is_rindex {
-                for (i, item) in a.iter().enumerate().rev() {
-                    if values_equal(item, target) {
-                        return Ok(Value::number(i as f64));
-                    }
-                }
-                Ok(Value::Null)
-            } else {
-                for (i, item) in a.iter().enumerate() {
-                    if values_equal(item, target) {
-                        return Ok(Value::number(i as f64));
-                    }
-                }
-                Ok(Value::Null)
+        (Value::Arr(_), _) => {
+            // jq defines `index(x): indices(x)|.[0]` and
+            // `rindex(x): indices(x)|.[-1:][0]`. Delegating to `rt_indices`
+            // covers both element search (scalar needle) and contiguous
+            // subsequence search (array needle); the previous element-only
+            // comparison returned null for an array needle (#779).
+            match rt_indices(v, target)? {
+                Value::Arr(list) => Ok(if is_rindex {
+                    list.last().cloned().unwrap_or(Value::Null)
+                } else {
+                    list.first().cloned().unwrap_or(Value::Null)
+                }),
+                _ => Ok(Value::Null),
             }
         }
         // jq's def is `index(x): indices(x) | .[0]` (and `rindex(x): ... | .[-1:][0]`),

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -3856,3 +3856,18 @@ null
 
 def f: label $o | (10, break $o, 20); try (f, 99) catch "c"
 null
+
+index([1,2])
+[0,1,2]
+
+rindex([2,3])
+[1,2,3,2,3]
+
+index([1,2])
+[1,2,1,2]
+
+rindex([1,2])
+[1,2,1,2]
+
+index({"a":1})
+[{"a":1},2,{"a":1}]

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -11274,3 +11274,23 @@ def f: label $o | (10, break $o, 20); try (f, 99) catch "c"
 null
 10
 99
+
+# Issue #779 index with an array argument is a contiguous-subsequence search
+index([1,2])
+[0,1,2]
+1
+
+# Issue #779 rindex with an array argument returns the last subsequence start
+rindex([2,3])
+[1,2,3,2,3]
+3
+
+# Issue #779 index still works for a scalar element needle
+index(1)
+[0,1,2]
+1
+
+# Issue #779 index with a no-match array needle returns null
+index([9])
+[0,1,2]
+null


### PR DESCRIPTION
Closes #779

## Problem

`index([...])` / `rindex([...])` with an **array** argument always returned `null`:

```
$ echo '[0,1,2]'     | jq    -c 'index([1,2])'   # 1
$ echo '[0,1,2]'     | jq-jit -c 'index([1,2])'   # null  ✗

$ echo '[1,2,3,2,3]' | jq    -c 'rindex([2,3])'  # 3
$ echo '[1,2,3,2,3]' | jq-jit -c 'rindex([2,3])'  # null  ✗
```

The array-input arm of `rt_str_index` compared each individual element against the *whole* array needle via `values_equal`, which can never match.

## Fix

jq defines `index(x): indices(x)|.[0]` and `rindex(x): indices(x)|.[-1:][0]`, where an array needle is a contiguous-subsequence search. `rt_indices` already implements both subsequence and element search correctly (`indices([1,2])` was always right). Delegate the array-input arm to it and take the first / last hit. Scalar, string-substring, and object needles are unaffected.

## Tests

4 regression cases + 5 corpus cases (array subsequence, last-match `rindex`, scalar element, no-match `null`, object needle). Zero-warning `cargo build --release`; full `cargo test --release` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)