### PR TITLE
fix(fast-path): emit null when a cond_chain branch reads a missing field

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -8084,6 +8084,11 @@ fn real_main() {
                                                     if raw_contains_escaped_solidus(val) { push_raw_canon_solidus(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
                                                 }
                                                 compact_buf.push(b'\n');
+                                            } else {
+                                                // A missing field is `null`, like `.x` — the
+                                                // absent-field case must still emit, not drop
+                                                // the output (#734).
+                                                compact_buf.extend_from_slice(b"null\n");
                                             }
                                         }
                                     }
@@ -15505,6 +15510,10 @@ fn real_main() {
                                                 if raw_contains_escaped_solidus(val) { push_raw_canon_solidus(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
                                             }
                                             compact_buf.push(b'\n');
+                                        } else {
+                                            // A missing field is `null`, like `.x` — emit it
+                                            // rather than dropping the output (#734).
+                                            compact_buf.extend_from_slice(b"null\n");
                                         }
                                     }
                                 }

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -3925,3 +3925,15 @@ sub("a*";"X";"n")
 
 capture("(?<x>a+)";"gn")
 "aXaa"
+
+if (.a >= .a) then .x else .a end
+{"a":0}
+
+if (.a >= .b) then .x else .y end
+{"a":0,"b":5}
+
+if (.a >= .a) then .a else .x end
+{"a":0}
+
+if (.a >= .b) then .a else .x end
+{"a":1,"b":5}

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -11349,3 +11349,18 @@ match("a*";"n")
 [match("a*";"gn")]
 "Xaa baa"
 [{"offset":1,"length":2,"string":"aa","captures":[]},{"offset":5,"length":2,"string":"aa","captures":[]}]
+
+# Issue #734 cond_chain: a then-branch reading a missing field yields null, not empty
+if (.a >= .a) then .x else .a end
+{"a":0}
+null
+
+# Issue #734 cond_chain: an else-branch missing field with field-vs-field condition yields null
+if (.a >= .b) then .x else .y end
+{"a":0,"b":5}
+null
+
+# Issue #734 cond_chain: present selected field still returns its value
+if (.a >= .a) then .x else .a end
+{"a":0,"x":9}
+9


### PR DESCRIPTION
Closes #734

## Problem

The `detect_cond_chain` raw-byte fast path emitted **no output** when the chosen `if/then/else` branch read a missing object field. jq and the interpreter both yield `null`:

```
$ echo '{"a":0}' | jq-jit -c 'if (.a >= .a) then .x else .a end'   # (empty)  ✗
$ echo '{"a":0}' | jq    -c 'if (.a >= .a) then .x else .a end'   # null
```

When the field is present, output was already correct.

## Cause / Fix

In the field-vs-field comparison arm, the `BranchOutput::Field` handler emitted the value when the field existed but had no `else` branch to emit `null` for an absent field — unlike the const-threshold and type-aware arms, which already did. Added the missing `else { extend("null\n") }` in both the stdin and file dispatch copies.

This was surfacing intermittently through the `equiv_arr_iter_roundtrip` metamorphic proptest (an `[f] | .[]` ≠ `f` self-consistency divergence).

## Tests

3 regression cases + 4 corpus cases (then/else missing-field with field-vs-field and const conditions, plus present-field controls). Zero-warning `cargo build --release`; full `cargo test --release` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)