### PR TITLE
fix(destructure): preserve . in the body when a ?// fallback fires

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1495,30 +1495,15 @@ impl Parser {
         let body = self.parse_pipe()?;
         self.scope.vars.truncate(saved_vars);
 
-        // Build: try (bind pattern1 | body) catch try (bind pattern2 | body) catch ... bind patternN | body
-        // The last alternative runs WITHOUT a try-catch so its error propagates —
-        // per the jq spec, "if they all fail, then an error is emitted" (issue #76).
-        let tmp_idx = self.scope.alloc_var("__altdestruct_tmp__");
-        let tmp_ref = Expr::LoadVar { var_index: tmp_idx };
-
-        let mut result: Option<Expr> = None;
-        for pattern in alt_patterns.into_iter().rev() {
-            let binding = self.build_binding_with_varmap(tmp_ref.clone(), &pattern, &var_map, body.clone())?;
-            result = Some(match result {
-                None => binding,
-                Some(prev) => Expr::TryCatch {
-                    try_expr: Box::new(binding),
-                    catch_expr: Box::new(prev),
-                },
-            });
-        }
-        let result = result.expect("alt_patterns has at least two entries here");
-
-        Ok(Expr::LetBinding {
-            var_index: tmp_idx,
-            value: Box::new(value_expr),
-            body: Box::new(result),
-        })
+        // Build the `try (bind P1 | body) catch (bind P2 | body) …` chain through
+        // the shared helper, which captures the original `.` up front and
+        // restores it at the head of every alternative's body. Without that, a
+        // fallback alternative would run `body` with `.` set to the caught
+        // destructuring *error* string instead of the original input (#736).
+        // The helper clones `value_expr` into each alternative rather than
+        // sharing it through a tmp slot; only one alternative ultimately runs
+        // (first success wins), matching jq.
+        self.build_alt_destructure(&value_expr, &alt_patterns, &var_map, &body)
     }
 
     /// Allocate the shared variables for a `?//` alternative-destructuring
@@ -1565,9 +1550,19 @@ impl Parser {
             left: Box::new(Expr::LoadVar { var_index: dot_var }),
             right: Box::new(body.clone()),
         };
+        // Evaluate the bound value against the restored `.` too: in a catch
+        // arm the ambient `.` is the caught error, so a `value_expr` that reads
+        // `.` (e.g. `. as [$a] ?// $a`) would otherwise destructure the error
+        // string instead of the original input (#736). For value_exprs that
+        // ignore `.` (a `LoadVar` element slot, as in reduce/foreach #712) this
+        // pipe is a harmless no-op.
+        let restored_value = Expr::Pipe {
+            left: Box::new(Expr::LoadVar { var_index: dot_var }),
+            right: Box::new(value_expr.clone()),
+        };
         let mut result: Option<Expr> = None;
         for pattern in alt_patterns.iter().rev() {
-            let binding = self.build_binding_with_varmap(value_expr.clone(), pattern, var_map, restored_body.clone())?;
+            let binding = self.build_binding_with_varmap(restored_value.clone(), pattern, var_map, restored_body.clone())?;
             result = Some(match result {
                 None => binding,
                 Some(prev) => Expr::TryCatch {

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -3937,3 +3937,18 @@ if (.a >= .a) then .a else .x end
 
 if (.a >= .b) then .a else .x end
 {"a":1,"b":5}
+
+5 as [$a] ?// $a | . + $a
+7
+
+. as [$a] ?// $a | . + $a
+7
+
+. as [$a] ?// $a | . + $a
+[3]
+
+(1,2,3) as [$a] ?// $a | . + $a
+10
+
+reduce .[] as [$a] ?// $a (0; . + $a)
+[1,[2],3]

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -11364,3 +11364,18 @@ null
 if (.a >= .a) then .x else .a end
 {"a":0,"x":9}
 9
+
+# Issue #736 destructure: a ?// fallback runs the body with the original ., not the caught error
+5 as [$a] ?// $a | . + $a
+7
+12
+
+# Issue #736 destructure: value_expr reading . is evaluated against the original input in the fallback
+. as [$a] ?// $a | . + $a
+7
+14
+
+# Issue #736 destructure: nested ?// alternatives restore . for the body
+. as {$x} ?// [$x] ?// $x | {d:.,x:$x}
+[42]
+{"d":[42],"x":42}


### PR DESCRIPTION
Closes #736

## Problem

A standalone `EXPR as P1 ?// P2 | BODY` lowered to `try (bind P1 | BODY) catch (bind P2 | BODY)`. jq's `try … catch` runs the catch with `.` set to the caught error, so whenever a fallback alternative fired, BODY (and any re-read of EXPR) saw the destructuring *error string* as `.` instead of the original input:

```
$ echo '7' | jq    -c '5 as [$a] ?// $a | . + $a'   # 12
$ echo '7' | jq-jit -c '5 as [$a] ?// $a | . + $a'   # error: string and number cannot be added   ✗
```

When the first pattern matched (no fallback), `.` was already correct.

## Fix

Route `parse_as_binding`'s inline chain through the shared `build_alt_destructure` helper — the one already used for `?//` in reduce/foreach (#712) — which captures the original `.` in `$__altdot__` and restores it at the head of every alternative's body.

That helper restored `.` for the *body* but still evaluated the bound value in the catch context, so `. as [$a] ?// $a` destructured the error string. Extend the helper to also pipe the bound value through the restored `.`. For value expressions that ignore `.` (the `LoadVar` element slot in reduce/foreach) this extra pipe is a no-op, so #712 is unaffected (verified).

## Tests

3 regression cases + 5 corpus cases (literal and `.`-reading value exprs, nested alternatives, generator value expr, and a reduce `?//` control for #712). Zero-warning `cargo build --release`; full `cargo test --release` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)