### PR TITLE
fix(builtin): tolerate a non-number depth in truncate_stream

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -6030,11 +6030,14 @@ fn eval_truncate_stream(
     env: &EnvRef,
     cb: &mut dyn FnMut(Value) -> GenResult,
 ) -> GenResult {
-    let depth = match &input {
-        Value::Num(n, _) if n.is_finite() && *n >= 0.0 => *n as usize,
-        Value::Num(_, _) => bail!("truncate_stream: depth must be a non-negative integer"),
-        _ => bail!("truncate_stream: depth must be a number"),
-    };
+    // jq's `truncate_stream` is `. as $n | null | stream | ... if (.[0]|length) > $n
+    // then setpath([0]; .[0][$n:]) else empty end`, so the depth `$n` (taken from
+    // `.`) is used both in a value comparison and as a slice bound. A non-number
+    // depth is therefore handled leniently rather than rejected: `null` passes the
+    // events through unchanged, while a string/array/object depth makes the
+    // `length > $n` comparison false and drops every event. We mirror those
+    // semantics instead of hard-requiring a numeric depth (#804).
+    let depth = input.clone();
     eval(f, input.clone(), env, &mut |event| {
         let arr = match &event {
             Value::Arr(a) => a.clone(),
@@ -6047,10 +6050,40 @@ fn eval_truncate_stream(
             Value::Arr(p) => p.clone(),
             _ => bail!("truncate_stream: stream event missing path"),
         };
-        if path_arr.len() <= depth {
+        let path_len = path_arr.len();
+        // `(.[0]|length) > $n` in jq's type ordering (null < bool < number < ...).
+        // A number is always greater than null/bool and always less than
+        // string/array/object, so only a Num depth participates numerically.
+        let keep = match &depth {
+            Value::Null | Value::True | Value::False => true,
+            Value::Num(n, _) => (path_len as f64) > *n,
+            _ => false,
+        };
+        if !keep {
             return Ok(true);
         }
-        let new_path: Vec<Value> = path_arr.iter().skip(depth).cloned().collect();
+        // `.[0][$n:]` slice bound. null means "from the start"; a number is
+        // floored and clamped like any jq array slice; anything else is an
+        // error ("must be integers"), matching jq when a bool depth survives
+        // the comparison above.
+        let start: usize = match &depth {
+            Value::Null => 0,
+            Value::Num(n, _) => {
+                let mut i = n.floor();
+                if i < 0.0 {
+                    i += path_len as f64;
+                }
+                if i < 0.0 {
+                    0
+                } else if i > path_len as f64 {
+                    path_len
+                } else {
+                    i as usize
+                }
+            }
+            _ => bail!("Array/string slice indices must be integers"),
+        };
+        let new_path: Vec<Value> = path_arr.iter().skip(start).cloned().collect();
         let mut new_event: Vec<Value> = Vec::with_capacity(arr.len());
         new_event.push(Value::Arr(Rc::new(new_path)));
         for v in arr.iter().skip(1) { new_event.push(v.clone()); }

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -1182,6 +1182,16 @@ null
 [truncate_stream({a:[1,2]} | tostream)]
 2
 
+# truncate_stream tolerates a non-number depth (#804)
+[truncate_stream({a:[1,2]} | tostream)]
+null
+
+[truncate_stream({a:[1,2]} | tostream)]
+"x"
+
+[truncate_stream({a:[1,2]} | tostream)]
+-1
+
 # ---------- Issue #65 parser coverage: path / leaf ----------
 
 [paths]

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -9809,6 +9809,26 @@ null
 2
 []
 
+# Issue #804: truncate_stream with a null depth passes events through unchanged
+[truncate_stream({a:[1,2]} | tostream)]
+null
+[[["a",0],1],[["a",1],2],[["a",1]],[["a"]]]
+
+# Issue #804: truncate_stream with a string depth drops every event (length > string is false)
+[truncate_stream({a:[1,2]} | tostream)]
+"x"
+[]
+
+# Issue #804: truncate_stream with an object depth drops every event
+[truncate_stream([[0],1])]
+{}
+[]
+
+# Issue #804: truncate_stream with a negative depth slices from the end
+[truncate_stream({a:[1,2]} | tostream)]
+-1
+[[[0],1],[[1],2],[[1]],[["a"]]]
+
 # Issue #551: (.. | scalars) |= f preserves all leaves after switching Update
 # from rt_setpath to rt_setpath_mut (Rc::make_mut). Verifies every scalar
 # in a deep binary tree still gets updated, not just the last branch.


### PR DESCRIPTION
## Summary

`truncate_stream(stream)` derives its truncation depth from `.` and jq uses that depth in two places — a comparison (`(.[0]|length) > $n`) and a slice bound (`.[0][$n:]`). A non-number depth is therefore handled leniently by jq, while jq-jit hard-required a numeric depth and errored.

### Before

```
$ echo 'null' | jq-jit -c 'truncate_stream([[0],1])'
jq: error (at <stdin>:0): truncate_stream: depth must be a number
```

### After (matches jq 1.8.1)

```
$ echo 'null' | jq-jit -c 'truncate_stream([[0],1])'
[[0],1]
```

## Behavior

- `null` depth → events pass through unchanged (`length > null` is always true; `[null:]` keeps the full path)
- string / array / object depth → every event dropped (`length > <non-number>` is false)
- `true`/`false` depth → integer-index error (comparison passes, slice rejects), matching jq
- negative number depth → slices from the end, matching jq's array-slice rules

## Testing

- Added regression cases in `tests/regression.test` (null / string / object / negative depth)
- Added differential corpus entries in `tests/differential/corpus.test`
- Full suite green: official 509/509, regression 0 fail, diff corpus + self-diff pass
- Confined to `eval_truncate_stream` (cold builtin path, no benchmark hot-path impact)

Closes #804

🤖 Generated with [Claude Code](https://claude.com/claude-code)