### PR TITLE
fix(builtin): combinations length-0 input and early termination

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -5838,9 +5838,28 @@ fn eval_call_builtin(name: &str, args: &[Expr], input: Value, env: &EnvRef, cb: 
 /// Yield each Cartesian-product combination of an array of arrays, in
 /// lexicographic order. Empty input array yields a single empty
 /// combination (matching jq).
+/// jq's `length` of a value is 0 for: null, an empty array/object/string, and
+/// the number 0. (Booleans have no length and error.) Used so `combinations`
+/// can mirror jq's `if length == 0 then [] else ...` short-circuit (#805).
+fn input_length_is_zero(v: &Value) -> bool {
+    match v {
+        Value::Null => true,
+        Value::Arr(a) => a.is_empty(),
+        Value::Obj(o) => o.is_empty(),
+        Value::Str(s) => s.as_str().is_empty(),
+        Value::Num(n, _) => *n == 0.0,
+        Value::True | Value::False | Value::Error(_) => false,
+    }
+}
+
 fn eval_combinations(input: &Value, cb: &mut dyn FnMut(Value) -> GenResult) -> GenResult {
     let arrays = match input {
         Value::Arr(a) => a.clone(),
+        // jq's `combinations` is `if length == 0 then [] else .[0][] as $x | ... end`,
+        // so any length-0 input (null, {}, "", 0) yields a single empty combination
+        // before the `.[0]` indexing in the else branch runs (#805). A non-array
+        // input with a non-zero length falls through to the array-indexing error.
+        _ if input_length_is_zero(input) => return cb(Value::Arr(Rc::new(vec![]))),
         _ => bail!("combinations requires array of arrays input"),
     };
     let mut current: Vec<Value> = Vec::with_capacity(arrays.len());
@@ -5851,8 +5870,9 @@ fn eval_combinations(input: &Value, cb: &mut dyn FnMut(Value) -> GenResult) -> G
         cb: &mut dyn FnMut(Value) -> GenResult,
     ) -> GenResult {
         if idx == arrays.len() {
-            cb(Value::Arr(Rc::new(current.clone())))?;
-            return Ok(true);
+            // Propagate the callback's continue/stop signal so an outer
+            // first/limit/isempty can truncate the Cartesian product (#815).
+            return cb(Value::Arr(Rc::new(current.clone())));
         }
         let inner = match &arrays[idx] {
             Value::Arr(a) => a.clone(),
@@ -5860,8 +5880,11 @@ fn eval_combinations(input: &Value, cb: &mut dyn FnMut(Value) -> GenResult) -> G
         };
         for v in inner.iter() {
             current.push(v.clone());
-            rec(arrays, idx + 1, current, cb)?;
+            let cont = rec(arrays, idx + 1, current, cb)?;
             current.pop();
+            if !cont {
+                return Ok(false);
+            }
         }
         Ok(true)
     }

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -1192,6 +1192,23 @@ null
 [truncate_stream({a:[1,2]} | tostream)]
 -1
 
+# combinations on a length-0 input yields a single empty combination (#805)
+[combinations]
+null
+
+[combinations]
+{}
+
+# combinations honors early termination (#815)
+first(combinations)
+[[1,2],[3,4]]
+
+[limit(2; combinations)]
+[[1,2],[3,4]]
+
+[isempty(combinations)]
+[[1],[2]]
+
 # ---------- Issue #65 parser coverage: path / leaf ----------
 
 [paths]

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -1437,6 +1437,31 @@ null
 [1,2]
 [[1,1],[1,2],[2,1],[2,2]]
 
+# Issue #805: combinations on null returns a single empty combination (length == 0)
+[combinations]
+null
+[[]]
+
+# Issue #805: combinations on {} returns a single empty combination
+[combinations]
+{}
+[[]]
+
+# Issue #815: first(combinations) truncates the Cartesian product after one tuple
+first(combinations)
+[[1,2],[3,4]]
+[1,3]
+
+# Issue #815: limit(2; combinations) stops after two tuples
+[limit(2; combinations)]
+[[1,2],[3,4]]
+[[1,3],[1,4]]
+
+# Issue #815: isempty(combinations) on a non-empty product is false (no spurious extra outputs)
+[isempty(combinations)]
+[[1],[2]]
+[false]
+
 # Issue #135: modf splits number into [fractional, integer] truncated toward zero
 modf
 1.5

--- a/tests/selfdiff_jit_interp.rs
+++ b/tests/selfdiff_jit_interp.rs
@@ -153,7 +153,7 @@ fn normalize(output: &str) -> String {
 ///   without also flipping `have_decnum` to `true` breaks the upstream
 ///   `tests/official/jq.test` decnum consistency check (#443). Tracked
 ///   in #415.
-const KNOWN_DIVERGENCES: &[usize] = &[2205, 2210, 2215, 2341, 2346];
+const KNOWN_DIVERGENCES: &[usize] = &[2230, 2235, 2240, 2366, 2371];
 
 #[test]
 fn jit_vs_interpreter_self_diff() {

--- a/tests/selfdiff_layers.rs
+++ b/tests/selfdiff_layers.rs
@@ -206,7 +206,7 @@ fn normalize(output: &str) -> String {
 /// (`tests/selfdiff_jit_interp.rs`). The 4-way harness inherits these so
 /// known upstream-tracked divergences do not double-fail. Keep in sync
 /// with `selfdiff_jit_interp.rs::KNOWN_DIVERGENCES`.
-const KNOWN_DIVERGENCES: &[usize] = &[2205, 2210, 2215, 2341, 2346];
+const KNOWN_DIVERGENCES: &[usize] = &[2230, 2235, 2240, 2366, 2371];
 
 #[test]
 fn layer_pinned_self_diff() {


### PR DESCRIPTION
## Summary

Two related correctness fixes to `combinations`, both surfaced by a differential bug sweep.

### #805 — length-0 input should return `[]`

jq's `combinations` is `if length == 0 then [] else .[0][] as $x | ... end`, so any length-0 input yields a single empty combination. jq-jit guarded on "array of arrays" *before* the length check and errored on `null`/`{}`.

```
$ echo 'null' | jq-jit -c 'combinations'   # was: error;  now: []
$ echo '{}'   | jq-jit -c 'combinations'   # was: error;  now: []
```

Length-0 inputs (`null`, `{}`, `""`, `0`) now short-circuit to `[]`; a non-array with a non-zero length still falls through to the array-indexing error, matching jq.

### #815 — honor early termination

`eval_combinations` discarded the bool returned by its callback and its own recursion, ignoring the `Ok(false) means STOP` generator convention, so `first`/`limit`/`isempty` could not truncate the Cartesian product (it ran to completion — a perf/termination hazard on large products).

```
$ echo '[[1,2],[3,4]]' | jq-jit -c 'first(combinations)'    # was: 4 outputs; now: [1,3]
$ echo '[[1],[2]]'     | jq-jit -c 'isempty(combinations)'  # was: false,true; now: false
```

The stop signal now propagates like `range`/`.[]`/`paths`/`tostream`. Also covers `combinations/1`.

## Testing

- Regression cases added to `tests/regression.test` (length-0 inputs; `first`/`limit`/`isempty` truncation)
- Differential corpus entries added in `tests/differential/corpus.test`
- Updated the `KNOWN_DIVERGENCES` line allowlist in both selfdiff tests (the inserted cases shifted line numbers)
- Full suite green: official 509/509, regression 0 fail, diff corpus + self-diff pass
- Confined to `eval_combinations` (cold builtin path, no benchmark hot-path impact)

Closes #805
Closes #815

🤖 Generated with [Claude Code](https://claude.com/claude-code)