### PR TITLE
fix(builtin): defer limit/nth count validation to the first generator value

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3358,16 +3358,28 @@ pub fn eval(
                         bail!("__jqerror__:\"limit doesn't support negative count\"");
                     }
                     // String / array / object surface jq's `$n - 1`
-                    // arithmetic error from the limit reduce.
+                    // arithmetic error from the limit reduce. jq computes that
+                    // update lazily — only once the generator yields its first
+                    // item — so an empty generator produces no error at all
+                    // (#806). Defer the error until `generator` yields.
                     other => {
                         let msg = format!(
                             "{} and number (1) cannot be subtracted",
                             crate::runtime::errdesc_pub(other),
                         );
-                        bail!(
+                        let err = format!(
                             "__jqerror__:{}",
                             crate::value::value_to_json_precise(&Value::from_string(msg)),
                         );
+                        let mut yielded = false;
+                        eval(generator, input.clone(), env, &mut |_val| {
+                            yielded = true;
+                            Ok(false)
+                        })?;
+                        if yielded {
+                            bail!("{}", err);
+                        }
+                        Ok(true)
                     }
                 }
             })
@@ -5511,15 +5523,28 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
                     Value::Null | Value::True | Value::False => {
                         bail!("__jqerror__:\"limit doesn't support negative count\"");
                     }
+                    // A string/array/object count surfaces jq's `$n - 1`
+                    // arithmetic error lazily — only when the generator yields
+                    // its first path — so an empty generator produces nothing
+                    // rather than erroring (#806).
                     other => {
                         let msg = format!(
                             "{} and number (1) cannot be subtracted",
                             crate::runtime::errdesc_pub(other),
                         );
-                        bail!(
+                        let err = format!(
                             "__jqerror__:{}",
                             crate::value::value_to_json_precise(&Value::from_string(msg)),
                         );
+                        let mut yielded = false;
+                        eval_path(generator, input.clone(), env, &mut |_p| {
+                            yielded = true;
+                            Ok(false)
+                        })?;
+                        if yielded {
+                            bail!("{}", err);
+                        }
+                        return Ok(true);
                     }
                 };
                 if n < 0.0 {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3954,7 +3954,15 @@ impl Parser {
                         cond: Box::new(Expr::BinOp {
                             op: BinOp::Eq,
                             lhs: Box::new(Expr::Input),
-                            rhs: Box::new(Expr::LoadVar { var_index: n_var }),
+                            // Floor the index per-item rather than eagerly at the
+                            // binding: jq evaluates the index lazily, so a
+                            // non-numeric index errors only once the generator
+                            // yields. An empty generator therefore produces no
+                            // output instead of an eager floor error (#806).
+                            rhs: Box::new(Expr::UnaryOp {
+                                op: UnaryOp::Floor,
+                                operand: Box::new(Expr::LoadVar { var_index: n_var }),
+                            }),
                         }),
                         then_branch: Box::new(Expr::LoadVar { var_index: x_var }),
                         else_branch: Box::new(Expr::Empty),
@@ -3978,17 +3986,16 @@ impl Parser {
                 };
                 // jq's nth(n; g) floors the index: nth(0.5) == nth(0), and a
                 // non-numeric index raises (floor errors on non-numbers). The
-                // foreach counter is integer-valued, so binding the raw float
-                // made `counter == $n` never match for fractional n (silently
-                // empty) and let a string index fall through to empty instead
-                // of erroring (#719). Flooring at the binding fixes both and
-                // leaves integer / negative indices unchanged.
+                // foreach counter is integer-valued, so `counter == $n` never
+                // matched for fractional n (silently empty) and a string index
+                // fell through to empty instead of erroring (#719). The floor
+                // now lives in the per-item comparison above so it stays lazy:
+                // the negative-index guard sees the raw value (`"a" < 0` is
+                // false, so a string index proceeds to the deferred error) and
+                // an empty generator never forces the floor at all (#806).
                 Ok(Expr::LetBinding {
                     var_index: n_var,
-                    value: Box::new(Expr::UnaryOp {
-                        op: UnaryOp::Floor,
-                        operand: Box::new(n_expr),
-                    }),
+                    value: Box::new(n_expr),
                     body: Box::new(body),
                 })
             }

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -38,6 +38,19 @@ null
 [limit(1; 1,2,3)]
 null
 
+# limit/nth tolerate an off-type count when the generator is empty (#806)
+[limit("a"; empty)]
+null
+
+[limit({}; empty)]
+null
+
+[nth("a"; empty)]
+null
+
+[nth({}; empty)]
+null
+
 # ---------- PR #27 bug 4: foreach emits per update yield ----------
 
 [foreach range(3) as $i (0; . + $i; .)]

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -11424,3 +11424,28 @@ if (.a >= .a) then .x else .a end
 . as {$x} ?// [$x] ?// $x | {d:.,x:$x}
 [42]
 {"d":[42],"x":42}
+
+# Issue #806: limit with an off-type count and an empty generator yields nothing (no error)
+[limit("a"; empty)]
+null
+[]
+
+# Issue #806: limit with an object count and an empty generator yields nothing
+[limit({}; empty)]
+null
+[]
+
+# Issue #806: limit with a non-number count still errors on a non-empty generator
+[limit("a"; 1,2,3)?]
+null
+[]
+
+# Issue #806: nth with an off-type index and an empty generator yields nothing
+[nth("a"; empty)]
+null
+[]
+
+# Issue #806: nth still floors a fractional index over a non-empty generator
+nth(0.5; 10,20,30)
+null
+10


### PR DESCRIPTION
## Summary

jq validates the `limit`/`nth` count lazily. `$n < 0` (null/false/true and negative numbers) errors eagerly, but a string/array/object count is not `< 0`, so it only reaches the per-item arithmetic (`$n - 1`) once the generator yields its first value. An **empty** generator therefore produces no error. jq-jit validated the count eagerly and errored even when the generator was empty.

### Before

```
$ echo 'null' | jq-jit -c '[limit("a"; empty)]'
jq: error: string ("a") and number (1) cannot be subtracted
$ echo 'null' | jq-jit -c '[nth("a"; empty)]'
jq: error: string ("a") number required
```

### After (matches jq 1.8.1)

```
$ echo 'null' | jq-jit -c '[limit("a"; empty)]'   # []
$ echo 'null' | jq-jit -c '[nth("a"; empty)]'     # []
```

## Changes

- **limit** (value and path mode): the string/array/object count arm defers the "cannot be subtracted" error until `generator` yields its first value.
- **nth**: the index floor moved from the eager `let $n = floor(...)` binding into the per-item comparison, so a non-numeric index no longer errors before the generator runs, and the negative-index guard sees the raw value (`"a" < 0` is false → proceeds to the deferred error, matching jq). Fractional indices still floor (`nth(0.5; …) == nth(0; …)`, #719) and a non-empty generator still errors.

Verified with a differential sweep over count types `{string, object, array, null, bool, negative, 0, positive, infinite, fractional}` × `{empty, non-empty}` generators — error-presence and value parity with jq 1.8.1.

## Testing

- Regression cases added (`tests/regression.test`) and differential corpus entries (`tests/differential/corpus.test`)
- Full suite green: official 509/509, regression 0 fail, diff corpus + self-diff pass
- Cold builtin/eval path, no benchmark hot-path impact

Closes #806

🤖 Generated with [Claude Code](https://claude.com/claude-code)