### PR TITLE
fix(parser): defer undefined-function errors in unused defs

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -833,6 +833,11 @@ pub struct Parser {
     /// inside transitively-called defs) are errors — jq never compiles the body
     /// of an uncalled def. #765
     deferred_unbound: Vec<(Option<usize>, String)>,
+    /// Unknown function/builtin references parked instead of erroring eagerly,
+    /// as `(enclosing_func_id, name, nargs)`. Same reachability rule as
+    /// `deferred_unbound`: jq resolves function names lazily, so an undefined
+    /// name in the body of an uncalled def is not an error. #807
+    deferred_unknown_func: Vec<(Option<usize>, String, usize)>,
 }
 
 /// Result of parsing: expression + compiled functions.
@@ -861,6 +866,7 @@ impl Parser {
             lib_dirs: lib_dirs.to_vec(),
             current_func: None,
             deferred_unbound: Vec::new(),
+            deferred_unknown_func: Vec::new(),
         };
 
         // Pre-register $ENV
@@ -890,6 +896,23 @@ impl Parser {
         }
     }
 
+    /// Record an unknown function/builtin reference (attributed to the def
+    /// currently being parsed) and return a placeholder that errors with jq's
+    /// message if it is ever evaluated. Deferred so a never-called def whose
+    /// body names an undefined function does not abort compilation — jq
+    /// resolves function names lazily. The real decision is made by
+    /// `check_unbound_reachability`. #807
+    fn defer_unknown_func(&mut self, name: &str, nargs: usize) -> Expr {
+        self.deferred_unknown_func
+            .push((self.current_func, name.to_string(), nargs));
+        Expr::Error {
+            msg: Some(Box::new(Expr::Literal(Literal::Str(format!(
+                "{}/{} is not defined",
+                name, nargs
+            ))))),
+        }
+    }
+
     /// Resolve `$name`, deferring the "not defined" error for an unbound
     /// reference (see `defer_unbound_var`). #765
     fn load_or_defer_var(&mut self, name: &str) -> Expr {
@@ -899,12 +922,14 @@ impl Parser {
         }
     }
 
-    /// Turn parked unbound `$var` references into errors, but only those that
-    /// are actually reachable: a top-level reference, or one inside a def that
-    /// the top-level program calls (transitively). jq never compiles the body
-    /// of an uncalled def, so a free variable there is not an error. #765
+    /// Turn parked unbound `$var` references and unknown function references
+    /// into errors, but only those that are actually reachable: a top-level
+    /// reference, or one inside a def that the top-level program calls
+    /// (transitively). jq never compiles the body of an uncalled def, so a
+    /// free variable (#765) or undefined function name (#807) there is not an
+    /// error.
     fn check_unbound_reachability(&self, program: &Expr) -> Result<()> {
-        if self.deferred_unbound.is_empty() {
+        if self.deferred_unbound.is_empty() && self.deferred_unknown_func.is_empty() {
             return Ok(());
         }
         let mut reachable: std::collections::HashSet<usize> = std::collections::HashSet::new();
@@ -917,13 +942,18 @@ impl Parser {
                 }
             }
         }
+        let is_reachable = |fid: &Option<usize>| match fid {
+            None => true, // top-level reference
+            Some(id) => reachable.contains(id),
+        };
         for (fid, name) in &self.deferred_unbound {
-            let is_reachable = match fid {
-                None => true, // top-level reference
-                Some(id) => reachable.contains(id),
-            };
-            if is_reachable {
+            if is_reachable(fid) {
                 bail!("${} is not defined", name);
+            }
+        }
+        for (fid, name, nargs) in &self.deferred_unknown_func {
+            if is_reachable(fid) {
+                bail!("{}/{} is not defined", name, nargs);
             }
         }
         Ok(())
@@ -1330,6 +1360,7 @@ impl Parser {
             lib_dirs: mod_lib_dirs,
             current_func: None,
             deferred_unbound: Vec::new(),
+            deferred_unknown_func: Vec::new(),
         };
 
         // Skip module statement
@@ -3195,7 +3226,7 @@ impl Parser {
         }
     }
 
-    fn compile_builtin_noargs(&self, name: &str) -> Result<Expr> {
+    fn compile_builtin_noargs(&mut self, name: &str) -> Result<Expr> {
         // A bare 0-arg name can resolve to a user `def` or a filter parameter
         // (including the implicit `x` filter introduced by a `$x` value param).
         // Both shadow same-named builtins, and between the two the lexically
@@ -3433,11 +3464,19 @@ impl Parser {
             _ => {
                 // User defs and filter parameters were already resolved at the
                 // top of this function (#766), so anything reaching here is a
-                // 0-arg builtin handled via runtime.
-                Ok(Expr::UnaryOp {
-                    op: name_to_unary_op(name)?,
-                    operand: Box::new(Expr::Input),
-                })
+                // 0-arg builtin handled via runtime — or an undefined name.
+                // jq resolves names lazily, so an undefined 0-arg name is only
+                // an error when reachable: defer it instead of erroring eagerly
+                // (#807). The deferred placeholder errors at runtime if it is
+                // reached, and `check_unbound_reachability` turns it into a
+                // compile error if its enclosing def is actually called.
+                match name_to_unary_op(name) {
+                    Ok(op) => Ok(Expr::UnaryOp {
+                        op,
+                        operand: Box::new(Expr::Input),
+                    }),
+                    Err(_) => Ok(self.defer_unknown_func(name, 0)),
+                }
             }
         }
     }
@@ -4359,7 +4398,9 @@ impl Parser {
                 if let Some(func_id) = self.scope.lookup_func(name, args.len()) {
                     Ok(self.scope.make_funccall(func_id, args))
                 } else {
-                    bail!("unknown function '{}' with {} args", name, args.len())
+                    // Undefined function name. jq resolves names lazily, so this
+                    // is only an error when reachable: defer it (#807).
+                    Ok(self.defer_unknown_func(name, args.len()))
                 }
             }
         }

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -912,6 +912,13 @@ def id: .; id | id | id
 def twice(f): f | f; twice(. + 1)
 0
 
+# an unused def referencing an undefined function is ignored (#807)
+def e: undefined_fn; 5
+null
+
+def e($p): undefined_fn(1,2); 5
+null
+
 # ---------- Issue #65 parser coverage: mutual recursion ----------
 
 def even: . == 0 or (. > 0 and (. - 1 | odd)); def odd: . > 0 and (. - 1 | even); 4 | even

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -11449,3 +11449,23 @@ null
 nth(0.5; 10,20,30)
 null
 10
+
+# Issue #807: an unused def referencing an undefined function is ignored
+def e: undefined_fn; 5
+null
+5
+
+# Issue #807: an unused parameterized def with an undefined function body is ignored
+def e($p): undefined_fn; 5
+null
+5
+
+# Issue #807: an unused def referencing an undefined function with args is ignored
+def e: undefined_fn(1,2); 5
+null
+5
+
+# Issue #807: a chain of unused defs ending in an undefined function is ignored
+def e: g; def g: undefined_fn; 5
+null
+5


### PR DESCRIPTION
## Summary

jq resolves function names lazily, so an undefined function name in the body of a `def` that is never called is **not** an error. jq-jit lowered def bodies eagerly: a 0-arg bareword fell through to `name_to_unary_op` and raised "unknown unary operation", and an N-arg call raised "unknown function", aborting compilation even when the def was unused.

### Before

```
$ echo 'null' | jq-jit -c 'def e: undefined_fn; 5'
jq: error: unknown unary operation: undefined_fn
```

### After (matches jq 1.8.1)

```
$ echo 'null' | jq-jit -c 'def e: undefined_fn; 5'
5
```

## Approach

Mirror the existing #765 free-variable mechanism for function names:

- Park an unknown function reference (attributed to the enclosing def via `current_func`) as a deferred `Error` placeholder instead of erroring eagerly — `compile_builtin_noargs` (0-arg) and `compile_funcall` (N-arg) both defer.
- In `check_unbound_reachability`, raise the `name/nargs is not defined` compile error only when the enclosing def is reachable from the top-level program (transitively).

A **reachable** undefined reference still errors at compile time, matching jq (verified for top-level refs and refs inside called defs). Error-presence and value parity confirmed against jq 1.8.1 across unused/used × 0-arg/N-arg/parameterized/chained-def cases.

## Testing

- Regression cases added (`tests/regression.test`) and corpus entries (`tests/differential/corpus.test`)
- Full suite green: official 509/509, regression 0 fail, diff corpus + self-diff pass

Closes #807

🤖 Generated with [Claude Code](https://claude.com/claude-code)