### PR TITLE
fix(ir): substitute $var inside @format operands

### DIFF
--- a/src/ir.rs
+++ b/src/ir.rs
@@ -1023,6 +1023,13 @@ impl Expr {
             Expr::Error { msg } => Expr::Error {
                 msg: msg.as_ref().map(|e| Box::new(e.substitute_var(var_index, replacement))),
             },
+            // `@fmt EXPR` formats its operand: a `$x` in the operand must be
+            // substituted, otherwise inlining `E as $x | $x | @json` leaves a
+            // dangling LoadVar that the input-free fast path reads as null (#808).
+            Expr::Format { name, expr } => Expr::Format {
+                name: name.clone(),
+                expr: Box::new(expr.substitute_var(var_index, replacement)),
+            },
             _ => self.clone(),
         }
     }

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -1112,6 +1112,13 @@ null
 @text
 42
 
+# @format reads the piped value, not the env input (#808)
+. as $x | $x | @json
+{"a":1}
+
+"abc" as $x | $x | @base64
+null
+
 # ---------- Issue #65 parser coverage: format with interpolation ----------
 
 @csv "\(.a),\(.b)"

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -11469,3 +11469,18 @@ null
 def e: g; def g: undefined_fn; 5
 null
 5
+
+# Issue #808: @format reads the piped value, not the env input
+. as $x | $x | @json
+{"a":1}
+"{\"a\":1}"
+
+# Issue #808: @text on a piped bound variable
+5 as $x | $x | @text
+null
+"5"
+
+# Issue #808: @base64 on a piped bound string
+"abc" as $x | $x | @base64
+null
+"YWJj"


### PR DESCRIPTION
## Summary

`substitute_var` fell through to the `_ => self.clone()` catch-all for `Expr::Format`, so it never replaced a `$x` inside an `@fmt` operand. When the `LetBinding` inliner rewrote `E as $x | $x | @json`, it dropped the binding but left a dangling `LoadVar`; the input-free output fast path then evaluated it against an empty env and emitted the format of `null`.

### Before (JIT-only)

```
$ echo '{"a":1}' | jq-jit -c '. as $x | $x | @json'
"null"
$ echo 'null' | jq-jit -c '"abc" as $x | $x | @base64'
"bnVsbA=="   # base64 of "null"
```

### After (matches jq 1.8.1)

```
$ echo '{"a":1}' | jq-jit -c '. as $x | $x | @json'
"{\"a\":1}"
$ echo 'null' | jq-jit -c '"abc" as $x | $x | @base64'
"YWJj"
```

## Fix

Recurse into `Expr::Format` in `substitute_var` like the other operand-bearing variants, so the format operand's variable is substituted instead of being left dangling. Confirmed `JQJIT_FORCE_INTERPRETER=1` already gave the correct result, isolating this to the substitution path used by the input-free fast path.

Same family as #556/#797 (input-free fast path reading the wrong value), distinct remaining site.

## Testing

- Regression cases (`@json`/`@text`/`@base64` via a piped bound variable) and corpus entries added
- Full suite green: official 509/509, regression 0 fail, diff corpus + self-diff pass

Closes #808

🤖 Generated with [Claude Code](https://claude.com/claude-code)