### PR TITLE
fix(jit): propagate the index-type error from fused field ops

### DIFF
--- a/src/jit.rs
+++ b/src/jit.rs
@@ -951,7 +951,14 @@ impl Flattener {
             JitOp::Index { .. } | JitOp::IndexField { .. } |
             JitOp::BinOp { .. } | JitOp::AddMove { .. } | JitOp::UnaryOp { .. } |
             JitOp::Negate { .. } | JitOp::CallBuiltin { .. } |
-            JitOp::MutateInplace { .. } | JitOp::ThrowError { .. }
+            JitOp::MutateInplace { .. } | JitOp::ThrowError { .. } |
+            // The fused field-op runtimes index `.field` on the base and return
+            // GEN_ERROR for a non-object base ("Cannot index <type> with string").
+            // Without a CheckError that error is set but never propagated, so the
+            // null in dst leaks out — e.g. `.[0]|=. | .a==1` returned null instead
+            // of erroring once the surrounding _modify pushed it onto the JIT
+            // path (#809).
+            JitOp::FieldBinopConst { .. } | JitOp::FieldBinopField { .. }
         );
         self.ops.push(op);
         if is_fallible {

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -149,6 +149,13 @@ null
 .[] |= . + 1
 [1,2,3]
 
+# a fused .field op after a _modify still raises the index-type error (#809)
+[.[0]|=. | (.a==1)?]
+[1,2]
+
+[(map_values(.) | .a+1)?]
+[1]
+
 # ---------- Issue #31: JIT→eval delegation must seed $vars buried deep in update ----------
 
 [100] as $r | (.a, .b) |= $r[0]

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -11484,3 +11484,18 @@ null
 "abc" as $x | $x | @base64
 null
 "YWJj"
+
+# Issue #809: a fused .field op after |= still raises the index-type error (caught by ?, collected empty)
+[.[0]|=. | (.a==1)?]
+[1,2]
+[]
+
+# Issue #809: fused .field arithmetic after map_values raises on the array element
+[(map_values(.) | .a+1)?]
+[1]
+[]
+
+# Issue #809: fused .field op after .[]|=. raises on a non-object element
+[(.[]|=. | .a==1 and true)?]
+[1,2]
+[]


### PR DESCRIPTION
## Summary

After an `_modify` operation (`|=`, `map_values`), a fused `.field <op>` fast path swallowed the "Cannot index … with string" type error and returned `null`/`false`.

### Before (JIT-only, after a `_modify` predecessor)

```
$ echo '[1,2]' | jq-jit -c '.[0]|=. | .a==1'
null                         # jq: error "Cannot index array with string \"a\""
$ echo '[1,2]' | jq-jit -c '.[0]|=. | .a==1 and true'
false
```

### After (matches jq 1.8.1)

```
$ echo '[1,2]' | jq-jit -c '.[0]|=. | .a==1'
jq: error (at <stdin>:0): Cannot index array with string "a"
```

## Root cause

The fused field-op runtimes (`jit_rt_field_binop_const` / `jit_rt_field_binop_field`) already detect a non-object base and return `GEN_ERROR`, but `FieldBinopConst`/`FieldBinopField` were absent from the JIT `is_fallible` set, so no `CheckError` was emitted after them — the error was set but never propagated and the `null` in `dst` leaked out. The bug only surfaced once a surrounding `_modify` pushed the tail onto the JIT path (standalone `.a==1` errors correctly via eval).

## Fix

Add both ops to `is_fallible`. An `.a?` operand still suppresses correctly, since `CheckError` routes to the enclosing try-catch target.

## Performance

The added `CheckError` is one predictable load+branch after each fused field op. A same-machine A/B over 8M objects on `if .x > N then … else … end` shows ~2% (0.50s → 0.51s) on that micro-benchmark — the unavoidable cost of not silently swallowing the error; other field-arith benchmarks are within noise.

## Testing

- Regression cases (`(.a==1)?` / `.a+1` after `|=`/`map_values`/`.[]|=.`) and corpus entries added
- Full suite green: official 509/509, regression 0 fail, diff corpus + self-diff pass

Closes #809

🤖 Generated with [Claude Code](https://claude.com/claude-code)