### PR TITLE
fix(builtin): treat NaN as a negative count/index, not unbounded

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3327,7 +3327,10 @@ pub fn eval(
                         // dropping the ceil item (#719). The JIT path already
                         // does this float compare (jit.rs emit_yield); this
                         // aligns the eval/interpreter path with it and with jq.
-                        if n < 0.0 {
+                        // jq orders NaN below every number, so `count < 0` is
+                        // true for NaN and it takes the negative-count error
+                        // path rather than acting as an unbounded count (#813).
+                        if n < 0.0 || n.is_nan() {
                             bail!("__jqerror__:\"limit doesn't support negative count\"");
                         }
                         if n == 0.0 { return Ok(true); } // 0.0 and -0.0 → empty
@@ -5547,7 +5550,7 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
                         return Ok(true);
                     }
                 };
-                if n < 0.0 {
+                if n < 0.0 || n.is_nan() {
                     bail!("__jqerror__:\"limit doesn't support negative count\"");
                 }
                 if n == 0.0 { return Ok(true); }

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -444,6 +444,7 @@ enum JitOp {
     // Range loop
     ToF64Var { dst_var: u32, src: SlotId },
     F64Less { dst_var: u32, a_var: u32, b_var: u32 },
+    F64Equal { dst_var: u32, a_var: u32, b_var: u32 },
     F64Add { dst_var: u32, a_var: u32, b_var: u32 },
     F64Sub { dst_var: u32, a_var: u32, b_var: u32 },
     F64Mul { dst_var: u32, a_var: u32, b_var: u32 },
@@ -3275,11 +3276,15 @@ impl Flattener {
                 self.emit(JitOp::F64Less { dst_var: cmp, a_var: zero_var, b_var: limit_var });
                 self.emit(JitOp::BranchOnVar { var: cmp, nonzero_label: start_label, zero_label });
                 self.emit(JitOp::Label { id: zero_label });
-                // limit <= 0: check if negative (error) or zero (skip)
-                let neg_cmp = self.alloc_var();
-                self.emit(JitOp::F64Less { dst_var: neg_cmp, a_var: limit_var, b_var: zero_var });
+                // Reached when `0 < limit` is false — i.e. limit is <= 0 or NaN.
+                // Skip (empty) only for an exact zero; a negative OR NaN count
+                // is an error (jq orders NaN below 0). NaN fails every F64Less
+                // comparison, so distinguish it from 0 with an equality test:
+                // `limit == 0` is true only for an exact zero (#813).
+                let eq_zero = self.alloc_var();
+                self.emit(JitOp::F64Equal { dst_var: eq_zero, a_var: limit_var, b_var: zero_var });
                 let error_label = self.alloc_label();
-                self.emit(JitOp::BranchOnVar { var: neg_cmp, nonzero_label: error_label, zero_label: done_label });
+                self.emit(JitOp::BranchOnVar { var: eq_zero, nonzero_label: done_label, zero_label: error_label });
                 self.emit(JitOp::Label { id: error_label });
                 // Negative limit: throw error
                 let err_msg = self.alloc_slot();
@@ -10024,6 +10029,17 @@ impl JitCompiler {
                         let a_f = b.ins().bitcast(types::F64, cranelift_codegen::ir::MemFlags::new(), a_bits);
                         let b_f = b.ins().bitcast(types::F64, cranelift_codegen::ir::MemFlags::new(), b_bits);
                         let cmp = b.ins().fcmp(cranelift_codegen::ir::condcodes::FloatCC::LessThan, a_f, b_f);
+                        let result = b.ins().uextend(ptr_ty, cmp);
+                        b.def_var(vars[*dst_var as usize], result);
+                    }
+                    JitOp::F64Equal { dst_var, a_var, b_var: bv } => {
+                        let a_bits = b.use_var(vars[*a_var as usize]);
+                        let b_bits = b.use_var(vars[*bv as usize]);
+                        let a_f = b.ins().bitcast(types::F64, cranelift_codegen::ir::MemFlags::new(), a_bits);
+                        let b_f = b.ins().bitcast(types::F64, cranelift_codegen::ir::MemFlags::new(), b_bits);
+                        // Ordered equality: NaN == anything is false, so a NaN
+                        // operand yields 0 here (used to flag a NaN limit count).
+                        let cmp = b.ins().fcmp(cranelift_codegen::ir::condcodes::FloatCC::Equal, a_f, b_f);
                         let result = b.ins().uextend(ptr_ty, cmp);
                         b.def_var(vars[*dst_var as usize], result);
                     }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2407,9 +2407,17 @@ pub fn rt_getpath(v: &Value, path: &Value) -> Result<Value> {
                         current = o.get(k.as_str()).cloned().unwrap_or(Value::Null);
                     }
                     (Value::Arr(a), Value::Num(n, _)) => {
-                        let idx = *n as i64;
-                        let actual = if idx < 0 { (a.len() as i64 + idx) as usize } else { idx as usize };
-                        current = a.get(actual).cloned().unwrap_or(Value::Null);
+                        // A NaN index is out of range → null, matching jq and
+                        // `.[nan]`. `nan as i64` would otherwise truncate to 0
+                        // and return the first element (#813). (An infinite
+                        // index saturates to i64::MAX/MIN and already misses.)
+                        if n.is_nan() {
+                            current = Value::Null;
+                        } else {
+                            let idx = *n as i64;
+                            let actual = if idx < 0 { (a.len() as i64 + idx) as usize } else { idx as usize };
+                            current = a.get(actual).cloned().unwrap_or(Value::Null);
+                        }
                     }
                     // Slice path element `{start, end}`. Originally added in
                     // #536 for `.[N:M] |= f` (eval's Update branch fetches the

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -3076,6 +3076,14 @@ null
 getpath(["a", 0])
 null
 
+# a NaN index is out of range (null), not truncated to 0 (#813)
+getpath([nan])
+[10,20]
+
+# limit with a NaN count errors (caught by ? → empty) (#813)
+[limit(nan; 1,2,3)?]
+null
+
 getpath(["a", "b", "c"])
 null
 

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -11529,3 +11529,23 @@ null
 [3,-1.9] | scalb(.[0]; .[1])
 null
 1.5
+
+# Issue #813: limit with a NaN count errors (NaN sorts below 0, not unbounded)
+[limit(nan; 1,2,3)?]
+null
+[]
+
+# Issue #813: limit with a NaN count and an empty generator still errors
+[limit(nan; empty)?]
+null
+[]
+
+# Issue #813: getpath with a NaN index is out of range (null), not truncated to 0
+getpath([nan])
+[10,20]
+null
+
+# Issue #813: .[nan] and getpath([nan]) agree (both null)
+.[nan]
+[10,20]
+null


### PR DESCRIPTION
## Summary

jq orders NaN below every number, so a NaN in a numeric-argument position takes the "negative" path. jq-jit mishandled two cases.

### limit(nan; g) — was unbounded, should error

```
$ echo 'null' | jq-jit -c '[limit(nan; 1,2,3)]'
[1,2,3]                       # jq: error "limit doesn't support negative count"
```

The eval paths compared with raw `n < 0.0` (false for NaN), and the JIT limit codegen reached the `limit <= 0` branch where `limit < 0` was also false for NaN and fell through to "skip". Fixed by guarding the eval check with `n.is_nan()`, and in the JIT distinguishing an exact-zero count (skip) from a negative/NaN count (error) with a new `F64Equal` op — NaN fails every ordered comparison, so `limit == 0` is the only reliable discriminator. (Reachable on the JIT path with large inputs, verified.)

### getpath([nan]) — was truncated to index 0, should be null

```
$ echo '[10,20]' | jq-jit -c 'getpath([nan])'
10                            # jq: null (out of range), matching .[nan]
```

`nan as i64` truncates to 0; guard the array-index arm on `n.is_nan()`. (An infinite index already saturates to i64::MAX/MIN and misses.)

## Testing

- Regression cases (limit nan eval; getpath/`.[nan]` parity) and corpus entries
- Full suite green: official 509/509, regression 0 fail, diff corpus + self-diff pass

Closes #813

🤖 Generated with [Claude Code](https://claude.com/claude-code)