### PR TITLE
fix(builtin): implode clamps an infinite codepoint to U+FFFD

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1773,8 +1773,15 @@ fn rt_implode(v: &Value) -> Result<Value> {
             for item in a.iter() {
                 match item {
                     Value::Num(n, _) => {
-                        if n.is_nan() || n.is_infinite() {
+                        // NaN is rejected ("number (null) can't be imploded"),
+                        // but jq clamps an *infinite* codepoint to U+FFFD rather
+                        // than erroring (#814).
+                        if n.is_nan() {
                             bail!("{} can't be imploded, unicode codepoint needs to be numeric", errdesc(item));
+                        }
+                        if n.is_infinite() {
+                            s.push('\u{FFFD}');
+                            continue;
                         }
                         let n_val = *n as i64;
                         // Negative, surrogate range (0xD800-0xDFFF), or > 0x10FFFF → replacement char

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -1837,6 +1837,11 @@ null
 [range(65; 70)] | implode
 null
 
+# NOTE: implode of an *infinite* codepoint (#814) is NOT in the corpus —
+# jq casts the codepoint with `(int)`, and `(int)inf` is implementation-
+# defined, so the system jq may differ across platforms. Covered in
+# tests/regression.test (jq-jit basis) instead.
+
 # ---------- Issue #65 parser coverage: nested try chains ----------
 
 try (try error("inner") catch error("outer")) catch .

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -11549,3 +11549,18 @@ null
 .[nan]
 [10,20]
 null
+
+# Issue #814: implode clamps an infinite codepoint to U+FFFD instead of erroring
+[infinite] | implode
+null
+"�"
+
+# Issue #814: implode clamps -infinite to U+FFFD, mixed with valid codepoints
+[65,infinite,66] | implode
+null
+"A�B"
+
+# Issue #814: implode still errors on a NaN codepoint
+[[nan] | implode?]
+null
+[]


### PR DESCRIPTION
## Summary

jq's `implode` clamps a non-finite-but-infinite codepoint to U+FFFD (the replacement character), the same as any other out-of-range codepoint (negative, surrogate, > U+10FFFF). jq-jit rejected both NaN and infinity with "can't be imploded".

### Before

```
$ echo 'null' | jq-jit -c '[infinite] | implode'
jq: error: number (1.797…) can't be imploded, unicode codepoint needs to be numeric
```

### After (matches jq 1.8.1)

```
$ echo 'null' | jq-jit -c '[infinite] | implode'        # "�"
$ echo 'null' | jq-jit -c '[65,infinite,66] | implode'  # "A�B"
```

Only NaN still errors ("number (null) can't be imploded"); an infinite codepoint now yields U+FFFD.

## Testing

- Regression cases (infinite / mixed / NaN-still-errors). The `implode(infinite)` differential is intentionally regression-only, not in the corpus — jq casts the codepoint with `(int)`, and `(int)inf` is implementation-defined, so the system jq may differ across CI platforms.
- Full suite green: official 509/509, regression 0 fail, diff corpus + self-diff pass.

Closes #814

🤖 Generated with [Claude Code](https://claude.com/claude-code)