### PR TITLE
fix(builtin): remove the accidental recurse_down/0 alias

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3182,7 +3182,7 @@ impl Parser {
             | "gmtime" | "localtime" | "mktime" | "now" | "abs"
             | "not" | "env" | "builtins" | "input" | "inputs"
             | "debug" | "stderr" | "modulemeta" | "path"
-            | "with_entries" | "recurse" | "recurse_down"
+            | "with_entries" | "recurse"
             | "has" | "in" | "contains" | "inside"
             | "getpath" | "setpath" | "delpaths"
             | "to_number" | "to_string" | "type_error"
@@ -3290,11 +3290,16 @@ impl Parser {
                     }),
                 })
             }
-            "recurse" | "recurse_down" => {
+            "recurse" => {
                 // jq: `def recurse: recurse(.[]?);`
                 // `EachOpt(Input)` represents `.[]?` and lets eval/JIT take
                 // the descent fast path; `recurse(.)` (which is infinite)
                 // takes the slow custom-step path instead. See #497.
+                // Note: `recurse_down/0` (a deprecated alias removed from jq
+                // before 1.8) is intentionally NOT handled here — jq 1.8.1
+                // compile-errors on it, and it is not a documented jqx
+                // extension, so it falls through to the undefined-function
+                // path ("recurse_down/0 is not defined") (#821).
                 Ok(Expr::Recurse {
                     input_expr: Box::new(Expr::EachOpt { input_expr: Box::new(Expr::Input) }),
                 })

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -285,7 +285,7 @@ pub fn call_builtin(name: &str, args: &[Value]) -> Result<Value> {
             // limit needs special handling as a generator
             Ok(Value::Null)
         }),
-        "first" | "last" | "nth" | "range" | "while" | "until" | "repeat" | "recurse" | "recurse_down"
+        "first" | "last" | "nth" | "range" | "while" | "until" | "repeat" | "recurse"
         | "getpath" | "setpath" | "delpaths" => {
             // These need special handling
             match name {

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -11564,3 +11564,13 @@ null
 [[nan] | implode?]
 null
 []
+
+# Issue #821: recurse_down/0 is no longer a builtin alias, so a user def is honored
+def recurse_down: recurse; [recurse_down]
+[1,[2]]
+[[1,[2]],1,[2],2]
+
+# Issue #821: recurse/0 still descends (unaffected by removing the recurse_down alias)
+[recurse]
+[1,[2,[3]]]
+[[1,[2,[3]]],1,[2,[3]],2,[3],3]


### PR DESCRIPTION
## Summary

`recurse_down/0` is a deprecated alias that jq removed before 1.8; jq 1.8.1 compile-errors with "recurse_down/0 is not defined". jq-jit still mapped it to `recurse`.

```
$ echo '[1,[2]]' | jq-jit -c 'recurse_down'   # was: descended like recurse
[1,[2]]
1
...
```

It is **not** a documented jqx extension and was never advertised by `builtins` (only `recurse/0,1,2` are), so it was an accidental compatibility leak rather than an intentional out-of-spec builtin (the jqx policy protects intentional extras, not stray aliases).

## Fix

Drop the parser alias plus the dead runtime/recognition entries. A bare `recurse_down` now falls through to the undefined-function path ("recurse_down/0 is not defined"), matching jq, while a user-defined `def recurse_down: ...` is honored (the builtin no longer shadows it).

## Testing

- Regression cases: a user `def recurse_down` works; `recurse`/`..` unaffected
- Full suite green: official 509/509, regression 0 fail, diff corpus + self-diff pass

Closes #821

🤖 Generated with [Claude Code](https://claude.com/claude-code)