### PR TITLE
fix(interpreter): don't inline a dot-reading binding into a rebound-. scope

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -576,6 +576,80 @@ fn expr_references_var(expr: &crate::ir::Expr, var_index: u16) -> bool {
     }
 }
 
+/// Returns true if `var_index` is referenced anywhere inside `expr` in a
+/// position where `.` has been rebound away from the value it had at `expr`'s
+/// entry. The LetBinding inliner uses this to refuse substituting a
+/// replacement that reads `.` (e.g. `.foo`, or `.` itself) into such a
+/// position — `. as $v | map($v)` must keep `$v` bound to the outer `.`, not
+/// the per-element `.` that `map`/`.[] |` rebinds (#818).
+///
+/// Sound by construction: only clearly dot-preserving constructs propagate
+/// `dot_same`; every other (or unenumerated) construct is treated as rebinding
+/// `.`, so a reference found there is reported (the inliner just declines the
+/// optimization and keeps the binding).
+fn var_in_rebound_dot_scope(expr: &crate::ir::Expr, var_index: u16) -> bool {
+    use crate::ir::{Expr, StringPart};
+    fn walk(e: &Expr, var: u16, dot_same: bool) -> bool {
+        match e {
+            Expr::LoadVar { var_index: v } => *v == var && !dot_same,
+            // Dot-preserving: every sub-expression sees the same `.`.
+            Expr::BinOp { lhs, rhs, .. } => walk(lhs, var, dot_same) || walk(rhs, var, dot_same),
+            Expr::UnaryOp { operand, .. }
+            | Expr::Negate { operand } => walk(operand, var, dot_same),
+            Expr::Format { expr, .. } => walk(expr, var, dot_same),
+            Expr::Index { expr, key } | Expr::IndexOpt { expr, key } => {
+                walk(expr, var, dot_same) || walk(key, var, dot_same)
+            }
+            Expr::Comma { left, right } => walk(left, var, dot_same) || walk(right, var, dot_same),
+            Expr::Collect { generator } => walk(generator, var, dot_same),
+            Expr::Each { input_expr } | Expr::EachOpt { input_expr } => walk(input_expr, var, dot_same),
+            Expr::IfThenElse { cond, then_branch, else_branch } => {
+                walk(cond, var, dot_same)
+                    || walk(then_branch, var, dot_same)
+                    || walk(else_branch, var, dot_same)
+            }
+            Expr::Alternative { primary, fallback } => {
+                walk(primary, var, dot_same) || walk(fallback, var, dot_same)
+            }
+            Expr::ObjectConstruct { pairs } => {
+                pairs.iter().any(|(k, v)| walk(k, var, dot_same) || walk(v, var, dot_same))
+            }
+            Expr::StringInterpolation { parts } => parts.iter().any(|p| {
+                matches!(p, StringPart::Expr(x) if walk(x, var, dot_same))
+            }),
+            Expr::Slice { expr, from, to } => {
+                walk(expr, var, dot_same)
+                    || from.as_ref().is_some_and(|x| walk(x, var, dot_same))
+                    || to.as_ref().is_some_and(|x| walk(x, var, dot_same))
+            }
+            Expr::Range { from, to, step } => {
+                walk(from, var, dot_same)
+                    || walk(to, var, dot_same)
+                    || step.as_ref().is_some_and(|x| walk(x, var, dot_same))
+            }
+            // `limit(n; g)` runs both n and g against the entry `.`.
+            Expr::Limit { count, generator } => {
+                walk(count, var, dot_same) || walk(generator, var, dot_same)
+            }
+            // `a | b`: `a` sees the entry `.`; `b` sees it only when `a` is the
+            // identity `.` (otherwise `b`'s `.` is whatever `a` produced).
+            Expr::Pipe { left, right } => {
+                walk(left, var, dot_same)
+                    || walk(right, var, dot_same && matches!(left.as_ref(), Expr::Input))
+            }
+            // A nested binding keeps `.`; the body is skipped if it shadows our var.
+            Expr::LetBinding { var_index: vi, value, body } => {
+                walk(value, var, dot_same) || (*vi != var && walk(body, var, dot_same))
+            }
+            // Everything else rebinds `.` (reduce/foreach update, while/until,
+            // try/catch handler, path updates, …) or is not clearly
+            // dot-preserving: any reference inside is treated as rebound.
+            other => expr_references_var(other, var),
+        }
+    }
+    walk(expr, var_index, true)
+}
+
 pub(crate) fn is_single_valued_expr(e: &crate::ir::Expr) -> bool {
     use crate::ir::Expr;
     match e {
@@ -1694,7 +1768,20 @@ fn simplify_expr(expr: &crate::ir::Expr) -> crate::ir::Expr {
             let sb = simplify_expr(body);
             if sv.is_simple_scalar() {
                 let body_uses_var = expr_references_var(&sb, *var_index);
-                if body_uses_var || expr_is_pure_scalar(&sv) {
+                if body_uses_var {
+                    // Substituting the var's value is unsafe when the value
+                    // reads `.` and a reference sits where `.` was rebound —
+                    // `. as $v | map($v)` would otherwise become `map(.)`,
+                    // reading the per-element `.` instead of the bound one
+                    // (#818). A value that doesn't read `.` is dot-independent
+                    // and always safe to substitute.
+                    let dot_safe = !contains_input(&sv)
+                        || !var_in_rebound_dot_scope(&sb, *var_index);
+                    if dot_safe {
+                        return sb.substitute_var(*var_index, &sv);
+                    }
+                } else if expr_is_pure_scalar(&sv) {
+                    // Unused binding with a side-effect-free value: drop it.
                     return sb.substitute_var(*var_index, &sv);
                 }
             }

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -876,6 +876,13 @@ fromjson
 . as $orig | . as [$a, $b] | [$orig, $a, $b]
 [5, 6]
 
+# `. as $v` stays bound to the outer value inside a rebound-`.` body (#818)
+. as $v | [.[] | $v]
+[1,2]
+
+. as $v | map($v)
+[10,20]
+
 # ---------- Issue #65 parser coverage: alternative destructuring ?// ----------
 
 . as [$a] ?// $a | $a

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -11574,3 +11574,23 @@ def recurse_down: recurse; [recurse_down]
 [recurse]
 [1,[2,[3]]]
 [[1,[2,[3]]],1,[2,[3]],2,[3],3]
+
+# Issue #818: . as $v keeps $v bound to the outer value inside .[]|$v (not the element)
+[1] | . as $v | [.[] | $v]
+null
+[[1]]
+
+# Issue #818: map($v) yields the whole bound array per element
+[10,20] | . as $v | map($v)
+null
+[[10,20],[10,20]]
+
+# Issue #818: the collected leak corrupts add, not just printing
+[1,2] | . as $v | [.[] | $v] | add
+null
+[1,2,1,2]
+
+# Issue #818: a dot-preserving body still inlines correctly (no regression)
+5 as $v | [$v, $v+1]
+null
+[5,6]


### PR DESCRIPTION
## Summary

The `LetBinding` inliner rewrites `E as $x | F` to `F[$x := E]` whenever `E` is a simple scalar — including `E = .`. But when `$x` is referenced inside a sub-expression where `.` has been rebound (e.g. `map($x)` / `.[] | $x`), substituting `.` reads the per-element input instead of the bound value.

### Before (JIT/fast-path)

```
$ echo 'null' | jq-jit -c '[10,20] | . as $v | map($v)'
[10,20]                          # jq: [[10,20],[10,20]]
$ echo 'null' | jq-jit -c '[1,2] | . as $v | [.[] | $v] | add'
3                                # jq: [1,2,1,2]
```

`. as $v | map($v)` collapsed to `map(.)` and the whole filter folded to the input array. `JQJIT_FORCE_INTERPRETER=1` gave the correct result, isolating it to the substitution feeding the input-free fast path.

## Fix

When the bound value reads `.` (`contains_input`), only inline if no `$x` reference sits in a rebound-`.` position. A new sound `var_in_rebound_dot_scope` walker tracks dot-context — only clearly dot-preserving constructs propagate the original `.`; the pipe RHS after a non-identity LHS, reduce/foreach update, try/catch handler, etc. are treated as rebinding. A dot-independent value (literal, outer `$var`) still inlines unconditionally.

## Testing

- Regression cases (the leak via `[.[]|$v]`/`map($v)`/`add`; a dot-preserving body still inlines) and corpus entries
- Full suite green: official 509/509, regression 0 fail, diff corpus + self-diff + fuzz pass

Closes #818

🤖 Generated with [Claude Code](https://claude.com/claude-code)