### PR TITLE
fix(destructure): apply ?// fallback per source value, not across the generator

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1568,45 +1568,55 @@ impl Parser {
         var_map: &std::collections::HashMap<String, u16>,
         body: &Expr,
     ) -> Result<Expr> {
-        // The fallback chain is `try (bind P1 | body) catch (bind P2 | body) …`.
-        // jq's `try … catch` runs the catch with `.` set to the *error*, which
-        // would clobber the input the body expects (e.g. a reduce UPDATE's
-        // accumulator). Capture the original input in `$__altdot__` up front
-        // and restore it at the head of every alternative's body, so each body
-        // sees the same `.` regardless of which alternative fires. The bind
-        // step only sets variables and leaves `.` untouched, so this is a
-        // no-op for the first (try) alternative and a correction for the rest.
+        // jq applies `?//` *per source value*: for each value of `value_expr`
+        // it tries P1, and only the values that fail P1 fall through to P2,
+        // etc. The source generator must therefore be bound ONCE, outside the
+        // try/catch — binding it per alternative (re-running it inside every
+        // `catch`) re-applies the fallback to values that already matched an
+        // earlier pattern, so `({a:1},2) as {a:$x} ?// $x | $x` leaked the
+        // whole `{a:1}` through the fallback alongside its real match (#819).
+        //
+        // Capture the original input in `$__altdot__` and the per-element
+        // source value in `$__altsrc__`. Each alternative is run as
+        // `$__altdot__ | (BIND-Pi | BODY)`, so the catch arm's `.` (set to the
+        // caught error by `try … catch`) is restored to the original input for
+        // both the pattern's computed keys and the body (#736/#803). The
+        // source binding sits outside the try/catch, evaluated against the
+        // original `.`, so reduce/foreach element sources (#712) and
+        // `.`-reading sources (#736) still see the right input.
         let dot_var = self.scope.alloc_var("__altdot__");
-        let restored_body = Expr::Pipe {
-            left: Box::new(Expr::LoadVar { var_index: dot_var }),
-            right: Box::new(body.clone()),
-        };
-        // Evaluate the bound value against the restored `.` too: in a catch
-        // arm the ambient `.` is the caught error, so a `value_expr` that reads
-        // `.` (e.g. `. as [$a] ?// $a`) would otherwise destructure the error
-        // string instead of the original input (#736). For value_exprs that
-        // ignore `.` (a `LoadVar` element slot, as in reduce/foreach #712) this
-        // pipe is a harmless no-op.
-        let restored_value = Expr::Pipe {
-            left: Box::new(Expr::LoadVar { var_index: dot_var }),
-            right: Box::new(value_expr.clone()),
-        };
+        let src_var = self.scope.alloc_var("__altsrc__");
         let mut result: Option<Expr> = None;
         for pattern in alt_patterns.iter().rev() {
-            let binding = self.build_binding_with_varmap(restored_value.clone(), pattern, var_map, restored_body.clone())?;
+            let binding = self.build_binding_with_varmap(
+                Expr::LoadVar { var_index: src_var },
+                pattern,
+                var_map,
+                body.clone(),
+            )?;
+            let restored = Expr::Pipe {
+                left: Box::new(Expr::LoadVar { var_index: dot_var }),
+                right: Box::new(binding),
+            };
             result = Some(match result {
-                None => binding,
+                None => restored,
                 Some(prev) => Expr::TryCatch {
-                    try_expr: Box::new(binding),
+                    try_expr: Box::new(restored),
                     catch_expr: Box::new(prev),
                 },
             });
         }
         let chain = result.expect("alt_patterns is non-empty");
+        // `value_expr as $__altsrc__ | chain`, iterated per source value.
+        let src_binding = Expr::LetBinding {
+            var_index: src_var,
+            value: Box::new(value_expr.clone()),
+            body: Box::new(chain),
+        };
         Ok(Expr::LetBinding {
             var_index: dot_var,
             value: Box::new(Expr::Input),
-            body: Box::new(chain),
+            body: Box::new(src_binding),
         })
     }
 

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -885,6 +885,13 @@ fromjson
 
 # ---------- Issue #65 parser coverage: alternative destructuring ?// ----------
 
+# ?// applies the fallback per source value, not across the whole generator (#819)
+[({a:1},2) as {a:$x} ?// $x | $x]
+null
+
+[([1],2,[3]) as [$a] ?// $a | $a]
+null
+
 . as [$a] ?// $a | $a
 "hello"
 

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -11619,3 +11619,18 @@ null
 [.[0,1] | .[0,1]]
 [[1,2],[3,4]]
 [1,2,3,4]
+
+# Issue #819: ?// fallback only applies to source values that fail the first pattern
+[({a:1},2) as {a:$x} ?// $x | $x]
+null
+[1,2]
+
+# Issue #819: array-pattern ?// leak across generator values
+[([1],2,[3]) as [$a] ?// $a | $a]
+null
+[1,2,3]
+
+# Issue #819: a matched value does not leak through the fallback (downstream stays typed)
+[({a:1},2) as {a:$x} ?// $x | $x | .+0]
+null
+[1,2]


### PR DESCRIPTION
## Summary

`EXPR as P1 ?// P2 | BODY` desugared to `try (EXPR as P1 | BODY) catch (EXPR as P2 | BODY)`, cloning the source generator into every catch arm. When `EXPR` is a generator and a later value fails P1, the catch re-ran the **whole** generator through P2 — re-applying the fallback to values that already matched P1.

### Before

```
$ echo 'null' | jq-jit -c '[({a:1},2) as {a:$x} ?// $x | $x]'
[1,{"a":1},2]                    # jq: [1,2]
```

`{a:1}` matched `{a:$x}` (→ 1) but jq-jit *also* yielded the whole object through the leaked fallback, and the leaked value caused spurious downstream type errors.

## Fix

Bind the source once, outside the try/catch: `EXPR as $__altsrc__ | try ($__altsrc__ as P1 | BODY) catch ($__altsrc__ as P2 | BODY)`, iterated per source value so each value only reaches the fallback if it fails P1. The original input is still captured in `$__altdot__` and restored at the head of every alternative, so the catch arm's `.` (the caught error) no longer clobbers the pattern's computed keys or the body (#736/#803 preserved).

## Testing

- Regression cases (object/array pattern leaks; matched value stays typed downstream) and corpus entries; #736/#803 regressions still pass
- Full suite green: official 509/509, regression 0 fail, diff corpus + self-diff + fuzz pass

Closes #819

🤖 Generated with [Claude Code](https://claude.com/claude-code)