### PR TITLE
fix(path): reject a navigating reduce update body as a path expression

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -5671,10 +5671,25 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
                     let base_val = crate::runtime::rt_getpath(&input, ap).unwrap_or(Value::Null);
                     env.borrow_mut().vars[ai as usize] = base_val.clone();
                     let ap_vec: Vec<Value> = match ap { Value::Arr(a) => a.as_ref().clone(), _ => vec![] };
-                    eval_path(update, base_val, env, &mut |rp| {
-                        let mut p = ap_vec.clone();
-                        if let Value::Arr(rpa) = &rp { p.extend(rpa.iter().cloned()); }
-                        next.push(Value::Arr(Rc::new(p)));
+                    eval_path(update, base_val.clone(), env, &mut |rp| {
+                        // jq only path-tracks a reduce whose UPDATE preserves the
+                        // accumulator path — an identity-equivalent body (`.`,
+                        // `select(true)`, `if true then . else . end`) yields the
+                        // base unchanged (relative path `[]`). A body that
+                        // navigates (`.a`, `.[$x]`, …) makes the reduce a value
+                        // computation, which jq rejects as a path expression
+                        // rather than tracking through it — otherwise `reduce 1
+                        // as $x (.; .a) |= 99` silently mutated `.a` (#816). The
+                        // reported result is the value at the navigated location.
+                        let nav_len = match &rp { Value::Arr(a) => a.len(), _ => 0 };
+                        if nav_len != 0 {
+                            let nav_val = crate::runtime::rt_getpath(&base_val, &rp).unwrap_or(Value::Null);
+                            bail!(
+                                "Invalid path expression with result {}",
+                                crate::value::value_to_json(&nav_val)
+                            );
+                        }
+                        next.push(Value::Arr(Rc::new(ap_vec.clone())));
                         Ok(true)
                     })?;
                 }

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -266,6 +266,14 @@ null
 reduce range(5) as $i (0; . + $i)
 null
 
+# a navigating reduce update body is not a path expression (#816)
+[path(reduce 1 as $x (.; .a))?]
+{"a":1}
+
+# an identity-equivalent update body still path-tracks the INIT path (#816)
+path(reduce 1 as $x (.a; select(true)))
+{"a":{"b":2}}
+
 reduce .[] as $x ({}; .[$x | tostring] = 1)
 [1,2,3,2,1]
 

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -11634,3 +11634,28 @@ null
 [({a:1},2) as {a:$x} ?// $x | $x | .+0]
 null
 [1,2]
+
+# Issue #816: a reduce whose update body navigates is not a path expression
+[path(reduce 1 as $x (.; .a))?]
+{"a":1}
+[]
+
+# Issue #816: |= over such a reduce errors instead of silently mutating
+[(reduce 1 as $x (.; .a) |= 99)?]
+{"a":1}
+[]
+
+# Issue #816: an identity-equivalent update body still path-tracks (init path)
+path(reduce 1 as $x (.a; select(true)))
+{"a":{"b":2}}
+["a"]
+
+# Issue #816: empty source still forwards the INIT path (#711 preserved)
+path(reduce empty as $x (.a; .b))
+{"a":{"b":2}}
+["a"]
+
+# Issue #816: an identity update body forwards the INIT path
+path(reduce 1 as $x (.a; .))
+{"a":{"b":2}}
+["a"]


### PR DESCRIPTION
## Summary

`path(reduce S as $x (INIT; UPDATE))` is only a valid path expression in jq when UPDATE preserves the accumulator's path — an identity-equivalent body (`.`, `select(true)`, `if true then . else . end`) yields the base unchanged (relative path `[]`). A body that navigates (`.a`, `.[$x]`) makes the reduce a value computation, which jq rejects with "Invalid path expression with result <value>". jq-jit instead path-tracked through the update body and forwarded a bogus path.

### Before

```
$ echo '{"a":1}' | jq-jit -c 'path(reduce 1 as $x (.; .a))'
["a"]                            # jq: error "Invalid path expression with result 1"
$ echo '{"a":1}' | jq-jit -c 'reduce 1 as $x (.; .a) |= 99'
{"a":99}                         # silent mutation! jq errors
```

## Fix

In `eval_path`'s Reduce handler, require the update's per-iteration relative path to be empty; a non-empty (navigated) path now errors with the value at the navigated location. Empty-source reduces still forward the INIT path (#711 preserved), as do identity-equivalent bodies (verified `select(true)`, `if true then . else . end`, `. | .` all accepted, matching jq).

## Testing

- Regression cases (navigating body rejected; `|=` no longer silently mutates; identity-equivalent + empty-source still path-track) and corpus entries
- Full suite green: official 509/509, regression 0 fail, diff corpus + self-diff + fuzz pass; #711 path tests intact

Closes #816

🤖 Generated with [Claude Code](https://claude.com/claude-code)