### PR TITLE
fix(path): track the try/catch catch-branch as a path expression

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -5425,10 +5425,15 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
             match result {
                 Ok(cont) => Ok(cont),
                 Err(e) => {
-                    // A caught `break` surfaces as `{"__jq": id}`, mirroring the
-                    // value-mode handler (#715).
+                    // In path context the catch branch is itself a path
+                    // expression, evaluated against the caught value (the error
+                    // payload, or the rethrown input for a bare `error`). jq
+                    // tracks `path(try error catch .b)` as `["b"]` and raises a
+                    // path-mode type error when the caught value can't accept
+                    // the navigation. Evaluating it in VALUE mode dropped the
+                    // tracking (#836).
                     if let Some(be) = e.downcast_ref::<BreakError>() {
-                        return eval(catch_expr, break_catch_value(be.0), env, cb);
+                        return eval_path(catch_expr, break_catch_value(be.0), env, cb);
                     }
                     let msg = format!("{}", e);
                     // halt / halt_error are non-recoverable: jq lets them
@@ -5440,7 +5445,7 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
                     } else {
                         Value::from_str(&msg)
                     };
-                    eval(catch_expr, catch_val, env, cb)
+                    eval_path(catch_expr, catch_val, env, cb)
                 }
             }
         }

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -4070,3 +4070,14 @@ if (.a >= .b) then .a else .x end
 
 reduce .[] as [$a] ?// $a (0; . + $a)
 [1,[2],3]
+
+# ---------- Issue #836: try/catch catch-branch path tracking ----------
+
+path(try error catch .b)
+{"b":2}
+
+(try error catch .b) |= .+10
+{"b":2}
+
+del(try error catch .b)
+{"b":2}

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -11659,3 +11659,18 @@ path(reduce empty as $x (.a; .b))
 path(reduce 1 as $x (.a; .))
 {"a":{"b":2}}
 ["a"]
+
+# Issue #836: try/catch catch-branch is path-tracked (path)
+path(try error catch .b)
+{"b":2}
+["b"]
+
+# Issue #836: try/catch catch-branch is path-tracked (update)
+(try error catch .b) |= .+10
+{"b":2}
+{"b":12}
+
+# Issue #836: try/catch catch-branch is path-tracked (del)
+del(try error catch .b)
+{"b":2}
+{}


### PR DESCRIPTION
## Summary

In path context the catch branch of `try A catch B` was evaluated in **value mode**, so when the try body errored and the catch handler ran as the path, jq-jit lost path tracking:

- `path(try error catch .b)` → `2` (jq: `["b"]`)
- `(try error catch .b) |= .+10` → "Path must be specified as an array" (jq: `{"b":12}`)
- `del(try error catch .b)` → type error (jq: `{}`)

## Fix

Evaluate the catch branch with `eval_path` against the caught value (the error payload, or the rethrown input for a bare `error`), mirroring jq. It now tracks the navigation as a path and raises a path-mode type error when the caught value can't accept it. The BreakError branch is handled the same way.

Only the catch branch was affected — `path(try .a catch .b)` (try-body succeeds) already agreed.

## Tests

- `tests/regression.test`: path / `|=` / `del` cases for `try error catch .b`
- `tests/differential/corpus.test`: matching probes
- `cargo test --release` green (official 509 + regression, diff_corpus, selfdiff)

Closes #836

🤖 Generated with [Claude Code](https://claude.com/claude-code)