### PR TITLE
fix(math): max keeps the last maximal element on ties

### DIFF
--- a/src/jit.rs
+++ b/src/jit.rs
@@ -7152,7 +7152,8 @@ extern "C" fn jit_rt_unaryop(dst: *mut Value, op: i32, input: *const Value) -> i
                 }
                 let mut m = &a[0];
                 for v in &a[1..] {
-                    if crate::runtime::compare_values(v, m) == std::cmp::Ordering::Greater { m = v; }
+                    // jq's `max` keeps the LAST maximal element on ties (#852).
+                    if crate::runtime::compare_values(v, m) != std::cmp::Ordering::Less { m = v; }
                 }
                 std::ptr::write(dst, m.clone());
                 return 0;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1405,7 +1405,11 @@ fn rt_max(v: &Value) -> Result<Value> {
         Value::Arr(a) => {
             let mut max = &a[0];
             for v in &a[1..] {
-                if compare_values(v, max) == std::cmp::Ordering::Greater {
+                // jq's `max` keeps the LAST maximal element on ties (its C fold
+                // updates on `>=`), so representation-distinct equal maxima
+                // settle on the last one (`[1.0,1]|max` → `1`, `[-0,0]|max` →
+                // `0`). `min` stays strict (keeps the first). See #852.
+                if compare_values(v, max) != std::cmp::Ordering::Less {
                     max = v;
                 }
             }

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -4095,3 +4095,14 @@ reduce .[] as $x (.a; .) |= 9
 
 path(reduce range(2) as $x (.a; .))
 {"a":1}
+
+# ---------- Issue #852: max keeps the last element on ties ----------
+
+max
+[1.0,1]
+
+max
+[1.0,1,1.00]
+
+min
+[1.0,1]

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -11699,3 +11699,18 @@ del(try error catch .b)
 path(reduce range(2) as $x (.a; .))
 {"a":1}
 ["a"]
+
+# Issue #852: max keeps the LAST maximal element on ties (min keeps first)
+max
+[1.0,1]
+1
+
+# Issue #852: max keeps the last of three representation-distinct equal maxima
+max
+[1.0,1,1.00]
+1.00
+
+# Issue #852: min still keeps the first maximal element on ties
+min
+[1.0,1]
+1.0


### PR DESCRIPTION
## Summary

jq's `max` keeps the **last** element among equal maxima (its C fold updates on `>=`), so representation-distinct equal maxima settle on the last one. jq-jit updated only on a strict `Greater`, keeping the first:

- `[1.0,1] | max` → `1` (was `1.0`)
- `[-0,0] | max` → `0` (was `-0`)
- `[1.0,1,1.00] | max` → `1.00` (confirms the LAST rule)

`min` stays strict (keeps the first), matching jq. `max_by`/`min_by` were already correct.

Fixed in both the runtime fold (`rt_max`) and the JIT `max` fast path (op 13); the value is cloned so the original number representation is preserved.

## Tests
`tests/regression.test` + `tests/differential/corpus.test`; `cargo test --release` green.

Closes #852

🤖 Generated with [Claude Code](https://claude.com/claude-code)