### PR TITLE
fix(io): input_line_number on input/inputs, and reject adjacent literal tokens

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -16,6 +16,38 @@ fn raw_contains_del_byte(bytes: &[u8]) -> bool {
     memchr::memchr(0x7F, bytes).is_some()
 }
 
+/// Parse a JSON document stream into `(value, input_line_number)` pairs for the
+/// `input`/`inputs` queue (#855). The reported line mirrors the main loop: the
+/// count of `\n` consumed up to the document's end, `+1` until the final
+/// newline is reached.
+fn json_inputs_with_lines(content: &str) -> Result<Vec<(Value, u64)>, String> {
+    let bytes = content.as_bytes();
+    let total_nl = bytes.iter().filter(|&&b| b == b'\n').count() as u64;
+    let mut out: Vec<(Value, u64)> = Vec::new();
+    let mut cnt: u64 = 0;
+    let mut at: usize = 0;
+    json_stream_offsets(content, |v, _start, end| {
+        while at < end {
+            if bytes[at] == b'\n' { cnt += 1; }
+            at += 1;
+        }
+        let line = if cnt < total_nl { cnt + 1 } else { cnt };
+        out.push((v, line));
+        Ok(())
+    })
+    .map_err(|e| format!("{}", e))?;
+    Ok(out)
+}
+
+/// Raw (`-R`) input lines paired with their 1-based line numbers (#855).
+fn raw_inputs_with_lines(content: &str) -> Vec<(Value, u64)> {
+    content
+        .lines()
+        .enumerate()
+        .map(|(i, l)| (Value::from_str(l), (i + 1) as u64))
+        .collect()
+}
+
 /// Returns true if `bytes` contains `\uD[8-F]X` — a JSON `\u` escape that
 /// decodes to a surrogate codepoint. Identity passthrough must defer to
 /// the slow parser for these so jq's lone-surrogate semantics apply
@@ -3457,21 +3489,18 @@ fn real_main() {
     if null_input {
         // Pre-read inputs for `input`/`inputs` builtins
         if filter.uses_inputs() {
-            let mut inputs_values = Vec::new();
+            let mut inputs_values: Vec<(Value, u64)> = Vec::new();
             if files.is_empty() {
                 // Read from stdin
                 let mut input_str = String::new();
                 io::stdin().lock().read_to_string(&mut input_str).unwrap_or(0);
                 if raw_input {
-                    for line in input_str.lines() {
-                        inputs_values.push(Value::from_str(line));
+                    inputs_values.extend(raw_inputs_with_lines(&input_str));
+                } else {
+                    match json_inputs_with_lines(&input_str) {
+                        Ok(vs) => inputs_values.extend(vs),
+                        Err(e) => { eprintln!("jq: error (at <stdin>:0): {}", e); process::exit(2); }
                     }
-                } else if let Err(e) = json_stream(&input_str, |v| {
-                    inputs_values.push(v);
-                    Ok(())
-                }) {
-                    eprintln!("jq: error (at <stdin>:0): {}", e);
-                    process::exit(2);
                 }
             } else {
                 // Read from files
@@ -3481,15 +3510,12 @@ fn real_main() {
                         Err(e) => { eprintln!("jq: error: Could not open file {}: {}", file, e); process::exit(2); }
                     };
                     if raw_input {
-                        for line in content.lines() {
-                            inputs_values.push(Value::from_str(line));
+                        inputs_values.extend(raw_inputs_with_lines(&content));
+                    } else {
+                        match json_inputs_with_lines(&content) {
+                            Ok(vs) => inputs_values.extend(vs),
+                            Err(e) => { eprintln!("jq: error (at {}:0): {}", file, e); process::exit(2); }
                         }
-                    } else if let Err(e) = json_stream(&content, |v| {
-                        inputs_values.push(v);
-                        Ok(())
-                    }) {
-                        eprintln!("jq: error (at {}:0): {}", file, e);
-                        process::exit(2);
                     }
                 }
             }
@@ -3503,24 +3529,24 @@ fn real_main() {
         // remaining stdin value (#196). Pre-load everything into the inputs
         // queue, then drain the queue while both sites pull through the same
         // `read_next_input`.
-        let mut inputs_values: Vec<Value> = Vec::new();
-        if raw_input {
+        let inputs_values: Vec<(Value, u64)> = if raw_input {
             let mut buf = String::new();
             if let Err(e) = io::stdin().lock().read_to_string(&mut buf) {
                 eprintln!("jq: error reading input: {}", e);
                 process::exit(2);
             }
-            for line in buf.lines() {
-                inputs_values.push(Value::from_str(line));
-            }
+            raw_inputs_with_lines(&buf)
         } else {
             let input_str = stdin_data.unwrap_or_default();
-            if let Err(e) = json_stream(&input_str, |v| { inputs_values.push(v); Ok(()) }) {
-                eprintln!("jq: error (at <stdin>:0): {}", e);
-                process::exit(2);
+            match json_inputs_with_lines(&input_str) {
+                Ok(vs) => vs,
+                Err(e) => { eprintln!("jq: error (at <stdin>:0): {}", e); process::exit(2); }
             }
-        }
+        };
         jq_jit::eval::set_inputs_queue(inputs_values);
+        // Drain the queue through `read_next_input` so the main-loop document
+        // and the `input`/`inputs` builtin share the cursor AND the
+        // `input_line_number` updates (#855).
         while let Some(v) = jq_jit::eval::read_next_input() {
             process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
         }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -57,7 +57,7 @@ pub type EnvRef = Rc<RefCell<Env>>;
 // Pre-populated by CLI before eval/JIT execution. Per-thread to keep
 // `cargo test` parallel runs honest — see `value::OBJMAP_POOL`.
 thread_local! {
-    static INPUTS_STATE: RefCell<(Vec<Value>, usize)> = const { RefCell::new((Vec::new(), 0)) };
+    static INPUTS_STATE: RefCell<(Vec<(Value, u64)>, usize)> = const { RefCell::new((Vec::new(), 0)) };
 }
 
 // Per-thread 1-indexed line number for `input_line_number`. The CLI updates
@@ -79,8 +79,11 @@ pub fn get_input_line_number() -> u64 {
     INPUT_LINE_STATE.with(|c| c.get())
 }
 
-/// Set the inputs queue for `input`/`inputs` builtins.
-pub fn set_inputs_queue(values: Vec<Value>) {
+/// Set the inputs queue for `input`/`inputs` builtins. Each entry pairs the
+/// document value with the `input_line_number` jq reports after consuming it
+/// (#855): reading a document via `input`/`inputs` advances the counter, just
+/// like the main per-document loop.
+pub fn set_inputs_queue(values: Vec<(Value, u64)>) {
     INPUTS_STATE.with_borrow_mut(|state| {
         state.0 = values;
         state.1 = 0;
@@ -95,9 +98,10 @@ pub fn clear_inputs_queue() {
     });
 }
 
-/// Read the next input value. Returns None if exhausted.
+/// Read the next input value, advancing `input_line_number` to the line on
+/// which that document ended (#855). Returns None if exhausted.
 pub fn read_next_input() -> Option<Value> {
-    INPUTS_STATE.with_borrow_mut(|state| {
+    let next = INPUTS_STATE.with_borrow_mut(|state| {
         if state.1 < state.0.len() {
             let idx = state.1;
             state.1 += 1;
@@ -105,7 +109,14 @@ pub fn read_next_input() -> Option<Value> {
         } else {
             None
         }
-    })
+    });
+    match next {
+        Some((v, line)) => {
+            set_input_line_number(line);
+            Some(v)
+        }
+        None => None,
+    }
 }
 
 /// Typed error for label/break to avoid string formatting/parsing overhead.

--- a/src/value.rs
+++ b/src/value.rs
@@ -846,8 +846,34 @@ where F: FnMut(Value) -> Result<()> {
     pos = skip_ws(bytes, pos);
     while pos < bytes.len() {
         let (val, end) = parse_json_value(bytes, pos, 0)?;
+        reject_adjacent_word_token(bytes, end)?;
         cb(val)?;
         pos = skip_ws(bytes, end);
+    }
+    Ok(())
+}
+
+/// Reject two bare-word/number tokens jammed together with no separator at the
+/// top level (`nullnull`, `true123`, `123true`, `false0`). jq tokenises a
+/// contiguous run of literal/number characters as a single token and errors;
+/// jq-jit's recursive parser would otherwise stop at the first valid token and
+/// split the rest into a second document. Structural values (`{}`, `[]`,
+/// strings) are self-delimiting, so the guard only fires when a word character
+/// runs straight into another word character. See #854.
+#[inline]
+fn reject_adjacent_word_token(bytes: &[u8], end: usize) -> Result<()> {
+    if end > 0 && end < bytes.len() {
+        let prev = bytes[end - 1];
+        let next = bytes[end];
+        // The value ended in a bare-word/number character …
+        let prev_word = prev.is_ascii_alphanumeric() || prev == b'.';
+        // … and the next character could extend a literal or number token
+        // (`false-1`, `1-2`, `1.2.3`, `nulltrue` all error in jq), as opposed
+        // to a separator or a self-delimiting structural/string value.
+        let next_word = next.is_ascii_alphanumeric() || matches!(next, b'.' | b'+' | b'-');
+        if prev_word && next_word {
+            bail!("Invalid literal");
+        }
     }
     Ok(())
 }
@@ -861,6 +887,7 @@ where F: FnMut(Value, usize, usize) -> Result<()> {
     pos = skip_ws(bytes, pos);
     while pos < bytes.len() {
         let (val, end) = parse_json_value(bytes, pos, 0)?;
+        reject_adjacent_word_token(bytes, end)?;
         cb(val, pos, end)?;
         pos = skip_ws(bytes, end);
     }

--- a/tests/input_line_number_builtin.rs
+++ b/tests/input_line_number_builtin.rs
@@ -1,0 +1,59 @@
+//! Issue #855: `input_line_number` must advance when a document is consumed via
+//! the `input` / `inputs` builtins, not only by the main per-document loop
+//! (a residual of #117). The regression-test harness can't express the `-n`
+//! flag plus a multi-document stream, so shell out directly.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn run(args: &[&str], stdin: &str) -> String {
+    let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
+    let mut child = Command::new(jq_jit)
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn jq-jit");
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(stdin.as_bytes())
+        .unwrap();
+    let out = child.wait_with_output().expect("wait failed");
+    String::from_utf8(out.stdout)
+        .expect("non-utf8 stdout")
+        .trim_end()
+        .to_string()
+}
+
+#[test]
+fn input_advances_line_number() {
+    assert_eq!(run(&["-nc", "input | input_line_number"], "1\n2\n"), "1");
+}
+
+#[test]
+fn inputs_advance_line_number_each_step() {
+    assert_eq!(
+        run(&["-nc", "[inputs as $x | input_line_number]"], "10\n20\n30\n"),
+        "[1,2,3]"
+    );
+}
+
+#[test]
+fn main_loop_counter_still_works() {
+    // The original #117 fix (main per-document loop) must remain intact.
+    assert_eq!(run(&["-c", "input_line_number"], "11\n22\n"), "1\n2");
+}
+
+#[test]
+fn input_then_line_number_interleaved() {
+    // Document 1 pulls document 2 via `input` (line 2); document 3 has no
+    // further `input` to read (the program then errors, but the first line's
+    // stdout is what we assert on).
+    assert_eq!(
+        run(&["-c", "[., input, input_line_number]"], "1\n2\n3\n"),
+        "[1,2,2]"
+    );
+}

--- a/tests/input_tokenizer_adjacent.rs
+++ b/tests/input_tokenizer_adjacent.rs
@@ -1,0 +1,64 @@
+//! Issue #854: the top-level input tokenizer must reject two bare-word/number
+//! tokens jammed together with no separator (`nullnull`, `true123`, `123true`,
+//! `false0`, `1-2`, `false-1`), the way jq does — jq-jit previously split them
+//! into separate documents. Self-delimiting values (`{}{}`, `[][]`, `"a""b"`,
+//! `"a"-1`, `[1]-2`) and whitespace-separated documents stay valid.
+//!
+//! The regression-test harness parses a single input per case, so a malformed
+//! multi-token stream can't be expressed there — shell out instead.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn run_inputs(stdin: &str) -> (String, bool) {
+    let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
+    let mut child = Command::new(jq_jit)
+        .args(["-cn", "[inputs]"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn jq-jit");
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(stdin.as_bytes())
+        .unwrap();
+    let out = child.wait_with_output().expect("wait failed");
+    (
+        String::from_utf8_lossy(&out.stdout).trim_end().to_string(),
+        out.status.success(),
+    )
+}
+
+#[test]
+fn adjacent_word_tokens_error() {
+    for bad in [
+        "nullnull", "truefalse", "true123", "123true", "false0", "1true", "1abc",
+        "1-2", "1+2", "1.2.3", "1e2e3", "false-1", "null-1", "-1-2", "false.x",
+    ] {
+        let (_, ok) = run_inputs(bad);
+        assert!(!ok, "expected `{bad}` to be rejected as adjacent tokens");
+    }
+}
+
+#[test]
+fn well_separated_and_structural_values_ok() {
+    let cases = [
+        ("null null", "[null,null]"),
+        ("1 2", "[1,2]"),
+        ("1\n2\n", "[1,2]"),
+        (r#"{"a":1}{"b":2}"#, r#"[{"a":1},{"b":2}]"#),
+        ("[1][2]", "[[1],[2]]"),
+        (r#""a""b""#, r#"["a","b"]"#),
+        (r#""a"-1"#, r#"["a",-1]"#),
+        ("[1]-2", "[[1],-2]"),
+        ("-1 -2", "[-1,-2]"),
+    ];
+    for (input, expected) in cases {
+        let (out, ok) = run_inputs(input);
+        assert!(ok, "expected `{input}` to parse");
+        assert_eq!(out, expected, "for input `{input}`");
+    }
+}


### PR DESCRIPTION
## Summary

Two io/stream fixes from the differential bug sweep.

### #855 — `input_line_number` after `input`/`inputs`
The counter stayed `0` after consuming a document via the `input`/`inputs` builtins (the main per-document loop tracked it via the #117 fix, but the builtin read path did not). The `input`/`inputs` queue now carries each document's line number, and `read_next_input` advances the counter as it hands out each value.

- `input | input_line_number` on `1\n2\n` → `1`
- `[inputs as $x | input_line_number]` on `10\n20\n30\n` → `[1,2,3]`

### #854 — adjacent bare-word/number tokens
The top-level tokenizer split two literal/number tokens jammed together with no separator into separate documents (`nullnull` → `[null,null]`); jq tokenises a contiguous literal/number run as one token and errors. The streamers now reject a bare-word/number value immediately followed by a literal- or number-extending character.

- `nullnull`, `true123`, `123true`, `false0`, `1-2`, `false-1`, `1.2.3` → error (both impls)
- self-delimiting / separated values stay valid: `{}{}`, `[][]`, `"a"-1`, `[1]-2`, `null null`

## Tests
New `tests/input_line_number_builtin.rs` and `tests/input_tokenizer_adjacent.rs` (the regression harness can't express the `-n` flag or a malformed multi-token stream). `cargo test --release` fully green (official 509, selfdiff, diff_corpus, fuzz).

Closes #854
Closes #855

🤖 Generated with [Claude Code](https://claude.com/claude-code)