### PR TITLE
fix(io): seed input queue when input/inputs hides in a path-expr arg

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -2685,39 +2685,64 @@ impl Filter {
     /// Returns true if the filter uses `input` or `inputs` anywhere.
     pub fn uses_inputs(&self) -> bool {
         use crate::ir::Expr;
-        fn walk(e: &Expr) -> bool {
+        // `funcs` lets us follow a `FuncCall` into its body: `def f: input; f`
+        // hides the stream read behind the call, and without descending we'd
+        // report no-inputs and skip seeding the queue (#853). `visited` guards
+        // against recursive/mutually-recursive defs.
+        fn walk(e: &Expr, funcs: &[crate::ir::CompiledFunc], visited: &mut Vec<usize>) -> bool {
+            macro_rules! walk { ($x:expr) => { walk($x, funcs, visited) }; }
             match e {
                 Expr::ReadInput | Expr::ReadInputs => true,
                 Expr::Pipe { left, right } | Expr::Comma { left, right }
                 | Expr::BinOp { lhs: left, rhs: right, .. }
-                | Expr::Alternative { primary: left, fallback: right } => walk(left) || walk(right),
+                | Expr::Alternative { primary: left, fallback: right } => walk!(left) || walk!(right),
                 Expr::UnaryOp { operand, .. } | Expr::Negate { operand }
                 | Expr::Collect { generator: operand } | Expr::Each { input_expr: operand }
-                | Expr::EachOpt { input_expr: operand } | Expr::Recurse { input_expr: operand } => walk(operand),
-                Expr::Index { expr, key } | Expr::IndexOpt { expr, key } => walk(expr) || walk(key),
-                Expr::IfThenElse { cond, then_branch, else_branch } => walk(cond) || walk(then_branch) || walk(else_branch),
-                Expr::TryCatch { try_expr, catch_expr } => walk(try_expr) || walk(catch_expr),
-                Expr::Reduce { source, init, update, .. } => walk(source) || walk(init) || walk(update),
-                Expr::Foreach { source, init, update, extract, .. } => walk(source) || walk(init) || walk(update) || extract.as_ref().map_or(false, |e| walk(e)),
-                Expr::Slice { expr, from, to } => walk(expr) || from.as_ref().map_or(false, |e| walk(e)) || to.as_ref().map_or(false, |e| walk(e)),
-                Expr::ObjectConstruct { pairs } => pairs.iter().any(|(k, v)| walk(k) || walk(v)),
-                Expr::LetBinding { value, body, .. } => walk(value) || walk(body),
-                Expr::Label { body, .. } => walk(body),
-                Expr::CallBuiltin { args, .. } => args.iter().any(|a| walk(a)),
-                Expr::Update { path_expr, update_expr } | Expr::Assign { path_expr, value_expr: update_expr } => walk(path_expr) || walk(update_expr),
-                Expr::Mutate { path_expr, value_expr, .. } => walk(path_expr) || walk(value_expr),
-                Expr::ClosureOp { input_expr, key_expr, .. } => walk(input_expr) || walk(key_expr),
-                Expr::Format { expr: e, .. } => walk(e),
-                Expr::Limit { count, generator } => walk(count) || walk(generator),
-                Expr::While { cond, update, .. } | Expr::Until { cond, update } => walk(cond) || walk(update),
-                Expr::Repeat { update, .. } => walk(update),
+                | Expr::EachOpt { input_expr: operand } | Expr::Recurse { input_expr: operand } => walk!(operand),
+                Expr::Index { expr, key } | Expr::IndexOpt { expr, key } => walk!(expr) || walk!(key),
+                Expr::IfThenElse { cond, then_branch, else_branch } => walk!(cond) || walk!(then_branch) || walk!(else_branch),
+                Expr::TryCatch { try_expr, catch_expr } => walk!(try_expr) || walk!(catch_expr),
+                Expr::Reduce { source, init, update, .. } => walk!(source) || walk!(init) || walk!(update),
+                Expr::Foreach { source, init, update, extract, .. } => walk!(source) || walk!(init) || walk!(update) || extract.as_ref().map_or(false, |e| walk!(e)),
+                Expr::Slice { expr, from, to } => walk!(expr) || from.as_ref().map_or(false, |e| walk!(e)) || to.as_ref().map_or(false, |e| walk!(e)),
+                Expr::ObjectConstruct { pairs } => pairs.iter().any(|(k, v)| walk!(k) || walk!(v)),
+                Expr::LetBinding { value, body, .. } => walk!(value) || walk!(body),
+                Expr::Label { body, .. } => walk!(body),
+                Expr::CallBuiltin { args, .. } => args.iter().any(|a| walk!(a)),
+                Expr::Update { path_expr, update_expr } | Expr::Assign { path_expr, value_expr: update_expr } => walk!(path_expr) || walk!(update_expr),
+                Expr::Mutate { path_expr, value_expr, .. } => walk!(path_expr) || walk!(value_expr),
+                Expr::ClosureOp { input_expr, key_expr, .. } => walk!(input_expr) || walk!(key_expr),
+                // Path-expression forms wrap a sub-expression that may pull from
+                // the input stream (`getpath([input])`, `setpath([input];9)`,
+                // `delpaths([[input]])`, `path(input|.a)`). Omitting these made
+                // `uses_inputs()` report false, so the binary never seeded the
+                // input queue and `input` raised a bogus `break` (#853).
+                Expr::GetPath { path } => walk!(path),
+                Expr::SetPath { path, value } => walk!(path) || walk!(value),
+                Expr::DelPaths { paths } => walk!(paths),
+                Expr::PathExpr { expr: e } | Expr::Debug { expr: e } => walk!(e),
+                Expr::StringInterpolation { parts } => parts.iter().any(|p| {
+                    matches!(p, crate::ir::StringPart::Expr(e) if walk!(e))
+                }),
+                Expr::Format { expr: e, .. } => walk!(e),
+                Expr::Limit { count, generator } => walk!(count) || walk!(generator),
+                Expr::While { cond, update, .. } | Expr::Until { cond, update } => walk!(cond) || walk!(update),
+                Expr::Repeat { update, .. } => walk!(update),
                 Expr::Range { from, to, step } => {
-                    walk(from) || walk(to) || step.as_ref().map_or(false, |s| walk(s))
+                    walk!(from) || walk!(to) || step.as_ref().map_or(false, |s| walk!(s))
+                }
+                // A user-defined call hides the stream read in its body; descend
+                // into it (guarding recursion via `visited`) plus its arguments.
+                Expr::FuncCall { func_id, args } => {
+                    if args.iter().any(|a| walk!(a)) { return true; }
+                    if visited.contains(func_id) { return false; }
+                    visited.push(*func_id);
+                    funcs.get(*func_id).map_or(false, |f| walk(&f.body, funcs, visited))
                 }
                 _ => false,
             }
         }
-        walk(&self.parsed.0)
+        walk(&self.parsed.0, &self.parsed.1, &mut Vec::new())
     }
 
     /// Returns true if the AST contains any runtime loop construct (Reduce,

--- a/tests/input_in_path_arg.rs
+++ b/tests/input_in_path_arg.rs
@@ -1,0 +1,84 @@
+//! Issue #853: `input`/`inputs` used inside a path-expression argument
+//! (`getpath([input])`, `setpath([input];v)`, `delpaths([[input]])`,
+//! `path(input|...)`) — or hidden behind a user-defined function — must seed
+//! the input queue. `uses_inputs()` previously didn't descend into the
+//! path-expression forms (or `FuncCall` bodies), so the binary skipped queue
+//! setup and `input` raised a bogus `break`.
+//!
+//! These need a multi-document stream, which the 3-line regression harness
+//! (one input per case) can't express, so shell out to the binary.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn run(args: &[&str], stdin: &str) -> (String, bool) {
+    let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
+    let mut child = Command::new(jq_jit)
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn jq-jit");
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(stdin.as_bytes())
+        .unwrap();
+    let out = child.wait_with_output().expect("wait failed");
+    (
+        String::from_utf8_lossy(&out.stdout).trim_end().to_string(),
+        out.status.success(),
+    )
+}
+
+#[test]
+fn input_inside_getpath_arg() {
+    let (out, ok) = run(&["-c", "getpath([input])"], r#"{"a":5} "a""#);
+    assert!(ok, "getpath([input]) should not error");
+    assert_eq!(out, "5");
+}
+
+#[test]
+fn input_as_literal_path_array() {
+    let (out, ok) = run(&["-c", "getpath(input)"], r#"{"a":5} ["a"]"#);
+    assert!(ok);
+    assert_eq!(out, "5");
+}
+
+#[test]
+fn input_inside_setpath_arg() {
+    let (out, ok) = run(&["-c", "setpath([input];9)"], r#"{"a":5} "a""#);
+    assert!(ok);
+    assert_eq!(out, r#"{"a":9}"#);
+}
+
+#[test]
+fn input_inside_delpaths_arg() {
+    let (out, ok) = run(&["-c", "delpaths([[input]])"], r#"{"a":5} "a""#);
+    assert!(ok);
+    assert_eq!(out, "{}");
+}
+
+#[test]
+fn input_hidden_behind_user_def() {
+    // The stream read is inside a `def` body — uses_inputs() must follow the call.
+    let (out, ok) = run(&["-c", "def f: input; f"], "1 2");
+    assert!(ok);
+    assert_eq!(out, "2");
+    let (out, ok) = run(&["-c", "def g: getpath([input]); g"], r#"{"a":5} "a""#);
+    assert!(ok);
+    assert_eq!(out, "5");
+}
+
+#[test]
+fn inputs_plural_in_path_arg_still_ok() {
+    // Regression guard: the plural form already worked; keep it working.
+    let (out, ok) = run(
+        &["-c", "{p:getpath([input]),rest:[inputs]}"],
+        r#"{"a":5} "a" "b""#,
+    );
+    assert!(ok);
+    assert_eq!(out, r#"{"p":5,"rest":["b"]}"#);
+}


### PR DESCRIPTION
## Summary

`input`/`inputs` used inside a path-expression argument leaked a `break`
control-flow signal, aborting the whole program:

```
$ printf '{"a":5} "a"' | jq-jit -c 'getpath([input])'
jq: error (at <stdin>:0): break    # jq prints 5
```

## Root cause

The binary seeds the `input`/`inputs` queue only when `uses_inputs()`
returns true. That AST walk omitted the path-expression forms
(`GetPath` / `SetPath` / `DelPaths` / `PathExpr`), `StringInterpolation`,
`Debug`, and `FuncCall`, all falling through to `_ => false`. So
`getpath([input])` was classified as not using inputs, the queue was
never populated, and `input` hit an empty queue and raised `break`.

This also explains the issue's clues: the plural `inputs` form worked
only by accident when another part of the program made `uses_inputs()`
true (e.g. `{p:getpath([input]), rest:[inputs]}`), and binding first
(`[input] as $p | getpath($p)`) worked because `LetBinding` was already
walked.

## Fix

- Add the missing structural recursions to `uses_inputs()`.
- Follow `FuncCall` into its body (guarded by a visited set against
  recursive/mutually-recursive defs), so `def f: input; f` is also
  classified correctly.

## Tests

- `tests/input_in_path_arg.rs` — shells out (multi-document streams can't
  be expressed in the 3-line regression harness): `getpath([input])`,
  `getpath(input)`, `setpath([input];9)`, `delpaths([[input]])`,
  input-behind-a-`def`, and a guard that the plural form still works.
- Full suite green (official 509 + regression + selfdiff + corpus + fuzz).
- Benchmark: no regression (the change only disables a fast path for
  stream-reading programs, which were already broken).

Closes #853

🤖 Generated with [Claude Code](https://claude.com/claude-code)