### PR TITLE
fix(io): flush valid leading documents before a later stream parse error

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -12525,8 +12525,18 @@ fn real_main() {
                     })
                 };
                 if let Err(e) = parse_result {
+                    // jq parses the document stream lazily and emits each valid
+                    // document's result before it reaches a malformed token, then
+                    // exits 5 (#856). Flush the buffered output we already
+                    // produced for the leading documents before reporting the
+                    // parse error and exiting.
+                    if !compact_buf.is_empty() {
+                        let _ = out.write_all(&compact_buf);
+                        compact_buf.clear();
+                    }
+                    let _ = out.flush();
                     eprintln!("jq: error (at <stdin>:0): {}", e);
-                    process::exit(2);
+                    process::exit(5);
                 }
             }
         }
@@ -21341,8 +21351,16 @@ fn real_main() {
                 })
             };
             if let Err(e) = parse_result {
+                // Flush the results already produced for valid leading documents
+                // before reporting the later parse error, and exit 5 like jq
+                // (#856).
+                if !compact_buf.is_empty() {
+                    let _ = out.write_all(&compact_buf);
+                    compact_buf.clear();
+                }
+                let _ = out.flush();
                 eprintln!("jq: error: {}", e);
-                process::exit(2);
+                process::exit(5);
             }
         }
         if slurp && !slurp_values.is_empty() {

--- a/tests/io_stream_partial_flush.rs
+++ b/tests/io_stream_partial_flush.rs
@@ -1,0 +1,65 @@
+//! Issue #856: jq parses the input document stream lazily and emits each valid
+//! document's result to stdout *before* it reaches a later malformed token,
+//! then exits 5. jq-jit previously buffered the whole stream's output and
+//! discarded it (emitting nothing) when any later token failed to parse,
+//! exiting 2.
+//!
+//! The regression-test harness parses a single input per case, so a stream that
+//! is valid up front and malformed later can't be expressed there — shell out
+//! instead.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn run(args: &[&str], stdin: &str) -> (String, Option<i32>) {
+    let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
+    let mut child = Command::new(jq_jit)
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn jq-jit");
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(stdin.as_bytes())
+        .unwrap();
+    let out = child.wait_with_output().expect("wait failed");
+    (
+        String::from_utf8_lossy(&out.stdout).trim_end().to_string(),
+        out.status.code(),
+    )
+}
+
+#[test]
+fn leading_documents_flush_before_parse_error() {
+    // Identity over a stream that goes bad after two valid documents.
+    let (out, code) = run(&["-c", "."], "1 2 xx");
+    assert_eq!(out, "1\n2", "valid leading documents must reach stdout");
+    assert_eq!(code, Some(5), "jq exits 5 on a stream parse error");
+}
+
+#[test]
+fn fast_path_filter_flushes_leading_documents() {
+    // A detect_* fast path (field alternative) must flush the same way.
+    let (out, code) = run(&["-c", ".a // .b"], "{\"a\":1}\n{\"b\":2}\ngarbage");
+    assert_eq!(out, "1\n2");
+    assert_eq!(code, Some(5));
+}
+
+#[test]
+fn pretty_output_flushes_leading_documents() {
+    // Non-compact (pretty) output path takes the same exit/flush route.
+    let (out, code) = run(&["."], "1 2 xx");
+    assert_eq!(out, "1\n2");
+    assert_eq!(code, Some(5));
+}
+
+#[test]
+fn clean_stream_still_succeeds() {
+    let (out, code) = run(&["-c", "."], "1 2 3");
+    assert_eq!(out, "1\n2\n3");
+    assert_eq!(code, Some(0));
+}


### PR DESCRIPTION
## Summary

jq parses the input document stream lazily and writes each valid document's result to stdout *before* it reaches a malformed token, then exits 5. jq-jit buffered the whole stream's output in `compact_buf` and, on a parse error, exited 2 via the streaming error handlers **without** flushing — so a stream like `1 2 xx` produced no stdout at all.

## Fix

Flush `compact_buf` (and the buffered writer) before reporting the parse error at both streaming error-exit sites (stdin and files), and exit 5 to match jq.

```
$ printf '1 2 xx' | jq-jit -c '.'
1
2
jq: error (at <stdin>:0): Unexpected character 'x' at position 4   # exit 5
```

## Tests

New integration test `tests/io_stream_partial_flush.rs` covers the identity path, a `detect_*` fast path (`.a // .b`), pretty output, and the clean-stream control. Full `cargo test --release` passes; benchmark unchanged (cold error-exit path only).

Closes #856

🤖 Generated with [Claude Code](https://claude.com/claude-code)