### PR TITLE
fix(encoding): normalize \u escapes in the tojson/@json fast path

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -80,6 +80,30 @@ fn raw_contains_surrogate_escape(bytes: &[u8]) -> bool {
     false
 }
 
+/// Returns true if `bytes` contains a JSON `\uXXXX` escape (a real escape,
+/// not a literal backslash-then-`u` produced by `\\u...`). The raw-byte
+/// `tojson`/`@json` fast path (`push_tojson_raw`) copies the input document
+/// verbatim and cannot reproduce jq's `\u` normalisation: a printable
+/// codepoint decodes to its UTF-8 form, a lone high surrogate is a parse
+/// error, a lone low surrogate becomes U+FFFD, and a valid pair combines
+/// into one codepoint. Callers defer to the real parser when this returns
+/// true so those semantics apply (#850). A `memchr` jump between backslashes
+/// keeps escape-free documents on the fast path.
+#[inline]
+fn raw_contains_unicode_escape(bytes: &[u8]) -> bool {
+    let mut start = 0;
+    while let Some(off) = memchr::memchr(b'\\', &bytes[start..]) {
+        let p = start + off;
+        if p + 1 < bytes.len() && bytes[p + 1] == b'u' {
+            return true;
+        }
+        // Skip the escaped character so `\\u...` (literal backslash + `u`)
+        // is not mistaken for a `\u` escape.
+        start = p + 2;
+    }
+    false
+}
+
 
 fn jqjit_trace_enabled() -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
@@ -12458,11 +12482,19 @@ fn real_main() {
                     // tojson: single-pass compact + escape
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        push_tojson_raw(&mut compact_buf, raw);
-                        compact_buf.push(b'\n');
-                        if compact_buf.len() >= 1 << 17 {
-                            let _ = out.write_all(&compact_buf);
-                            compact_buf.clear();
+                        if raw_contains_unicode_escape(raw) {
+                            // The raw copy can't reproduce jq's `\u` normalisation
+                            // (printable decode, lone-surrogate validation /
+                            // substitution); defer to the real parser (#850).
+                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                        } else {
+                            push_tojson_raw(&mut compact_buf, raw);
+                            compact_buf.push(b'\n');
+                            if compact_buf.len() >= 1 << 17 {
+                                let _ = out.write_all(&compact_buf);
+                                compact_buf.clear();
+                            }
                         }
                         Ok(())
                     })
@@ -21175,11 +21207,18 @@ fn real_main() {
                 let content_bytes = content.as_bytes();
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    push_tojson_raw(&mut compact_buf, raw);
-                    compact_buf.push(b'\n');
-                    if compact_buf.len() >= 1 << 17 {
-                        let _ = out.write_all(&compact_buf);
-                        compact_buf.clear();
+                    if raw_contains_unicode_escape(raw) {
+                        // Defer `\u`-containing documents to the real parser so
+                        // jq's surrogate/printable normalisation applies (#850).
+                        let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                        process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                    } else {
+                        push_tojson_raw(&mut compact_buf, raw);
+                        compact_buf.push(b'\n');
+                        if compact_buf.len() >= 1 << 17 {
+                            let _ = out.write_all(&compact_buf);
+                            compact_buf.clear();
+                        }
                     }
                     Ok(())
                 })

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -4158,3 +4158,17 @@ del(.[1:3])
 
 del(.a, .a[1:3])
 {"a":[0,1,2,3]}
+
+# Issue #850: tojson/@json normalizes \u escapes (printable decode,
+# lone low surrogate -> U+FFFD, valid pair -> codepoint)
+@json
+"\u0041"
+
+@json
+"\udc00"
+
+tojson
+"\ud83d\ude00"
+
+@json
+{"k":"A\udc00"}

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -11814,3 +11814,33 @@ del(.a, .a[1:3])
 del(.a[(0,2):(1,4)])
 {"a":[10,20,30,40,50,60]}
 {"a":[50,60]}
+
+# Issue #850: the tojson/@json raw-byte fast path must normalize \u escapes the
+# way jq does instead of copying them verbatim. Printable escapes decode to
+# UTF-8, a lone low surrogate becomes U+FFFD, and a valid surrogate pair
+# combines into one codepoint, including inside nested objects. (Lone high
+# surrogate -> parse error is pinned in tests/tojson_unicode_escape.rs since it
+# has no stdout to assert here.)
+@json
+"\u0041"
+"\"A\""
+
+@json
+"\u263a"
+"\"☺\""
+
+tojson
+"\u00e9"
+"\"é\""
+
+@json
+"\udc00"
+"\"�\""
+
+tojson
+"\ud83d\ude00"
+"\"😀\""
+
+@json
+{"k":"A\udc00"}
+"{\"k\":\"A�\"}"

--- a/tests/tojson_unicode_escape.rs
+++ b/tests/tojson_unicode_escape.rs
@@ -1,0 +1,72 @@
+//! Issue #850: the top-level `@json`/`tojson` raw-byte fast path
+//! (`push_tojson_raw`) used to copy the input document's bytes verbatim,
+//! leaking `\uXXXX` escapes that jq normalizes on the real parse path.
+//!
+//! A lone *high* surrogate (`"\ud83d"`) is a parse error in jq (exit 5 with no
+//! stdout), so it can't be expressed in the 3-line regression-test format — it
+//! is pinned here instead. The value-producing cases (printable decode, lone
+//! low surrogate -> U+FFFD, valid pair) live in `tests/regression.test`.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn run(filter: &str, stdin: &str) -> (String, Option<i32>) {
+    let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
+    let mut child = Command::new(jq_jit)
+        .args(["-c", filter])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn jq-jit");
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(stdin.as_bytes())
+        .unwrap();
+    let out = child.wait_with_output().expect("wait failed");
+    (
+        String::from_utf8_lossy(&out.stdout).trim_end().to_string(),
+        out.status.code(),
+    )
+}
+
+#[test]
+fn lone_high_surrogate_is_a_parse_error() {
+    // `"\ud83d"` — a JSON string with a lone high surrogate escape.
+    for filter in ["@json", "tojson"] {
+        let (out, code) = run(filter, "\"\\ud83d\"");
+        assert!(out.is_empty(), "{filter}: expected no stdout, got {out:?}");
+        assert_eq!(code, Some(5), "{filter}: expected exit 5 (parse error)");
+    }
+}
+
+#[test]
+fn lone_high_surrogate_in_nested_object_is_a_parse_error() {
+    let (out, code) = run("@json", "{\"k\":\"\\ud83d\"}");
+    assert!(out.is_empty());
+    assert_eq!(code, Some(5));
+}
+
+#[test]
+fn value_producing_escapes_match_jq() {
+    // Mirror of the regression-test cases, asserted here too for locality.
+    let cases = [
+        ("@json", "\"\\u0041\"", "\"\\\"A\\\"\""),
+        ("@json", "\"\\udc00\"", "\"\\\"\u{fffd}\\\"\""),
+        ("tojson", "\"\\ud83d\\ude00\"", "\"\\\"\u{1f600}\\\"\""),
+    ];
+    for (filter, input, expected) in cases {
+        let (out, code) = run(filter, input);
+        assert_eq!(out, expected, "{filter} on {input}");
+        assert_eq!(code, Some(0));
+    }
+}
+
+#[test]
+fn escape_free_input_is_unchanged() {
+    let (out, code) = run("tojson", "{\"x\":1,\"y\":\"hi\"}");
+    assert_eq!(out, "\"{\\\"x\\\":1,\\\"y\\\":\\\"hi\\\"}\"");
+    assert_eq!(code, Some(0));
+}


### PR DESCRIPTION
## Summary

The top-level `@json`/`tojson` raw-byte fast path (`push_tojson_raw`) copied the input document's bytes verbatim, leaking `\uXXXX` escapes that jq normalizes on the real parse path:

- a printable codepoint decodes to its UTF-8 form (`"A"` → `A`)
- a lone high surrogate (`"\ud83d"`) is a parse error (exit 5)
- a lone low surrogate (`"\udc00"`) becomes U+FFFD
- a valid surrogate pair (`"😀"`) combines into one codepoint

Reported for lone surrogates (#850); the same verbatim copy also leaked printable `\u` escapes (the leak flagged in maintenance notes), which this fixes in the same gate.

## Fix

Gate the fast path with `raw_contains_unicode_escape` — a `memchr`-jumped scan that ignores literal `\\u`. When the document carries a real `\u` escape, defer to the real parser + `process_input` so jq's normalization applies; escape-free documents stay on the fast path.

```
$ printf '"\ud83d"' | jq-jit -c '@json'    # now: parse error, exit 5 (was: "\"\\ud83d\"")
$ printf '"\udc00"' | jq-jit -c '@json'    # now: "\"<U+FFFD>\""
$ printf '"A"' | jq-jit -c 'tojson'   # now: "\"A\""
```

## Tests

- `tests/regression.test`: 6 value-producing cases (printable decode, lone low → U+FFFD, valid pair, nested object).
- `tests/tojson_unicode_escape.rs`: lone-high-surrogate parse error (exit 5, no stdout) + value-producing parity, plus an escape-free control.
- `tests/differential/corpus.test`: 4 parity-clean cases vs jq 1.8.

Full `cargo test --release` passes with zero warnings. Benchmark numbers within run-to-run noise (the gate is one `memchr` for escape-free input).

Closes #850

🤖 Generated with [Claude Code](https://claude.com/claude-code)