### PR TITLE
fix(error): preserve non-finite error() payloads through catch

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -129,6 +129,62 @@ impl std::fmt::Display for BreakError {
 }
 impl std::error::Error for BreakError {}
 
+thread_local! {
+    /// Lossless payload slot for the most recently raised `error(value)`
+    /// (#844). `Value` holds `Rc`s, so it cannot live inside an
+    /// `anyhow::Error` (which requires `Send + Sync`); instead `error`
+    /// stashes the value here and bails with the `Send + Sync` [`ErrorValue`]
+    /// marker. The matching `catch` takes the value straight back. This
+    /// mirrors jit.rs's `JIT_ERROR_VALUE` channel. The slot is safe as a
+    /// single cell because error propagation is synchronous LIFO unwinding:
+    /// only one `error(value)` is ever in flight, and the catching `try`
+    /// takes it immediately. A stale value left by an uncaught error is
+    /// overwritten by the next `error` and is never read by the string path
+    /// (which only fires when the `ErrorValue` downcast fails).
+    static ERROR_PAYLOAD: std::cell::RefCell<Option<Value>> = const { std::cell::RefCell::new(None) };
+}
+
+/// Typed marker error carrying an `error(value)` payload losslessly (#844).
+///
+/// The string channel (`__jqerror__:<JSON>`) serializes the payload with
+/// `value_to_json_precise`, which is lossy for non-finite numbers anywhere
+/// in the value: `nan` becomes `null` and `±infinite` saturates to the
+/// nearest finite f64. Round-tripping that JSON back in a `catch` branch
+/// therefore corrupts the caught value. The exact `Value` rides in
+/// [`ERROR_PAYLOAD`] instead; `Display` still emits the `__jqerror__:<JSON>`
+/// form so uncaught errors print exactly as before.
+#[derive(Debug)]
+struct ErrorValue {
+    display: String,
+}
+impl ErrorValue {
+    /// Stash `value` in the thread-local payload slot and build the marker
+    /// error whose `Display` reproduces the legacy `__jqerror__:<JSON>` text.
+    fn raise(value: Value) -> anyhow::Error {
+        let display = format!("__jqerror__:{}", crate::value::value_to_json_precise(&value));
+        ERROR_PAYLOAD.with(|slot| *slot.borrow_mut() = Some(value));
+        ErrorValue { display }.into()
+    }
+}
+impl std::fmt::Display for ErrorValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.display)
+    }
+}
+impl std::error::Error for ErrorValue {}
+
+/// Take the payload stashed by the most recent `error(value)`. Falls back to
+/// re-parsing the marker's `display` JSON if the slot is somehow empty.
+fn take_error_payload(ev: &ErrorValue) -> Value {
+    if let Some(v) = ERROR_PAYLOAD.with(|slot| slot.borrow_mut().take()) {
+        return v;
+    }
+    match ev.display.strip_prefix("__jqerror__:") {
+        Some(json) => crate::value::json_to_value(json).unwrap_or_else(|_| Value::from_str(&ev.display)),
+        None => Value::from_str(&ev.display),
+    }
+}
+
 /// The value a `try ... catch` / `?` receives when it catches a `break`
 /// signal. jq surfaces the break as `{"__jq": <label id>}`; matching the
 /// shape lets `catch`/`?` handle it like any other error. Only the shape is
@@ -2389,6 +2445,12 @@ pub fn eval(
                     if let Some(be) = e.downcast_ref::<BreakError>() {
                         return eval(catch_expr, break_catch_value(be.0), env, cb);
                     }
+                    // A typed `error(value)` payload is recovered losslessly,
+                    // dodging the lossy JSON round-trip (#844).
+                    if let Some(ev) = e.downcast_ref::<ErrorValue>() {
+                        let v = take_error_payload(ev);
+                        return eval(catch_expr, v, env, cb);
+                    }
                     let msg = format!("{}", e);
                     // halt / halt_error are non-recoverable: jq lets them
                     // propagate past `try ... catch` so the process exits with
@@ -3542,12 +3604,15 @@ pub fn eval(
         }
 
         Expr::Error { msg } => {
+            // Carry the payload as a typed `ErrorValue` so a downstream
+            // `catch` recovers the exact value, including non-finite numbers
+            // that the JSON channel would corrupt (#844).
             if let Some(msg_expr) = msg {
                 eval(msg_expr, input, env, &mut |val| {
-                    bail!("__jqerror__:{}", crate::value::value_to_json_precise(&val))
+                    Err(ErrorValue::raise(val))
                 })
             } else {
-                bail!("__jqerror__:{}", crate::value::value_to_json_precise(&input))
+                Err(ErrorValue::raise(input))
             }
         }
 
@@ -5487,6 +5552,11 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
                     // tracking (#836).
                     if let Some(be) = e.downcast_ref::<BreakError>() {
                         return eval_path(catch_expr, break_catch_value(be.0), env, cb);
+                    }
+                    // Recover a typed `error(value)` payload losslessly (#844).
+                    if let Some(ev) = e.downcast_ref::<ErrorValue>() {
+                        let v = take_error_payload(ev);
+                        return eval_path(catch_expr, v, env, cb);
                     }
                     let msg = format!("{}", e);
                     // halt / halt_error are non-recoverable: jq lets them

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -4172,3 +4172,13 @@ tojson
 
 @json
 {"k":"A\udc00"}
+
+# Issue #844: non-finite error() payload survives the catch channel
+try error(nan) catch isnan
+null
+
+try error(infinite) catch isinfinite
+null
+
+try error({a:[{b:nan}]}) catch (.a[0].b | isnan)
+null

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -11844,3 +11844,31 @@ tojson
 @json
 {"k":"A\udc00"}
 "{\"k\":\"A�\"}"
+
+# Issue #844: a non-finite error() payload must survive the catch channel.
+# The interpreter serialized the payload to JSON (nan -> null, +-inf -> finite
+# DBL_MAX) and parsed it back, corrupting the value. catch now recovers the
+# exact Value, including nested non-finite numbers and rethrows.
+try error(nan) catch isnan
+null
+true
+
+try error(nan) catch type
+null
+"number"
+
+try error(infinite) catch isinfinite
+null
+true
+
+try error(nan) catch (.+1)
+null
+null
+
+try error({a:[{b:nan}]}) catch (.a[0].b | isnan)
+null
+true
+
+try (try error(nan) catch error) catch isnan
+null
+true


### PR DESCRIPTION
## Summary

A non-finite (`nan`/`infinite`) value carried as an `error()` payload lost its value when caught. The interpreter raised `error(value)` through the string channel (`__jqerror__:<JSON>`), serializing the payload with `value_to_json_precise` and re-parsing it in `catch`. That round-trip is lossy for non-finite numbers anywhere in the value: `NaN` became `null` and `±infinite` saturated to the nearest finite f64.

```
$ echo null | jq-jit -c 'try error(nan) catch isnan'        # was: false  → now: true
$ echo null | jq-jit -c 'try error(nan) catch type'         # was: "null" → now: "number"
$ echo null | jq-jit -c 'try error(infinite) catch isinfinite'  # was: false → now: true
```

(The JIT path already preserved the value via its `JIT_ERROR_VALUE` channel; the corruption was interpreter-only.)

## Fix

Carry the payload as a typed `ErrorValue` marker whose exact `Value` rides in a thread-local slot (mirroring jit.rs's `JIT_ERROR_VALUE`); `catch` and `eval_path`'s `catch` take it back losslessly. `Value` holds `Rc`s, so it can't live inside an `anyhow::Error` (`Send + Sync`) directly — hence the thread-local. `Display` still emits the `__jqerror__:<JSON>` form so uncaught errors print exactly as before. The slot is a single cell because error propagation is synchronous LIFO unwinding.

Verified against nested payloads (`error({a:[{b:nan}]})`), rethrow, and interleaved/sequential error stress cases.

## Tests

- `tests/regression.test`: 6 cases (isnan, type, isinfinite, `.+1`, nested, rethrow).
- `tests/differential/corpus.test`: 3 parity cases vs jq 1.8.
- Full `cargo test --release` passes (incl. self-diff JIT↔interp), zero warnings; benchmark `try-catch`/`alternative //` unchanged.

Closes #844

🤖 Generated with [Claude Code](https://claude.com/claude-code)