### PR TITLE
fix(path): make ?// alternative destructuring path-transparent

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -384,7 +384,7 @@ fn subst_inner(
             let new_idx = alloc!(*var_index);
             Expr::LetBinding { var_index: new_idx, value, body: sb!(body) }
         }
-        Expr::TryCatch { try_expr, catch_expr } => Expr::TryCatch { try_expr: sb!(try_expr), catch_expr: sb!(catch_expr) },
+        Expr::TryCatch { try_expr, catch_expr, restore_dot } => Expr::TryCatch { try_expr: sb!(try_expr), catch_expr: sb!(catch_expr), restore_dot: *restore_dot },
         Expr::Collect { generator } => Expr::Collect { generator: sb!(generator) },
         Expr::Negate { operand } => Expr::Negate { operand: sb!(operand) },
         Expr::Alternative { primary, fallback } => Expr::Alternative { primary: sb!(primary), fallback: sb!(fallback) },
@@ -504,7 +504,7 @@ pub(crate) fn append_call_args(expr: &Expr, target: usize, extra: &[Expr]) -> Ex
         Expr::LetBinding { var_index, value, body } => Expr::LetBinding {
             var_index: *var_index, value: rb!(value), body: rb!(body),
         },
-        Expr::TryCatch { try_expr, catch_expr } => Expr::TryCatch { try_expr: rb!(try_expr), catch_expr: rb!(catch_expr) },
+        Expr::TryCatch { try_expr, catch_expr, restore_dot } => Expr::TryCatch { try_expr: rb!(try_expr), catch_expr: rb!(catch_expr), restore_dot: *restore_dot },
         Expr::Collect { generator } => Expr::Collect { generator: rb!(generator) },
         Expr::Negate { operand } => Expr::Negate { operand: rb!(operand) },
         Expr::Alternative { primary, fallback } => Expr::Alternative { primary: rb!(primary), fallback: rb!(fallback) },
@@ -653,12 +653,13 @@ fn subst_cow(expr: &Expr, pv: &[u16], args: &[Expr]) -> Option<Expr> {
                 body: Box::new(b.unwrap_or_else(|| body.as_ref().clone())),
             })
         }
-        Expr::TryCatch { try_expr, catch_expr } => {
+        Expr::TryCatch { try_expr, catch_expr, restore_dot } => {
             let t = s!(try_expr); let c = s!(catch_expr);
             if t.is_none() && c.is_none() { return None; }
             Some(Expr::TryCatch {
                 try_expr: Box::new(t.unwrap_or_else(|| try_expr.as_ref().clone())),
                 catch_expr: Box::new(c.unwrap_or_else(|| catch_expr.as_ref().clone())),
+                restore_dot: *restore_dot,
             })
         }
         Expr::Collect { generator } => s!(generator).map(|g| Expr::Collect { generator: Box::new(g) }),
@@ -939,7 +940,7 @@ fn contains_func_call(expr: &Expr, target: usize) -> bool {
         Expr::Each { input_expr } | Expr::EachOpt { input_expr } | Expr::Recurse { input_expr } => c!(input_expr),
         Expr::IfThenElse { cond, then_branch, else_branch } => c!(cond) || c!(then_branch) || c!(else_branch),
         Expr::LetBinding { value, body, .. } => c!(value) || c!(body),
-        Expr::TryCatch { try_expr, catch_expr } => c!(try_expr) || c!(catch_expr),
+        Expr::TryCatch { try_expr, catch_expr, .. } => c!(try_expr) || c!(catch_expr),
         Expr::Collect { generator } => c!(generator),
         Expr::Alternative { primary, fallback } => c!(primary) || c!(fallback),
         Expr::Reduce { source, init, update, .. } => c!(source) || c!(init) || c!(update),
@@ -1000,7 +1001,7 @@ fn expr_uses_outer_input(expr: &Expr) -> bool {
         | Expr::Alternative { primary: left, fallback: right }
         | Expr::Index { expr: left, key: right }
         | Expr::IndexOpt { expr: left, key: right }
-        | Expr::TryCatch { try_expr: left, catch_expr: right } => {
+        | Expr::TryCatch { try_expr: left, catch_expr: right, .. } => {
             expr_uses_outer_input(left) || expr_uses_outer_input(right)
         }
         // GetPath/SetPath/DelPaths/Update/Assign always read `.` to produce
@@ -1084,7 +1085,7 @@ pub(crate) fn expr_uses_var(expr: &Expr, target: u16) -> bool {
         | Expr::Update { path_expr: left, update_expr: right }
         | Expr::Assign { path_expr: left, value_expr: right }
         | Expr::SetPath { path: left, value: right }
-        | Expr::TryCatch { try_expr: left, catch_expr: right } => {
+        | Expr::TryCatch { try_expr: left, catch_expr: right, .. } => {
             expr_uses_var(left, target) || expr_uses_var(right, target)
         }
         Expr::Mutate { path_expr, value_expr, .. } => {
@@ -1162,7 +1163,7 @@ pub(crate) fn collect_func_calls(expr: &Expr, out: &mut Vec<usize>) {
         | Expr::Update { path_expr: left, update_expr: right }
         | Expr::Assign { path_expr: left, value_expr: right }
         | Expr::SetPath { path: left, value: right }
-        | Expr::TryCatch { try_expr: left, catch_expr: right } => {
+        | Expr::TryCatch { try_expr: left, catch_expr: right, .. } => {
             collect_func_calls(left, out);
             collect_func_calls(right, out);
         }
@@ -2417,7 +2418,7 @@ pub fn eval(
             })
         }
 
-        Expr::TryCatch { try_expr, catch_expr } => {
+        Expr::TryCatch { try_expr, catch_expr, .. } => {
             let cb_error = std::cell::Cell::new(false);
             let result = eval(try_expr, input.clone(), env, &mut |val| {
                 match &val {
@@ -5538,12 +5539,26 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
                 bail!("undefined function id {}", func_id)
             }
         }
-        Expr::TryCatch { try_expr, catch_expr } => {
+        Expr::TryCatch { try_expr, catch_expr, restore_dot } => {
             let result = eval_path(try_expr, input.clone(), env, cb);
             match result {
                 Ok(cont) => Ok(cont),
                 Err(e) => {
-                    // In path context the catch branch is itself a path
+                    let msg = format!("{}", e);
+                    // halt / halt_error are non-recoverable: jq lets them
+                    // propagate past `try ... catch` so the process exits with
+                    // the requested code (#182).
+                    if msg.starts_with("__halt__:") { return Err(e); }
+                    // The `?//` desugar (`restore_dot`) keeps `.` set to the
+                    // original input across fallbacks rather than binding the
+                    // caught destructuring error: jq never exposes that error to
+                    // the body, so a path expression in the body stays
+                    // path-transparent — `path(. as [$a] ?// $a | .x)` is
+                    // `["x"]` and `del(. as [$a] ?// $a | .x)` drops `.x` (#840).
+                    if *restore_dot {
+                        return eval_path(catch_expr, input.clone(), env, cb);
+                    }
+                    // Plain `try/catch`: the catch branch is itself a path
                     // expression, evaluated against the caught value (the error
                     // payload, or the rethrown input for a bare `error`). jq
                     // tracks `path(try error catch .b)` as `["b"]` and raises a
@@ -5558,11 +5573,6 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
                         let v = take_error_payload(ev);
                         return eval_path(catch_expr, v, env, cb);
                     }
-                    let msg = format!("{}", e);
-                    // halt / halt_error are non-recoverable: jq lets them
-                    // propagate past `try ... catch` so the process exits with
-                    // the requested code (#182).
-                    if msg.starts_with("__halt__:") { return Err(e); }
                     let catch_val = if let Some(json) = msg.strip_prefix("__jqerror__:") {
                         crate::value::json_to_value(json).unwrap_or(Value::from_str(&msg))
                     } else {

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -526,7 +526,7 @@ fn expr_references_var(expr: &crate::ir::Expr, var_index: u16) -> bool {
         | Expr::Update { path_expr: left, update_expr: right }
         | Expr::Assign { path_expr: left, value_expr: right }
         | Expr::SetPath { path: left, value: right }
-        | Expr::TryCatch { try_expr: left, catch_expr: right } => {
+        | Expr::TryCatch { try_expr: left, catch_expr: right, .. } => {
             expr_references_var(left, var_index) || expr_references_var(right, var_index)
         }
         Expr::IfThenElse { cond, then_branch, else_branch } => {
@@ -1163,7 +1163,7 @@ fn simplify_expr(expr: &crate::ir::Expr) -> crate::ir::Expr {
                             Expr::IfThenElse { cond, then_branch, else_branch } => {
                                 is_single_valued(cond) && is_single_valued(then_branch) && is_single_valued(else_branch)
                             }
-                            Expr::TryCatch { try_expr, catch_expr } => {
+                            Expr::TryCatch { try_expr, catch_expr, .. } => {
                                 is_single_valued(try_expr) && is_single_valued(catch_expr)
                             }
                             Expr::Alternative { primary, fallback } => {
@@ -1254,7 +1254,7 @@ fn simplify_expr(expr: &crate::ir::Expr) -> crate::ir::Expr {
                                     Expr::Pipe { left, right } => is_single_valued_idx(left) && is_single_valued_idx(right),
                                     Expr::IfThenElse { cond, then_branch, else_branch } =>
                                         is_single_valued_idx(cond) && is_single_valued_idx(then_branch) && is_single_valued_idx(else_branch),
-                                    Expr::TryCatch { try_expr, catch_expr } =>
+                                    Expr::TryCatch { try_expr, catch_expr, .. } =>
                                         is_single_valued_idx(try_expr) && is_single_valued_idx(catch_expr),
                                     Expr::Alternative { primary, fallback } =>
                                         is_single_valued_idx(primary) && is_single_valued_idx(fallback),
@@ -2078,8 +2078,8 @@ fn simplify_expr(expr: &crate::ir::Expr) -> crate::ir::Expr {
             }
             Expr::Assign { path_expr: Box::new(sp), value_expr: Box::new(sv) }
         }
-        Expr::TryCatch { try_expr, catch_expr } => {
-            Expr::TryCatch { try_expr: Box::new(simplify_expr(try_expr)), catch_expr: Box::new(simplify_expr(catch_expr)) }
+        Expr::TryCatch { try_expr, catch_expr, restore_dot } => {
+            Expr::TryCatch { try_expr: Box::new(simplify_expr(try_expr)), catch_expr: Box::new(simplify_expr(catch_expr)), restore_dot: *restore_dot }
         }
         // delpaths([["field"]]) → del(.field)
         Expr::Limit { count, generator } => {
@@ -2208,7 +2208,7 @@ fn contains_input(expr: &crate::ir::Expr) -> bool {
         Expr::Foreach { source, init, update, extract, .. } => contains_input(source) || contains_input(init) || contains_input(update) || extract.as_ref().map_or(false, |e| contains_input(e)),
         Expr::While { cond, update } | Expr::Until { cond, update } => contains_input(cond) || contains_input(update),
         Expr::Repeat { update } => contains_input(update),
-        Expr::TryCatch { try_expr, catch_expr } => contains_input(try_expr) || contains_input(catch_expr),
+        Expr::TryCatch { try_expr, catch_expr, .. } => contains_input(try_expr) || contains_input(catch_expr),
         // CallBuiltin implicitly operates on the current input (passed as first arg)
         Expr::CallBuiltin { .. } => true,
         Expr::Range { from, to, step } => contains_input(from) || contains_input(to) || step.as_ref().map_or(false, |s| contains_input(s)),
@@ -2263,7 +2263,7 @@ fn input_behind_short_circuit(e: &crate::ir::Expr) -> bool {
             input_behind_short_circuit(primary) || contains_input(fallback)
                 || input_behind_short_circuit(fallback)
         }
-        Expr::TryCatch { try_expr, catch_expr } => {
+        Expr::TryCatch { try_expr, catch_expr, .. } => {
             // try_expr's errors are caught; the post-substitution
             // result no longer raises. catch_expr only fires on error;
             // its evaluation order is conditional.
@@ -2659,7 +2659,7 @@ impl Filter {
                 Expr::IfThenElse { cond, then_branch, else_branch } => {
                     walk(cond) || walk(then_branch) || walk(else_branch)
                 }
-                Expr::TryCatch { try_expr, catch_expr } => walk(try_expr) || walk(catch_expr),
+                Expr::TryCatch { try_expr, catch_expr, .. } => walk(try_expr) || walk(catch_expr),
                 Expr::Reduce { source, init, update, .. } => walk(source) || walk(init) || walk(update),
                 Expr::Foreach { source, init, update, extract, .. } => {
                     walk(source) || walk(init) || walk(update) || extract.as_ref().map_or(false, |e| walk(e))
@@ -2701,7 +2701,7 @@ impl Filter {
                 | Expr::EachOpt { input_expr: operand } | Expr::Recurse { input_expr: operand } => walk!(operand),
                 Expr::Index { expr, key } | Expr::IndexOpt { expr, key } => walk!(expr) || walk!(key),
                 Expr::IfThenElse { cond, then_branch, else_branch } => walk!(cond) || walk!(then_branch) || walk!(else_branch),
-                Expr::TryCatch { try_expr, catch_expr } => walk!(try_expr) || walk!(catch_expr),
+                Expr::TryCatch { try_expr, catch_expr, .. } => walk!(try_expr) || walk!(catch_expr),
                 Expr::Reduce { source, init, update, .. } => walk!(source) || walk!(init) || walk!(update),
                 Expr::Foreach { source, init, update, extract, .. } => walk!(source) || walk!(init) || walk!(update) || extract.as_ref().map_or(false, |e| walk!(e)),
                 Expr::Slice { expr, from, to } => walk!(expr) || from.as_ref().map_or(false, |e| walk!(e)) || to.as_ref().map_or(false, |e| walk!(e)),
@@ -2770,7 +2770,7 @@ impl Filter {
                 Expr::Index { expr, key } | Expr::IndexOpt { expr, key } => walk(expr) || walk(key),
                 Expr::IfThenElse { cond, then_branch, else_branch } =>
                     walk(cond) || walk(then_branch) || walk(else_branch),
-                Expr::TryCatch { try_expr, catch_expr } => walk(try_expr) || walk(catch_expr),
+                Expr::TryCatch { try_expr, catch_expr, .. } => walk(try_expr) || walk(catch_expr),
                 Expr::Slice { expr, from, to } => walk(expr)
                     || from.as_ref().map_or(false, |e| walk(e))
                     || to.as_ref().map_or(false, |e| walk(e)),
@@ -2823,7 +2823,7 @@ impl Filter {
                 | Expr::EachOpt { input_expr: operand } | Expr::Recurse { input_expr: operand } => count(operand),
                 Expr::Index { expr, key } | Expr::IndexOpt { expr, key } => count(expr) + count(key),
                 Expr::IfThenElse { cond, then_branch, else_branch } => count(cond) + count(then_branch) + count(else_branch),
-                Expr::TryCatch { try_expr, catch_expr } => count(try_expr) + count(catch_expr),
+                Expr::TryCatch { try_expr, catch_expr, .. } => count(try_expr) + count(catch_expr),
                 Expr::Reduce { source, init, update, .. } => count(source) + count(init) + count(update),
                 Expr::Foreach { source, init, update, extract, .. } => {
                     count(source) + count(init) + count(update)

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -61,9 +61,19 @@ pub enum Expr {
     },
 
     /// Try-catch: `try expr catch handler`
+    ///
+    /// `restore_dot` marks the `try/catch` synthesised by the `?//`
+    /// alternative-destructuring desugar (see `build_alt_destructure`). In a
+    /// path context jq keeps `.` set to the original input across `?//`
+    /// fallbacks rather than the caught destructuring error, so the body stays
+    /// path-transparent (`path(. as [$a] ?// $a | .x)` is `["x"]`). When this
+    /// flag is set, the path-mode handler runs the catch branch against the
+    /// try's input instead of the error payload. Plain `try/catch` (the flag is
+    /// `false`) keeps jq's normal behaviour of binding `.` to the error (#840).
     TryCatch {
         try_expr: Box<Expr>,
         catch_expr: Box<Expr>,
+        restore_dot: bool,
     },
 
     /// Array iteration `.[]`
@@ -983,9 +993,10 @@ impl Expr {
                 value_expr: Box::new(value_expr.substitute_var(var_index, replacement)),
                 kind: *kind,
             },
-            Expr::TryCatch { try_expr, catch_expr } => Expr::TryCatch {
+            Expr::TryCatch { try_expr, catch_expr, restore_dot } => Expr::TryCatch {
                 try_expr: Box::new(try_expr.substitute_var(var_index, replacement)),
                 catch_expr: Box::new(catch_expr.substitute_var(var_index, replacement)),
+                restore_dot: *restore_dot,
             },
             Expr::StringInterpolation { parts } => Expr::StringInterpolation {
                 parts: parts.iter().map(|p| match p {

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -221,7 +221,7 @@ fn can_scalar_collect(expr: &Expr) -> bool {
         Expr::LetBinding { value, body, .. } => {
             (is_scalar(value) || can_scalar_collect(value)) && can_scalar_collect(body)
         }
-        Expr::TryCatch { try_expr, catch_expr } => {
+        Expr::TryCatch { try_expr, catch_expr, .. } => {
             can_scalar_collect(try_expr) && can_scalar_collect(catch_expr)
         }
         Expr::Error { msg } => msg.as_ref().is_none_or(|m| is_scalar(m)),
@@ -276,7 +276,7 @@ fn is_scalar(expr: &Expr) -> bool {
         Expr::Stderr { expr } => is_scalar(expr),
         // TryCatch is scalar when both try and catch are scalar:
         // try produces one value or fails, catch produces one value on failure
-        Expr::TryCatch { try_expr, catch_expr } => is_scalar(try_expr) && is_scalar(catch_expr),
+        Expr::TryCatch { try_expr, catch_expr, .. } => is_scalar(try_expr) && is_scalar(catch_expr),
         Expr::StringInterpolation { parts } => parts.iter().all(|p| match p {
             StringPart::Literal(_) => true,
             StringPart::Expr(e) => is_scalar(e),
@@ -771,9 +771,10 @@ impl Flattener {
                 path_expr: Box::new(self.inline_func_calls(path_expr)),
                 update_expr: Box::new(self.inline_func_calls(update_expr)),
             },
-            Expr::TryCatch { try_expr, catch_expr } => Expr::TryCatch {
+            Expr::TryCatch { try_expr, catch_expr, restore_dot } => Expr::TryCatch {
                 try_expr: Box::new(self.inline_func_calls(try_expr)),
                 catch_expr: Box::new(self.inline_func_calls(catch_expr)),
+                restore_dot: *restore_dot,
             },
             Expr::Alternative { primary, fallback } => Expr::Alternative {
                 primary: Box::new(self.inline_func_calls(primary)),
@@ -1735,7 +1736,7 @@ impl Flattener {
                 self.emit(JitOp::Drop { slot: val });
                 out
             }
-            Expr::TryCatch { try_expr, catch_expr } => {
+            Expr::TryCatch { try_expr, catch_expr, .. } => {
                 // Scalar try-catch: try produces one value, or catch produces one value
                 let catch_label = self.alloc_label();
                 let done_label = self.alloc_label();
@@ -2372,6 +2373,7 @@ impl Flattener {
                             key: Box::new((**key_expr).clone()),
                         }),
                         catch_expr: Box::new(Expr::Empty),
+                        restore_dot: false,
                     };
                     return self.flatten_gen(&try_catch, input_slot);
                 }
@@ -2384,6 +2386,7 @@ impl Flattener {
                             key: Box::new((**key_expr).clone()),
                         }),
                         catch_expr: Box::new(Expr::Empty),
+                        restore_dot: false,
                     }),
                 };
                 self.flatten_gen(&inner, input_slot)
@@ -2740,7 +2743,7 @@ impl Flattener {
                 true
             }
 
-            Expr::TryCatch { try_expr, catch_expr } => {
+            Expr::TryCatch { try_expr, catch_expr, .. } => {
                 self.flatten_gen_try_catch(try_expr, catch_expr, input_slot)
             }
 
@@ -3939,7 +3942,7 @@ impl Flattener {
                 true
             }
             // TryCatch | right: compile try-catch body inline, each output piped to right
-            Expr::TryCatch { try_expr, catch_expr } => {
+            Expr::TryCatch { try_expr, catch_expr, .. } => {
                 // Pre-check: try body and right must be compilable
                 {
                     let mut test = self.test_flattener();
@@ -4822,7 +4825,7 @@ impl Flattener {
                 Self::collect_loadvar_indices(then_branch, out);
                 Self::collect_loadvar_indices(else_branch, out);
             }
-            Expr::TryCatch { try_expr, catch_expr } => {
+            Expr::TryCatch { try_expr, catch_expr, .. } => {
                 Self::collect_loadvar_indices(try_expr, out);
                 Self::collect_loadvar_indices(catch_expr, out);
             }
@@ -6283,7 +6286,7 @@ fn contains_func_call(expr: &Expr) -> bool {
         Expr::Each { input_expr } | Expr::EachOpt { input_expr } => contains_func_call(input_expr),
         Expr::IfThenElse { cond, then_branch, else_branch } => contains_func_call(cond) || contains_func_call(then_branch) || contains_func_call(else_branch),
         Expr::LetBinding { value, body, .. } => contains_func_call(value) || contains_func_call(body),
-        Expr::TryCatch { try_expr, catch_expr } => contains_func_call(try_expr) || contains_func_call(catch_expr),
+        Expr::TryCatch { try_expr, catch_expr, .. } => contains_func_call(try_expr) || contains_func_call(catch_expr),
         Expr::Collect { generator } => contains_func_call(generator),
         Expr::BinOp { lhs, rhs, .. } => contains_func_call(lhs) || contains_func_call(rhs),
         Expr::UnaryOp { operand, .. } | Expr::Negate { operand } => contains_func_call(operand),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1603,6 +1603,9 @@ impl Parser {
                 Some(prev) => Expr::TryCatch {
                     try_expr: Box::new(restored),
                     catch_expr: Box::new(prev),
+                    // `?//` keeps `.` = original input across fallbacks in a
+                    // path context, so the body stays path-transparent (#840).
+                    restore_dot: true,
                 },
             });
         }
@@ -2423,6 +2426,7 @@ impl Parser {
                     expr = Expr::TryCatch {
                         try_expr: Box::new(expr),
                         catch_expr: Box::new(Expr::Empty),
+                        restore_dot: false,
                     };
                 }
                 _ => break,
@@ -2596,6 +2600,7 @@ impl Parser {
                 Ok(Expr::TryCatch {
                     try_expr: Box::new(try_expr),
                     catch_expr: Box::new(catch_expr),
+                    restore_dot: false,
                 })
             }
 
@@ -4564,7 +4569,8 @@ fn remap_func_ids(expr: Expr, map: &[(usize, usize)]) -> Expr {
             then_branch: Box::new(remap_func_ids(*then_branch, map)),
             else_branch: Box::new(remap_func_ids(*else_branch, map)),
         },
-        Expr::TryCatch { try_expr, catch_expr } => Expr::TryCatch {
+        Expr::TryCatch { try_expr, catch_expr, restore_dot } => Expr::TryCatch {
+            restore_dot,
             try_expr: Box::new(remap_func_ids(*try_expr, map)),
             catch_expr: Box::new(remap_func_ids(*catch_expr, map)),
         },

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -4182,3 +4182,12 @@ null
 
 try error({a:[{b:nan}]}) catch (.a[0].b | isnan)
 null
+
+path(. as [$a] ?// $a | .x)
+{"x":42}
+
+del(. as [$a] ?// $a | .x)
+{"x":1,"y":2}
+
+path(. as [$a] ?// {p:$a} ?// $a | .q)
+{"p":1,"q":2}

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -11872,3 +11872,28 @@ true
 try (try error(nan) catch error) catch isnan
 null
 true
+
+# Issue #840: ?// alternative destructuring is path-transparent (path context)
+path(. as [$a] ?// $a | .x)
+{"x":42}
+["x"]
+
+# Issue #840: ?// path-transparency under del (fallback alt, body is a path)
+del(. as [$a] ?// $a | .x)
+{"x":1,"y":2}
+{"y":2}
+
+# Issue #840: ?// transparency through a successful object-pattern alternative
+path(. as {a:$x} ?// $x | .a.b)
+{"a":{"b":9}}
+["a","b"]
+
+# Issue #840: ?// transparency through nested 3-alternative fallback chain
+path(. as [$a] ?// {p:$a} ?// $a | .q)
+{"p":1,"q":2}
+["q"]
+
+# Issue #840: ?// path-transparency drives an assignment LHS update
+. as {a:$x} ?// $x | .a.b |= 100
+{"a":{"b":9}}
+{"a":{"b":100}}


### PR DESCRIPTION
## Summary

In a path context jq keeps `.` set to the original input across `?//`
fallbacks instead of binding the caught destructuring error, so a path
expression in the `?//` body stays transparent. jq-jit lost that
transparency and either errored or evaluated the body as a value (#840).

```
# before → after (jq parity)
echo '{"x":42}'    | jq-jit -c 'path(. as [$a] ?// $a | .x)'   # 42 / err → ["x"]
echo '{"x":1,"y":2}'| jq-jit -c 'del(. as [$a] ?// $a | .x)'   # err     → {"y":2}
```

## Root cause

jq-jit desugars `?//` to a `try/catch` chain whose arms restore `.` via a
captured identity variable (`$__altdot__`). In **value** mode that restore
works. In **path** mode, the catch branch ran against the caught error
payload, so the leading identity-variable load failed its `v == input`
check (`input` was the error, not the original `.`) and the body was
rejected as an invalid path expression.

## Fix

Add a `restore_dot` flag to `Expr::TryCatch`, set **only** by the `?//`
desugar (`build_alt_destructure`). The path-mode `eval_path` handler runs
the catch branch against the *try's original input* when the flag is set.
Plain `try/catch` (flag `false`) keeps jq's normal behaviour of binding
`.` to the caught value (#836/#844) — general path-context try/catch is
unchanged. Value mode, JIT, and every walker thread the flag verbatim, so
behaviour outside path mode is untouched.

## Scope / not covered

This fixes the **body's** path-transparency (the `path()` and `del`
divergences in #840). The remaining `|=` masking case —
`[7] | . |= (. as [$a] ?// $a | $a)` where jq raises "Paths must be
specified as an array" — depends on jq's `?//` **pattern-variable path
provenance** (e.g. `path(. as [$a] ?// $a | $a)` → `[0]` while
`. as [$a] ?// $a | path($a)` → `[]` — internally inconsistent in jq
itself). That is a separate, larger piece of work and is intentionally
left out here; hence `Refs` rather than `Closes`.

## Verification

- `cargo build --release` — zero warnings
- `cargo test --release` — official **509/0**, regression **0 fail**,
  selfdiff/corpus/scenarios/enforce-* all green; 5 new regression cases +
  3 corpus probes
- `./bench/comprehensive.sh` — try-catch `0.024s`, alternative `0.035s`
  (matches `docs/benchmark-history`; path-mode-only change, no hot-path
  impact)

Refs #840

🤖 Generated with [Claude Code](https://claude.com/claude-code)