### PR TITLE
fix(path): defer non-path values through discarding filters in path context

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -5433,8 +5433,42 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
                                 bail!("Invalid path expression near attempt to iterate through {}", json);
                             }
                             _ => {
-                                // Pass __pathexpr_result__ through for higher-level handlers
-                                Err(e)
+                                // jq evaluates `A | B` in path context by running B
+                                // on the VALUE A produced, even when A is a rootless
+                                // (non-path) value. A discarding B (`empty`,
+                                // `select(false)`, an `else empty` branch) yields
+                                // nothing, so no invalid-path error reaches the sink:
+                                // `path(last(empty))` = `… reduce empty … | if
+                                // length>0 then .[0] else empty end` → []. A
+                                // transforming B surfaces its own result/error. When
+                                // B navigates the rootless value, jq reports the
+                                // first hop (`near attempt to access element 0 of
+                                // [1]`); an identity B leaves the value at the sink
+                                // (`result <A>`). #839
+                                match crate::value::json_to_value(json) {
+                                    Ok(v) => {
+                                        let mut nav: Option<Value> = None;
+                                        match eval_path(right, v.clone(), env, &mut |rp| {
+                                            nav = Some(rp);
+                                            Ok(false)
+                                        }) {
+                                            Err(re) => Err(re),
+                                            Ok(_) => match &nav {
+                                                None => Ok(true),
+                                                Some(Value::Arr(comps)) if !comps.is_empty() => {
+                                                    let key_desc = match &comps[0] {
+                                                        Value::Num(n, _) => format!("element {} of", crate::value::format_jq_number(*n)),
+                                                        Value::Str(s) => format!("element \"{}\" of", s),
+                                                        other => format!("element {} of", crate::value::value_to_json(other)),
+                                                    };
+                                                    bail!("Invalid path expression near attempt to access {} {}", key_desc, crate::value::value_to_json(&v))
+                                                }
+                                                _ => Err(e),
+                                            },
+                                        }
+                                    }
+                                    Err(_) => Err(e),
+                                }
                             }
                         }
                     } else {
@@ -5801,7 +5835,32 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
             let ai = *acc_index;
             { let mut e = env.borrow_mut(); e.ensure_var(vi); e.ensure_var(ai); }
             let mut acc_paths: Vec<Value> = Vec::new();
-            eval_path(init, input.clone(), env, &mut |p| { acc_paths.push(p); Ok(true) })?;
+            if let Err(e) = eval_path(init, input.clone(), env, &mut |p| { acc_paths.push(p); Ok(true) }) {
+                let msg = format!("{}", e);
+                if msg.starts_with("__pathexpr_result__:") {
+                    // A non-path INIT means the reduce isn't path-trackable: jq
+                    // treats it as a value computation whose (rootless) result
+                    // flows to the sink. Compute that value and defer it as the
+                    // sentinel so a downstream discard (`| if … else empty`,
+                    // `path(last(empty))`) swallows it and a navigation/assignment
+                    // surfaces the real result rather than the INIT value. #839
+                    let reduced = Expr::Reduce {
+                        source: source.clone(),
+                        init: init.clone(),
+                        var_index: *var_index,
+                        acc_index: *acc_index,
+                        update: update.clone(),
+                    };
+                    let mut last_val = Value::Null;
+                    let mut has = false;
+                    eval(&reduced, input, env, &mut |v| { last_val = v; has = true; Ok(true) })?;
+                    if has {
+                        bail!("__pathexpr_result__:{}", crate::value::value_to_json(&last_val));
+                    }
+                    return Ok(true);
+                }
+                return Err(e);
+            }
             // jq rejects a reduce SOURCE that navigates the tracked input in
             // path context (`.[]`, `.a`, …) — it must be a plain value generator
             // (range, literals, empty, input). Otherwise the reduce silently

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -11897,3 +11897,38 @@ path(. as [$a] ?// {p:$a} ?// $a | .q)
 . as {a:$x} ?// $x | .a.b |= 100
 {"a":{"b":9}}
 {"a":{"b":100}}
+
+# Issue #839: a non-path value piped into a discarding filter yields no path (last(empty))
+[path(last(empty))]
+{"a":1}
+[]
+
+# Issue #839: a rootless value piped into empty is swallowed, not an error
+[path(1 | empty)]
+{"a":1}
+[]
+
+# Issue #839: select(false) discards the rootless value in path context
+[path(5 | select(. > 10))]
+{"a":1}
+[]
+
+# Issue #839: a non-path reduce result flows through a discarding downstream
+[path(reduce empty as $x (.a; .) | if false then . else empty end)]
+{"a":1}
+[]
+
+# Issue #839: a transforming downstream surfaces the deferred result at the sink
+try path(1 | .+1) catch .
+{"a":1}
+"Invalid path expression with result 2"
+
+# Issue #839: navigating a rootless value reports jq's first-hop message
+try path([1] | if length>0 then .[0] else empty end) catch .
+{"a":1}
+"Invalid path expression near attempt to access element 0 of [1]"
+
+# Issue #839: an identity downstream leaves the rootless value at the sink
+try path(1 | select(true)) catch .
+{"a":1}
+"Invalid path expression with result 1"


### PR DESCRIPTION
## Summary

In path context, jq evaluates `A | B` by running `B` on the value `A`
produced — even when `A` is a **rootless (non-path) value**. A discarding
`B` (`empty`, `select(false)`, an `else empty` branch) yields no path and
therefore no error; a transforming `B` surfaces its own result/error at the
sink. jq-jit instead bailed eagerly at `A`, so it over-strictly errored
where jq emits nothing.

This is the `last(empty)` half of #839. `last(g)` desugars to
`reduce g as $x ([]; [$x]) | if length>0 then .[0] else empty end`, so
`path(last(empty))` reduces to `[] | (if length>0 … else empty)` — jq
discards it (length 0 → `empty`) and prints nothing; jq-jit errored
`Invalid path expression with result []`. The same eager bail broke the
whole `value | discard` class.

```
$ echo '{"a":1}' | jq      -c 'path(last(empty))'       # (no output)
$ echo '{"a":1}' | jq-jit  -c 'path(last(empty))'       # before: error; after: (no output) ✓
$ echo '{"a":1}' | jq-jit  -c 'path(1 | empty)'         # before: error; after: (no output) ✓
$ echo '{"a":1}' | jq-jit  -c 'path(1 | .+1)'           # before: result 1; after: result 2 (matches jq) ✓
```

## Changes

Two changes to the path engine (`src/eval.rs::eval_path`, shared by both
engines):

- **Pipe path handler** — when the left side bails with a rootless-value
  sentinel and the right side is not a bare index/iterate, re-run the right
  in path mode on that value. No output is swallowed; a navigation reports
  jq's first-hop message (`near attempt to access element N of V`); an
  identity leaves the value-shaped `result <A>` error at the sink; a
  transform/error surfaces its own.
- **Reduce path handler** — a non-path INIT is not path-trackable, so
  compute the reduce as a value and defer its **result** (not the INIT) so a
  downstream discard swallows it and a navigation/assignment reports the
  real result. Prevents `path(last(.a))` collapsing to no output.

## Scope

Covers the `last(empty)` / `value | discard` half of #839. The
`foreach`/value-generator-source half (`path(foreach range(2) as $i (.a;.;.))`,
`path(nth(1; range(5)))`) is a separate mechanism (accumulator-path
threading, mirroring the reduce handler) and lands as a follow-up PR, after
which #839 closes. Marked `Refs` rather than `Closes`.

## Verification

- `cargo build --release` — zero warnings
- `cargo test --release` — official 509 + regression + selfdiff + corpus +
  enforce/fuzz suites all green (0 failures across 38 test binaries)
- 7 new regression cases in `tests/regression.test`
- `./bench/comprehensive.sh` — in line with history (changes are cold-path
  only; no hot-path impact)

Refs #839

🤖 Generated with [Claude Code](https://claude.com/claude-code)