### PR TITLE
fix(path): thread accumulator path through foreach over a value generator

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -5783,10 +5783,41 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
             // element var is bound to the element VALUE (for use in
             // update/cond) and registered in FOREACH_PATH_BIND so a bare `$x`
             // in the extract forwards the element path — this is what makes the
-            // `nth(n; g)` desugar path-transparent. #711.
+            // `nth(n; .[])` desugar path-transparent. #711.
             let vi = *var_index;
             let ai = *acc_index;
             { let mut e = env.borrow_mut(); e.ensure_var(vi); e.ensure_var(ai); }
+
+            // Decide whether SOURCE navigates the tracked input (a path
+            // generator like `.[]`) or is a plain value generator (`range`,
+            // literals, `empty` — the `nth(n; range)` / #839 shape). A
+            // navigating source forwards the element path through `$x` (handled
+            // by the block below); a value generator instead threads the
+            // ACCUMULATOR as the path carrier. Only probe when the source reads
+            // `.` (otherwise it cannot navigate), mirroring the reduce probe so
+            // a stream-consuming `input` is not evaluated twice. #839
+            let source_navigates = if expr_uses_outer_input(source) {
+                let mut nav = false;
+                match eval_path(source, input.clone(), env, &mut |_p| { nav = true; Ok(false) }) {
+                    Ok(_) => {}
+                    Err(e) => {
+                        let m = format!("{}", e);
+                        if !m.starts_with("__pathexpr_result__:") { return Err(e); }
+                    }
+                }
+                nav
+            } else {
+                false
+            };
+
+            if !source_navigates {
+                // Value-generator source: the accumulator carries the path.
+                // Kept out-of-line so the (cold) path-mode foreach machinery
+                // does not bloat eval_path's hot index/reduce arms. #839
+                return eval_foreach_valuegen_path(source, init, vi, ai, update, extract, &input, env, cb);
+            }
+
+            // ---- navigating source: forward the element path through `$x` ----
             eval(init, input.clone(), env, &mut |init_val| {
                 let mut acc = init_val;
                 eval_path(source, input.clone(), env, &mut |src_path| {
@@ -5957,6 +5988,137 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
                     return cb(Value::Arr(Rc::new(vec![])));
                 }
                 bail!("__pathexpr_result__:{}", crate::value::value_to_json(&result_val));
+            }
+            Ok(true)
+        }
+    }
+}
+
+/// Path-context `foreach` over a value-generator source (`range`, literals,
+/// `empty`): the accumulator — not the source — carries the path. Held in a
+/// separate, never-inlined function so the cold machinery does not bloat
+/// `eval_path`'s hot index/reduce arms. #839
+#[inline(never)]
+fn eval_foreach_valuegen_path(
+    source: &Expr,
+    init: &Expr,
+    vi: u16,
+    ai: u16,
+    update: &Expr,
+    extract: &Option<Box<Expr>>,
+    input: &Value,
+    env: &EnvRef,
+    cb: &mut dyn FnMut(Value) -> GenResult,
+) -> GenResult {
+    let source_vals = {
+        let mut v = Vec::new();
+        eval(source, input.clone(), env, &mut |x| { v.push(x); Ok(true) })?;
+        v
+    };
+    // Classify INIT: a path-valued seed threads the accumulator as PATH(s) so
+    // a path-preserving body (`.`) or a navigating body (`.b`) extends it
+    // (`path(foreach range(2) as $i (.a;.;.))` → ["a"],["a"]); a rootless seed
+    // threads it as a VALUE, the `nth(n; range)` counter shape
+    // (`path(nth(1; range(5)))` → result 1).
+    let mut init_paths: Vec<Value> = Vec::new();
+    let init_res = eval_path(init, input.clone(), env, &mut |p| { init_paths.push(p); Ok(true) });
+    match init_res {
+        Ok(_) => {
+            // PATH-threaded accumulator.
+            for seed in init_paths {
+                let mut acc_paths: Vec<Value> = vec![seed];
+                for sv in &source_vals {
+                    let old_var = { let mut e = env.borrow_mut(); std::mem::replace(&mut e.vars[vi as usize], sv.clone()) };
+                    let mut next: Vec<Value> = Vec::new();
+                    let mut stop = false;
+                    for ap in &acc_paths {
+                        let base = crate::runtime::rt_getpath(input, ap).unwrap_or(Value::Null);
+                        let ap_vec: Vec<Value> = match ap { Value::Arr(a) => a.as_ref().clone(), _ => vec![] };
+                        let old_acc = { let mut e = env.borrow_mut(); std::mem::replace(&mut e.vars[ai as usize], base.clone()) };
+                        // UPDATE in path mode: each output is relative to the
+                        // accumulator value and extends its path.
+                        let r = eval_path(update, base.clone(), env, &mut |rp| {
+                            let mut np_vec = ap_vec.clone();
+                            if let Value::Arr(a) = &rp { np_vec.extend(a.iter().cloned()); }
+                            let np = Value::Arr(Rc::new(np_vec.clone()));
+                            next.push(np.clone());
+                            // EXTRACT emits per updated accumulator, with the
+                            // accumulator value bound for navigation.
+                            let nbase = crate::runtime::rt_getpath(input, &np).unwrap_or(Value::Null);
+                            let old_acc2 = { let mut e = env.borrow_mut(); std::mem::replace(&mut e.vars[ai as usize], nbase.clone()) };
+                            let ec = if let Some(ex) = extract {
+                                eval_path(ex, nbase, env, &mut |ep| {
+                                    let mut comb = np_vec.clone();
+                                    if let Value::Arr(a) = &ep { comb.extend(a.iter().cloned()); }
+                                    cb(Value::Arr(Rc::new(comb)))
+                                })
+                            } else {
+                                bail!("__pathexpr_result__:{}", crate::value::value_to_json(&nbase));
+                            };
+                            env.borrow_mut().vars[ai as usize] = old_acc2;
+                            let c = ec?;
+                            if !c { stop = true; }
+                            Ok(c)
+                        });
+                        env.borrow_mut().vars[ai as usize] = old_acc;
+                        // Keep $i bound across all accumulator branches of this
+                        // source element; restore it only after the loop (or on
+                        // error) so a multi-valued UPDATE doesn't reset it
+                        // mid-iteration.
+                        if let Err(e) = r {
+                            env.borrow_mut().vars[vi as usize] = old_var;
+                            return Err(e);
+                        }
+                        if stop { break; }
+                    }
+                    env.borrow_mut().vars[vi as usize] = old_var;
+                    if stop { return Ok(false); }
+                    acc_paths = next;
+                }
+            }
+            Ok(true)
+        }
+        Err(e) => {
+            let m = format!("{}", e);
+            if !m.starts_with("__pathexpr_result__:") { return Err(e); }
+            // VALUE-threaded accumulator (the `nth` counter): a bare `$x` in
+            // EXTRACT is the source value, not a path, so it surfaces as the
+            // sink's "result <x>" — no FOREACH_PATH_BIND is registered.
+            let init_vals = {
+                let mut v = Vec::new();
+                eval(init, input.clone(), env, &mut |x| { v.push(x); Ok(true) })?;
+                v
+            };
+            for seed in init_vals {
+                let mut acc = seed;
+                for sv in &source_vals {
+                    let (old_var, old_acc) = {
+                        let mut e = env.borrow_mut();
+                        let ov = std::mem::replace(&mut e.vars[vi as usize], sv.clone());
+                        let oa = std::mem::replace(&mut e.vars[ai as usize], acc.clone());
+                        (ov, oa)
+                    };
+                    let acc_in = acc.clone();
+                    let mut stop = false;
+                    let r = eval(update, acc_in, env, &mut |new_acc| {
+                        acc = new_acc.clone();
+                        env.borrow_mut().vars[ai as usize] = new_acc.clone();
+                        let c = if let Some(ex) = extract {
+                            eval_path(ex, new_acc.clone(), env, cb)?
+                        } else {
+                            bail!("__pathexpr_result__:{}", crate::value::value_to_json(&new_acc));
+                        };
+                        if !c { stop = true; }
+                        Ok(c)
+                    });
+                    {
+                        let mut e = env.borrow_mut();
+                        e.vars[ai as usize] = old_acc;
+                        e.vars[vi as usize] = old_var;
+                    }
+                    r?;
+                    if stop { return Ok(false); }
+                }
             }
             Ok(true)
         }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -11932,3 +11932,48 @@ try path([1] | if length>0 then .[0] else empty end) catch .
 try path(1 | select(true)) catch .
 {"a":1}
 "Invalid path expression with result 1"
+
+# Issue #839: foreach over a value-generator threads the accumulator path (identity body)
+[path(foreach range(2) as $i (.a; .; .))]
+{"a":1}
+[["a"],["a"]]
+
+# Issue #839: a navigating foreach extract extends the accumulator path
+[path(foreach range(2) as $i (.a; .; .b))]
+{"a":{"b":9}}
+[["a","b"],["a","b"]]
+
+# Issue #839: a value-valued foreach extract surfaces jq's path error at the sink
+try path(foreach range(2) as $i (.a; .; $i)) catch .
+{"a":1}
+"Invalid path expression with result 0"
+
+# Issue #839: nth over a value generator reports the counter result, not the last source value
+try path(nth(1; range(5))) catch .
+{"a":1}
+"Invalid path expression with result 1"
+
+# Issue #839: a comma-list value source also threads the accumulator path
+[path(foreach (1,2) as $i (.a; .; .))]
+{"a":{"b":1}}
+[["a"],["a"]]
+
+# Issue #839: a discarding foreach extract drops iterations in path context
+[path(foreach range(3) as $i (.a; .; select($i!=1)))]
+{"a":1}
+[["a"],["a"]]
+
+# Issue #839: an empty value source yields no foreach paths
+[path(foreach empty as $i (.a; .; .))]
+{"a":1}
+[]
+
+# Issue #839: a foreach-derived path drives an assignment LHS
+(foreach range(2) as $i (.a; .; .)) |= 99
+{"a":1}
+{"a":99}
+
+# Issue #839: a foreach-derived path drives del
+del(foreach range(1) as $i (.a; .; .))
+{"a":1,"b":2}
+{"b":2}


### PR DESCRIPTION
## Summary

In path context jq's `foreach` carries the path on whichever operand has
one. For a **navigating source** (`.[]`) the element variable forwards the
source path — the `nth(n; .[])` shape, already handled. For a **value
generator** (`range`, literals, `empty`) the path instead lives on the
**accumulator**, which jq-jit dropped: it evaluated the source in path mode,
so the value generator fell through to the sentinel catch-all and reported
the last source value.

```
$ echo '{"a":1}' | jq     -c 'path(foreach range(2) as $i (.a;.;.))'   # ["a"] / ["a"]
$ echo '{"a":1}' | jq-jit -c 'path(foreach range(2) as $i (.a;.;.))'   # before: error;  after: ["a"] ["a"] ✓
$ echo '{"a":1}' | jq     -c 'path(nth(1; range(5)))'                  # error: result 1
$ echo '{"a":1}' | jq-jit -c 'path(nth(1; range(5)))'                  # before: result 4; after: result 1 ✓
```

This is the `foreach` half of #839; #868 fixed the `last(empty)` half.

## Changes

The foreach path handler (`src/eval.rs`) now probes whether the source
navigates (gated on `expr_uses_outer_input` so a stream-consuming `input`
isn't evaluated twice). A navigating source keeps the existing element-path
machinery unchanged; a value generator is handled out of line by
`eval_foreach_valuegen_path`:

- A **path-valued INIT** threads the accumulator as a path. The body extends
  it (`.` keeps it, `.b` descends); EXTRACT emits `accumulator-path ++
  relative` per iteration; a value-valued EXTRACT (`$i`) surfaces jq's path
  error at the sink. A multi-valued UPDATE branches the accumulator.
- A **rootless INIT** (the `nth` counter, `-1`) threads the accumulator as a
  value with no path bound, so `$x` in EXTRACT reports `result <x>`.

## Performance

The helper is `#[inline(never)]` deliberately: inlining its ~120 lines into
`eval_path` regressed the path-heavy `.[i] += 1` / nested-reduce benchmarks
~12% through code layout, even though those paths never reach it. Out of
line, a **same-machine A/B** (pre-change vs this branch, 20-iter user CPU)
shows parity:

```
p126 nested reduce   old=2.18  new=2.18
p126 w/ mutate       old=2.35  new=2.34
```

## Verification

- `cargo build --release` — zero warnings
- `cargo test --release` — official 509 + regression + selfdiff + corpus +
  enforce/fuzz all green (0 failures across the suite)
- 9 new regression cases in `tests/regression.test`
- `./bench/comprehensive.sh` — in line with history; same-machine A/B parity

## Out of scope

A later iteration where UPDATE navigates the accumulator into a scalar
reports jq-jit's value-style index message (`Cannot index …`) rather than
jq's `near attempt to access element K of V`. Both error; this is the
existing index-arm wording, not a behavior change, and not a #839 repro.

Closes #839

🤖 Generated with [Claude Code](https://claude.com/claude-code)