### PR TITLE
fix(path): treat a rootless catch payload as a non-path in path context

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -5600,19 +5600,19 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
                     // the navigation. Evaluating it in VALUE mode dropped the
                     // tracking (#836).
                     if let Some(be) = e.downcast_ref::<BreakError>() {
-                        return eval_path(catch_expr, break_catch_value(be.0), env, cb);
+                        return eval_path_catch(catch_expr, break_catch_value(be.0), &input, env, cb);
                     }
                     // Recover a typed `error(value)` payload losslessly (#844).
                     if let Some(ev) = e.downcast_ref::<ErrorValue>() {
                         let v = take_error_payload(ev);
-                        return eval_path(catch_expr, v, env, cb);
+                        return eval_path_catch(catch_expr, v, &input, env, cb);
                     }
                     let catch_val = if let Some(json) = msg.strip_prefix("__jqerror__:") {
                         crate::value::json_to_value(json).unwrap_or(Value::from_str(&msg))
                     } else {
                         Value::from_str(&msg)
                     };
-                    eval_path(catch_expr, catch_val, env, cb)
+                    eval_path_catch(catch_expr, catch_val, &input, env, cb)
                 }
             }
         }
@@ -5991,6 +5991,46 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
             }
             Ok(true)
         }
+    }
+}
+
+/// Evaluate a `try … catch` body in path context against the caught value.
+/// jq gives the caught value a path only when it is the try's own input (a
+/// bare `error` / `error(.)` re-raising `.`); an `error(LITERAL)` payload is
+/// rootless, so a body that navigates it reports the first hop, an identity
+/// body leaves the value-shaped "result <payload>" at the sink, and a
+/// discarding body (`catch empty`) yields nothing. `path(try error("E")
+/// catch .)` errors with `result "E"` where jq-jit used to emit `[]`. The
+/// value-provenance distinction jq draws between `error(5)` and `error(.)`
+/// on an identical input is approximated here by value equality. Extends the
+/// try/catch path tracking of #836.
+fn eval_path_catch(
+    catch_expr: &Expr,
+    payload: Value,
+    input: &Value,
+    env: &EnvRef,
+    cb: &mut dyn FnMut(Value) -> GenResult,
+) -> GenResult {
+    if &payload == input {
+        // The caught value sits at the current path position (re-raised `.`),
+        // so the body tracks normally.
+        return eval_path(catch_expr, payload, env, cb);
+    }
+    let mut nav: Option<Value> = None;
+    match eval_path(catch_expr, payload.clone(), env, &mut |rp| { nav = Some(rp); Ok(false) }) {
+        Err(e) => Err(e),
+        Ok(_) => match &nav {
+            None => Ok(true),
+            Some(Value::Arr(comps)) if !comps.is_empty() => {
+                let key_desc = match &comps[0] {
+                    Value::Num(n, _) => format!("element {} of", crate::value::format_jq_number(*n)),
+                    Value::Str(s) => format!("element \"{}\" of", s),
+                    other => format!("element {} of", crate::value::value_to_json(other)),
+                };
+                bail!("Invalid path expression near attempt to access {} {}", key_desc, crate::value::value_to_json(&payload))
+            }
+            _ => bail!("__pathexpr_result__:{}", crate::value::value_to_json(&payload)),
+        },
     }
 }
 

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -11977,3 +11977,43 @@ try path(nth(1; range(5))) catch .
 del(foreach range(1) as $i (.a; .; .))
 {"a":1,"b":2}
 {"b":2}
+
+# Path tracking: a rootless error() payload bound by catch is not the identity path
+try path(try error("E") catch .) catch .
+{"a":1}
+"Invalid path expression with result \"E\""
+
+# Path tracking: a rootless catch payload errors even under an outer navigation
+try path(.a | try error("E") catch .) catch .
+{"a":1}
+"Invalid path expression with result \"E\""
+
+# Path tracking: a bare error re-raises . so catch . is the identity path
+[path(try error catch .)]
+5
+[[]]
+
+# Path tracking: error(.) re-raises the tracked input, so catch . stays trackable
+[path(try error(.) catch .)]
+5
+[[]]
+
+# Path tracking: navigating a rootless catch payload reports jq's first hop
+try path(try error([1,2]) catch .[0]) catch .
+5
+"Invalid path expression near attempt to access element 0 of [1,2]"
+
+# Path tracking: a discarding catch body yields no path for a rootless payload
+[path(try error("E") catch empty)]
+5
+[]
+
+# Path tracking: a catch value flows through an assignment LHS update
+.a |= (try error("X") catch .)
+{"a":1}
+{"a":"X"}
+
+# Path tracking: a bare error under navigation keeps the catch body trackable
+[path(.a | try error catch .b)]
+{"a":{"b":9}}
+[["a","b"]]


### PR DESCRIPTION
## Summary

`try … catch BODY` binds `.` in the catch to the caught value. In path
context jq gives that value a path **only when it is the try's own input** —
a bare `error` / `error(.)` re-raising `.`. An `error(LITERAL)` payload is
rootless, so a `.` body is the identity of a value with no path, not the
empty path. jq-jit's `Expr::Input` path handler unconditionally returns `[]`,
so `path(try error("E") catch .)` emitted `[]` where jq errors.

```
$ echo '{"a":1}' | jq     -c 'path(try error("E") catch .)'   # error: result "E"
$ echo '{"a":1}' | jq-jit -c 'path(try error("E") catch .)'   # before: []  →  after: error: result "E" ✓

$ echo 5 | jq     -c 'path(try error catch .)'   # []  (error/0 re-raises ., trackable)
$ echo 5 | jq-jit -c 'path(try error catch .)'   # [] ✓ (unchanged)
```

Found by a differential sweep while finishing the #839 path work; this is the
`Expr::Input`-returns-`[]` latent gap noted there.

## Changes

The catch sites of the path-mode `TryCatch` handler (`src/eval.rs`) now route
through a new `eval_path_catch` helper:

- payload **equals** the try's input → track normally (identity / navigation,
  as before — `path(.a | try error catch .b)` stays `["a","b"]`);
- payload is **rootless** → evaluate the body against it like the pipe
  rootless-defer: a discarding body (`catch empty`) yields nothing, a
  navigating body reports jq's first hop (`near attempt to access element 0
  of [1,2]`), an identity body leaves `result <payload>` at the sink.

`restore_dot` (the `?//` desugar, #840) is unaffected — its payload is the
original input by construction.

## Verification

- `cargo build --release` — zero warnings
- `cargo test --release` — official 509 + regression + selfdiff + corpus +
  enforce/fuzz all green (0 failures)
- 8 new regression cases
- `./bench/comprehensive.sh` — `try-catch` 0.024s, `alternative //` 0.035s,
  `label-break` 0.004s all match history (the change is on the catch error
  path only)

## Out of scope (pre-existing, not regressions)

- **Value provenance**: jq distinguishes `error(5)` from `error(.)` on input
  `5` (the literal carries no path); the equality approximation treats a
  literal payload that equals the tracked value as the identity path.
- **Long-value truncation**: jq truncates the value in `Invalid path
  expression with result X` at ~25 chars with `…`; jq-jit prints it in full.
  This affects every `result X` message (e.g. `path("long string" | .)`), not
  just catch, and is a separate formatting follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)