### PR TITLE
fix(path): truncate long value dumps in path-expression error messages

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1795,7 +1795,7 @@ fn eval_update_body(
     if let Err(e) = path_result {
         let msg = format!("{}", e);
         if let Some(json) = msg.strip_prefix("__pathexpr_result__:") {
-            bail!("Invalid path expression with result {}", json);
+            bail!("Invalid path expression with result {}", trunc_path_dump(json));
         }
         return Err(e);
     }
@@ -1865,7 +1865,7 @@ fn eval_assign_body(
         if let Err(e) = path_result {
             let msg = format!("{}", e);
             if let Some(json) = msg.strip_prefix("__pathexpr_result__:") {
-                bail!("Invalid path expression with result {}", json);
+                bail!("Invalid path expression with result {}", trunc_path_dump(json));
             }
             return Err(e);
         }
@@ -1885,7 +1885,7 @@ fn eval_assign_body(
         if let Err(e) = path_result {
             let msg = format!("{}", e);
             if let Some(json) = msg.strip_prefix("__pathexpr_result__:") {
-                bail!("Invalid path expression with result {}", json);
+                bail!("Invalid path expression with result {}", trunc_path_dump(json));
             }
             return Err(e);
         }
@@ -3171,7 +3171,7 @@ pub fn eval(
                 Err(e) => {
                     let msg = format!("{}", e);
                     if let Some(json) = msg.strip_prefix("__pathexpr_result__:") {
-                        bail!("Invalid path expression with result {}", json);
+                        bail!("Invalid path expression with result {}", trunc_path_dump(json));
                     }
                     Err(e)
                 }
@@ -5176,7 +5176,7 @@ pub fn eval_path_standalone(path_expr: &Expr, input: Value, env_ref: &Rc<RefCell
         Err(e) => {
             let msg = format!("{}", e);
             if let Some(json) = msg.strip_prefix("__pathexpr_result__:") {
-                bail!("Invalid path expression with result {}", json);
+                bail!("Invalid path expression with result {}", trunc_path_dump(json));
             }
             Err(e)
         }
@@ -5291,6 +5291,23 @@ fn emit_slice_path(
     cb(Value::Arr(Rc::new(p)))
 }
 
+/// Truncate a rendered JSON dump for path-expression error messages the way
+/// jq's `jv_dump_string_trunc` does (buffer size 30): a dump longer than 29
+/// bytes keeps its first 26 bytes followed by "...". jq does a raw byte
+/// `strncpy`; we cut at the largest char boundary at or below byte 26 so the
+/// message stays valid UTF-8 (identical to jq for ASCII, which covers the
+/// "result <X>" and "near attempt to access <K> of <V>" sinks). #870 follow-up.
+fn trunc_path_dump(s: &str) -> String {
+    if s.len() <= 29 {
+        return s.to_string();
+    }
+    let mut cut = 26;
+    while !s.is_char_boundary(cut) {
+        cut -= 1;
+    }
+    format!("{}...", &s[..cut])
+}
+
 fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) -> GenResult) -> GenResult {
     match expr {
         Expr::Input => cb(Value::Arr(Rc::new(vec![]))),
@@ -5369,7 +5386,7 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
                             Value::Str(s) => format!("element \"{}\" of", s),
                             _ => format!("element {} of", crate::value::value_to_json(&key_val)),
                         };
-                        bail!("Invalid path expression near attempt to access {} {}", key_desc, json);
+                        bail!("Invalid path expression near attempt to access {} {}", key_desc, trunc_path_dump(json));
                     }
                     Err(e)
                 }
@@ -5427,7 +5444,7 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
                                     Value::Str(s) => format!("element \"{}\" of", s),
                                     _ => format!("element {} of", crate::value::value_to_json(&key_val)),
                                 };
-                                bail!("Invalid path expression near attempt to access {} {}", key_desc, json);
+                                bail!("Invalid path expression near attempt to access {} {}", key_desc, trunc_path_dump(json));
                             }
                             Expr::Each { .. } | Expr::EachOpt { .. } => {
                                 bail!("Invalid path expression near attempt to iterate through {}", json);
@@ -5461,7 +5478,7 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
                                                         Value::Str(s) => format!("element \"{}\" of", s),
                                                         other => format!("element {} of", crate::value::value_to_json(other)),
                                                     };
-                                                    bail!("Invalid path expression near attempt to access {} {}", key_desc, crate::value::value_to_json(&v))
+                                                    bail!("Invalid path expression near attempt to access {} {}", key_desc, trunc_path_dump(&crate::value::value_to_json(&v)))
                                                 }
                                                 _ => Err(e),
                                             },
@@ -5946,7 +5963,7 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
                             let nav_val = crate::runtime::rt_getpath(&base_val, &rp).unwrap_or(Value::Null);
                             bail!(
                                 "Invalid path expression with result {}",
-                                crate::value::value_to_json(&nav_val)
+                                trunc_path_dump(&crate::value::value_to_json(&nav_val))
                             );
                         }
                         next.push(Value::Arr(Rc::new(ap_vec.clone())));
@@ -6027,7 +6044,7 @@ fn eval_path_catch(
                     Value::Str(s) => format!("element \"{}\" of", s),
                     other => format!("element {} of", crate::value::value_to_json(other)),
                 };
-                bail!("Invalid path expression near attempt to access {} {}", key_desc, crate::value::value_to_json(&payload))
+                bail!("Invalid path expression near attempt to access {} {}", key_desc, trunc_path_dump(&crate::value::value_to_json(&payload)))
             }
             _ => bail!("__pathexpr_result__:{}", crate::value::value_to_json(&payload)),
         },
@@ -6844,7 +6861,9 @@ fn eval_pick(f: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) -> 
     .map_err(|e| {
         let msg = format!("{}", e);
         match msg.strip_prefix("__pathexpr_result__:") {
-            Some(json) => anyhow::anyhow!("Invalid path expression with result {}", json),
+            Some(json) => {
+                anyhow::anyhow!("Invalid path expression with result {}", trunc_path_dump(json))
+            }
             None => e,
         }
     })?;
@@ -7141,7 +7160,9 @@ fn eval_del(f: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) -> G
         .map_err(|e| {
             let msg = format!("{}", e);
             match msg.strip_prefix("__pathexpr_result__:") {
-                Some(json) => anyhow::anyhow!("Invalid path expression with result {}", json),
+                Some(json) => {
+                anyhow::anyhow!("Invalid path expression with result {}", trunc_path_dump(json))
+            }
                 None => e,
             }
         })?;

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -12017,3 +12017,33 @@ try path(try error([1,2]) catch .[0]) catch .
 [path(.a | try error catch .b)]
 {"a":{"b":9}}
 [["a","b"]]
+
+# Path error result truncation: jq truncates a value dump longer than 29 bytes to its first 26 bytes + "..."
+try (path("this is a fairly long string value here")) catch .
+null
+"Invalid path expression with result \"this is a fairly long str..."
+
+# Path error result truncation: long array dump
+try (path([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15])) catch .
+null
+"Invalid path expression with result [1,2,3,4,5,6,7,8,9,10,11,1..."
+
+# Path error result truncation: long object dump
+try (path({"key":"value","another":"thing","more":"data"})) catch .
+null
+"Invalid path expression with result {\"key\":\"value\",\"another\":\"..."
+
+# Path error result truncation: dump of exactly 28 bytes is left intact (no truncation under the threshold)
+try (path([1,2,3,4,5,6,7,8,9,10,11,12])) catch .
+null
+"Invalid path expression with result [1,2,3,4,5,6,7,8,9,10,11,12]"
+
+# Path error near-attempt truncation: rootless navigate into a long string value
+try (path("this is a fairly long string value here" | .x)) catch .
+null
+"Invalid path expression near attempt to access element \"x\" of \"this is a fairly long str..."
+
+# Path error near-attempt truncation: rootless navigate into a long array value
+try (path([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16] | .[20])) catch .
+null
+"Invalid path expression near attempt to access element 20 of [1,2,3,4,5,6,7,8,9,10,11,1..."


### PR DESCRIPTION
## Problem

jq caps the value dump in path-expression error messages via `jv_dump_string_trunc` (buffer size 30): a dump longer than 29 bytes is shown as its first 26 bytes followed by `...`. This applies to both message shapes:

- `Invalid path expression with result <X>`
- `Invalid path expression near attempt to access <K> of <V>`

jq-jit printed the **full** dump, so any path error over a long string / array / object diverged from jq:

```
$ echo null | jq    'try path("this is a fairly long string value here") catch .'
"Invalid path expression with result \"this is a fairly long str..."
$ echo null | jq-jit 'try path("this is a fairly long string value here") catch .'   # before
"Invalid path expression with result \"this is a fairly long string value here\""
```

This surfaced as a follow-up while fixing the path-tracking model gap (#868/#869/#870): the deferred-path work made jq-jit emit these messages for many more inputs, exposing the missing truncation.

## Fix

- Add a `trunc_path_dump` helper applying jq's rule: dumps longer than 29 bytes keep their first 26 bytes + `...`. It cuts at a char boundary at or below byte 26 so the message stays valid UTF-8 (identical to jq for ASCII, which covers these sinks).
- Route every `result` / `near attempt` formatting site through it.
- The internal `__pathexpr_result__:<json>` sentinel is left **untruncated** so the deferred-path logic still re-formats the real value at the sink.

## Verification

- `cargo build --release`: zero warnings.
- `cargo test --release`: all pass (official + regression + selfdiff + corpus).
- Regression cases added: string/array/object truncation, the 28-byte under-threshold (no-truncation) boundary, and the near-attempt navigate variants.
- Error-path-only change; p126 path-heavy benchmark at parity on a same-machine A/B (base 1.13–1.17s vs new 1.08–1.10s user, 10-iter loops, identical result).

🤖 Generated with [Claude Code](https://claude.com/claude-code)