### PR TITLE
fix(encoding): preserve precision-edge literal exponents in @csv/@tsv

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -5698,6 +5698,19 @@ pub fn push_value_num_repr_str(buf: &mut String, n: f64, repr: Option<&Rc<str>>)
         } else {
             buf.push_str(r);
         }
+    } else if let Some(canonical) = repr
+        .filter(|r| is_valid_json_number(r) && n.is_finite() && n != 0.0)
+        .and_then(|r| normalize_jq_repr(r))
+        .filter(|c| c.as_str().parse::<f64>().ok() == Some(n))
+    {
+        // Subnormal/precision-edge literals (#616): `repr_is_exact_for_f64` is
+        // too conservative for >15-sig-digit mantissas and exponents < -323,
+        // but the canonical literal still round-trips through f64 — e.g.
+        // DBL_MAX `1.7976931348623157e308` and the smallest subnormal `5e-324`.
+        // jq's @csv/@tsv preserve the literal's uppercase-E decnum form here
+        // exactly as `tostring`/tojson do, so mirror `push_value_tojson`
+        // instead of falling through to the lossy lowercase f64 dtoa form.
+        buf.push_str(&canonical);
     } else {
         push_jq_number_str(buf, n);
     }
@@ -5713,6 +5726,13 @@ pub fn push_value_num_repr_bytes(buf: &mut Vec<u8>, n: f64, repr: Option<&Rc<str
         } else {
             buf.extend_from_slice(r.as_bytes());
         }
+    } else if let Some(canonical) = repr
+        .filter(|r| is_valid_json_number(r) && n.is_finite() && n != 0.0)
+        .and_then(|r| normalize_jq_repr(r))
+        .filter(|c| c.as_str().parse::<f64>().ok() == Some(n))
+    {
+        // Subnormal/precision-edge literals (#616) — see push_value_num_repr_str.
+        buf.extend_from_slice(canonical.as_bytes());
     } else {
         push_jq_number_bytes(buf, n);
     }

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -4191,3 +4191,19 @@ del(. as [$a] ?// $a | .x)
 
 path(. as [$a] ?// {p:$a} ?// $a | .q)
 {"p":1,"q":2}
+
+# ---------- @csv/@tsv preserve precision-edge literal exponents (#616-class) ----------
+[1.7976931348623157e308] | @csv
+null
+
+[5e-324] | @csv
+null
+
+[9.999999999999999e22] | @tsv
+null
+
+[1.234567890123456e30] | @csv
+null
+
+[5e-324 * 1] | @csv
+null

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -12047,3 +12047,33 @@ null
 try (path([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16] | .[20])) catch .
 null
 "Invalid path expression near attempt to access element 20 of [1,2,3,4,5,6,7,8,9,10,11,1..."
+
+# @csv/@tsv preserve a precision-edge literal's uppercase-E decnum form (DBL_MAX, #616-class)
+[1.7976931348623157e308]|@csv
+null
+"1.7976931348623157E+308"
+
+# @csv/@tsv preserve the smallest-subnormal literal's decnum form
+[5e-324]|@csv
+null
+"5E-324"
+
+# @tsv preserves a 16-significant-digit literal exponent (was lossy decimal-expanded)
+[9.999999999999999e22]|@tsv
+null
+"9.999999999999999E+22"
+
+# @csv preserves a large high-precision literal in exponent form (was decimal-expanded)
+[1.234567890123456e30]|@csv
+null
+"1.234567890123456E+30"
+
+# @csv on a COMPUTED edge value keeps jq's lowercase dtoa form (literal-vs-computed split)
+[5e-324*1]|@csv
+null
+"5e-324"
+
+# @tsv preserves the smallest normal-double literal's decnum form
+[2.2250738585072014e-308]|@tsv
+null
+"2.2250738585072014E-308"


### PR DESCRIPTION
## Problem

`@csv`/`@tsv` format numbers via `push_value_num_repr_str` / `push_value_num_repr_bytes`, which preserved a literal's canonical decnum form (uppercase `E`) only when `repr_is_exact_for_f64` accepted the repr. `tostring`/`tojson` (`push_value_tojson`) carry a **second tier** added in #616: even when that exactness check is too conservative (>15-significant-digit mantissas, exponents `< -323`), the canonical repr is kept if it round-trips to the same f64 bits. The CSV/TSV formatters lacked this tier, so precision-edge literals fell through to the lossy lowercase f64 dtoa form.

```
$ echo '[1.7976931348623157e308]' | jq    -c '@csv'
"1.7976931348623157E+308"
$ echo '[1.7976931348623157e308]' | jq-jit -c '@csv'   # before
"1.7976931348623157e+308"
```

Also affected:

| literal | jq (`@csv`) | jq-jit before |
|---|---|---|
| `5e-324` (smallest subnormal) | `5E-324` | `5e-324` |
| `2.2250738585072014e-308` (smallest normal) | `2.2250738585072014E-308` | `2.2250738585072014e-308` |
| `9.999999999999999e22` | `9.999999999999999E+22` | `1e+23` |
| `1.234567890123456e30` | `1.234567890123456E+30` | `1234567890123456000000000000000` |

`tostring`/`tojson` were already correct for all of these — only the CSV/TSV path diverged.

## Fix

Add the same #616 fallback to both CSV/TSV number formatters. The literal-vs-computed split is preserved: `[5e-324] | @csv` → `5E-324` but `[5e-324*1] | @csv` → `5e-324`, matching jq. NaN-cell-empty handling (#771) is unchanged.

## Verification

- `cargo build --release`: zero warnings.
- `cargo test --release`: all pass (official + regression + selfdiff + corpus). Added 6 regression cases + 5 differential-corpus probes (incl. the computed lowercase guard).
- Differential sweep against jq 1.8.1: 15 literal-exponent magnitudes now all match for both `@csv` and `@tsv`.
- Cold-branch-only addition (runs only when the exactness check fails); `@csv`/`tojson` number-heavy benchmarks at parity on a same-machine A/B (the forced-fallback workload is actually faster).

Found by a differential number-formatting sweep; extends #616 / #475.

🤖 Generated with [Claude Code](https://claude.com/claude-code)