### PR TITLE
fix(fast-path): error on non-object input in .field|tostring|length

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -12094,8 +12094,22 @@ fn real_main() {
                                 }
                             }
                         } else {
-                            // null field: tostring = "null", length = 4
-                            compact_buf.extend_from_slice(b"4\n");
+                            // None means either an object missing the field
+                            // (→ null, tostring "null", length 4) or a
+                            // non-object input, which jq rejects with an
+                            // indexing error. Distinguish by the leading
+                            // non-whitespace byte: only `{` is the object case.
+                            let mut p = 0;
+                            while p < raw.len() && matches!(raw[p], b' ' | b'\t' | b'\n' | b'\r') { p += 1; }
+                            if p < raw.len() && raw[p] == b'{' {
+                                // object missing the field: tostring = "null", length = 4
+                                compact_buf.extend_from_slice(b"4\n");
+                            } else {
+                                // non-object input: defer to the slow path so jq's
+                                // "Cannot index <type> with string" error is raised
+                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                            }
                         }
                         if compact_buf.len() >= 1 << 17 {
                             let _ = out.write_all(&compact_buf);
@@ -12157,8 +12171,21 @@ fn real_main() {
                                 }
                             }
                         } else {
-                            // null field: length = 0, tostring = "0"
-                            compact_buf.extend_from_slice(b"\"0\"\n");
+                            // None means either an object missing the field
+                            // (→ null, length 0, tostring "0") or a non-object
+                            // input, which jq rejects with an indexing error.
+                            // Distinguish by the leading non-whitespace byte.
+                            let mut p = 0;
+                            while p < raw.len() && matches!(raw[p], b' ' | b'\t' | b'\n' | b'\r') { p += 1; }
+                            if p < raw.len() && raw[p] == b'{' {
+                                // object missing the field: length = 0, tostring = "0"
+                                compact_buf.extend_from_slice(b"\"0\"\n");
+                            } else {
+                                // non-object input: defer to the slow path so jq's
+                                // "Cannot index <type> with string" error is raised
+                                let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                                process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                            }
                         }
                         if compact_buf.len() >= 1 << 17 {
                             let _ = out.write_all(&compact_buf);
@@ -20803,7 +20830,17 @@ fn real_main() {
                             }
                         }
                     } else {
-                        compact_buf.extend_from_slice(b"4\n");
+                        // None: object missing the field (→ "null", length 4)
+                        // vs non-object input (jq raises an indexing error).
+                        // Distinguish by the leading non-whitespace byte.
+                        let mut p = 0;
+                        while p < raw.len() && matches!(raw[p], b' ' | b'\t' | b'\n' | b'\r') { p += 1; }
+                        if p < raw.len() && raw[p] == b'{' {
+                            compact_buf.extend_from_slice(b"4\n");
+                        } else {
+                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                        }
                     }
                     if compact_buf.len() >= 1 << 17 {
                         let _ = out.write_all(&compact_buf);
@@ -20861,7 +20898,17 @@ fn real_main() {
                             }
                         }
                     } else {
-                        compact_buf.extend_from_slice(b"\"0\"\n");
+                        // None: object missing the field (→ length 0, "0")
+                        // vs non-object input (jq raises an indexing error).
+                        // Distinguish by the leading non-whitespace byte.
+                        let mut p = 0;
+                        while p < raw.len() && matches!(raw[p], b' ' | b'\t' | b'\n' | b'\r') { p += 1; }
+                        if p < raw.len() && raw[p] == b'{' {
+                            compact_buf.extend_from_slice(b"\"0\"\n");
+                        } else {
+                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                        }
                     }
                     if compact_buf.len() >= 1 << 17 {
                         let _ = out.write_all(&compact_buf);

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -12077,3 +12077,45 @@ null
 [2.2250738585072014e-308]|@tsv
 null
 "2.2250738585072014E-308"
+
+# #873: .field | tostring | length must error on non-object input
+# (fast path used to conflate "object missing field" with "not an object").
+# boolean
+.a | tostring | length
+false
+
+# #873: number input
+.a | tostring | length
+5
+
+# #873: string input
+.a | tostring | length
+"x"
+
+# #873: object missing the field stays null -> "null" -> length 4
+.a | tostring | length
+{}
+4
+
+# #873: present field is unaffected
+.a | tostring | length
+{"a":12}
+2
+
+# #873 sibling: .field | length | tostring must error on non-object input
+.a | length | tostring
+false
+
+# #873 sibling: number input
+.a | length | tostring
+5
+
+# #873 sibling: object missing the field stays 0 -> "0"
+.a | length | tostring
+{}
+"0"
+
+# #873 sibling: present array field is unaffected
+.a | length | tostring
+{"a":[1,2]}
+"2"


### PR DESCRIPTION
## Summary

The `.field | tostring | length` raw fast path emitted `4` (the length of `"null"`) when the input was a non-object scalar (`false`, a number, a string), instead of raising jq's indexing error. The root cause: `json_object_get_field_raw` returns `None` both when an object lacks the field (jq → `null`) and when the input is not an object at all (jq → error), and the `else` branch unconditionally treated `None` as a null field.

```console
$ echo 'false' | jq-jit '.a | tostring | length'   # before: 4   after: error
$ echo 'false' | jq     '.a | tostring | length'    # jq: error (Cannot index boolean with string "a")
```

## Fix

In the `None` branch, peek the input's leading non-whitespace byte: only `{` is the object-missing-field case (keep the fast emit — `null`→`"null"`→`4`). Otherwise defer to the slow path so jq's `Cannot index <type> with string "<field>"` error is raised.

The sibling `.field | length | tostring` fast path had the identical latent bug (emitted `"0"` on non-object input). Fixed both, across the stdin and file code paths (4 sites total).

## Verification

| filter | input | before | after / jq |
|---|---|---|---|
| `.a \| tostring \| length` | `false` / `5` / `"x"` | `4` | error |
| `.a \| tostring \| length` | `{}` | `4` | `4` |
| `.a \| tostring \| length` | `{"a":12}` | `2` | `2` |
| `.a \| length \| tostring` | `false` / `5` | `"0"` | error |
| `.a \| length \| tostring` | `{}` | `"0"` | `"0"` |

- `cargo build --release`: zero warnings
- `cargo test --release`: all pass (official 509 + regression + selfdiff + diff_corpus + metamorphic)
- `bench/comprehensive.sh`: no regression (cold None-branch only; hot path untouched)
- Added regression cases in `tests/regression.test` for non-object inputs (must error) and the object cases (missing field, present field) that must stay correct.

Closes #873

🤖 Generated with [Claude Code](https://claude.com/claude-code)