### PR TITLE
test: parallelize spawn-bound differential harnesses

### DIFF
--- a/tests/common/jq_test_format.rs
+++ b/tests/common/jq_test_format.rs
@@ -306,8 +306,11 @@ pub fn run_jq_test_suite(label: &str, test_file_path: &str) {
     let mut skip = 0usize;
     let mut failures: Vec<TestResult> = Vec::new();
 
-    for case in &cases {
-        let result = run_test(case);
+    // Each case spawns its own jq-jit subprocess and shares no in-process
+    // state, so the suite fans out across cores; results come back in input
+    // order to keep the report deterministic.
+    let results = super::parallel::par_map(&cases, |case| run_test(case));
+    for (case, result) in cases.iter().zip(results) {
         match &result.status {
             TestStatus::Pass => pass += 1,
             TestStatus::Fail => {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -16,6 +16,8 @@
 //! - `jq_test_format` — parser + runner for the 3-line group format
 //!   (`filter / input / expected_output`) shared by `tests/official/jq.test`
 //!   and `tests/regression.test`.
+//! - `parallel` — `par_map`, a dep-free order-preserving parallel map used to
+//!   fan the spawn-bound differential harnesses across CPU cores.
 //!
 //! `#[allow(dead_code)]` is applied because each integration test imports
 //! only the subset of helpers it needs; unused ones look dead from the
@@ -27,3 +29,4 @@ pub mod diff_harness;
 pub mod filter_strategy;
 pub mod jq_test_format;
 pub mod json_normalize;
+pub mod parallel;

--- a/tests/common/parallel.rs
+++ b/tests/common/parallel.rs
@@ -1,0 +1,72 @@
+//! Dep-free parallel map for the spawn-bound differential test harnesses.
+//!
+//! The heavy compat / selfdiff / diff-corpus suites are each a single
+//! `#[test]` that loops over thousands of cases, spawning `jq-jit` and the
+//! reference `jq` as subprocesses per case. That work is process-isolated
+//! (each case touches only its own child processes and local buffers — no
+//! shared in-process state), so it parallelises cleanly without reviving the
+//! cranelift JIT race that historically forced `--test-threads=1` (resolved
+//! by thread-localising the JIT pools, #173, and dropping the libjq FFI).
+//!
+//! `par_map` fans a closure across `available_parallelism()` scoped worker
+//! threads using an atomic work-stealing cursor (load-balanced when per-case
+//! cost varies), and returns results in the original input order so callers
+//! keep their deterministic reporting. No `unsafe`, no external crates.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::thread;
+
+/// Apply `f` to every element of `items` across worker threads and return the
+/// results in the original order. Falls back to a sequential map when there is
+/// nothing to gain (single core, or 0/1 items).
+pub fn par_map<T, R, F>(items: &[T], f: F) -> Vec<R>
+where
+    T: Sync,
+    R: Send,
+    F: Fn(&T) -> R + Sync,
+{
+    let len = items.len();
+    let workers = thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1)
+        .min(len.max(1));
+
+    if workers <= 1 || len <= 1 {
+        return items.iter().map(&f).collect();
+    }
+
+    let next = AtomicUsize::new(0);
+    // Each worker drains the shared cursor and records (index, result) pairs
+    // into its own local Vec, so no two threads write the same memory.
+    let collected: Vec<Vec<(usize, R)>> = thread::scope(|scope| {
+        let handles: Vec<_> = (0..workers)
+            .map(|_| {
+                let next = &next;
+                let f = &f;
+                scope.spawn(move || {
+                    let mut local = Vec::new();
+                    loop {
+                        let i = next.fetch_add(1, Ordering::Relaxed);
+                        if i >= len {
+                            break;
+                        }
+                        local.push((i, f(&items[i])));
+                    }
+                    local
+                })
+            })
+            .collect();
+        handles.into_iter().map(|h| h.join().unwrap()).collect()
+    });
+
+    // Reassemble in input order.
+    let mut out: Vec<Option<R>> = (0..len).map(|_| None).collect();
+    for chunk in collected {
+        for (i, r) in chunk {
+            out[i] = Some(r);
+        }
+    }
+    out.into_iter()
+        .map(|slot| slot.expect("every index produced exactly one result"))
+        .collect()
+}

--- a/tests/coverage_fast_path.rs
+++ b/tests/coverage_fast_path.rs
@@ -25,6 +25,8 @@
 //! reviewers can see the hot/cold distribution without opening a CI
 //! artifact.
 
+mod common;
+
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::process::Command;
@@ -150,13 +152,17 @@ fn fast_paths_have_nonzero_corpus_coverage() {
     // "generic" fallbacks, reported separately
     let mut generic_counts: BTreeMap<String, usize> = BTreeMap::new();
 
-    for case in &cases {
-        if let Some(name) = trace_one(jq_jit, &case.filter, &case.input) {
-            if name == "jit" || name == "eval" {
-                *generic_counts.entry(name).or_insert(0) += 1;
-            } else {
-                *counts.entry(name).or_insert(0) += 1;
-            }
+    // Each case spawns its own traced jq-jit subprocess (no shared in-process
+    // state), so collect the matched names across cores, then fold into the
+    // count maps sequentially.
+    let traced = common::parallel::par_map(&cases, |case| {
+        trace_one(jq_jit, &case.filter, &case.input)
+    });
+    for name in traced.into_iter().flatten() {
+        if name == "jit" || name == "eval" {
+            *generic_counts.entry(name).or_insert(0) += 1;
+        } else {
+            *counts.entry(name).or_insert(0) += 1;
         }
     }
 

--- a/tests/diff_corpus.rs
+++ b/tests/diff_corpus.rs
@@ -76,64 +76,67 @@ fn differential_against_jq_1_8() {
     let mut fail = 0usize;
     let mut failures: Vec<String> = Vec::new();
 
-    for case in &cases {
+    // Each case spawns its own jq and jq-jit subprocesses with no shared
+    // in-process state, so fan out across cores; verdicts are folded back in
+    // input order to keep the failure report deterministic.
+    let verdicts = common::parallel::par_map(&cases, |case| -> Result<(), String> {
         let jq_out = run_filter(&jq, &case.filter, &case.input, TIMEOUT);
         let jit_out = run_filter(jq_jit, &case.filter, &case.input, TIMEOUT);
 
         let (Some(a), Some(b)) = (jq_out, jit_out) else {
-            fail += 1;
-            failures.push(format!(
+            return Err(format!(
                 "  line {}: spawn failure\n    filter: {}\n    input:  {}",
                 case.line, case.filter, case.input
             ));
-            continue;
         };
 
         if a.is_error && b.is_error {
-            pass += 1;
-            continue;
+            return Ok(());
         }
         if a.is_error != b.is_error {
-            fail += 1;
-            failures.push(format!(
+            return Err(format!(
                 "  line {}: error mismatch (jq error={}, jit error={})\n    filter: {}\n    input:  {}\n    jq:  {}\n    jit: {}",
                 case.line, a.is_error, b.is_error, case.filter, case.input,
                 a.stdout.trim(), b.stdout.trim()
             ));
-            continue;
         }
 
         let a_norm = match normalize(&a.stdout) {
             Ok(s) => s,
             Err(e) => {
-                fail += 1;
-                failures.push(format!(
+                return Err(format!(
                     "  line {}: jq output not JSON-parsable ({})\n    filter: {}\n    input:  {}\n    jq:  {}",
                     case.line, e, case.filter, case.input, a.stdout.trim()
                 ));
-                continue;
             }
         };
         let b_norm = match normalize(&b.stdout) {
             Ok(s) => s,
             Err(e) => {
-                fail += 1;
-                failures.push(format!(
+                return Err(format!(
                     "  line {}: jit output not JSON-parsable ({})\n    filter: {}\n    input:  {}\n    jit: {}",
                     case.line, e, case.filter, case.input, b.stdout.trim()
                 ));
-                continue;
             }
         };
 
         if a_norm == b_norm {
-            pass += 1;
+            Ok(())
         } else {
-            fail += 1;
-            failures.push(format!(
+            Err(format!(
                 "  line {}: value mismatch\n    filter: {}\n    input:  {}\n    jq:  {}\n    jit: {}",
                 case.line, case.filter, case.input, a_norm, b_norm
-            ));
+            ))
+        }
+    });
+
+    for verdict in verdicts {
+        match verdict {
+            Ok(()) => pass += 1,
+            Err(msg) => {
+                fail += 1;
+                failures.push(msg);
+            }
         }
     }
 

--- a/tests/selfdiff_jit_interp.rs
+++ b/tests/selfdiff_jit_interp.rs
@@ -155,6 +155,17 @@ fn normalize(output: &str) -> String {
 ///   in #415.
 const KNOWN_DIVERGENCES: &[usize] = &[2230, 2235, 2240, 2366, 2371];
 
+/// Per-case verdict, produced in parallel and folded sequentially so the
+/// counters and reporting stay identical to the original serial loop.
+enum Outcome {
+    /// Agreed (jit == interp). `Some(line)` if the case is on the allowlist
+    /// yet agreed anyway — counts as a pass *and* flags a stale entry.
+    Pass(Option<usize>),
+    KnownDiverged,
+    SpawnFail(String),
+    Fail(String),
+}
+
 #[test]
 fn jit_vs_interpreter_self_diff() {
     let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
@@ -178,52 +189,66 @@ fn jit_vs_interpreter_self_diff() {
     let mut unexpected_pass: Vec<usize> = Vec::new();
     let mut failures: Vec<String> = Vec::new();
 
-    for case in &cases {
+    // Each case spawns two isolated jq-jit subprocesses (JIT vs forced
+    // interpreter); no shared in-process state, so fan out across cores and
+    // fold the verdicts back in input order.
+    let outcomes = common::parallel::par_map(&cases, |case| {
         let known = KNOWN_DIVERGENCES.contains(&case.line);
         let jit = run_once(jq_jit, &case.filter, &case.input, false);
         let interp = run_once(jq_jit, &case.filter, &case.input, true);
 
         let (Some(jit), Some(interp)) = (jit, interp) else {
-            spawn_fail += 1;
-            failures.push(format!(
+            return Outcome::SpawnFail(format!(
                 "  line {}: spawn failure\n    filter: {}\n    input:  {}",
                 case.line, case.filter, case.input
             ));
-            continue;
         };
 
         if jit.is_error && interp.is_error {
-            if known { unexpected_pass.push(case.line); }
-            pass += 1;
-            continue;
+            return Outcome::Pass(known.then_some(case.line));
         }
         if jit.is_error != interp.is_error {
             if known {
-                known_diverged += 1;
-                continue;
+                return Outcome::KnownDiverged;
             }
-            fail += 1;
-            failures.push(format!(
+            return Outcome::Fail(format!(
                 "  line {}: error-class mismatch (jit error={}, interp error={})\n    filter: {}\n    input:  {}\n    jit:    {}\n    interp: {}",
                 case.line, jit.is_error, interp.is_error, case.filter, case.input,
                 jit.stdout.trim(), interp.stdout.trim()
             ));
-            continue;
         }
 
         let jit_norm = normalize(&jit.stdout);
         let interp_norm = normalize(&interp.stdout);
         if jit_norm == interp_norm {
-            if known { unexpected_pass.push(case.line); }
-            pass += 1;
+            Outcome::Pass(known.then_some(case.line))
         } else if known {
-            known_diverged += 1;
+            Outcome::KnownDiverged
         } else {
-            fail += 1;
-            failures.push(format!(
+            Outcome::Fail(format!(
                 "  line {}: value mismatch\n    filter: {}\n    input:  {}\n    jit:    {}\n    interp: {}",
                 case.line, case.filter, case.input, jit_norm, interp_norm
-            ));
+            ))
+        }
+    });
+
+    for outcome in outcomes {
+        match outcome {
+            Outcome::Pass(maybe_line) => {
+                pass += 1;
+                if let Some(line) = maybe_line {
+                    unexpected_pass.push(line);
+                }
+            }
+            Outcome::KnownDiverged => known_diverged += 1,
+            Outcome::SpawnFail(msg) => {
+                spawn_fail += 1;
+                failures.push(msg);
+            }
+            Outcome::Fail(msg) => {
+                fail += 1;
+                failures.push(msg);
+            }
         }
     }
 

--- a/tests/selfdiff_layers.rs
+++ b/tests/selfdiff_layers.rs
@@ -208,6 +208,17 @@ fn normalize(output: &str) -> String {
 /// with `selfdiff_jit_interp.rs::KNOWN_DIVERGENCES`.
 const KNOWN_DIVERGENCES: &[usize] = &[2230, 2235, 2240, 2366, 2371];
 
+/// Per-case verdict, produced in parallel and folded sequentially so the
+/// counters and reporting stay identical to the original serial loop.
+enum Outcome {
+    /// Agreed across all configs. `Some(line)` if the case is on the allowlist
+    /// yet agreed anyway — counts as a pass *and* flags a stale entry.
+    Pass(Option<usize>),
+    KnownDiverged,
+    SpawnFail(String),
+    Fail(String),
+}
+
 #[test]
 fn layer_pinned_self_diff() {
     let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
@@ -231,7 +242,10 @@ fn layer_pinned_self_diff() {
     let mut unexpected_pass: Vec<usize> = Vec::new();
     let mut failures: Vec<String> = Vec::new();
 
-    for case in &cases {
+    // Each case spawns four isolated jq-jit subprocesses (one per layer
+    // config); no shared in-process state, so fan out across cores and fold
+    // the verdicts back in input order.
+    let outcomes = common::parallel::par_map(&cases, |case| {
         let known = KNOWN_DIVERGENCES.contains(&case.line);
 
         // Run all four configs. Baseline is the oracle every other config
@@ -245,12 +259,10 @@ fn layer_pinned_self_diff() {
             }
         }
         if spawn_failed {
-            spawn_fail += 1;
-            failures.push(format!(
+            return Outcome::SpawnFail(format!(
                 "  line {}: spawn failure\n    filter: {}\n    input:  {}",
                 case.line, case.filter, case.input
             ));
-            continue;
         }
 
         // Per-config normalized output (stdout) and error class. The
@@ -270,16 +282,12 @@ fn layer_pinned_self_diff() {
         }
 
         if disagreeing.is_empty() {
-            if known { unexpected_pass.push(case.line); }
-            pass += 1;
-            continue;
+            return Outcome::Pass(known.then_some(case.line));
         }
         if known {
-            known_diverged += 1;
-            continue;
+            return Outcome::KnownDiverged;
         }
 
-        fail += 1;
         let mut buf = String::new();
         buf.push_str(&format!(
             "  line {}: layer divergence\n    filter: {}\n    input:  {}\n",
@@ -309,7 +317,27 @@ fn layer_pinned_self_diff() {
             configs_off.join(", "),
         ));
         buf.push_str("       multiple configs differ ⇒ inspect baseline output for the canonical answer)\n");
-        failures.push(buf);
+        Outcome::Fail(buf)
+    });
+
+    for outcome in outcomes {
+        match outcome {
+            Outcome::Pass(maybe_line) => {
+                pass += 1;
+                if let Some(line) = maybe_line {
+                    unexpected_pass.push(line);
+                }
+            }
+            Outcome::KnownDiverged => known_diverged += 1,
+            Outcome::SpawnFail(msg) => {
+                spawn_fail += 1;
+                failures.push(msg);
+            }
+            Outcome::Fail(msg) => {
+                fail += 1;
+                failures.push(msg);
+            }
+        }
     }
 
     eprintln!();


### PR DESCRIPTION
## Problem

The heavy compat / selfdiff / diff-corpus suites are each a **single `#[test]`** that loops over thousands of cases, spawning `jq-jit` (and reference `jq`) as subprocesses per case. libtest only parallelizes *across* `#[test]` functions, so these monolithic suites ran fully serial. On the slow macOS / Windows CI runners, process-spawn overhead made them the dominant cost — CI wall time was bounded by the slowest matrix leg at **~20 min** (e.g. macOS 20m52s, Windows 17m9s; ubuntu 8m26s for the same content).

## Why it's safe to parallelize

Each case is **process-isolated** — it touches only its own child processes and local buffers, no shared in-process state. So the work parallelizes cleanly without reviving the cranelift JIT race that historically forced `--test-threads=1` (resolved long ago by thread-localising the JIT pools, #173, and dropping the libjq FFI). The old `--test-threads=1` flag is already gone from CI.

## Change

Add `tests/common/parallel.rs::par_map` — a **dep-free, `unsafe`-free, order-preserving** parallel map that fans a closure across `available_parallelism()` scoped worker threads via an atomic work-stealing cursor (load-balanced when per-case cost varies). No 3rd-party actions or crates.

Wire it into the five hot harnesses, keeping each as **one `#[test]` with its curated aggregate summary intact**; counters and failure reports are folded sequentially from the order-preserved results, so output stays deterministic:

- `jq_test_format` (compat_official + compat_regression)
- `selfdiff_jit_interp` (2-way JIT vs interpreter)
- `selfdiff_layers` (4-way layer-pinned)
- `diff_corpus` (vs jq 1.8.x)
- `coverage_fast_path` (trace-based)

## Local impact (16-core)

| suite | before | after |
|---|---|---|
| compat_official | 6.65s | 0.61s |
| compat_regression | 29.64s | 2.07s |
| selfdiff_jit_interp | 28.29s | 2.21s |
| selfdiff_layers | 56.59s | 4.23s |
| diff_corpus | 41.76s | 11.00s |
| coverage_fast_path | 13.26s | 5.46s |

Full `cargo test --release` wall-clock: **~64s** (was dominated by the ~175s serial sum of these suites). CI runners have fewer cores (~3–4), so expect a proportionally smaller but still large cut on the macOS/Windows legs.

## Verification

- `cargo build --release`: zero warnings
- `cargo test --release`: all pass, zero failures (official 509 + regression + selfdiff 2-way/4-way + diff_corpus + metamorphic + coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)