### PR TITLE
ci: cache cargo registry and release build tree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,29 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # Cache the cargo registry and the release build tree so warm runs skip
+      # recompiling the heavy third-party deps (cranelift, serde, proptest),
+      # which dominate the job now that test execution is parallelized. The
+      # key busts on the toolchain version and Cargo.lock; restore-keys lets a
+      # changed lockfile still warm-start from the previous build tree.
+      # actions/cache is GitHub-first-party (same trust boundary as the
+      # checkout / upload-artifact actions already in use).
+      - name: Capture toolchain version
+        id: rust
+        shell: bash
+        run: echo "ver=$(rustc --version | tr ' ' '-')" >> "$GITHUB_OUTPUT"
+
+      - name: Cache cargo registry and build tree
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ steps.rust.outputs.ver }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ steps.rust.outputs.ver }}-
+
       - name: Install jq 1.8.1 (for differential tests)
         shell: bash
         run: |


### PR DESCRIPTION
## Context

After #875 parallelized the differential test suites, test *execution* dropped from ~18 min to ~1 min, but the macOS/Windows CI legs only fell to ~13–15.5 min. The step breakdown shows the new bottleneck is **recompiling the release build tree from scratch every run** — the `Run tests` step spends ~10 min compiling third-party deps (cranelift, serde, proptest) before running anything.

| leg | Build | Run tests (≈compile + run) |
|---|---|---|
| macOS | 1m41s | 11m12s (~10m compile) |
| Windows | 4m20s | 11m05s (~10m compile) |
| ubuntu | 1m41s | 6m04s (~5m compile) |

## Change

Add an `actions/cache` step (GitHub-first-party — same trust boundary as the `actions/checkout` / `actions/upload-artifact` already in use; no new third-party supply-chain surface) that caches `~/.cargo/{registry,git}` and `target/`, keyed on the toolchain version + `Cargo.lock`, with `restore-keys` so a changed lockfile still warm-starts from the previous tree.

Warm runs skip the heavy dep rebuild. Expected: `Run tests` compile portion ~10 min → ~1–2 min, bringing the gate (slowest leg) from ~15.5 min toward ~5–7 min.

## ⚠️ Cold first run

The first CI run on this branch populates the cache **without** benefiting (cold miss). The speedup appears from the **second** run onward. This PR is intentionally **not** auto-merged — I'll trigger a second run to confirm the warm timing before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)