### PR TITLE
ci: ubuntu-only on PR, full matrix daily + on demand; drop LTO in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,16 +5,32 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Daily full-matrix run: catches platform-specific regressions within a day
+  # of merge (PR/push only gate on ubuntu) and gives the proptest suites a
+  # fresh-seed fuzzing cadence. Owner is notified on failure.
+  schedule:
+    - cron: "17 15 * * *" # 00:17 JST
+  # Manual full-matrix run on demand.
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
+  # CI only: drop LTO and maximise codegen parallelism to cut the test-binary
+  # compile (~34% locally). Correctness is unaffected — LTO/codegen-units are
+  # pure optimizations. The shipped binary keeps `lto = "thin"`: release.yml
+  # has no such override, so the tag build still tests the production config.
+  CARGO_PROFILE_RELEASE_LTO: "false"
+  CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "256"
 
 jobs:
   build-and-test:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-2025]
+        # PR / push: ubuntu only (fast feedback). schedule / manual: full
+        # 3-OS matrix. Release coverage on all three lives in release.yml,
+        # which gates the tag build on `cargo test --release`.
+        os: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && fromJSON('["ubuntu-latest", "macos-latest", "windows-2025"]') || fromJSON('["ubuntu-latest"]') }}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Goal

Cut CI wall time further (after #875 parallelized execution), without any third-party actions.

## Changes

**1. Matrix by event**
- **PR / push to main** → `ubuntu-latest` only. Fast merge feedback (~7 min, less with the LTO change below).
- **Daily schedule + `workflow_dispatch`** → full `ubuntu / macOS / windows` matrix.
- **Release** → already full-matrix in `release.yml` (gates the tag build on `cargo test --release`), so a release is never cut without all three passing.

The daily run catches platform-specific regressions within ~24 h of merge (instead of only at release) and doubles as a **fresh-seed proptest fuzzing cadence** — the same mechanism that surfaced #873 and #877. The owner is notified on scheduled-run failure.

Tradeoff: a platform-specific bug merged via an ubuntu-green PR is caught by the next daily run / at release, not at merge time. Acceptable given the daily safety net + release gate.

**2. CI-only build profile**
- `CARGO_PROFILE_RELEASE_LTO=false` + `CARGO_PROFILE_RELEASE_CODEGEN_UNITS=256` in the CI workflow env.
- Measured locally (clean `cargo test --release --no-run`): **53.4 s → 35.0 s (~34%)**. Thin-LTO link cost multiplied across ~35 integration-test binaries was the dominant compile cost.
- Correctness unaffected (pure optimizations). `release.yml` has **no** override → the shipped binary keeps `lto = "thin"` and the tag build still tests the production config.

## Note

This PR runs as a `pull_request` event, so its own CI is the new **ubuntu-only + LTO-off** fast path — a live demo of the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)