### PR TITLE
fix(jit): propagate bail when TryCatch|right pipe's right side can't compile

### DIFF
--- a/src/jit.rs
+++ b/src/jit.rs
@@ -3956,6 +3956,18 @@ impl Flattener {
                     let t_in = test.alloc_slot();
                     if !test.flatten_gen(catch_expr, t_in) { return false; }
                 }
+                // Pre-check: `right` must be compilable too. Both branches below
+                // pipe into it via `flatten_gen(right, …)` whose return value is
+                // ignored, so a `right` that bails mid-compile (e.g. a non-scalar
+                // `reduce` with a `?`-bearing update body, which has no flatten_gen
+                // arm) would leave partial ops yet still report success — silently
+                // dropping the reduce and swallowing its error (#877). The sibling
+                // `Collect | right` arm guards `right` the same way.
+                {
+                    let mut test = self.test_flattener();
+                    let t_in = test.alloc_slot();
+                    if !test.flatten_gen(right, t_in) { return false; }
+                }
 
                 let catch_label = self.alloc_label();
                 let done_label = self.alloc_label();

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -12119,3 +12119,17 @@ false
 .a | length | tostring
 {"a":[1,2]}
 "2"
+
+# #877: array construct via (try…catch…)|(.[0], reduce …) must propagate the
+# reduce source's error, not silently drop the reduce. The reduce's `?`-bearing
+# update body made is_scalar(reduce) false (TryCatch with an empty catch), and
+# the TryCatch|right pipe arm ignored the failed flatten_gen(right) — shipping a
+# JIT program with the reduce dropped, leaking [null] instead of erroring.
+[(try (.) catch (values)) | (.[0]),reduce (.a) as $x (0; . + ($x | tonumber? // 0))]
+[]
+
+# #877: same filter on null takes the no-error path and must still produce both
+# elements (guards the fix from over-bailing when `right` is compilable).
+[(try (.) catch (values)) | (.[0]),reduce (.a) as $x (0; . + ($x | tonumber? // 0))]
+null
+[null,0]


### PR DESCRIPTION
## Summary

Fixes #877. A two-element array construction like

```
[(try (.) catch (values)) | (.[0]), reduce (.a) as $x (0; . + ($x | tonumber? // 0))]
```

emitted `[null]` on input `[]` instead of raising jq's `Cannot index array with string "a"`.

## Root cause

The `TryCatch | right` arm of `flatten_gen_pipe` pipes both the try-branch and catch-branch outputs into `right` via `flatten_gen(right, …)` — but **discards the return value**. When `right` fails to compile, the failure is swallowed: the JIT ships a program with `right` partially/wholly dropped while still reporting success, rather than bailing to the interpreter.

Here `right` is `(.[0], reduce …)`. The reduce's update body `$x | tonumber? // 0` contains a `?`, which desugars to a `TryCatch` with an **empty catch**. `is_scalar` treats that as non-scalar, so the whole `reduce` is non-scalar — and `flatten_gen` has no non-scalar `Reduce` arm, so it returns `false` emitting nothing. The ignored return value let the JIT emit only the `.[0]` element (→ `null`) and finish the array, dropping the reduce and swallowing its source error.

## Fix

Add a `right` pre-check at the top of the `TryCatch | right` arm, mirroring the sibling `Range | right` and `Collect | right` arms that already guard `right` the same way. If `right` isn't compilable, bail to the interpreter (which handles it correctly).

The change is **compile-time only** (a feasibility probe) — no hot-path impact.

## Verification

- `[…] []` now errors (matches jq); `[…] null` still yields `[null,0]` (guards against over-bailing when `right` is compilable).
- `cargo build --release`: zero warnings.
- `cargo test --release`: all pass (official + regression + selfdiff).
- `bench/comprehensive.sh`: in line with `docs/benchmark-history.md` (try-catch 0.023s, alternative // 0.032s, label-break 0.004s) — no regression.
- Regression cases appended to `tests/regression.test` (erroring case + non-erroring guard case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)