### PR TITLE
fix(eval): while/until echo the input instead of null; track paths in path context

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -5558,6 +5558,20 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
                 }
             })
         }
+        // `until(cond; update)` / `while(cond; update)` in path context. jq
+        // desugars them to recursive if/pipe forms that all preserve paths:
+        //   _until: if cond then . else (update | _until) end
+        //   _while: if cond then ., (update | _while) else empty end
+        // so a loop that survives by identity yields the path of the input
+        // (e.g. `path(until(true; .a))` = []) rather than an "Invalid path
+        // expression" error. Mirror the value-mode desugar, tracking the path
+        // through `update` exactly as the Pipe arm composes sub-paths. #882.
+        Expr::Until { cond, update } => {
+            eval_path_until(cond, update, input.clone(), Vec::new(), env, cb)
+        }
+        Expr::While { cond, update } => {
+            eval_path_while(cond, update, input.clone(), Vec::new(), env, cb)
+        }
         Expr::Slice { expr: base_expr, from, to } => {
             // Slice bounds are generators: produce the Cartesian product of
             // path components, nested from (outer) → to (middle) → base (inner),
@@ -6445,6 +6459,57 @@ fn eval_foreach_valuegen_path(
             Ok(true)
         }
     }
+}
+
+/// Path-context evaluation of `until(cond; update)`. Faithful to jq's
+/// `def _until: if cond then . else (update | _until) end;`: when `cond` is
+/// truthy on the current value the current path is emitted; otherwise the path
+/// is extended through `update` (a path expression) and the loop recurses.
+/// `cur_val` is the value at `prefix`; `prefix` is the absolute path from the
+/// document root. See #882.
+fn eval_path_until(
+    cond: &Expr, update: &Expr, cur_val: Value, prefix: Vec<Value>,
+    env: &EnvRef, cb: &mut dyn FnMut(Value) -> GenResult,
+) -> GenResult {
+    stacker::maybe_grow(128 * 1024, 32 * 1024 * 1024, || {
+        eval(cond, cur_val.clone(), env, &mut |cv| {
+            if cv.is_truthy() {
+                cb(Value::Arr(Rc::new(prefix.clone())))
+            } else {
+                eval_path(update, cur_val.clone(), env, &mut |up| {
+                    let sub = crate::runtime::rt_getpath(&cur_val, &up).unwrap_or(Value::Null);
+                    let mut next = prefix.clone();
+                    if let Value::Arr(a) = &up { next.extend(a.iter().cloned()); }
+                    eval_path_until(cond, update, sub, next, env, cb)
+                })
+            }
+        })
+    })
+}
+
+/// Path-context evaluation of `while(cond; update)`. Faithful to jq's
+/// `def _while: if cond then ., (update | _while) else empty end;`: when `cond`
+/// is truthy the current path is emitted AND the loop continues through
+/// `update`; otherwise the branch terminates. See #882.
+fn eval_path_while(
+    cond: &Expr, update: &Expr, cur_val: Value, prefix: Vec<Value>,
+    env: &EnvRef, cb: &mut dyn FnMut(Value) -> GenResult,
+) -> GenResult {
+    stacker::maybe_grow(128 * 1024, 32 * 1024 * 1024, || {
+        eval(cond, cur_val.clone(), env, &mut |cv| {
+            if cv.is_truthy() {
+                if !cb(Value::Arr(Rc::new(prefix.clone())))? { return Ok(false); }
+                eval_path(update, cur_val.clone(), env, &mut |up| {
+                    let sub = crate::runtime::rt_getpath(&cur_val, &up).unwrap_or(Value::Null);
+                    let mut next = prefix.clone();
+                    if let Value::Arr(a) = &up { next.extend(a.iter().cloned()); }
+                    eval_path_while(cond, update, sub, next, env, cb)
+                })
+            } else {
+                Ok(true)
+            }
+        })
+    })
 }
 
 fn eval_recurse_paths(val: &Value, prefix: &Value, cb: &mut dyn FnMut(Value) -> GenResult) -> GenResult {

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -2206,7 +2206,15 @@ fn contains_input(expr: &crate::ir::Expr) -> bool {
         Expr::LetBinding { value, body, .. } => contains_input(value) || contains_input(body),
         Expr::Reduce { source, init, update, .. } => contains_input(source) || contains_input(init) || contains_input(update),
         Expr::Foreach { source, init, update, extract, .. } => contains_input(source) || contains_input(init) || contains_input(update) || extract.as_ref().map_or(false, |e| contains_input(e)),
-        Expr::While { cond, update } | Expr::Until { cond, update } => contains_input(cond) || contains_input(update),
+        // `while(cond; update)` / `until(cond; update)` always emit the current
+        // value (the input) — jq desugars them to `if cond then ., (update|_loop)
+        // …` (while) and `if cond then . else …` (until), both of which yield `.`.
+        // So they are input-dependent regardless of whether cond/update mention
+        // `.`. Classifying e.g. `while(true; empty)` by its sub-exprs marked it
+        // input-free, so the fast path evaluated it against `null` and emitted
+        // `null` instead of echoing the input. Same family as `recurse` (#713)
+        // and the assignment forms (#716) below.
+        Expr::While { .. } | Expr::Until { .. } => true,
         Expr::Repeat { update } => contains_input(update),
         Expr::TryCatch { try_expr, catch_expr, .. } => contains_input(try_expr) || contains_input(catch_expr),
         // CallBuiltin implicitly operates on the current input (passed as first arg)

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -12212,3 +12212,48 @@ try path(. as [[$a],[$b]] | $a) catch .
 try path(foreach .[] as $x (null; $x+1)) catch .
 [1,2]
 "Invalid path expression with result 2"
+
+# #882: while/until with a constant-true cond and an empty update emit the input (not null).
+while(true; empty)
+5
+5
+
+# #882: until with a constant-true cond and an empty update echoes the input.
+until(true; empty)
+{"a":1}
+{"a":1}
+
+# #882: a statically-truthy (non-literal) cond with an empty update still passes input through.
+while(1==1; empty)
+[1,2]
+[1,2]
+
+# #882: a zero-output update (range(0)) under a true cond passes input through once.
+while(true; range(0))
+"x"
+"x"
+
+# #882: first() over while(true; empty) yields the input, not null.
+first(while(true; empty), 88)
+7
+7
+
+# #882: until as a path expression — identity-surviving loop yields the input path [].
+path(until(true; .a))
+{"a":1}
+[]
+
+# #882: until navigating via .a until the value is an array tracks the path.
+path(until(type=="array"; .a))
+{"a":{"a":[1]}}
+["a","a"]
+
+# #882: while as a path expression tracks every emitted value's path.
+[path(while(.a|type=="object"; .a))]
+{"a":{"a":{}}}
+[[],["a"]]
+
+# #882: assignment through an until path navigates and updates the surviving leaf.
+(until(.a|not; .a)) = 9
+{"a":{"a":{}}}
+{"a":{"a":9}}


### PR DESCRIPTION
## Summary

`while`/`until` with a compile-time-constant truthy condition and an empty/error update body emitted `null` instead of passing the input through unchanged. Found via the round-5 differential bug sweep.

Root cause: the binary's `detect_input_free_output` raw-byte fast path uses `contains_input`, which classified `while(cond; update)` / `until(cond; update)` by their cond/update sub-expressions alone. Both constructs **always emit the current value** (jq desugars them to `if cond then ., (update|_loop) … end` and `if cond then . else … end`, both yielding `.`), so a loop whose cond/update never mention `.` — e.g. `while(true; empty)` — was wrongly marked input-free, evaluated against `null`, and emitted `null`. Now While/Until are unconditionally input-dependent, matching the existing `recurse` (#713) and assignment-form (#716) precedents.

This PR also closes the second manifestation documented in #882: `while`/`until` as **path expressions**. They previously fell through to "Invalid path expression"; new `eval_path` arms mirror the desugar (composing the path through `update` like the `Pipe` arm), so identity-surviving loops yield the input's path.

## Repro (before → after)

```
$ echo 5 | jq-jit -c 'while(true; empty)'      # was: null   now: 5
$ echo 5 | jq-jit -c 'until(true; empty)'      # was: null   now: 5
$ echo '{"a":1}' | jq-jit -c 'path(until(true; .a))'  # was: error  now: []
$ echo '{"a":{"a":[1]}}' | jq-jit -c 'path(until(type=="array"; .a))'  # ["a","a"]
```

All match the jq 1.8.1 oracle.

## Tests
- Added 9 regression cases to `tests/regression.test` (value-mode passthrough, `first()` wrapping, path-context tracking, assignment through an until path).
- `cargo build --release` zero warnings; `cargo test --release` all pass (incl. selfdiff jit/interp + layers).
- `bench/comprehensive.sh`: within noise of v1.8.1 (p126 +1.8% / +4.5% is the documented eval.rs layout-lottery jitter; the fix touches neither the reduce nor mutate hot path).

Closes #882

🤖 Generated with [Claude Code](https://claude.com/claude-code)