### PR TITLE
fix(parser): INDEX desugar via setpath assignment so a generator key keeps all keys

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3501,6 +3501,35 @@ impl Parser {
         }
     }
 
+    /// Desugar `INDEX(stream; f)` to jq's real definition
+    /// `reduce stream as $x ({}; .[$x|f|tostring] = $x)`. The assignment LHS is
+    /// a path expression whose key (`$x|f|tostring`) may be a generator; each
+    /// produced key is then set to `$x` (last-write-wins across the fan-out).
+    /// The earlier `. + {($x|f|tostring): $x}` object-merge collapsed a
+    /// multi-output index expression to only its last key. See #883.
+    fn index_reduce(stream: Expr, f: Expr, x_var: u16, acc_var: u16) -> Expr {
+        let key = Expr::Pipe {
+            left: Box::new(Expr::LoadVar { var_index: x_var }),
+            right: Box::new(Expr::Pipe {
+                left: Box::new(f),
+                right: Box::new(Expr::UnaryOp { op: UnaryOp::ToString, operand: Box::new(Expr::Input) }),
+            }),
+        };
+        Expr::Reduce {
+            source: Box::new(stream),
+            init: Box::new(Expr::ObjectConstruct { pairs: vec![] }),
+            var_index: x_var,
+            acc_index: acc_var,
+            update: Box::new(Expr::Assign {
+                path_expr: Box::new(Expr::Index {
+                    expr: Box::new(Expr::Input),
+                    key: Box::new(key),
+                }),
+                value_expr: Box::new(Expr::LoadVar { var_index: x_var }),
+            }),
+        }
+    }
+
     fn compile_funcall(&mut self, name: &str, args: Vec<Expr>) -> Result<Expr> {
         // User-defined functions shadow builtins (matches jq semantics).
         if let Some(func_id) = self.scope.lookup_func(name, args.len()) {
@@ -4282,58 +4311,16 @@ impl Parser {
                 let stream = Expr::Each { input_expr: Box::new(Expr::Input) };
                 let x_var = self.scope.alloc_var("__idx_x__");
                 let acc_var = self.scope.alloc_var("__idx_acc__");
-                Ok(Expr::Reduce {
-                    source: Box::new(stream),
-                    init: Box::new(Expr::ObjectConstruct { pairs: vec![] }),
-                    var_index: x_var,
-                    acc_index: acc_var,
-                    update: Box::new(Expr::BinOp {
-                        op: BinOp::Add,
-                        lhs: Box::new(Expr::Input),
-                        rhs: Box::new(Expr::ObjectConstruct {
-                            pairs: vec![(
-                                Expr::Pipe {
-                                    left: Box::new(Expr::LoadVar { var_index: x_var }),
-                                    right: Box::new(Expr::Pipe {
-                                        left: Box::new(f),
-                                        right: Box::new(Expr::UnaryOp { op: UnaryOp::ToString, operand: Box::new(Expr::Input) }),
-                                    }),
-                                },
-                                Expr::LoadVar { var_index: x_var },
-                            )],
-                        }),
-                    }),
-                })
+                Ok(Self::index_reduce(stream, f, x_var, acc_var))
             }
-            // INDEX/2: INDEX(stream; f) = reduce stream as $x ({}; . + {($x|f|tostring): $x})
+            // INDEX/2: INDEX(stream; f) = reduce stream as $x ({}; .[$x|f|tostring] = $x)
             ("INDEX", 2) => {
                 let mut args = args.into_iter();
                 let stream = args.next().unwrap();
                 let f = args.next().unwrap();
                 let x_var = self.scope.alloc_var("__idx_x__");
                 let acc_var = self.scope.alloc_var("__idx_acc__");
-                Ok(Expr::Reduce {
-                    source: Box::new(stream),
-                    init: Box::new(Expr::ObjectConstruct { pairs: vec![] }),
-                    var_index: x_var,
-                    acc_index: acc_var,
-                    update: Box::new(Expr::BinOp {
-                        op: BinOp::Add,
-                        lhs: Box::new(Expr::Input),
-                        rhs: Box::new(Expr::ObjectConstruct {
-                            pairs: vec![(
-                                Expr::Pipe {
-                                    left: Box::new(Expr::LoadVar { var_index: x_var }),
-                                    right: Box::new(Expr::Pipe {
-                                        left: Box::new(f),
-                                        right: Box::new(Expr::UnaryOp { op: UnaryOp::ToString, operand: Box::new(Expr::Input) }),
-                                    }),
-                                },
-                                Expr::LoadVar { var_index: x_var },
-                            )],
-                        }),
-                    }),
-                })
+                Ok(Self::index_reduce(stream, f, x_var, acc_var))
             }
             // JOIN/2: JOIN($idx; f) = [.[] | [., $idx[f|tostring]]]
             ("JOIN", 2) => {

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -12257,3 +12257,28 @@ path(until(type=="array"; .a))
 (until(.a|not; .a)) = 9
 {"a":{"a":{}}}
 {"a":{"a":9}}
+
+# #883: INDEX with a generator index-expression sets one key per emitted value (not just the last).
+INDEX(.[]; .[])
+[["a","b"]]
+{"a":["a","b"],"b":["a","b"]}
+
+# #883: INDEX/1 with a multi-output index expression keeps every key.
+INDEX(.[])
+[[1,2,3]]
+{"1":[1,2,3],"2":[1,2,3],"3":[1,2,3]}
+
+# #883: multi-row multi-output INDEX preserves last-write-wins overwrite ordering.
+INDEX(.[]; .[])
+[["a","b"],["b","c"]]
+{"a":["a","b"],"b":["b","c"],"c":["b","c"]}
+
+# #883: a comma index-expression (INDEX(.a,.b)) fans out to both keys.
+INDEX(.a,.b)
+[{"a":1,"b":2}]
+{"1":{"a":1,"b":2},"2":{"a":1,"b":2}}
+
+# #883: ordinary single-key INDEX still de-duplicates by last-write-wins.
+INDEX(.[]; .id)
+[{"id":1},{"id":1,"x":9},{"id":2}]
+{"1":{"id":1,"x":9},"2":{"id":2}}


### PR DESCRIPTION
## Summary

`INDEX` collapsed to only the **last** key when the index expression was a generator. Found via the round-5 differential bug sweep.

Root cause: `INDEX(stream; f)` was desugared to `reduce stream as $x ({}; . + {($x|f|tostring): $x})`. An object-construct with a generator key keeps only the last emitted key, so `INDEX(.[]; .[])` over `[["a","b"]]` returned `{"b":...}` instead of `{"a":...,"b":...}`.

Fix: use jq's real definition `reduce stream as $x ({}; .[$x|f|tostring] = $x)` — the assignment LHS is a path expression whose key may be a generator, so each produced key is set to `$x` (last-write-wins across the fan-out). INDEX/1 and INDEX/2 now share one `index_reduce` helper.

## Repro (before → after)

```
$ echo '[["a","b"]]' | jq-jit -c 'INDEX(.[]; .[])'
# was: {"b":["a","b"]}   now: {"a":["a","b"],"b":["a","b"]}
$ echo '[[1,2,3]]' | jq-jit -c 'INDEX(.[])'
# was: {"3":[1,2,3]}     now: {"1":...,"2":...,"3":...}
```

Ordinary single-key INDEX (`INDEX(.id)`) and last-write-wins de-dup are unchanged; all match the jq 1.8.1 oracle.

## Tests
- 5 regression cases added to `tests/regression.test` (multi-output, multi-row overwrite ordering, comma index-expr, single-key control).
- `cargo build --release` zero warnings; `cargo test --release` all pass.
- `bench/comprehensive.sh`: within noise of v1.8.1 (parser-only change; p126 jitter is the documented layout-lottery, eval hot path untouched).

Closes #883

🤖 Generated with [Claude Code](https://claude.com/claude-code)