### PR TITLE
fix(runtime): normalize negative delpaths indices before the descending-order delete

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2787,8 +2787,39 @@ pub fn rt_delpaths(v: &Value, paths: &Value) -> Result<Value> {
             // whose parent is not an array is left intact so `delete_path`
             // raises jq's type error (non-array container) or no-ops (missing
             // key). See #841/#842/#843.
-            let mut expanded: Vec<Value> = Vec::with_capacity(ps.len());
-            for path in ps.iter() {
+            // Resolve negative array indices to their absolute positions
+            // BEFORE sorting/dedup/delete. jq's `delpaths_sorted` normalizes
+            // each path against the ORIGINAL document so e.g. `[[-1],[2]]` on
+            // `[1,2,3]` collapses to a single deletion (both name index 2), and
+            // the descending-delete safety property holds. Without this, the raw
+            // `[-1]` sorts before `[2]` and the wrong elements are removed. Each
+            // negative component is resolved against the array at its (already
+            // normalized) parent path; non-array parents leave it untouched so
+            // `delete_path` still raises jq's type error / no-ops. See #884.
+            let normalized: Vec<Value> = ps
+                .iter()
+                .map(|path| match path {
+                    Value::Arr(pa) => {
+                        let mut np: Vec<Value> = Vec::with_capacity(pa.len());
+                        for comp in pa.iter() {
+                            let parent =
+                                rt_getpath(v, &Value::Arr(Rc::new(np.clone()))).unwrap_or(Value::Null);
+                            let nc = match (&parent, comp) {
+                                (Value::Arr(arr), Value::Num(n, _)) if *n < 0.0 => {
+                                    let idx = *n as i64 + arr.len() as i64;
+                                    if idx >= 0 { Value::number(idx as f64) } else { comp.clone() }
+                                }
+                                _ => comp.clone(),
+                            };
+                            np.push(nc);
+                        }
+                        Value::Arr(Rc::new(np))
+                    }
+                    other => other.clone(),
+                })
+                .collect();
+            let mut expanded: Vec<Value> = Vec::with_capacity(normalized.len());
+            for path in normalized.iter() {
                 if let Value::Arr(pa) = path {
                     if let Some(Value::Obj(ObjInner(spec))) = pa.last() {
                         let parent: Vec<Value> = pa[..pa.len() - 1].to_vec();

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -12282,3 +12282,28 @@ INDEX(.a,.b)
 INDEX(.[]; .id)
 [{"id":1},{"id":1,"x":9},{"id":2}]
 {"1":{"id":1,"x":9},"2":{"id":2}}
+
+# #884: delpaths normalizes a negative index against a positive twin before dedup.
+delpaths([[-1],[2]])
+[1,2,3]
+[1,2]
+
+# #884: delpaths deletes both elements when given two negative indices.
+delpaths([[-1],[-2]])
+[1,2]
+[]
+
+# #884: scattered negative indices delete the correct (descending) positions.
+delpaths([[-3],[-1],[-5]])
+[1,2,3,4,5,6]
+[1,3,5]
+
+# #884: negative indices nested under an object key are resolved against that array.
+delpaths([["a",-1],["a",-2]])
+{"a":[1,2,3,4]}
+{"a":[1,2]}
+
+# #884: an out-of-range negative index is a no-op (matches jq).
+delpaths([[-10]])
+[1,2]
+[1,2]


### PR DESCRIPTION
## Summary

`delpaths` with negative array indices deleted the wrong elements. Found via the round-5 differential bug sweep.

Root cause: the path pre-pass resolved terminal *slice* components against the original array but never normalized negative *integer* indices. The raw path values were sorted and deleted last-to-first, so `[-1]` sorted before `[2]` and the descending-delete safety property broke; negatives were also not deduped against their positive twins.

Fix: resolve each negative array index to its absolute position against the array at its (already normalized) parent path in the original document, before the existing slice-expansion / sort / dedup / reverse-delete pipeline — matching jq's `delpaths_sorted`. Out-of-range negatives and non-array parents are left untouched so `delete_path` still no-ops / raises jq's type error.

## Repro (before → after)

```
$ echo '[1,2,3]'   | jq-jit -c 'delpaths([[-1],[2]])'   # was [1]   now [1,2]
$ echo '[1,2]'     | jq-jit -c 'delpaths([[-1],[-2]])'  # was [1]   now []
$ echo '{"a":[1,2,3,4]}' | jq-jit -c 'delpaths([["a",-1],["a",-2]])'  # was {"a":[1,3]} now {"a":[1,2]}
```

All match the jq 1.8.1 oracle. `del(.[-1],.[-2])`, positive-index, slice, and overlapping-path deletes are unchanged.

## Tests
- 5 regression cases added (negative/positive twin dedup, multiple negatives, nested-under-object, out-of-range no-op).
- `cargo build --release` zero warnings; `cargo test --release` all pass.
- `bench/comprehensive.sh`: within noise of v1.8.1 (del benches normal, p126 unaffected).

Closes #884

🤖 Generated with [Claude Code](https://claude.com/claude-code)