### PR TITLE
fix(bsearch): round the midpoint up to match jq's index for duplicate targets

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -7577,7 +7577,12 @@ fn rt_bsearch(input: &Value, target: &Value) -> Result<Value> {
             let mut lo: i64 = 0;
             let mut hi: i64 = a.len() as i64 - 1;
             while lo <= hi {
-                let mid = (lo + hi) / 2;
+                // jq's `bsearch` (builtin.jq) rounds the midpoint UP —
+                // `((.[0]+.[1]+1)/2)|floor` — so for a run of equal elements it
+                // converges on a higher index than a floor-midpoint search. The
+                // returned index is an observable, deterministic value, so the
+                // midpoint must match jq's exactly. See #887.
+                let mid = (lo + hi + 1) / 2;
                 let cmp = crate::runtime::compare_values(&a[mid as usize], target);
                 match cmp {
                     std::cmp::Ordering::Equal => return Ok(Value::number(mid as f64)),

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -630,7 +630,10 @@ pub fn call_builtin(name: &str, args: &[Value]) -> Result<Value> {
                     let mut lo: i64 = 0;
                     let mut hi: i64 = a.len() as i64 - 1;
                     while lo <= hi {
-                        let mid = (lo + hi) / 2;
+                        // jq's `bsearch` rounds the midpoint UP (see eval.rs
+                        // `rt_bsearch` / #887), converging on a higher index for
+                        // runs of equal elements.
+                        let mid = (lo + hi + 1) / 2;
                         let cmp = compare_values(&a[mid as usize], target);
                         match cmp {
                             std::cmp::Ordering::Equal => return Ok(Value::number(mid as f64)),

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -12357,3 +12357,28 @@ reduce .[] as [$ENV] (null; $ENV)
 "hi" as $ENV | $ENV
 null
 "hi"
+
+# #887: bsearch on a duplicate target converges on jq's (higher) index via a ceil midpoint.
+bsearch(1)
+[1,1]
+1
+
+# #887: an even-width run of equal elements returns jq's midpoint-up index.
+bsearch(2)
+[2,2,2,2]
+2
+
+# #887: bsearch inside a longer array with a run of equal targets.
+bsearch(3)
+[1,2,3,3,3,5]
+3
+
+# #887: bsearch is type-agnostic — string duplicates match jq too.
+bsearch("b")
+["a","b","b","c"]
+2
+
+# #887: a not-found target still returns jq's -1-insertion_point.
+bsearch(2)
+[1,3,5]
+-2


### PR DESCRIPTION
## Summary

`bsearch` returned the wrong index for a target that appears multiple times in the sorted array. Found via the round-5 differential bug sweep.

jq's `bsearch` (builtin.jq) computes the midpoint as `((.[0]+.[1]+1)/2)|floor` — it rounds **up** — so for a run of equal elements it converges on a higher index than the floor-midpoint search jq-jit used. The returned index is an observable, deterministic value.

Fix: change the midpoint in both implementations (`eval.rs` `rt_bsearch` and the `runtime.rs` dispatch) from `(lo+hi)/2` to `(lo+hi+1)/2`.

## Repro (before → after)

```
$ echo '[1,1]'     | jq-jit -c 'bsearch(1)'   # was 0  now 1
$ echo '[2,2,2,2]' | jq-jit -c 'bsearch(2)'   # was 1  now 2
$ echo '[1,2,3,3,3,5]' | jq-jit -c 'bsearch(3)'  # was 2  now 3
```

Verified against jq 1.8.1 across a grid of array shapes (including string/null/array elements) and targets — found-duplicate and not-found (`-1 - insertion_point`) cases all match.

## Tests
- 5 regression cases added (duplicate target, even-width run, string elements, not-found).
- `cargo build --release` zero warnings; `cargo test --release` all pass.
- `bench/comprehensive.sh`: one-line formula change in a cold function; same-machine interleaved A/B on p126 (main vs branch: identical) confirms no regression.

Closes #887

🤖 Generated with [Claude Code](https://claude.com/claude-code)