### PR TITLE
fix(parser): reject a constant non-string literal as a destructuring pattern key

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1913,6 +1913,25 @@ impl Parser {
                 self.advance();
                 let key_expr = self.parse_pipe()?;
                 self.expect(&Token::RParen)?;
+                // jq rejects a constant non-string literal key at compile time
+                // ("Cannot use number (0) as object key"); jq-jit otherwise
+                // deferred to runtime and treated `(0)` as the index `.[0]`,
+                // returning a value for array input. Only literal constants are
+                // rejected — runtime expressions like `(.x)` / `(0|tostring)`
+                // and a negated `(-0)` (a Negate node, not a literal) defer as
+                // before. See #888.
+                if let Expr::Literal(lit) = &key_expr {
+                    let bad = match lit {
+                        Literal::Num(n, _) => Some(("number", crate::value::format_jq_number(*n))),
+                        Literal::Null => Some(("null", "null".to_string())),
+                        Literal::True => Some(("boolean", "true".to_string())),
+                        Literal::False => Some(("boolean", "false".to_string())),
+                        Literal::Str(_) => None,
+                    };
+                    if let Some((ty, val)) = bad {
+                        bail!("Cannot use {} ({}) as object key", ty, val);
+                    }
+                }
                 self.expect(&Token::Colon)?;
                 let pat = self.parse_pattern()?;
                 Ok((key_expr, pat))

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -12382,3 +12382,18 @@ bsearch("b")
 bsearch(2)
 [1,3,5]
 -2
+
+# #888: a constant string key in a destructuring pattern still works (not over-rejected).
+. as {("x"):$v} | $v
+{"x":1}
+1
+
+# #888: a runtime-computed pattern key (.k) is deferred, not rejected.
+. as {(.k):$v} | $v
+{"k":"a","a":9}
+9
+
+# #888: a string-producing pipe key (0|tostring) is allowed.
+. as {(0|tostring):$v} | $v
+{"0":7}
+7


### PR DESCRIPTION
## Summary

A computed object-pattern key `(expr)` in a destructuring binding deferred all keys to runtime, so a constant non-string literal like `. as {(0):$v}` was treated as the index `.[0]` and returned a value for array input, where jq rejects it at compile time. Found via the round-5 differential bug sweep.

Fix: reject a literal `Num`/`Null`/`True`/`False` pattern key at parse time with jq's wording ("Cannot use number (0) as object key"). Only literal constants are rejected — runtime expressions (`(.x)`, `(0|tostring)`), string literals, and a negated `(-0)` (a Negate node, not a literal, which jq itself defers to runtime) are unaffected.

## Repro (before → after)

```
$ echo '[10,20]' | jq-jit -c '. as {(0):$v}|$v'      # was 10   now: Cannot use number (0) as object key
$ echo '[[1,2]]' | jq-jit -c 'reduce .[] as {(0):$x} (0;.+$x)'  # was 4  now: compile error
```

Matches jq 1.8.1 exactly (wording included). String keys, runtime-computed keys, and object construction `{(0):1}` are unchanged.

## Tests
- 3 control regression cases (string / runtime / pipe-to-string keys keep working — guards against over-rejection).
- `cargo build --release` zero warnings; `cargo test --release` all pass.
- `bench/comprehensive.sh`: parser-only (parse-time validation); no eval.rs / runtime change, so p126 is unaffected (the run's drift is the documented machine-load noise confirmed by prior A/Bs).

Closes #888

🤖 Generated with [Claude Code](https://claude.com/claude-code)