### PR TITLE
fix(cli): -R keeps a trailing CR; split raw input on \n only (jq compat)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -40,9 +40,20 @@ fn json_inputs_with_lines(content: &str) -> Result<Vec<(Value, u64)>, String> {
 }
 
 /// Raw (`-R`) input lines paired with their 1-based line numbers (#855).
+/// Split raw (`-R`) input into lines the way jq does: on `\n` ONLY, keeping any
+/// trailing `\r` as line content (so a CRLF file yields `"a\r"`). Rust's
+/// `str::lines()` / `BufRead::lines()` additionally strip a trailing `\r`, which
+/// diverges from jq. A trailing newline does not produce an empty final line,
+/// and empty input yields no lines at all. See #889.
+fn split_raw_lines(content: &str) -> impl Iterator<Item = &str> {
+    let body = content.strip_suffix('\n').unwrap_or(content);
+    // `"".split('\n')` would yield one empty line; empty input must yield none.
+    let n = if content.is_empty() { 0 } else { usize::MAX };
+    body.split('\n').take(n)
+}
+
 fn raw_inputs_with_lines(content: &str) -> Vec<(Value, u64)> {
-    content
-        .lines()
+    split_raw_lines(content)
         .enumerate()
         .map(|(i, l)| (Value::from_str(l), (i + 1) as u64))
         .collect()
@@ -3588,9 +3599,21 @@ fn real_main() {
                 }
                 process_input(&Value::from_str(&buf), None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
             } else {
-                for line in stdin.lock().lines() {
-                    match line {
-                        Ok(l) => {
+                // Stream line-by-line, splitting on '\n' only and keeping any
+                // trailing '\r' (jq compat, #889). `BufRead::lines()` would strip
+                // the CR; `read_until` preserves it and keeps the path streaming
+                // (so e.g. `tail -f | jq -R` still works incrementally).
+                let mut reader = stdin.lock();
+                let mut buf: Vec<u8> = Vec::new();
+                loop {
+                    buf.clear();
+                    match reader.read_until(b'\n', &mut buf) {
+                        Ok(0) => break,
+                        Ok(_) => {
+                            if buf.last() == Some(&b'\n') {
+                                buf.pop();
+                            }
+                            let l = String::from_utf8_lossy(&buf);
                             process_input(&Value::from_str(&l), None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }
                         Err(e) => {
@@ -12609,7 +12632,7 @@ fn real_main() {
                 io::stdin().lock().read_to_string(&mut s).unwrap_or(0);
                 if slurp {
                     if raw_input {
-                        for line in s.lines() {
+                        for line in split_raw_lines(&s) {
                             slurp_values.push(Value::from_str(line));
                         }
                     } else {
@@ -12619,7 +12642,7 @@ fn real_main() {
                         }
                     }
                 } else if raw_input {
-                    for line in s.lines() {
+                    for line in split_raw_lines(&s) {
                         let val = Value::from_str(line);
                         process_input(&val, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                     }
@@ -12668,7 +12691,7 @@ fn real_main() {
                 // Slurp: collect all JSON values into an array, process once
                 let mut values = Vec::new();
                 let r = if raw_input {
-                    for line in content.lines() {
+                    for line in split_raw_lines(content) {
                         values.push(Value::from_str(line));
                     }
                     Ok(())

--- a/tests/raw_input_crlf.rs
+++ b/tests/raw_input_crlf.rs
@@ -1,0 +1,74 @@
+//! Issue #889: `-R` (raw input) must split on `\n` only and keep a trailing
+//! `\r` as line content (a CRLF file yields `"a\r"`), matching jq. Rust's
+//! `lines()` strips the CR. The regression-test harness can't express the `-R`
+//! flag, so shell out directly and assert exact stdout (CR included).
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn run(args: &[&str], stdin: &[u8]) -> String {
+    let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
+    let mut child = Command::new(jq_jit)
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn jq-jit");
+    child.stdin.take().unwrap().write_all(stdin).unwrap();
+    let out = child.wait_with_output().expect("wait failed");
+    String::from_utf8(out.stdout)
+        .expect("non-utf8 stdout")
+        .trim_end_matches('\n')
+        .to_string()
+}
+
+#[test]
+fn crlf_line_keeps_trailing_cr() {
+    // "a\r\n" -> one line "a\r" (jq escapes the CR as \r in JSON output).
+    assert_eq!(run(&["-Rc", "."], b"a\r\n"), r#""a\r""#);
+}
+
+#[test]
+fn crlf_line_length_counts_the_cr() {
+    assert_eq!(run(&["-Rc", ".|length"], b"a\r\n"), "2");
+}
+
+#[test]
+fn multiple_crlf_lines_each_keep_cr() {
+    assert_eq!(
+        run(&["-Rc", "."], b"a\r\nb\r\n"),
+        "\"a\\r\"\n\"b\\r\""
+    );
+}
+
+#[test]
+fn lone_cr_mid_line_is_preserved() {
+    assert_eq!(run(&["-Rc", "."], b"a\rb\r\n"), r#""a\rb\r""#);
+}
+
+#[test]
+fn lf_only_lines_are_unaffected() {
+    assert_eq!(run(&["-Rc", "."], b"a\nb"), "\"a\"\n\"b\"");
+}
+
+#[test]
+fn trailing_newline_yields_no_empty_final_line() {
+    assert_eq!(run(&["-Rc", "."], b"a\n"), "\"a\"");
+}
+
+#[test]
+fn empty_input_yields_no_lines() {
+    assert_eq!(run(&["-Rc", "."], b""), "");
+}
+
+#[test]
+fn bare_newline_yields_one_empty_line() {
+    assert_eq!(run(&["-Rc", "."], b"\n"), "\"\"");
+}
+
+#[test]
+fn slurp_raw_keeps_cr_unchanged() {
+    // -Rs reads the whole input as one string; the CR was already preserved.
+    assert_eq!(run(&["-Rsc", ".|length"], b"a\r\nb"), "4");
+}


### PR DESCRIPTION
## Summary

`-R` (raw input) stripped a trailing `\r` from a `\r\n` line ending. Found via the round-5 differential bug sweep.

jq splits raw input on `\n` **only** and keeps a trailing `\r` as line content, so a CRLF stream yields `"a\r"`. jq-jit used Rust's `str::lines()` / `BufRead::lines()`, which strip the CR.

Fix: add a `split_raw_lines` helper (split on `\n`, keep `\r`, a trailing newline yields no empty final line, empty input yields no lines) and route every raw-input line split through it. The streaming stdin path now reads with `read_until(b'\n')` instead of `BufRead::lines()`, preserving both the CR and incremental streaming (`tail -f | jq-jit -R` still works).

## Repro (before → after)

```
$ printf 'a\r\n' | jq-jit -R -c '.'         # was "a"  now "a\r"
$ printf 'a\r\n' | jq-jit -R -c '.|length'  # was 1    now 2
```

Verified byte-for-byte against jq 1.8.1 across stdin streaming, `-Rs` slurp, and the `inputs` builtin paths.

Note: `-R` with a **file argument** is independently broken on `main` (it tries to parse the file as JSON / mis-slurps) — a separate pre-existing bug unrelated to this CR-stripping fix, left out of scope.

## Tests
- New `tests/raw_input_crlf.rs` integration test (9 cases: CRLF, multi-line, lone CR, LF-only, trailing-newline, empty, bare-newline, slurp).
- `cargo build --release` zero warnings; `cargo test --release` all pass.
- `bench/comprehensive.sh`: CLI-only change (no eval.rs touch); p126 unaffected (run drift is the documented machine-load noise).

Closes #889

🤖 Generated with [Claude Code](https://claude.com/claude-code)