### PR TITLE
fix(cli): --seq omits the RS prefix for raw string output (-r/-j)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -3417,8 +3417,11 @@ fn real_main() {
             }
             // RFC 7464 JSON Text Sequences: every output value is preceded
             // by an RS (0x1e) byte. The trailing LF is already produced by
-            // each emitter below.
-            if seq {
+            // each emitter below. jq omits the RS for a RAW STRING output
+            // (`-r`/`-j` applied to a string), since that bypasses the JSON
+            // dumper; numbers/bools/arrays/objects (JSON-encoded even under
+            // `-r`) and default JSON output keep the RS. See #890.
+            if seq && !(raw_output && matches!(result, Value::Str(_))) {
                 if use_compact_buf || use_pretty_buf {
                     cbuf.push(0x1e);
                 } else {

--- a/tests/seq_raw_string.rs
+++ b/tests/seq_raw_string.rs
@@ -1,0 +1,54 @@
+//! Issue #890: under `--seq`, jq omits the RS (0x1e) record-separator prefix for
+//! a RAW STRING output (`-r` / `-j` applied to a string), since that bypasses the
+//! JSON dumper. Numbers/bools/arrays/objects (JSON-encoded even under `-r`) and
+//! default JSON output keep the RS. The regression-test harness can't express
+//! `--seq`, so shell out and assert exact stdout bytes.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+/// Run jq-jit with the given args, feeding `stdin`, returning raw stdout bytes.
+fn run(args: &[&str], stdin: &[u8]) -> Vec<u8> {
+    let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
+    let mut child = Command::new(jq_jit)
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn jq-jit");
+    child.stdin.take().unwrap().write_all(stdin).unwrap();
+    child.wait_with_output().expect("wait failed").stdout
+}
+
+// RS-framed input so the --seq parser is happy.
+const IN_STR: &[u8] = b"\x1e\"a\"\n";
+const IN_NUM: &[u8] = b"\x1e5\n";
+
+#[test]
+fn raw_string_output_omits_rs() {
+    // -j on a string: just the bytes, no RS.
+    assert_eq!(run(&["--seq", "-j", "."], IN_STR), b"a");
+    // -r on a string: bytes + newline, no RS.
+    assert_eq!(run(&["--seq", "-r", "."], IN_STR), b"a\n");
+}
+
+#[test]
+fn raw_number_output_keeps_rs() {
+    // A number is JSON-encoded even under -r, so the RS stays.
+    assert_eq!(run(&["--seq", "-r", "."], IN_NUM), b"\x1e5\n");
+}
+
+#[test]
+fn default_json_string_keeps_rs() {
+    // No -r/-j: default JSON output keeps the RS.
+    assert_eq!(run(&["--seq", "-c", "."], IN_STR), b"\x1e\"a\"\n");
+}
+
+#[test]
+fn multiple_raw_strings_have_no_separators() {
+    assert_eq!(
+        run(&["--seq", "-j", "."], b"\x1e\"a\"\n\x1e\"b\"\n"),
+        b"ab"
+    );
+}


### PR DESCRIPTION
## Summary

Under `--seq`, jq-jit prepended the RS (0x1e) record separator to **every** output. jq omits the RS for a RAW STRING output (`-r`/`-j` applied to a string) because that bypasses the JSON dumper; numbers/bools/arrays/objects (JSON-encoded even under `-r`) and default JSON output keep it. Found via the round-5 differential bug sweep.

So `printf '\x1e"a"\n' | jq-jit --seq -j .` emitted `\x1ea` where jq emits `a`.

Fix: skip the RS only when `raw_output` is set and the value is a string. (`-j` sets `raw_output`, so both `-r` and `-j` are covered.)

## Repro (before → after)

```
$ printf '\x1e"a"\n' | jq-jit --seq -j '.' | xxd   # was: 1e 61   now: 61
$ printf '\x1e"a"\n' | jq-jit --seq -r '.' | xxd   # was: 1e 61 0a now: 61 0a
```

Controls that keep the RS (unchanged, all match jq): `--seq -r` on a number, `--seq -c` on a string.

## Tests
- New `tests/seq_raw_string.rs` (4 cases: raw string omits RS, raw number keeps RS, default JSON keeps RS, multiple raw strings have no separators). Verified byte-for-byte against jq 1.8.1 across flags × value types.
- `cargo build --release` zero warnings; `cargo test --release` all pass.
- `bench/comprehensive.sh`: the change is `--seq`-gated, so every benchmark (no `--seq`) takes the byte-identical short-circuit path; p126 drift is the documented machine-load noise.

Closes #890

🤖 Generated with [Claude Code](https://claude.com/claude-code)