### PR TITLE
fix(parser): allow builtin names empty/not/error as user def/parameter names

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1065,10 +1065,31 @@ impl Parser {
         Ok(result)
     }
 
+    /// jq treats the builtin names `empty`/`not`/`error` and the literal
+    /// keywords `true`/`false`/`null` as ordinary identifiers in function-name
+    /// and parameter-name position, so a user `def` may carry one of these
+    /// names. Our lexer emits dedicated tokens for them; map those back to the
+    /// identifier string here (#902). Returns None for genuine keywords
+    /// (`if`/`reduce`/`as`/…) that jq also rejects in this position.
+    fn def_name_token(t: &Token) -> Option<&'static str> {
+        match t {
+            Token::Empty => Some("empty"),
+            Token::Not => Some("not"),
+            Token::Error => Some("error"),
+            Token::True => Some("true"),
+            Token::False => Some("false"),
+            Token::Null => Some("null"),
+            _ => None,
+        }
+    }
+
     fn parse_funcdef(&mut self) -> Result<()> {
         self.expect(&Token::Def)?;
         let name = match self.advance() {
             Token::Ident(s) => s,
+            ref t if Self::def_name_token(t).is_some() => {
+                Self::def_name_token(t).unwrap().to_string()
+            }
             t => bail!("expected function name, got {:?}", t),
         };
 
@@ -1081,6 +1102,9 @@ impl Parser {
                     Token::Variable(p) => params.push((p, true)),
                     Token::RParen => break,
                     Token::Semicolon => continue,
+                    ref t if Self::def_name_token(t).is_some() => {
+                        params.push((Self::def_name_token(t).unwrap().to_string(), false))
+                    }
                     t => bail!("expected parameter name, got {:?}", t),
                 }
             }
@@ -2701,9 +2725,14 @@ impl Parser {
                 }
             }
 
+            // `empty`, `error`, and `not` are ordinary builtins in jq, not
+            // reserved words, so a user `def` (or a same-named parameter) may
+            // shadow them. Route through the shadow-aware resolvers — they look
+            // up a user func / filter param first and fall back to the builtin
+            // Expr only when nothing shadows it (#902).
             Token::Empty => {
                 self.advance();
-                Ok(Expr::Empty)
+                self.compile_builtin_noargs("empty")
             }
 
             Token::Error => {
@@ -2711,15 +2740,15 @@ impl Parser {
                 if self.eat(&Token::LParen) {
                     let msg = self.parse_pipe()?;
                     self.expect(&Token::RParen)?;
-                    Ok(Expr::Error { msg: Some(Box::new(msg)) })
+                    self.compile_funcall("error", vec![msg])
                 } else {
-                    Ok(Expr::Error { msg: None })
+                    self.compile_builtin_noargs("error")
                 }
             }
 
             Token::Not => {
                 self.advance();
-                Ok(Expr::Not)
+                self.compile_builtin_noargs("not")
             }
 
             Token::Variable(name) => {
@@ -3310,6 +3339,10 @@ impl Parser {
         match name {
             "not" => Ok(Expr::Not),
             "empty" => Ok(Expr::Empty),
+            // `error`/0 (rethrow current input as an error). Reached only via the
+            // `Token::Error` primary arm, which routes here so a user `def error`
+            // or an `error` parameter can shadow the builtin (#902).
+            "error" => Ok(Expr::Error { msg: None }),
             "env" => Ok(Expr::Env),
             "builtins" => Ok(Expr::Builtins),
             "input" => Ok(Expr::ReadInput),

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -12397,3 +12397,28 @@ bsearch(2)
 . as {(0|tostring):$v} | $v
 {"0":7}
 7
+
+# #902: empty/not/error are builtins, not keywords; a user def may shadow them.
+def empty: 1; empty
+null
+1
+
+# #902: user def shadows the error builtin (0-arg rethrow form).
+def error: 1; error
+null
+1
+
+# #902: error/1 user def shadows the builtin error/1.
+def error(x): [x,x]; error("hi")
+null
+["hi","hi"]
+
+# #902: builtin name accepted as a parameter name and used as a value.
+def f(not): not+1; f(10)
+null
+11
+
+# #902: literal keywords true/false/null are accepted as def names (dead def; body literal wins).
+def true: 1; [true]
+null
+[true]


### PR DESCRIPTION
## Summary

`empty`, `not`, and `error` are ordinary builtins in jq (`empty/0`, `not/0`, `error/0,1` all appear in `builtins`), not reserved keywords, so a user `def` — or a same-named parameter — may shadow them. The literal keywords `true`/`false`/`null` are likewise accepted in def-name position (the def is dead because a body reference lexes as the literal). jq-jit's lexer emits dedicated tokens for these names and the def-name / parameter-name parser only accepted `Token::Ident`, so any program declaring such a name failed at parse time.

```
$ echo null | jq-jit -c 'def empty: 1; empty'   # before: error: expected function name, got Empty
1                                                # after: matches jq
$ echo null | jq-jit -c 'def error(x): [x,x]; error("hi")'
["hi","hi"]
$ echo null | jq-jit -c 'def f(not): not+1; f(10)'
11
```

## Fix

- Add `def_name_token` mapping the keyword/literal tokens back to their identifier string; accept them in def-name and parameter-name position.
- Route the `Token::Empty` / `Token::Not` / `Token::Error` primary-expression arms through the shadow-aware resolvers (`compile_builtin_noargs` / `compile_funcall`) so a user def or parameter shadows the builtin, falling back to the builtin Expr only when nothing shadows it.
- Add an `error`/0 fallback arm to `compile_builtin_noargs`.

## Tests

- 18/18 differential checks vs jq 1.8.1 pass (shadow cases + bare-builtin regressions).
- 5 regression cases appended to `tests/regression.test`.
- `cargo build --release` zero warnings; `cargo test --release` all pass.
- Bench: parser-only change, hot path untouched. Full-run p126 noise confirmed via same-machine interleaved A/B (main == branch, 0.11/0.11/0.12s each).

Closes #902

🤖 Generated with [Claude Code](https://claude.com/claude-code)