### PR TITLE
fix(runtime): order nan-vs-nan as Equal so equal-NaN keys keep input order

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1137,7 +1137,11 @@ pub fn values_equal(a: &Value, b: &Value) -> bool {
 pub fn cmp_num_jq(x: f64, y: f64) -> std::cmp::Ordering {
     use std::cmp::Ordering;
     match (x.is_nan(), y.is_nan()) {
-        (true, true) => Ordering::Less,
+        // jq's total order treats NaN as the smallest value AND nan-vs-nan as
+        // EQUAL. Returning Less here would make the comparator non-antisymmetric,
+        // so a stable sort reverses any run of >=2 elements that share a NaN key
+        // (sort/sort_by/group_by/unique_by). #903
+        (true, true) => Ordering::Equal,
         (true, false) => Ordering::Less,
         (false, true) => Ordering::Greater,
         (false, false) => x.partial_cmp(&y).unwrap_or(Ordering::Equal),

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -12422,3 +12422,18 @@ null
 def true: 1; [true]
 null
 [true]
+
+# #903: nan-vs-nan compares Equal, so a stable sort preserves input order of equal-NaN keys.
+[[nan,1],[nan,2],[nan,3]]|sort
+null
+[[null,1],[null,2],[null,3]]
+
+# #903: sort_by stability with a NaN tie-breaking key keeps input order.
+[{"a":1,"b":nan,"i":0},{"a":1,"b":nan,"i":1}]|sort_by(.a,.b)|map(.i)
+null
+[0,1]
+
+# #903: group_by over equal-NaN keys yields singleton groups in input order.
+[{"k":nan,"i":0},{"k":nan,"i":1},{"k":nan,"i":2}]|group_by(.k)|map(map(.i))
+null
+[[0],[1],[2]]


### PR DESCRIPTION
## Summary

jq's total order treats NaN as the smallest value **and** nan-vs-nan as equal. `cmp_num_jq` returned `Ordering::Less` for the both-NaN case, making the comparator non-antisymmetric: Rust's stable sort then **reverses** any run of two or more elements that share a NaN key. This surfaced in `sort`, `sort_by`, `group_by`, and `unique_by`.

```
$ echo null | jq-jit -c '[[nan,1],[nan,2]]|sort'
[[null,2],[null,1]]    # before (reversed)
[[null,1],[null,2]]    # after  (matches jq)

$ echo null | jq-jit -c '[{"k":nan,"i":0},{"k":nan,"i":1},{"k":nan,"i":2}]|group_by(.k)|map(map(.i))'
[[0],[1],[2]]          # after (matches jq; before: [[2],[1],[0]])
```

## Fix

Change the `(true, true)` arm of `cmp_num_jq` to `Ordering::Equal`. NaN-distinctness in `unique`/`group_by` is governed by `values_equal` (nan != nan, intentional) and is unaffected — each NaN stays its own singleton group, now in input order.

Distinct from #115 (NaN-smallest ordering, single NaN per run) and #770 (the `_by` comparator routing); both had at most one NaN per adjacent run, so the stability facet was untested.

## Tests

- 20/20 differential checks vs jq 1.8.1 pass (stability cases + existing NaN-ordering + unique/group NaN-distinctness regressions).
- 3 regression cases appended to `tests/regression.test`.
- Stress: `fuzz_axis_assign` 2000 cases pass; full `cargo test --release` green (0 failures); zero warnings.
- Bench: comparator hot path, confirmed neutral via same-machine interleaved A/B (sort(2M) 0.02==0.02, unique(1M) within noise).

Closes #903

🤖 Generated with [Claude Code](https://claude.com/claude-code)