### PR TITLE
fix(del): treat fractional negative array index in (-1,0) as out of range

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -7445,8 +7445,19 @@ fn eval_del(f: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) -> G
                             if let Value::Arr(pa) = p {
                                 if pa.len() == 1 {
                                     if let Value::Num(n, _) = &pa[0] {
-                                        let mut idx = *n as i64;
-                                        if idx < 0 { idx += len; }
+                                        // Decide the negative-index offset from the
+                                        // ORIGINAL float, not the truncated int:
+                                        // `*n as i64` truncates toward zero, so a
+                                        // fractional index in (-1, 0) (e.g. -0.9)
+                                        // would become 0 and wrongly delete element
+                                        // 0. jq treats such indices as out of range
+                                        // (no-op). Mirror rt_delpaths (#884): add len
+                                        // when `*n < 0.0`, then range-check. #904
+                                        let idx = if *n < 0.0 {
+                                            *n as i64 + len
+                                        } else {
+                                            *n as i64
+                                        };
                                         if idx >= 0 && idx < len {
                                             indices_to_del.insert(idx);
                                         }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -12437,3 +12437,18 @@ null
 [{"k":nan,"i":0},{"k":nan,"i":1},{"k":nan,"i":2}]|group_by(.k)|map(map(.i))
 null
 [[0],[1],[2]]
+
+# #904: del with a fractional negative array index in (-1,0) is out of range (no-op), not element 0.
+del(.[-0.9])
+[0,1,2,3,4]
+[0,1,2,3,4]
+
+# #904: multi-target del where one index is fractional-negative deletes only the in-range target.
+del(.[-0.5],.[1])
+[10,20,30,40]
+[10,30,40]
+
+# #904: a fractional negative index <= -1 still normalizes (e.g. -1.5 -> last element).
+del(.[-1.5])
+[1,2,3]
+[1,2]


### PR DESCRIPTION
## Summary

The top-level-array fast path in `eval_del` computed the index with `*n as i64` (truncation toward zero) before the `idx < 0` sign check. A fractional negative index in (-1, 0) — e.g. `-0.9`, `-0.5` — truncates to 0, which is no longer negative, so it was kept as a valid in-range index and element 0 was wrongly deleted. jq treats such an index as out of range and deletes nothing.

```
$ echo null | jq-jit -c '[0,1,2,3,4]|del(.[-0.9])'
[1,2,3,4]     # before (element 0 deleted)
[0,1,2,3,4]   # after  (matches jq)
```

## Fix

Decide the negative-index offset from the original float (`*n < 0.0`) instead of the truncated int, mirroring the `rt_delpaths` normalize pass (#884). Matches jq across the full fractional grid: (-1,0) → out of range; -1.x → len-1; -5.x → 0; positives truncate toward zero. The `delpaths` fallback and nested-path forms were already correct; only this `eval_del` fast path bypassed that normalization.

## Tests

- 21/21 differential checks vs jq 1.8.1 (full fractional grid + multi-target + integer/nested regressions).
- 3 regression cases appended to `tests/regression.test`.
- `cargo test --release` green (0 failures); zero warnings.
- Bench: `eval_del` is outside the p126 hot path; full-run p126 noise confirmed neutral via same-machine interleaved A/B (main == branch, 0.11–0.12s).

Closes #904

🤖 Generated with [Claude Code](https://claude.com/claude-code)