### PR TITLE
fix(join): defer separator type-check until the separator is inserted

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2202,10 +2202,16 @@ fn rt_join(v: &Value, sep: &Value) -> Result<Value> {
     // jq treats `null` as the additive identity for strings (`"a" + null == "a"`),
     // and `join` is internally a reduce over `acc + sep + item`, so a `null`
     // separator collapses to the empty string. See #430.
-    let sep_bytes: &[u8] = match sep {
-        Value::Str(s) => s.as_bytes(),
-        Value::Null => b"",
-        _ => bail!("join requires array and string"),
+    //
+    // The separator's type only matters when it is actually inserted (between
+    // two or more elements). jq's reduce never touches `$sep` for a 0- or
+    // 1-element input, so `join` returns a value there regardless of `$sep`'s
+    // type. Defer the type check: `None` means "not a string/null", which is
+    // only an error once the separator is reached (i > 0 below). #905
+    let sep_bytes: Option<&[u8]> = match sep {
+        Value::Str(s) => Some(s.as_bytes()),
+        Value::Null => Some(b""),
+        _ => None,
     };
     // jq's `join` desugars to a reduce that iterates the input. Both arrays
     // and objects are accepted (#533); for objects we walk the values in
@@ -2217,10 +2223,21 @@ fn rt_join(v: &Value, sep: &Value) -> Result<Value> {
         // wording adopted across other iteration sites (#481/#505/#517).
         _ => bail!("Cannot iterate over {}", errdesc(v)),
     };
-    let cap = items.len() * (8 + sep_bytes.len());
+    let cap = items.len() * (8 + sep_bytes.map_or(0, |s| s.len()));
     let mut buf: Vec<u8> = Vec::with_capacity(cap);
     for (i, item) in items.iter().enumerate() {
-        if i > 0 { buf.extend_from_slice(sep_bytes); }
+        if i > 0 {
+            match sep_bytes {
+                Some(sb) => buf.extend_from_slice(sb),
+                // Separator is now actually used but is neither a string nor
+                // null: jq raises its addition error (`acc + $sep`), where `acc`
+                // is the partial string built so far. #905
+                None => {
+                    let partial = Value::from_string(unsafe { String::from_utf8_unchecked(buf) });
+                    bail!("{} and {} cannot be added", errdesc(&partial), errdesc(sep));
+                }
+            }
+        }
         match item {
             Value::Str(sv) => buf.extend_from_slice(sv.as_bytes()),
             Value::Null => {},

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -12452,3 +12452,18 @@ del(.[-0.5],.[1])
 del(.[-1.5])
 [1,2,3]
 [1,2]
+
+# #905: join defers separator type-check; a 0-element array returns "" for any sep.
+join([])
+[]
+""
+
+# #905: a 1-element array returns the element regardless of separator type (sep never inserted).
+join({})
+[42]
+"42"
+
+# #905: a non-string separator is fine when never inserted (single element).
+join(1)
+["a"]
+"a"


### PR DESCRIPTION
## Summary

`join` eagerly validated that the separator was a string or null up front and errored for any other type, even when the input array had 0 or 1 elements (where the separator is never inserted). jq implements `join` as a reduce that only concatenates the separator between successive elements, so for a 0- or 1-element input the separator's type is never exercised and jq returns a value regardless of its type.

```
$ echo '[]'    | jq-jit -c 'join([])'   # before: error -> after: ""
$ echo '["a"]' | jq-jit -c 'join([])'   # before: error -> after: "a"
$ echo '[42]'  | jq-jit -c 'join(1)'    # before: error -> after: "42"
```

## Fix

Make `sep_bytes` an `Option`: `None` means "not a string/null". It is only an error once the separator is actually reached (the second and later elements), where jq raises its addition error `<acc> and <sep> cannot be added` with the partial string as the left operand — matching jq byte-for-byte. Multi-element joins with a non-string separator already errored (only the wording differed); they now produce jq's exact wording.

## Tests

- 28/28 differential checks vs jq 1.8.1 (0/1-element value cases across sep types + sep-used error wording + normal joins + object input + object-item / non-iterable error paths).
- 3 regression cases appended to `tests/regression.test`.
- `cargo test --release` green (0 failures); zero warnings.
- Bench: join hot path neutral via same-machine interleaved A/B (0.03 == 0.03 across rounds).

Closes #905

🤖 Generated with [Claude Code](https://claude.com/claude-code)