### PR TITLE
fix(eval): fork while/until on a generator (multi-valued) condition

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1914,14 +1914,38 @@ fn eval_while_gen(
 ) -> GenResult {
     loop {
         if !always_true {
-            let is_true = if let Ok(v) = eval_one(cond, &current, env) {
-                v.is_truthy()
-            } else {
-                let mut t = false;
-                eval(cond, current.clone(), env, &mut |v| { t = v.is_truthy(); Ok(true) })?;
-                t
-            };
-            if !is_true { return Ok(true); }
+            // jq desugars `while` to `if cond then ., (update|_while) else empty
+            // end`. A generator `cond` forks the `if` per output: each truthy
+            // output emits the current value and recurses through `update`, each
+            // falsy output contributes nothing. eval_one only succeeds for a
+            // single-output cond (the hot path); a multi-valued (or erroring)
+            // cond falls to the fork below. Folding it to the last output —
+            // as the previous code did — dropped the multiplicity and could
+            // even stop the loop on a trailing falsy value. #906
+            match eval_one(cond, &current, env) {
+                Ok(v) => {
+                    if !v.is_truthy() { return Ok(true); }
+                    // single truthy → emit + advance via the tail path below
+                }
+                Err(_) => {
+                    let mut conds: Vec<bool> = Vec::new();
+                    eval(cond, current.clone(), env, &mut |v| { conds.push(v.is_truthy()); Ok(true) })?;
+                    for is_true in conds {
+                        if !is_true { continue; }
+                        if !cb(current.clone())? { return Ok(false); }
+                        let mut succ: Vec<Value> = Vec::new();
+                        eval(update, current.clone(), env, &mut |v| { succ.push(v); Ok(true) })?;
+                        for u in succ {
+                            if !stacker::maybe_grow(128 * 1024, 32 * 1024 * 1024,
+                                || eval_while_gen(cond, update, always_true, u, env, cb))?
+                            {
+                                return Ok(false);
+                            }
+                        }
+                    }
+                    return Ok(true);
+                }
+            }
         }
         if !cb(current.clone())? { return Ok(false); }
         // Advance through `update`, honouring its generator semantics.
@@ -1936,7 +1960,9 @@ fn eval_while_gen(
             1 => current = succ.pop().unwrap(),    // single value → tail-iterate
             _ => {                                 // multi-valued → fan out (#767)
                 for u in succ {
-                    if !eval_while_gen(cond, update, always_true, u, env, cb)? {
+                    if !stacker::maybe_grow(128 * 1024, 32 * 1024 * 1024,
+                        || eval_while_gen(cond, update, always_true, u, env, cb))?
+                    {
                         return Ok(false);
                     }
                 }
@@ -1957,14 +1983,39 @@ fn eval_until_gen(
     env: &EnvRef, cb: &mut dyn FnMut(Value) -> GenResult,
 ) -> GenResult {
     loop {
-        let is_true = if let Ok(v) = eval_one(cond, &current, env) {
-            v.is_truthy()
-        } else {
-            let mut t = false;
-            eval(cond, current.clone(), env, &mut |v| { t = v.is_truthy(); Ok(true) })?;
-            t
-        };
-        if is_true { return cb(current); }
+        // jq desugars `until` to `if cond then . else (update|_until) end`. A
+        // generator `cond` forks the `if` per output: each truthy output emits
+        // the current value, each falsy output recurses through `update`.
+        // eval_one only succeeds for a single-output cond (the hot path); a
+        // multi-valued (or erroring) cond falls to the fork below. Folding it to
+        // the last output — as the previous code did — dropped the multiplicity
+        // and, on a trailing falsy value, looped forever emitting nothing. #906
+        match eval_one(cond, &current, env) {
+            Ok(v) => {
+                if v.is_truthy() { return cb(current); }
+                // single falsy → advance via the tail path below
+            }
+            Err(_) => {
+                let mut conds: Vec<bool> = Vec::new();
+                eval(cond, current.clone(), env, &mut |v| { conds.push(v.is_truthy()); Ok(true) })?;
+                for is_true in conds {
+                    if is_true {
+                        if !cb(current.clone())? { return Ok(false); }
+                    } else {
+                        let mut succ: Vec<Value> = Vec::new();
+                        eval(update, current.clone(), env, &mut |v| { succ.push(v); Ok(true) })?;
+                        for u in succ {
+                            if !stacker::maybe_grow(128 * 1024, 32 * 1024 * 1024,
+                                || eval_until_gen(cond, update, u, env, cb))?
+                            {
+                                return Ok(false);
+                            }
+                        }
+                    }
+                }
+                return Ok(true);
+            }
+        }
         if let Ok(next) = eval_one(update, &current, env) {
             current = next; // single value → tail-iterate (hot path)
             continue;
@@ -1976,7 +2027,9 @@ fn eval_until_gen(
             1 => current = succ.pop().unwrap(),    // single value → tail-iterate
             _ => {                                 // multi-valued → fan out
                 for u in succ {
-                    if !eval_until_gen(cond, update, u, env, cb)? {
+                    if !stacker::maybe_grow(128 * 1024, 32 * 1024 * 1024,
+                        || eval_until_gen(cond, update, u, env, cb))?
+                    {
                         return Ok(false);
                     }
                 }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -12467,3 +12467,23 @@ join({})
 join(1)
 ["a"]
 "a"
+
+# #906: while with a generator condition forks per output; (true,false) recurses on the truthy branch.
+[limit(6; while((true,false); .+1))]
+0
+[0,1,2,3,4,5]
+
+# #906: until with a generator condition: each truthy output emits, each falsy recurses (no hang).
+[limit(6; until((true,false); .+1))]
+0
+[0,1,2,3,4,5]
+
+# #906: a multi-truthy until condition emits the current value once per truthy output.
+[limit(4; until((true,true); .+1))]
+0
+[0,0]
+
+# #906: first() over a generator-condition while terminates lazily.
+[first(while((true,false); .+1))]
+0
+[0]


### PR DESCRIPTION
## Summary

jq desugars `while(c;u)` to `if c then ., (u|_while) else empty end` and `until(c;u)` to `if c then . else (u|_until) end`. A generator condition forks the `if` per output. `eval_while_gen` / `eval_until_gen` instead collapsed a multi-valued condition to its **last** output's truthiness, which:

- `while`: dropped the fork — a `(true,false)` condition stopped on the trailing `false`, emitting nothing.
- `until`: looped forever on a trailing `false` (an outright **hang**), and lost multiplicity when several condition outputs were truthy.

```
$ echo 0 | jq-jit -c '[limit(6; while((true,false); .+1))]'   # before []   -> after [0,1,2,3,4,5]
$ echo 0 | jq-jit -c '[limit(6; until((true,false); .+1))]'   # before HANG -> after [0,1,2,3,4,5]
$ echo 0 | jq-jit -c '[limit(4; until((true,true); .+1))]'    # before [0]  -> after [0,0]
```

## Fix

Keep the single-output `eval_one(cond)` fast path; when it reports a non-single result, enumerate the condition as a generator and fork per output — for `while`, each truthy output emits the current value and recurses through `update`; for `until`, each truthy output emits and each falsy output recurses. Recursive self-calls are wrapped in `stacker::maybe_grow` so deep forked chains (e.g. `limit(50000; until((true,false); .+1))`) don't overflow the stack.

Distinct from #882 (constant single-true cond + empty body) and #767 (multi-valued update body); here the multiplicity is in the condition.

## Tests

- 15/15 differential checks vs jq 1.8.1 (the three reported cases incl. the former hang, multi-truthy/multi-falsy forks, empty cond, single-cond regressions, multi-valued update, error-cond propagation).
- Deep recursion `limit(50000; until((true,false);.+1))` matches jq with no stack overflow.
- 4 regression cases appended to `tests/regression.test`.
- `cargo test --release` green (0 failures); zero warnings.
- Bench: single-output hot path unchanged — `until (100M)` 0.30 == 0.30 (main vs branch); p126 within noise via same-machine interleaved A/B.

Closes #906

🤖 Generated with [Claude Code](https://claude.com/claude-code)