### PR TITLE
fix: guard i64::MIN % -1 overflow panic on arithmetic fast paths

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1270,7 +1270,7 @@ fn get_num_leaf(expr: &Expr, input: &Value, vars: &[Value]) -> Option<f64> {
                 BinOp::Sub => ln - rn,
                 BinOp::Mul => ln * rn,
                 BinOp::Div => { if rn == 0.0 { return None; } ln / rn }
-                BinOp::Mod => { if !ln.is_finite() || !rn.is_finite() { return None; } let yi = rn as i64; if yi == 0 { return None; } (ln as i64 % yi) as f64 }
+                BinOp::Mod => { if !ln.is_finite() || !rn.is_finite() { return None; } let yi = rn as i64; if yi == 0 { return None; } crate::runtime::jq_mod_i64(ln as i64, yi) as f64 }
                 _ => return None,
             })
         }
@@ -1366,7 +1366,7 @@ fn get_num_leaf_override(expr: &Expr, vars: &[Value], override_vi: u16, override
                 BinOp::Sub => ln - rn,
                 BinOp::Mul => ln * rn,
                 BinOp::Div => { if rn == 0.0 { return None; } ln / rn }
-                BinOp::Mod => { if !ln.is_finite() || !rn.is_finite() { return None; } let yi = rn as i64; if yi == 0 { return None; } (ln as i64 % yi) as f64 }
+                BinOp::Mod => { if !ln.is_finite() || !rn.is_finite() { return None; } let yi = rn as i64; if yi == 0 { return None; } crate::runtime::jq_mod_i64(ln as i64, yi) as f64 }
                 _ => return None,
             })
         }
@@ -1451,7 +1451,7 @@ fn eval_one(expr: &Expr, input: &Value, env: &EnvRef) -> std::result::Result<Val
                                         if !ln.is_finite() || !rn.is_finite() { drop(e); return Err(()); }
                                         let yi = rn as i64;
                                         if yi == 0 { drop(e); return Err(()); }
-                                        Value::number((ln as i64 % yi) as f64)
+                                        Value::number(crate::runtime::jq_mod_i64(ln as i64, yi) as f64)
                                     }
                                     BinOp::Eq => if ln == rn { Value::True } else { Value::False },
                                     BinOp::Ne => if ln != rn { Value::True } else { Value::False },
@@ -1480,7 +1480,7 @@ fn eval_one(expr: &Expr, input: &Value, env: &EnvRef) -> std::result::Result<Val
                                 if !ln.is_finite() || !rn.is_finite() { return eval_binop(*op, &l, &r).map_err(|_| ()); }
                                 let yi = *rn as i64;
                                 if yi == 0 { return eval_binop(*op, &l, &r).map_err(|_| ()); }
-                                Value::number((*ln as i64 % yi) as f64)
+                                Value::number(crate::runtime::jq_mod_i64(*ln as i64, yi) as f64)
                             }
                             BinOp::Eq => if ln == rn { Value::True } else { Value::False },
                             BinOp::Ne => if ln != rn { Value::True } else { Value::False },
@@ -4110,7 +4110,7 @@ pub fn eval_binop(op: BinOp, lhs: &Value, rhs: &Value) -> Result<Value> {
                 if !ln.is_finite() || !rn.is_finite() { return crate::runtime::rt_mod(lhs, rhs); }
                 let yi = *rn as i64;
                 if yi == 0 { return crate::runtime::rt_mod(lhs, rhs); }
-                Value::number((*ln as i64 % yi) as f64)
+                Value::number(crate::runtime::jq_mod_i64(*ln as i64, yi) as f64)
             }
             BinOp::Eq => if ln == rn { Value::True } else { Value::False },
             BinOp::Ne => if ln != rn { Value::True } else { Value::False },
@@ -4156,7 +4156,7 @@ fn eval_binop_owned(op: BinOp, lhs: Value, rhs: &Value) -> Result<Value> {
                 if !ln.is_finite() || !rn.is_finite() { return crate::runtime::rt_mod(&lhs, rhs); }
                 let yi = *rn as i64;
                 if yi == 0 { return crate::runtime::rt_mod(&lhs, rhs); }
-                Value::number((*ln as i64 % yi) as f64)
+                Value::number(crate::runtime::jq_mod_i64(*ln as i64, yi) as f64)
             }
             BinOp::Eq => if ln == rn { Value::True } else { Value::False },
             BinOp::Ne => if ln != rn { Value::True } else { Value::False },

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1051,6 +1051,14 @@ pub fn jq_mod_f64<A: std::borrow::Borrow<f64>, B: std::borrow::Borrow<f64>>(a: A
     Some(r as f64)
 }
 
+/// Integer modulo with jq's `i64::MIN % -1 => 0` overflow guard. The bare
+/// `xi % yi` panics (SIGABRT) on that one input; callers on the arithmetic
+/// fast paths must route through here. Divisor-zero must be checked by callers.
+#[inline]
+pub fn jq_mod_i64(xi: i64, yi: i64) -> i64 {
+    if xi == i64::MIN && yi == -1 { 0 } else { xi % yi }
+}
+
 pub fn rt_mod(a: &Value, b: &Value) -> Result<Value> {
     match (a, b) {
         (Value::Num(x, _), Value::Num(y, _)) => {

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -12487,3 +12487,18 @@ join(1)
 [first(while((true,false); .+1))]
 0
 [0]
+
+# #918: i64::MIN % -1 must not overflow/panic on the arithmetic fast path (jq returns 0).
+. % -1
+-9223372036854775808
+0
+
+# #918: i64::MIN % -1 via a bound variable also stays on the safe path.
+. as $x | $x % -1
+-9223372036854775808
+0
+
+# #918: i64::MIN % -1 inside reduce (binop fast path on a runtime value).
+reduce range(1) as $i (.; . % -1)
+-9223372036854775808
+0


### PR DESCRIPTION
## Summary

`i64::MIN % -1` overflowed and **panicked** (SIGABRT) on the arithmetic-operator fast path. jq returns `0`. The canonical slow path `rt_mod` already guarded this case; the six fast-path / const-fold copies in `src/eval.rs` computed `(xi % yi) as f64` with only a divisor-zero guard.

The trigger surface is wide because the `f64 -> i64` cast rounds nearby values to `i64::MIN`:

```
echo '-9223372036854775808'  | jq-jit -c '. % -1'                      # panicked, now 0
echo '-9223372036854775807'  | jq-jit -c '. % -1'                      # panicked, now 0
echo '-9.223372036854776e18' | jq-jit -c '. % -1'                      # panicked, now 0
echo '-9223372036854775808'  | jq-jit -c '. as $x | $x % -1'           # panicked, now 0
echo '-9223372036854775808'  | jq-jit -c 'reduce range(1) as $i (.; . % -1)'  # panicked, now 0
```

## Fix

Add `runtime::jq_mod_i64`, which replicates jq's `i64::MIN && -1 => 0` guard, and route all six modulo fast-path sites (eval.rs:1273, 1369, 1454, 1483, 4113, 4159) through it.

## Tests

Added 3 regression cases to `tests/regression.test`. Full suite passes; zero build warnings. Cold-branch-only change, no hot-path impact (benchmark skipped per workflow).

Closes #918

🤖 Generated with [Claude Code](https://claude.com/claude-code)