### PR TITLE
fix: reject NaN array index in del/delpaths instead of deleting index 0

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -7498,6 +7498,13 @@ fn eval_del(f: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) -> G
                             if let Value::Arr(pa) = p {
                                 if pa.len() == 1 {
                                     if let Value::Num(n, _) = &pa[0] {
+                                        // A NaN index casts to 0 and would silently
+                                        // delete element 0; reject it, mirroring the
+                                        // set path and rt_delpaths. (Upstream jq hangs
+                                        // here — see #921 — so we do not match it.)
+                                        if n.is_nan() {
+                                            bail!("Cannot delete array element at NaN index");
+                                        }
                                         // Decide the negative-index offset from the
                                         // ORIGINAL float, not the truncated int:
                                         // `*n as i64` truncates toward zero, so a

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2917,6 +2917,10 @@ fn delete_path(v: &Value, path: &Value) -> Result<Value> {
                     Ok(Value::object_from_map(new_obj))
                 }
                 (Value::Arr(a), Value::Num(n, _)) => {
+                    // A NaN array index casts to 0 and would silently delete
+                    // element 0; reject it, mirroring the set path's guard.
+                    // (Upstream jq hangs here — see #921 — so we do not match it.)
+                    if n.is_nan() { bail!("Cannot delete array element at NaN index"); }
                     let ni = *n as i64;
                     let idx = if ni < 0 { a.len() as i64 + ni } else { ni };
                     if idx >= 0 && (idx as usize) < a.len() {
@@ -2961,6 +2965,10 @@ fn delete_path(v: &Value, path: &Value) -> Result<Value> {
                     }
                 }
                 (Value::Arr(a), Value::Num(n, _)) => {
+                    // A NaN array index casts to 0 and would silently delete
+                    // element 0; reject it, mirroring the set path's guard.
+                    // (Upstream jq hangs here — see #921 — so we do not match it.)
+                    if n.is_nan() { bail!("Cannot delete array element at NaN index"); }
                     let ni = *n as i64;
                     let idx = if ni < 0 { a.len() as i64 + ni } else { ni };
                     if idx >= 0 && (idx as usize) < a.len() {

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -12502,3 +12502,18 @@ join(1)
 reduce range(1) as $i (.; . % -1)
 -9223372036854775808
 0
+
+# #921: del with a NaN array index errors instead of silently deleting index 0 (top-level fast path).
+try del(.[nan]) catch .
+[10,20,30]
+"Cannot delete array element at NaN index"
+
+# #921: del with a NaN array index through a nested path also errors.
+try del(.a[nan]) catch .
+{"a":[1,2,3]}
+"Cannot delete array element at NaN index"
+
+# #921: delpaths with a NaN array index errors (mixed with a valid path).
+try delpaths([[0],[nan]]) catch .
+[10,20,30]
+"Cannot delete array element at NaN index"


### PR DESCRIPTION
## Summary

`del(.[nan])` / `delpaths([[nan]])` silently coerced a NaN array index to `0` and deleted element 0, while the set path correctly errors. Rust's `f64 as i64` yields `0` for NaN, so the guard present on set was missing on delete — an internal inconsistency and silent data corruption.

```
$ echo '[10,20,30]'    | jq-jit -c '.[nan]=9'          # Cannot set array element at NaN index (correct)
$ echo '[10,20,30]'    | jq-jit -c 'del(.[nan])'       # was [20,30], now errors
$ echo '{"a":[1,2,3]}' | jq-jit -c 'del(.a[nan])'      # was {"a":[2,3]}, now errors
$ echo '[10,20,30]'    | jq-jit -c 'delpaths([[0],[nan]])'  # was [30], now errors
```

## Fix

Guard the NaN index on the `eval_del` top-level array fast path and on both array-index arms of `runtime::delete_path`, erroring `Cannot delete array element at NaN index`.

Upstream jq **hangs** (infinite loop) on this input, so we deliberately do not match it; rejecting mirrors jq-jit's own set path.

## Tests

Added 3 regression cases (`try ... catch .`) covering the top-level fast path, nested path, and `delpaths`. Full suite passes; zero build warnings.

Closes #921

🤖 Generated with [Claude Code](https://claude.com/claude-code)