### PR TITLE
fix: clamp out-of-range implode codepoint to U+FFFD on the JIT fast path

### DIFF
--- a/src/jit.rs
+++ b/src/jit.rs
@@ -7046,11 +7046,23 @@ extern "C" fn jit_rt_unaryop(dst: *mut Value, op: i32, input: *const Value) -> i
                 let mut ok = true;
                 for item in a.iter() {
                     if let Value::Num(n, _) = item {
-                        let cp = *n as u32;
-                        if let Some(c) = char::from_u32(cp) {
-                            s.push(c);
-                        } else {
+                        // NaN can't be imploded — fall back to rt_implode for the
+                        // error. `*n as u32` saturates negatives to 0 (NUL), so
+                        // mirror rt_implode's i64 clamp: negative / surrogate /
+                        // > 0x10FFFF (and ±inf, which saturate past the range) →
+                        // U+FFFD, not U+0000. #932 (cf. #814).
+                        if n.is_nan() {
+                            ok = false;
+                            break;
+                        }
+                        let n_val = *n as i64;
+                        if n_val < 0 || (0xD800..=0xDFFF).contains(&n_val) || n_val > 0x10FFFF {
                             s.push('\u{FFFD}');
+                        } else {
+                            match char::from_u32(n_val as u32) {
+                                Some(c) => s.push(c),
+                                None => s.push('\u{FFFD}'),
+                            }
                         }
                     } else {
                         ok = false;

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -12517,3 +12517,18 @@ try del(.a[nan]) catch .
 try delpaths([[0],[nan]]) catch .
 [10,20,30]
 "Cannot delete array element at NaN index"
+
+# #932: implode of a negative codepoint clamps to U+FFFD on the JIT fast path (was U+0000).
+[-1]|implode|explode
+null
+[65533]
+
+# #932: implode of an out-of-range negative magnitude also clamps to U+FFFD.
+[-1e300]|implode|explode
+null
+[65533]
+
+# #932: implode of -infinite clamps to U+FFFD on the JIT fast path.
+[-infinite]|implode|explode
+null
+[65533]


### PR DESCRIPTION
## Summary

The JIT `implode` fast path (reached under `-n` / constant-folded programs) computed `*n as u32`, which saturates negative codepoints to `0`, producing U+0000 (NUL) instead of jq's U+FFFD replacement character. The runtime `rt_implode` already clamped correctly, so only the JIT path diverged.

```
$ jq     -cn '[-1]|implode|explode'      ->  [65533]
$ jq-jit -cn '[-1]|implode|explode'      ->  was [0], now [65533]
$ jq-jit -cn '[-1e300]|implode|explode'  ->  was [0], now [65533]
$ jq-jit -cn '[-infinite]|implode|explode' -> was [0], now [65533]
```

## Fix

Mirror `rt_implode`'s i64-based clamp: negative, surrogate (`D800-DFFF`), or `> 0x10FFFF` (and ±inf, which saturate past the range) → U+FFFD. NaN falls back to the runtime path for the proper "can't be imploded" error.

Verified against jq 1.8.1 for negative, -infinite, surrogate, and `> 0x10FFFF` inputs — all agree.

## Tests

Added 3 regression cases. Full suite passes; zero build warnings.

Closes #932

🤖 Generated with [Claude Code](https://claude.com/claude-code)