### PR TITLE
fix: normalize literal -0 to 0 under -n (null-input mode)

### DIFF
--- a/src/jit.rs
+++ b/src/jit.rs
@@ -107,8 +107,14 @@ fn try_const_eval(expr: &Expr) -> Option<Value> {
             Literal::Str(s) => Value::from_str(s),
         }),
         Expr::Negate { operand } => {
-            if let Value::Num(n, _) = try_const_eval(operand)? {
-                Some(Value::number(-n))
+            if let Value::Num(n, crate::value::NumRepr(repr)) = try_const_eval(operand)? {
+                // Mirror the runtime Negate path (eval.rs): normalize -0 to 0
+                // and carry the sign-flipped repr (negate_repr drops the sign
+                // for zero-valued reprs). Without this, `jq-jit -n '-0'`
+                // const-folds to -0.0 / "-0" while piped `null` renders "0",
+                // and `-1.0` loses its decimal. jq normalizes in both modes. #919
+                let neg = if n == 0.0 { 0.0 } else { -n };
+                Some(Value::number_opt(neg, crate::value::Value::negate_repr(repr)))
             } else { None }
         }
         Expr::Collect { generator } => {
@@ -1096,6 +1102,17 @@ impl Flattener {
                 out
             }
             Expr::Negate { operand } => {
+                // Constant fold a negated literal so its (sign-flipped) repr is
+                // preserved — `-1.0` stays "-1.0", `-0`/`-0.0` normalize to
+                // "0"/"0.0" — matching the runtime/piped path. The JitOp::Negate
+                // fast path below carries no repr, so without this `-n` rendered
+                // negated literals without their decimals. #919
+                if let Some(val) = try_const_eval(expr) {
+                    let ptr = self.hoist_value(val);
+                    let out = self.alloc_slot();
+                    self.emit(JitOp::LoadConst { dst: out, const_ptr: ptr });
+                    return out;
+                }
                 let val = self.flatten_scalar(operand, input_slot);
                 let out = self.alloc_slot();
                 self.emit(JitOp::Negate { dst: out, src: val });
@@ -9702,7 +9719,12 @@ impl JitCompiler {
                         let s2 = slot_addr(&mut b, *src);
                         let d2 = slot_addr(&mut b, *dst);
                         let f_val = b.ins().load(types::F64, cranelift_codegen::ir::MemFlags::new(), s2, 8);
-                        let neg = b.ins().fneg(f_val);
+                        // `0.0 - x`, not `fneg(x)`: this normalizes -0 to +0
+                        // (0.0 - ±0.0 == +0.0) while negating everything else
+                        // identically, matching the runtime eval and const-fold
+                        // paths so `-0` renders "0" rather than "-0". #919
+                        let zero_f = b.ins().f64const(0.0);
+                        let neg = b.ins().fsub(zero_f, f_val);
                         let tag_word = b.ins().iconst(ptr_ty, 3);
                         b.ins().store(cranelift_codegen::ir::MemFlags::new(), tag_word, d2, 0);
                         b.ins().store(cranelift_codegen::ir::MemFlags::new(), neg, d2, 8);

--- a/tests/null_input_neg_zero.rs
+++ b/tests/null_input_neg_zero.rs
@@ -1,0 +1,55 @@
+//! Issue #919: a literal `-0` in program source must normalize to `0` under
+//! `-n` (null-input mode), matching both jq and jq-jit's own piped-input path.
+//! The JIT `-n` path previously const-folded `Negate` via a raw IEEE negate,
+//! leaking a signed zero (`-0`) and dropping a negated literal's decimal repr
+//! (`-1.0` -> `-1`). The regression-test harness only pipes input (interpreter
+//! path), so the `-n` JIT path is exercised by shelling out directly.
+
+use std::process::Command;
+
+fn run(filter: &str) -> String {
+    let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
+    let out = Command::new(jq_jit)
+        .args(["-nc", filter])
+        .output()
+        .expect("failed to spawn jq-jit");
+    String::from_utf8(out.stdout)
+        .expect("non-utf8 stdout")
+        .trim_end()
+        .to_string()
+}
+
+#[test]
+fn literal_neg_zero_normalizes_under_null_input() {
+    assert_eq!(run("-0"), "0");
+}
+
+#[test]
+fn literal_neg_zero_decimal_keeps_decimal_drops_sign() {
+    assert_eq!(run("-0.0"), "0.0");
+}
+
+#[test]
+fn literal_neg_zero_in_array() {
+    assert_eq!(run("[-0]"), "[0]");
+}
+
+#[test]
+fn literal_neg_zero_in_object_value() {
+    assert_eq!(run("{\"a\":-0}"), "{\"a\":0}");
+}
+
+#[test]
+fn negated_decimal_literal_keeps_decimal_repr() {
+    // The broader gap the #919 fix closed: the JIT Negate fast path carried no
+    // repr, so `-1.0` rendered "-1" under -n.
+    assert_eq!(run("-1.0"), "-1.0");
+}
+
+#[test]
+fn ordinary_negation_unaffected() {
+    assert_eq!(run("-5"), "-5");
+    assert_eq!(run("-3.5"), "-3.5");
+    assert_eq!(run("0|-."), "0");
+    assert_eq!(run("5|-."), "-5");
+}


### PR DESCRIPTION
## Summary

A literal `-0` in program source was normalized to `0` on the interpreter (piped-input) path but **not** under `-n`, where the program is JIT-compiled — an internal inconsistency and a divergence from jq:

```
$ jq -nc '-0'        ->  0      $ jq-jit -nc '-0'        ->  was -0, now 0
$ jq -nc '-0.0'      ->  0.0    $ jq-jit -nc '-0.0'      ->  was -0, now 0.0
$ jq -nc '[-0]'      ->  [0]    $ jq-jit -nc '[-0]'      ->  was [-0], now [0]
$ jq -nc '{"a":-0}'  ->  {"a":0}$ jq-jit -nc '{"a":-0}'  ->  was {"a":-0}, now {"a":0}
$ echo null | jq-jit -c '-0'    ->  0  (already correct)
```

## Root cause & fix

The JIT `Negate` fast path emitted a raw IEEE `fneg` (turning `0.0` into `-0.0`) and carried no repr, so it also dropped a negated literal's decimal (`-1.0` → `-1` under `-n`). The runtime eval path already normalized via `negate_repr`.

- **`JitOp::Negate`**: compute `0.0 - x` instead of `fneg(x)` — normalizes a runtime `-0` to `+0` (e.g. `0 | -.`), identical otherwise.
- **`try_const_eval` Negate**: preserve the sign-flipped repr via `negate_repr` (which already drops the sign for zero-valued reprs).
- **`flatten_scalar` Negate**: const-fold a negated literal so its repr survives, mirroring the existing `Collect` const-fold.

`-n` now agrees with jq and the piped path for `-0`, `-0.0`, `[-0]`, `{"a":-0}`, and negated decimals like `-1.0`.

## Tests

Added `tests/null_input_neg_zero.rs` (6 cases) — the regression harness only pipes input (interpreter path), so the `-n` JIT path is guarded by shelling out directly. Full suite passes (selfdiff JIT-vs-interp clean); zero build warnings. Const-fold change emits strictly fewer ops, no hot-path impact (benchmark skipped per workflow).

Closes #919

🤖 Generated with [Claude Code](https://claude.com/claude-code)