### PR TITLE
fix: escape embedded NUL in @csv/@tsv (and TSV special chars on the raw path)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -115,6 +115,36 @@ fn raw_contains_unicode_escape(bytes: &[u8]) -> bool {
     false
 }
 
+/// CSV-escape already-decoded cell bytes into `buf` for the raw `-r @csv`
+/// fast path: double `"` and escape an embedded NUL to the two-char `\0`,
+/// matching jq and the value formatter (`eval::eval_format`). #929
+fn push_csv_decoded_cell(buf: &mut Vec<u8>, bytes: &[u8]) {
+    for &b in bytes {
+        match b {
+            b'"' => { buf.push(b'"'); buf.push(b'"'); }
+            0 => buf.extend_from_slice(b"\\0"),
+            _ => buf.push(b),
+        }
+    }
+}
+
+/// TSV-escape already-decoded cell bytes into `buf` for the raw `-r @tsv`
+/// fast path: `\\`, tab, newline, CR, and NUL are escaped, matching jq and
+/// the value formatter. The previous raw path emitted these bytes verbatim,
+/// so `\t`/`\n`/`\r`/`\\`/NUL all leaked unescaped. #929
+fn push_tsv_decoded_cell(buf: &mut Vec<u8>, bytes: &[u8]) {
+    for &b in bytes {
+        match b {
+            b'\\' => buf.extend_from_slice(b"\\\\"),
+            b'\t' => buf.extend_from_slice(b"\\t"),
+            b'\n' => buf.extend_from_slice(b"\\n"),
+            b'\r' => buf.extend_from_slice(b"\\r"),
+            0 => buf.extend_from_slice(b"\\0"),
+            _ => buf.push(b),
+        }
+    }
+}
+
 
 fn jqjit_trace_enabled() -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
@@ -3774,13 +3804,9 @@ fn real_main() {
                                     if is_csv {
                                         compact_buf.push(b'"');
                                         if inner.contains(&b'\\') {
-                                            // Has JSON escapes — decode first
-                                            let decoded = json_unescape_bytes(inner);
-                                            // CSV-escape: double any quotes
-                                            for &b in &decoded {
-                                                if b == b'"' { compact_buf.push(b'"'); }
-                                                compact_buf.push(b);
-                                            }
+                                            // Has JSON escapes — decode, then CSV-escape
+                                            // (double `"`, NUL -> `\0`).
+                                            push_csv_decoded_cell(&mut compact_buf, &json_unescape_bytes(inner));
                                         } else if inner.contains(&b'"') {
                                             for &b in inner.iter() {
                                                 if b == b'"' { compact_buf.push(b'"'); }
@@ -3791,9 +3817,9 @@ fn real_main() {
                                         }
                                         compact_buf.push(b'"');
                                     } else {
-                                        // TSV: output raw
+                                        // TSV: decode, then TSV-escape (\\ tab nl cr NUL).
                                         if inner.contains(&b'\\') {
-                                            compact_buf.extend_from_slice(&json_unescape_bytes(inner));
+                                            push_tsv_decoded_cell(&mut compact_buf, &json_unescape_bytes(inner));
                                         } else {
                                             compact_buf.extend_from_slice(inner);
                                         }
@@ -12827,11 +12853,7 @@ fn real_main() {
                                 if is_csv {
                                     compact_buf.push(b'"');
                                     if inner.contains(&b'\\') {
-                                        let decoded = json_unescape_bytes(inner);
-                                        for &b in &decoded {
-                                            if b == b'"' { compact_buf.push(b'"'); }
-                                            compact_buf.push(b);
-                                        }
+                                        push_csv_decoded_cell(&mut compact_buf, &json_unescape_bytes(inner));
                                     } else if inner.contains(&b'"') {
                                         for &b in inner.iter() {
                                             if b == b'"' { compact_buf.push(b'"'); }
@@ -12843,7 +12865,7 @@ fn real_main() {
                                     compact_buf.push(b'"');
                                 } else {
                                     if inner.contains(&b'\\') {
-                                        compact_buf.extend_from_slice(&json_unescape_bytes(inner));
+                                        push_tsv_decoded_cell(&mut compact_buf, &json_unescape_bytes(inner));
                                     } else {
                                         compact_buf.extend_from_slice(inner);
                                     }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -4462,10 +4462,16 @@ pub fn eval_format(name: &str, val: &Value) -> Result<String> {
                 match v {
                     Value::Str(s) => {
                         buf.push('"');
-                        if s.contains('"') {
+                        // jq doubles `"` and escapes an embedded NUL to the
+                        // two-char `\0` (the #849 NUL fix missed @csv/@tsv).
+                        // Single pass over the cell bytes. #929
+                        if s.as_bytes().iter().any(|&b| b == b'"' || b == 0) {
                             for c in s.chars() {
-                                if c == '"' { buf.push('"'); }
-                                buf.push(c);
+                                match c {
+                                    '"' => { buf.push('"'); buf.push('"'); }
+                                    '\0' => buf.push_str("\\0"),
+                                    _ => buf.push(c),
+                                }
                             }
                         } else {
                             buf.push_str(s);
@@ -4502,6 +4508,8 @@ pub fn eval_format(name: &str, val: &Value) -> Result<String> {
                                 '\t' => buf.push_str("\\t"),
                                 '\n' => buf.push_str("\\n"),
                                 '\r' => buf.push_str("\\r"),
+                                // jq escapes an embedded NUL to `\0` (#849/#929).
+                                '\0' => buf.push_str("\\0"),
                                 _ => buf.push(c),
                             }
                         }

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -8274,10 +8274,17 @@ extern "C" fn jit_rt_call_builtin(dst: *mut Value, name_ptr: *const u8, name_len
                         match v {
                             Value::Str(s) => {
                                 buf.push(b'"');
-                                if s.as_bytes().contains(&b'"') {
+                                // jq doubles `"` and escapes an embedded NUL to
+                                // the two-char `\0` (the #849 NUL fix missed
+                                // @csv/@tsv). One SIMD pass (memchr2) over the
+                                // cell for both bytes, keeping the hot path fast. #929
+                                if memchr::memchr2(b'"', 0, s.as_bytes()).is_some() {
                                     for &b in s.as_bytes() {
-                                        if b == b'"' { buf.push(b'"'); }
-                                        buf.push(b);
+                                        match b {
+                                            b'"' => { buf.push(b'"'); buf.push(b'"'); }
+                                            0 => buf.extend_from_slice(b"\\0"),
+                                            _ => buf.push(b),
+                                        }
                                     }
                                 } else {
                                     buf.extend_from_slice(s.as_bytes());
@@ -8316,6 +8323,8 @@ extern "C" fn jit_rt_call_builtin(dst: *mut Value, name_ptr: *const u8, name_len
                                         b'\t' => buf.extend_from_slice(b"\\t"),
                                         b'\n' => buf.extend_from_slice(b"\\n"),
                                         b'\r' => buf.extend_from_slice(b"\\r"),
+                                        // jq escapes an embedded NUL to `\0` (#849/#929).
+                                        0 => buf.extend_from_slice(b"\\0"),
                                         _ => buf.push(b),
                                     }
                                 }

--- a/tests/csv_tsv_nul_escape.rs
+++ b/tests/csv_tsv_nul_escape.rs
@@ -1,0 +1,94 @@
+//! Issue #929: `@csv`/`@tsv` must escape an embedded NUL to the two-char `\0`
+//! (the #849 NUL fix covered `@html`/`@sh` but missed the CSV/TSV formatters).
+//! While fixing it, the `-r` raw CSV/TSV field fast path was also found to emit
+//! TSV special bytes (`\t \n \r \\`) and NUL verbatim instead of escaping them;
+//! that path is now aligned with jq / the value formatter too.
+//!
+//! The regression-test harness only runs without `-r`, so the raw fast path is
+//! exercised here by shelling out with `-r` and a JSON input carrying escapes.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn run(args: &[&str], stdin: &str) -> Vec<u8> {
+    let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
+    let mut child = Command::new(jq_jit)
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn jq-jit");
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(stdin.as_bytes())
+        .unwrap();
+    let out = child.wait_with_output().expect("wait failed");
+    let mut bytes = out.stdout;
+    while bytes.last() == Some(&b'\n') {
+        bytes.pop();
+    }
+    bytes
+}
+
+// --- Value-formatter path (@csv/@tsv applied to a constructed array) ---
+
+#[test]
+fn csv_escapes_embedded_nul() {
+    // [[97,0,98]|implode] -> "a\0b", @csv cell = "a\0b" (NUL -> backslash-zero).
+    // -r so we see the raw @csv string, not its JSON re-encoding.
+    assert_eq!(
+        run(&["-rc", "[[97,0,98]|implode]|@csv"], "null"),
+        b"\"a\\0b\""
+    );
+}
+
+#[test]
+fn tsv_escapes_embedded_nul() {
+    assert_eq!(run(&["-rc", "[[97,0,98]|implode]|@tsv"], "null"), b"a\\0b");
+}
+
+// --- Raw `-r` field fast path (`[.a,.b]|@csv`/`@tsv`) ---
+
+#[test]
+fn raw_csv_escapes_nul_field() {
+    assert_eq!(
+        run(&["-rc", "[.a,.b]|@csv"], "{\"a\":\"\\u0000\",\"b\":\"z\"}"),
+        b"\"\\0\",\"z\""
+    );
+}
+
+#[test]
+fn raw_tsv_escapes_nul_field() {
+    assert_eq!(
+        run(&["-rc", "[.a,.b]|@tsv"], "{\"a\":\"\\u0000\",\"b\":\"z\"}"),
+        b"\\0\tz"
+    );
+}
+
+#[test]
+fn raw_tsv_escapes_tab_newline_cr_backslash() {
+    // These leaked unescaped on the raw fast path before the #929 fix.
+    assert_eq!(
+        run(&["-rc", "[.a,.b]|@tsv"], "{\"a\":\"x\\ty\",\"b\":\"z\"}"),
+        b"x\\ty\tz"
+    );
+    assert_eq!(
+        run(&["-rc", "[.a,.b]|@tsv"], "{\"a\":\"x\\ny\",\"b\":\"z\"}"),
+        b"x\\ny\tz"
+    );
+    assert_eq!(
+        run(&["-rc", "[.a,.b]|@tsv"], "{\"a\":\"x\\\\y\",\"b\":\"z\"}"),
+        b"x\\\\y\tz"
+    );
+}
+
+#[test]
+fn raw_csv_quote_doubling_unaffected() {
+    assert_eq!(
+        run(&["-rc", "[.a,.b]|@csv"], "{\"a\":\"x\\\"y\",\"b\":\"z\"}"),
+        b"\"x\"\"y\",\"z\""
+    );
+}

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -12532,3 +12532,18 @@ null
 [-infinite]|implode|explode
 null
 [65533]
+
+# #929: @csv escapes an embedded NUL to the two-char \0 (codepoints shown via explode).
+[[0]|implode]|@csv|explode
+null
+[34,92,48,34]
+
+# #929: @csv escapes a mid-string NUL (a\0b inside the quoted cell).
+[[97,0,98]|implode]|@csv|explode
+null
+[34,97,92,48,98,34]
+
+# #929: @tsv escapes an embedded NUL to \0 (a\0b).
+[[97,0,98]|implode]|@tsv|explode
+null
+[97,92,48,98]


### PR DESCRIPTION
## Summary

The #849 NUL→`\0` escaping covered `@html`/`@sh` but missed the `@csv`/`@tsv` formatters: an embedded NUL was emitted as a literal NUL byte inside the cell instead of the two characters `\0`, corrupting downstream parsers.

```
$ printf 'null' | jq     -c '[[0]|implode]|@csv' | xxd   # ... 22 5c 30 22 ...  ("\0")
$ printf 'null' | jq-jit -c '[[0]|implode]|@csv' | xxd   # was ... 22 00 22 ... (literal NUL), now matches jq
```

## Fix — every @csv/@tsv emission site

- **`src/eval.rs` `eval_format`** `@csv` (single-pass byte scan for `"`/NUL) and `@tsv`.
- **`src/jit.rs`** inline `@csv` (one `memchr2` pass over `"`/NUL) and `@tsv` fast paths.
- **`src/bin/jq-jit.rs`** raw `-r` field fast path (`raw_csv_fields`), via new `push_csv_decoded_cell` / `push_tsv_decoded_cell` helpers.
- **`array_fields_format`** (`-c [.a,.b]|@csv`) already delegates any escaped field to the value formatter, so it is correct via the `eval_format` fix.

## Additional gap found & fixed

While fixing the raw `-r @tsv` path, it was also emitting `\t`, `\n`, `\r`, and `\\` **verbatim** after JSON-decoding the field (e.g. a tab-containing field came out as a literal tab, breaking the row):

```
$ echo '{"a":"x\ty","b":"z"}' | jq     -rc '[.a,.b]|@tsv'   # x\ty<TAB>z
$ echo '{"a":"x\ty","b":"z"}' | jq-jit -rc '[.a,.b]|@tsv'   # was x<TAB>y<TAB>z, now x\ty<TAB>z
```

`push_tsv_decoded_cell` escapes the full TSV set, aligning the raw path with jq and the value formatter.

## Tests & perf

- `tests/regression.test`: 3 cases (`@csv`/`@tsv` NUL via `explode`).
- `tests/csv_tsv_nul_escape.rs`: 6 cases covering the value-formatter and raw `-r` paths, including the TSV tab/newline/CR/backslash gap (the regression harness doesn't use `-r`).
- Full suite passes; zero warnings. The escape-free fast branch is unchanged; `@csv`/`@tsv` benchmarks are within historical noise (`@csv` 0.118s, array variants 0.015s).

Closes #929

🤖 Generated with [Claude Code](https://claude.com/claude-code)