### PR TITLE
fix: gmtime/localtime/todate negative fractional epoch (sign of the split)

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -3667,11 +3667,14 @@ struct BrokenTime {
 fn rt_gmtime(v: &Value) -> Result<Value> {
     match v {
         Value::Num(n, _) => {
-            // jq preserves fractional seconds in tm_sec: trunc toward zero
-            // for the conversion, then add |n - trunc| (always non-negative)
-            // back. `(-1.5) | gmtime | .[5]` is `59.5`, not `58.5`. See #436.
+            // jq derives the broken-down second from `trunc(n)` (toward zero)
+            // but the fractional remainder from `n - floor(n)` (always in
+            // [0,1)). For negative non-integer epochs these disagree, e.g.
+            // `-0.3 | gmtime | .[5]` is `0.7` (tm_sec 0 from trunc, frac 0.7
+            // from floor), not `0.3`. Using `|n - trunc|` gave `1 - frac`
+            // here. `(-1.5) | .[5]` stays `59.5`. See #436/#924.
             let secs = n.trunc() as i64;
-            let frac = (n - n.trunc()).abs();
+            let frac = n - n.floor();
             Ok(broken_to_value(&epoch_to_utc_broken(secs), frac))
         }
         _ => bail!("gmtime() requires numeric inputs"),
@@ -3681,8 +3684,9 @@ fn rt_gmtime(v: &Value) -> Result<Value> {
 fn rt_localtime(v: &Value) -> Result<Value> {
     match v {
         Value::Num(n, _) => {
+            // See rt_gmtime: tm_sec from trunc, fraction from `n - floor(n)`. #924
             let secs = n.trunc() as i64;
-            let frac = (n - n.trunc()).abs();
+            let frac = n - n.floor();
             Ok(broken_to_value(&epoch_to_local_broken(secs), frac))
         }
         _ => bail!("localtime() requires numeric inputs"),
@@ -4257,11 +4261,13 @@ fn rt_toisodate(v: &Value) -> Result<Value> {
         _ => unreachable!(),
     };
 
-    // jq's `def todate: strftime("%Y-%m-%dT%H:%M:%SZ")` floors the epoch to
-    // whole seconds before formatting (the broken-down-time `tm` produced by
-    // gmtime has no subsecond field), so any fractional input must be
-    // dropped to keep `todate | fromdateiso8601` round-tripping. See #613.
-    let secs = epoch.floor() as i64;
+    // jq's `def todate: strftime("%Y-%m-%dT%H:%M:%SZ")` drops the subsecond
+    // part (the `tm` from gmtime has no fraction), keeping the round-trip
+    // `todate | fromdateiso8601` stable (#613). The truncation must be toward
+    // zero, matching gmtime's `trunc(n)` calendar second: `todate(-0.5)` is
+    // `1970-01-01T00:00:00Z` (trunc -> epoch 0), not `…23:59:59Z` (floor ->
+    // epoch -1). For non-negative epochs trunc == floor. See #924.
+    let secs = epoch.trunc() as i64;
     let dt = DateTime::from_timestamp(secs, 0)
         .ok_or_else(|| anyhow::anyhow!("toisodate: invalid epoch: {}", epoch))?;
     let formatted = strip_expanded_year_sign(dt.format("%Y-%m-%dT%H:%M:%SZ").to_string());

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -12572,3 +12572,23 @@ strftime("%G")
 strftime("%Y%z")
 [10000,0,1,0,0,0,0,0]
 "10000+0000"
+
+# #924: gmtime of a negative fractional epoch puts frac = epoch - floor(epoch) in .[5].
+gmtime|.[5]
+-0.3
+0.7
+
+# #924: gmtime negative fractional, tm_sec from trunc but frac from floor.
+gmtime|.[5]
+-2.25
+58.75
+
+# #924: todate of a negative fractional epoch truncates toward zero (epoch 0, not -1).
+todate
+-0.5
+"1970-01-01T00:00:00Z"
+
+# #924: todate of -1.5 lands on 23:59:59 (trunc -> epoch -1), matching jq.
+todate
+-1.5
+"1969-12-31T23:59:59Z"


### PR DESCRIPTION
## Summary

For a **negative fractional epoch**, jq derives the broken-down second from `trunc(n)` (toward zero) but the fractional remainder from `n - floor(n)` (always in `[0,1)`). jq-jit used `|n - trunc(n)|`, which yields `1 - frac` for negative non-integers.

```
$ echo -0.3  | TZ=UTC jq-jit -c 'gmtime|.[5]'   # was 0.3,  jq/now 0.7
$ echo -2.25 | TZ=UTC jq-jit -c 'gmtime|.[5]'   # was 58.25, jq/now 58.75
$ echo -0.5  | TZ=UTC jq-jit -c 'todate'        # was "…23:59:59Z", jq/now "1970-01-01T00:00:00Z"
```

`todate` had the matching downstream bug: it floored the epoch toward −∞, landing on the wrong calendar second.

## Fix

- `frac = n - n.floor()` in `rt_gmtime`/`rt_localtime` (the `tm_sec` calendar second stays `trunc(n)`).
- `epoch.trunc()` instead of `epoch.floor()` in `rt_toisodate`, so `todate` lands on the same calendar second as `gmtime`.

For non-negative epochs `trunc == floor`, so positive cases — and the #436 `-1.5 -> 59.5` case — are unchanged. This is jq's actual (reference) behavior; the mixed trunc/floor split is replicated for parity.

## Tests

4 regression cases (gmtime `.[5]` for -0.3/-2.25, todate for -0.5/-1.5), kept in `tests/regression.test` (UTC path, TZ-independent, pure arithmetic). Full suite passes; zero warnings. Not a benchmarked path.

Closes #924

🤖 Generated with [Claude Code](https://claude.com/claude-code)