### PR TITLE
fix: honor sub(re;repl;"g") global flag on the runtime dispatch path

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -273,8 +273,13 @@ pub fn call_builtin(name: &str, args: &[Value]) -> Result<Value> {
             if args.len() >= 4 {
                 // sub/gsub with flags: input, regex, replacement, flags
                 let pat_str = coerce_regex_pat_str(&args[1])?;
-                let (pat, _, not_empty) = apply_regex_flags(&pat_str, &args[3])?;
-                rt_sub_gsub(&args[0], &Value::from_string(pat), &args[2], name == "gsub", not_empty)
+                // The `"g"` flag controls replacement count, not the pattern, so
+                // it must be honored here — `sub(re; repl; "g")` replaces all
+                // matches. Discarding it (binding to `_`) silently dropped the
+                // global flag on this dispatch (the JIT scalar path). #931
+                let (pat, flag_global, not_empty) = apply_regex_flags(&pat_str, &args[3])?;
+                let global = name == "gsub" || flag_global;
+                rt_sub_gsub(&args[0], &Value::from_string(pat), &args[2], global, not_empty)
             } else if args.len() >= 3 {
                 rt_sub_gsub(&args[0], &args[1], &args[2], name == "gsub", false)
             } else {

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -12612,3 +12612,18 @@ try gmtime catch .
 nan|gmtime
 null
 [1970,0,1,0,0,null,4,0]
+
+# #931: sub(re;repl;"g") must replace all matches on the JIT scalar path (>= ~1000 iters), not just the first.
+[range(2000)|"aaa"] | map(sub("a";"X";"g")) | unique
+null
+["XXX"]
+
+# #931: the "ig" flags both survive on the JIT path (case-insensitive + global).
+[range(2000)|"AaA"] | map(sub("A";"x";"ig")) | unique
+null
+["xxx"]
+
+# #931: sub without "g" still replaces only the first match (no over-correction).
+[range(2000)|"aaa"] | map(sub("a";"X")) | unique
+null
+["Xaa"]


### PR DESCRIPTION
## Summary

`sub(re; repl; "g")` replaced only the **first** match instead of all matches on the JIT-compiled scalar path. The runtime builtin dispatch bound the extracted global flag to `_` and always passed `name == "gsub"` as the global argument, so an explicit `"g"` on `sub` was discarded. The eval path (`sub_gsub_segments` with `global || flag_global`) was already correct, so only JIT-compiled hot loops (≥ ~1000 iterations) surfaced the bug — a naive single-shot test passes.

```
$ jq-jit -cn '[range(2000)|"aaa"] | map(sub("a";"X";"g"))[0]'   # was "Xaa", now "XXX"
$ jq-jit -cn '[range(2000)|"AaA"] | map(sub("A";"x";"ig"))[0]'  # was "xaA", now "xxx"
```

## Fix

Capture `flag_global` from `apply_regex_flags` and pass `name == "gsub" || flag_global` into `rt_sub_gsub`. The `"i"` flag was unaffected (baked into the compiled pattern); only `"g"` (which controls replacement count, not the pattern) was lost. The 3-arg branch (no flags) and the benchmarked 3-arg `gsub` are unchanged.

## Tests

3 regression cases over a `range(2000)` hot loop (`sub …"g"`, `sub …"ig"`, and `sub` without `"g"` to guard against over-correction), collapsed with `unique` to assert every iteration replaced correctly. Full suite passes; zero warnings.

Closes #931

🤖 Generated with [Claude Code](https://claude.com/claude-code)