### PR TITLE
fix: any/all 2-arg with an input-consuming generator (inputs/input)

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -2734,6 +2734,12 @@ impl Filter {
                 }),
                 Expr::Format { expr: e, .. } => walk!(e),
                 Expr::Limit { count, generator } => walk!(count) || walk!(generator),
+                // `any(inputs; cond)` / `all(inputs; cond)` (and an
+                // input-consuming predicate like `any(.[]; . == input)`) read
+                // the stream. Omitting these made `uses_inputs()` report false,
+                // so the binary never seeded the input queue under `-n` and the
+                // generator yielded nothing (any -> false, all -> true). #928
+                Expr::AnyShort { generator, predicate } | Expr::AllShort { generator, predicate } => walk!(generator) || walk!(predicate),
                 Expr::While { cond, update, .. } | Expr::Until { cond, update } => walk!(cond) || walk!(update),
                 Expr::Repeat { update, .. } => walk!(update),
                 Expr::Range { from, to, step } => {

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -2112,6 +2112,21 @@ impl Flattener {
                 out
             }
             Expr::AllShort { generator, predicate } => {
+                // Bail when the generator isn't JIT-compilable (e.g. `inputs`):
+                // flatten_gen_with_each_output would silently emit no loop body,
+                // collapsing all/2 to its vacuous `true`. Fall back to the
+                // interpreter, which drives the input stream. See #928 (cf. the
+                // reduce-source bailout, #683).
+                {
+                    let mut test = self.test_flattener();
+                    let t_in = test.alloc_slot();
+                    if !test.flatten_gen(generator, t_in) {
+                        self.has_unresolved_recursion = true;
+                        let out = self.alloc_slot();
+                        self.emit(JitOp::Null { dst: out });
+                        return out;
+                    }
+                }
                 // all(pred): iterate generator, short-circuit to false on first falsey predicate
                 let result_var = self.alloc_var();
                 // result = 1 (true)
@@ -2145,6 +2160,21 @@ impl Flattener {
                 out
             }
             Expr::AnyShort { generator, predicate } => {
+                // Bail when the generator isn't JIT-compilable (e.g. `inputs`):
+                // flatten_gen_with_each_output would silently emit no loop body,
+                // collapsing any/2 to its vacuous `false`. Fall back to the
+                // interpreter, which drives the input stream. See #928 (cf. the
+                // reduce-source bailout, #683).
+                {
+                    let mut test = self.test_flattener();
+                    let t_in = test.alloc_slot();
+                    if !test.flatten_gen(generator, t_in) {
+                        self.has_unresolved_recursion = true;
+                        let out = self.alloc_slot();
+                        self.emit(JitOp::Null { dst: out });
+                        return out;
+                    }
+                }
                 // any(pred): iterate generator, short-circuit to true on first truthy predicate
                 let result_var = self.alloc_var();
                 self.emit(JitOp::InitVar { var: result_var }); // result = 0 (false)

--- a/tests/any_all_inputs.rs
+++ b/tests/any_all_inputs.rs
@@ -1,0 +1,87 @@
+//! Issue #928: `any(inputs; cond)` / `all(inputs; cond)` (and an
+//! input-consuming generator like `any(inputs == 5; .)`) must drive the input
+//! stream. Two defects combined to drop it: `uses_inputs()` didn't recurse into
+//! `AnyShort`/`AllShort` (so `-n` never seeded the input queue), and the JIT
+//! `any/all` compile ignored an uncompilable generator (silently emitting no
+//! loop body, collapsing any/2 to `false` and all/2 to `true`). The
+//! regression-test harness can't express `-n` plus a multi-document stream, so
+//! shell out directly. Run both the default (JIT) and forced-interpreter paths.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn run_env(args: &[&str], stdin: &str, force_interp: bool) -> String {
+    let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
+    let mut cmd = Command::new(jq_jit);
+    cmd.args(args);
+    if force_interp {
+        cmd.env("JQJIT_FORCE_INTERPRETER", "1");
+    }
+    let mut child = cmd
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn jq-jit");
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(stdin.as_bytes())
+        .unwrap();
+    let out = child.wait_with_output().expect("wait failed");
+    String::from_utf8(out.stdout)
+        .expect("non-utf8 stdout")
+        .trim_end()
+        .to_string()
+}
+
+/// Assert both the JIT and forced-interpreter paths produce `expected`.
+fn both(args: &[&str], stdin: &str, expected: &str) {
+    assert_eq!(run_env(args, stdin, false), expected, "JIT path: {:?}", args);
+    assert_eq!(run_env(args, stdin, true), expected, "interp path: {:?}", args);
+}
+
+#[test]
+fn any_inputs_true_when_a_value_matches() {
+    both(&["-nc", "any(inputs; .>2)"], "1 2 3", "true");
+}
+
+#[test]
+fn all_inputs_false_when_a_value_fails() {
+    both(&["-nc", "all(inputs; .>0)"], "1 2 -3", "false");
+}
+
+#[test]
+fn any_inputs_true_predicate_sees_every_value() {
+    both(&["-nc", "any(inputs; true)"], "1 2 3", "true");
+}
+
+#[test]
+fn all_inputs_false_predicate_sees_every_value() {
+    both(&["-nc", "all(inputs; false)"], "1 2 3", "false");
+}
+
+#[test]
+fn any_inputs_truthy_value() {
+    both(&["-nc", "any(inputs; .)"], "0 0 1", "true");
+}
+
+#[test]
+fn input_consuming_generator_expression() {
+    // `inputs == 5` is the generator; the stream's 5 must reach it.
+    both(&["-nc", "any(inputs == 5; .)"], "5", "true");
+}
+
+#[test]
+fn any_inputs_false_when_none_match() {
+    both(&["-nc", "any(inputs; .>10)"], "1 2 3", "false");
+}
+
+#[test]
+fn non_input_generators_still_work() {
+    // The JIT must still compile these (the bailout is generator-specific).
+    both(&["-nc", "any(range(2000); .>1998)"], "", "true");
+    both(&["-nc", "all(range(2000); .>=0)"], "", "true");
+    both(&["-nc", "any(1,2,3; .>2)"], "", "true");
+}


### PR DESCRIPTION
## Summary

`any(inputs; cond)` / `all(inputs; cond)` (and an input-consuming generator expression like `any(inputs == 5; .)`) never evaluated the condition — `any/2` collapsed to its vacuous `false` and `all/2` to `true`, ignoring the stream.

```
$ printf '1 2 3'  | jq-jit -nc 'any(inputs; .>2)'   # was false, now true
$ printf '1 2 -3' | jq-jit -nc 'all(inputs; .>0)'   # was true,  now false
$ printf '5'      | jq-jit -nc 'any(inputs == 5; .)' # was false, now true
```

## Root cause — two combined defects

1. **`uses_inputs()`** (interpreter.rs) didn't recurse into `AnyShort`/`AllShort`, so under `-n` the binary never seeded the input queue and `inputs` yielded nothing on the interpreter path. (Confirmed: `any(inputs;…), [inputs]` worked, because the `[inputs]` made `uses_inputs` true.)
2. The **JIT** `any`/`all` compile drove the generator via `flatten_gen_with_each_output` but **ignored its `false` return**. An uncompilable generator (`inputs`) emitted no loop body, so even with the queue seeded the JIT path produced the vacuous result.

## Fix

- Walk the generator and predicate in `uses_inputs()`.
- Pre-check the generator in the JIT `any`/`all` arms; request a bailout to the interpreter (which drives the stream) when it isn't compilable — mirroring the reduce-source bailout (#683).

Normal generators (`range`, comma, `.[]`) still JIT and behave identically; the bailout is generator-specific (the compile-time pre-check adds no runtime cost).

## Tests

`tests/any_all_inputs.rs` (8 cases) asserts both the **JIT** and **forced-interpreter** paths for `any`/`all` over `inputs`, an input-consuming generator expression, and non-input generators (which must still JIT). Full suite passes; zero warnings.

Closes #928

🤖 Generated with [Claude Code](https://claude.com/claude-code)