### PR TITLE
fix: track input_line_number in -R raw and -s/-Rs slurp paths

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -53,9 +53,15 @@ fn split_raw_lines(content: &str) -> impl Iterator<Item = &str> {
 }
 
 fn raw_inputs_with_lines(content: &str) -> Vec<(Value, u64)> {
+    // jq reports `input_line_number` as the count of `\n` consumed when the
+    // value is emitted. A terminated line N gets N; an unterminated final line
+    // adds no newline, so it keeps the prior count. Cap at the total `\n` count
+    // so the last line of input without a trailing newline doesn't bump the
+    // counter (`a\nb\nc` -> 1,2,2; `a\nb\nc\n` -> 1,2,3). #925
+    let total_nl = content.bytes().filter(|&b| b == b'\n').count() as u64;
     split_raw_lines(content)
         .enumerate()
-        .map(|(i, l)| (Value::from_str(l), (i + 1) as u64))
+        .map(|(i, l)| (Value::from_str(l), ((i as u64) + 1).min(total_nl)))
         .collect()
 }
 
@@ -3630,6 +3636,9 @@ fn real_main() {
                     eprintln!("jq: error reading input: {}", e);
                     process::exit(2);
                 }
+                // Slurp consumes the whole stream, so `input_line_number` is the
+                // total `\n` count consumed (#925).
+                jq_jit::eval::set_input_line_number(buf.bytes().filter(|&b| b == b'\n').count() as u64);
                 process_input(&Value::from_str(&buf), None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
             } else {
                 // Stream line-by-line, splitting on '\n' only and keeping any
@@ -3638,14 +3647,22 @@ fn real_main() {
                 // (so e.g. `tail -f | jq -R` still works incrementally).
                 let mut reader = stdin.lock();
                 let mut buf: Vec<u8> = Vec::new();
+                // Count of `\n` consumed so far. A terminated line bumps it
+                // (line N -> N); an unterminated final line keeps the prior
+                // count, so `a\nb\nc` reports 1,2,2 and `a\nb\nc\n` reports
+                // 1,2,3, matching jq's `input_line_number` (#925).
+                let mut nl_consumed: u64 = 0;
                 loop {
                     buf.clear();
                     match reader.read_until(b'\n', &mut buf) {
                         Ok(0) => break,
                         Ok(_) => {
-                            if buf.last() == Some(&b'\n') {
+                            let terminated = buf.last() == Some(&b'\n');
+                            if terminated {
                                 buf.pop();
+                                nl_consumed += 1;
                             }
+                            jq_jit::eval::set_input_line_number(nl_consumed);
                             let l = String::from_utf8_lossy(&buf);
                             process_input(&Value::from_str(&l), None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         }
@@ -3670,6 +3687,9 @@ fn real_main() {
                     eprintln!("jq: error (at <stdin>:0): {}", e);
                     process::exit(2);
                 }
+                // Slurp consumes the whole stream: `input_line_number` is the
+                // total `\n` count consumed (#925).
+                jq_jit::eval::set_input_line_number(input_str.bytes().filter(|&b| b == b'\n').count() as u64);
                 let arr = Value::Arr(std::rc::Rc::new(values));
                 process_input(&arr, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
             } else {

--- a/tests/input_line_number_raw_slurp.rs
+++ b/tests/input_line_number_raw_slurp.rs
@@ -1,0 +1,82 @@
+//! Issue #925: `input_line_number` must advance in the `-R` (raw) main loop
+//! and the `-s` / `-Rs` slurp paths (it returned 0), and the raw `inputs`
+//! line number must not bump on an unterminated final line. jq reports the
+//! count of `\n` consumed when the value was emitted; a terminated line N gets
+//! N, an unterminated final line keeps the prior count. The regression-test
+//! harness can't express these flags/streams, so shell out directly.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn run(args: &[&str], stdin: &str) -> String {
+    let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
+    let mut child = Command::new(jq_jit)
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn jq-jit");
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(stdin.as_bytes())
+        .unwrap();
+    let out = child.wait_with_output().expect("wait failed");
+    String::from_utf8(out.stdout)
+        .expect("non-utf8 stdout")
+        .trim_end()
+        .to_string()
+}
+
+// --- -R raw main loop ---
+
+#[test]
+fn raw_main_loop_unterminated_final_line() {
+    // a->1, b->2, c->2 (c has no trailing newline, so no extra \n consumed).
+    assert_eq!(run(&["-Rc", "input_line_number"], "a\nb\nc"), "1\n2\n2");
+}
+
+#[test]
+fn raw_main_loop_trailing_newline() {
+    assert_eq!(run(&["-Rc", "input_line_number"], "a\nb\nc\n"), "1\n2\n3");
+}
+
+#[test]
+fn raw_main_loop_single_unterminated_line() {
+    assert_eq!(run(&["-Rc", "input_line_number"], "x"), "0");
+}
+
+// --- -s JSON slurp ---
+
+#[test]
+fn json_slurp_reports_total_newlines() {
+    assert_eq!(run(&["-sc", "input_line_number"], "1\n2\n3\n"), "3");
+    assert_eq!(run(&["-sc", "input_line_number"], "1\n2\n3"), "2");
+    assert_eq!(run(&["-sc", "input_line_number"], "1 2 3"), "0");
+}
+
+// --- -Rs raw slurp ---
+
+#[test]
+fn raw_slurp_reports_total_newlines() {
+    assert_eq!(run(&["-Rsc", "input_line_number"], "a\nb\n"), "2");
+    assert_eq!(run(&["-Rsc", "input_line_number"], "a\nb"), "1");
+}
+
+// --- raw inputs (-Rn) off-by-one on the unterminated final line ---
+
+#[test]
+fn raw_inputs_unterminated_final_line_no_bump() {
+    assert_eq!(run(&["-Rnc", "[inputs] | input_line_number"], "a\nb\nc"), "2");
+    assert_eq!(run(&["-Rnc", "[inputs] | input_line_number"], "a\nb\nc\n"), "3");
+    assert_eq!(run(&["-Rnc", "[inputs|input_line_number]"], "a\nb\nc"), "[1,2,2]");
+}
+
+// --- regression guard: the JSON streaming main loop still works ---
+
+#[test]
+fn json_stream_main_loop_unaffected() {
+    assert_eq!(run(&["-c", "input_line_number"], "1\n2\n3"), "1\n2\n2");
+}


### PR DESCRIPTION
## Summary

`input_line_number` always returned `0` in the `-R` (raw) main loop and the `-s` / `-Rs` slurp paths (#117/#855 wired only the JSON-stream loop and explicit `input`/`inputs` reads), and the raw `inputs` line number bumped on an unterminated final line.

```
$ printf 'a\nb\nc'   | jq-jit -Rc 'input_line_number'   # was 0 0 0, now 1 2 2
$ printf '1\n2\n3\n' | jq-jit -sc 'input_line_number'   # was 0,     now 3
$ printf 'a\nb\n'    | jq-jit -Rsc 'input_line_number'  # was 0,     now 2
$ printf 'a\nb\nc'   | jq-jit -Rnc '[inputs]|input_line_number'  # was 3, now 2
```

## Fix

jq reports `input_line_number` as the count of `\n` consumed when the value is emitted: a terminated line N gets N; an unterminated final line adds no newline and keeps the prior count.

- **`raw_inputs_with_lines`**: cap the per-line number at the total `\n` count (`a\nb\nc` → 1,2,2; `a\nb\nc\n` → 1,2,3) — fixes the raw `inputs` off-by-one.
- **`-R` stdin main loop**: maintain a consumed-newline counter, bumping only on a terminated line, set before each value.
- **`-s` / `-Rs` slurp**: set the counter to the total `\n` consumed before processing the slurped value.

The non-raw JSON streaming main loop is unchanged.

## Tests

`tests/input_line_number_raw_slurp.rs` (7 cases) covers `-R`/`-s`/`-Rs`/`-Rn` including unterminated-final-line and single-line edges, plus a regression guard that the JSON streaming loop still reports `1,2,2`. Verified against jq 1.8.1 across all modes. Full suite passes; zero warnings.

> Scope: the issue's repros are all stdin-based; file-argument line-number accounting (a separate, unreported path) is unchanged.

Closes #925

🤖 Generated with [Claude Code](https://claude.com/claude-code)