### PR TITLE
fix: seed input queue for sub/gsub replacement reading the stream

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -2740,6 +2740,20 @@ impl Filter {
                 // so the binary never seeded the input queue under `-n` and the
                 // generator yielded nothing (any -> false, all -> true). #928
                 Expr::AnyShort { generator, predicate } | Expr::AllShort { generator, predicate } => walk!(generator) || walk!(predicate),
+                // Regex builtins evaluate their sub-expressions against the
+                // input, and `sub`/`gsub` evaluate the replacement (`tostr`)
+                // as a generator that can pull from the stream
+                // (`gsub(re; input)`). Omitting these made `uses_inputs()`
+                // report false, so the binary never seeded the input queue:
+                // `input` raised a bogus `break` and the main loop replayed
+                // each remaining document as a separate top-level input,
+                // producing the wrong output shape (#930).
+                Expr::RegexTest { input_expr, re, flags }
+                | Expr::RegexMatch { input_expr, re, flags }
+                | Expr::RegexCapture { input_expr, re, flags }
+                | Expr::RegexScan { input_expr, re, flags } => walk!(input_expr) || walk!(re) || walk!(flags),
+                Expr::RegexSub { input_expr, re, tostr, flags }
+                | Expr::RegexGsub { input_expr, re, tostr, flags } => walk!(input_expr) || walk!(re) || walk!(tostr) || walk!(flags),
                 Expr::While { cond, update, .. } | Expr::Until { cond, update } => walk!(cond) || walk!(update),
                 Expr::Repeat { update, .. } => walk!(update),
                 Expr::Range { from, to, step } => {

--- a/tests/gsub_input_stream.rs
+++ b/tests/gsub_input_stream.rs
@@ -1,0 +1,96 @@
+//! Issue #930: when the replacement of `sub`/`gsub` pulls from `input`/`inputs`
+//! (`gsub(re; input)`), the input queue must be seeded so the read consumes the
+//! shared stream instead of raising a bogus `break` at EOF. The bug: the
+//! `uses_inputs()` walker had no arm for the Regex* expressions, so the binary
+//! never seeded the queue. `input` then hit EOF (printing a leaked `break`,
+//! exit 5) and the main loop replayed each remaining document as its own
+//! top-level input, producing the wrong output shape (`"X"`,`"Y"` instead of
+//! the joined `"XY"`). The regression-test harness feeds a single document, so
+//! we shell out to drive a multi-document stream.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn run(args: &[&str], stdin: &str) -> (String, i32) {
+    let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
+    let mut child = Command::new(jq_jit)
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn jq-jit");
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(stdin.as_bytes())
+        .unwrap();
+    let out = child.wait_with_output().expect("wait failed");
+    let code = out.status.code().unwrap_or(-1);
+    let s = String::from_utf8(out.stdout)
+        .expect("non-utf8 stdout")
+        .trim_end()
+        .to_string();
+    (s, code)
+}
+
+#[test]
+fn gsub_single_match_consumes_one_input() {
+    // "a" matches once; replacement reads the next document "X". Clean exit.
+    assert_eq!(run(&["-c", r#"gsub("a"; input)"#], "\"a\"\n\"X\""), ("\"X\"".to_string(), 0));
+}
+
+#[test]
+fn gsub_two_matches_lockstep_joins_into_one_string() {
+    // Two matches each pull one input in lockstep -> a single joined "XY",
+    // NOT two separate top-level outputs.
+    assert_eq!(
+        run(&["-c", r#"gsub("a"; input)"#], "\"aa\"\n\"X\"\n\"Y\""),
+        ("\"XY\"".to_string(), 0)
+    );
+}
+
+#[test]
+fn sub_single_match_consumes_one_input() {
+    assert_eq!(run(&["-c", r#"sub("a"; input)"#], "\"a\"\n\"R\""), ("\"R\"".to_string(), 0));
+}
+
+#[test]
+fn gsub_with_capture_and_input() {
+    assert_eq!(
+        run(&["-c", r#"gsub("(?<x>a)"; input)"#], "\"a\"\n\"Z\""),
+        ("\"Z\"".to_string(), 0)
+    );
+}
+
+#[test]
+fn gsub_inputs_drains_remaining_stream() {
+    // `inputs` is a generator: the first match drains the whole remaining
+    // stream (["X","Y"]); the second match's `inputs` yields nothing. The
+    // lockstep length is 2, so output index 0 -> "X", index 1 -> "Y" (the
+    // empty second-match generator drops out at each index). This matches
+    // jq exactly; the point of the test is no leaked `break`/exit 5.
+    assert_eq!(
+        run(&["-c", r#"gsub("a"; inputs)"#], "\"aa\"\n\"X\"\n\"Y\""),
+        ("\"X\"\n\"Y\"".to_string(), 0)
+    );
+}
+
+#[test]
+fn gsub_genuine_eof_still_breaks() {
+    // No second document: the read genuinely hits EOF. jq surfaces an
+    // uncaught break (exit 5); we must match that, not silently swallow it.
+    let (_out, code) = run(&["-c", r#"gsub("a"; input)"#], "\"a\"");
+    assert_eq!(code, 5);
+}
+
+#[test]
+fn gsub_no_input_replacement_unaffected() {
+    // The replacement does not read the stream: the second document must
+    // remain a separate top-level input, each producing its own output.
+    assert_eq!(
+        run(&["-c", r#"gsub("a"; "b")"#], "\"aaa\"\n\"junk\""),
+        ("\"bbb\"\n\"junk\"".to_string(), 0)
+    );
+}


### PR DESCRIPTION
## Summary

`gsub(re; input)` (and any `sub`/`gsub` whose replacement pulls from `input`/`inputs`) leaked an internal `break`: it printed an uncaught error (exit 5) and, with multiple matches, produced the wrong output shape (separate strings instead of one joined string).

```
$ printf '"a"\n"X"'        | jq-jit -c 'gsub("a"; input)'   # before: error "break" + "X", exit 5  →  after: "X"
$ printf '"aa"\n"X"\n"Y"'  | jq-jit -c 'gsub("a"; input)'   # before: error + "X" + "Y", exit 5    →  after: "XY"
```

## Root cause

`Filter::uses_inputs()` had **no arm for the `Regex*` expressions**, so `gsub(re; input)` fell through to `_ => false`. The binary uses that verdict to decide whether to seed the shared input queue. Unseeded, the `input` builtin hit EOF and raised a bogus `break`, and the CLI main loop replayed each remaining document as its own top-level input — hence the wrong shape.

The replacement-evaluator lockstep in `eval.rs` was already correct (`gsub("a"; ("P","Q"))` already matched jq); the only gap was queue seeding.

## Fix

Add the `RegexTest`/`RegexMatch`/`RegexCapture`/`RegexScan`/`RegexSub`/`RegexGsub` arms to the `uses_inputs()` walker (mirroring `has_any_runtime_loop_construct`'s coverage). `sub`/`gsub` also walk the replacement (`tostr`) so a stream read there seeds the queue. Replacements that don't read the stream (`gsub(re; "x")`) still classify as not using inputs, so there's no over-seeding.

Same class as #853 (path-expression forms) and #928 (any/all short-circuit).

## Tests

New `tests/gsub_input_stream.rs` (multi-document stream behavior the regression harness can't express): single-match consume, two-match lockstep join, `sub`, named-capture + input, `inputs` drain, genuine-EOF still breaks (exit 5, matching jq), and a no-input-replacement guard against over-seeding. Verified against jq 1.8.1 across the JIT and `JQJIT_FORCE_INTERPRETER=1` paths. Full `cargo test --release` green (one transient oracle `<timeout>` on an unrelated `paths` case cleared on re-run).

Closes #930

🤖 Generated with [Claude Code](https://claude.com/claude-code)