### PR TITLE
fix: path(recurse(f)) follows the step and propagates leaf errors

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -5587,7 +5587,21 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
             if !cont { return Ok(false); }
             eval_path(right, input, env, cb)
         }
-        Expr::Recurse { .. } => eval_recurse_paths(&input, &Value::Arr(Rc::new(vec![])), cb),
+        Expr::Recurse { input_expr } => {
+            // The 0-arg `recurse` / `..` desugar to `recurse(.[]?)` —
+            // `EachOpt { Input }` — whose path closure is the full descent.
+            // A custom step `recurse(f)` must instead follow `f` in path
+            // mode at every level: jq navigates via `f` (not the default
+            // descent) and propagates a per-step type error when `f` cannot
+            // apply to a leaf (`1 | .a`). Ignoring the step both produced the
+            // wrong paths and masked that error (#917).
+            if matches!(input_expr.as_ref(), Expr::EachOpt { input_expr: ie } if matches!(ie.as_ref(), Expr::Input)) {
+                eval_recurse_paths(&input, &Value::Arr(Rc::new(vec![])), cb)
+            } else {
+                let mut path: Vec<Value> = Vec::new();
+                eval_recurse_step_paths(input_expr, &input, &mut path, env, cb)
+            }
+        }
         Expr::LetBinding { var_index, value, body } => {
             // Identity (`. as $x`, #837) and tracked-navigation destructuring
             // sub-bindings (`$src[k] as $a`, #880) both forward a path and are
@@ -6730,6 +6744,33 @@ fn eval_recurse_paths_inner(val: &Value, path: &mut Vec<Value>, cb: &mut dyn FnM
         _ => {}
     }
     Ok(true)
+}
+
+/// Path-mode `recurse(f)`: yield the current path, then follow the step `f`
+/// in path mode at each level (`def r: ., (f | r)`). Paths are relative to the
+/// value passed in (Pipe concatenates any prefix). A step that cannot apply to
+/// a leaf surfaces jq's per-step type error rather than stopping silently
+/// (`path(recurse(.a))` on `{"a":{"a":1}}` → "Cannot index number"). The
+/// recursion is lazy: a `cb` stop request (`limit`/`first`) halts the descent,
+/// and `stacker::maybe_grow` guards deep navigation. #917
+fn eval_recurse_step_paths(
+    step: &Expr,
+    val: &Value,
+    path: &mut Vec<Value>,
+    env: &EnvRef,
+    cb: &mut dyn FnMut(Value) -> GenResult,
+) -> GenResult {
+    if !cb(Value::Arr(Rc::new(path.clone())))? { return Ok(false); }
+    eval_path(step, val.clone(), env, &mut |sp| {
+        let child = crate::runtime::rt_getpath(val, &sp).unwrap_or(Value::Null);
+        let saved = path.len();
+        if let Value::Arr(a) = &sp { path.extend(a.iter().cloned()); }
+        let r = stacker::maybe_grow(64 * 1024, 1024 * 1024, || {
+            eval_recurse_step_paths(step, &child, path, env, cb)
+        });
+        path.truncate(saved);
+        r
+    })
 }
 
 fn eval_call_builtin(name: &str, args: &[Expr], input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) -> GenResult) -> GenResult {

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -12732,3 +12732,28 @@ try path(all) catch .
 path(any(.[]; .x))
 [{"x":false},{"x":true}]
 [1,"x"]
+
+# #917: path(recurse(f)) propagates the per-step leaf type error
+try ([path(recurse(.a))]) catch .
+{"a":{"a":1}}
+"Cannot index number with string \"a\""
+
+# #917: 2-arg recurse(f; cond) likewise propagates the leaf error
+try ([path(recurse(.a; true))]) catch .
+{"a":{"a":1}}
+"Cannot index number with string \"a\""
+
+# #917: path(recurse(f)) follows the step f, not the default descent
+[limit(5; path(recurse(.a)))]
+{"a":{"b":9}}
+[[],["a"],["a","a"],["a","a","a"],["a","a","a","a"]]
+
+# #917: guarded custom step terminates with the navigated paths
+[path(recurse(.a | objects))]
+{"a":{"a":1}}
+[[],["a"]]
+
+# #917: plain recurse / .. still uses the full descent (regression guard)
+[path(recurse)]
+{"a":{"b":9},"c":7}
+[[],["a"],["a","b"],["c"]]


### PR DESCRIPTION
## Summary

`path(recurse(f))` ignored the step `f`: it walked the default full descent (every child key) instead of navigating via `f`, and never evaluated `f`, so it silently swallowed the per-step type error jq raises at a leaf.

```
$ echo '{"a":{"a":1}}' | jq     -c '[path(recurse(.a))]'   # jq: error "Cannot index number with string \"a\""
$ echo '{"a":{"a":1}}' | jq-jit -c '[path(recurse(.a))]'   # before: [[],["a"],["a","a"]]  → after: same error as jq
```

The wrong-paths half showed up wherever the step differs from the full descent — `limit(5; path(recurse(.a)))` walked `.b`/`.c` instead of the `["a"]*` spine.

## Fix

The `Expr::Recurse` path arm now branches on the step:

- `recurse` / `..` (parser desugar `recurse(.[]?)` = `EachOpt { Input }`) keep the optimized full-descent helper `eval_recurse_paths`.
- A custom step `recurse(f)` uses the new `eval_recurse_step_paths`: yield the current path, then follow `f` in path mode at each level (`def r: ., (f | r)`). A step that cannot apply to a leaf surfaces jq's type error; recursion stays lazy (honours `limit`/`first`) and is `stacker`-guarded.

## Tests

5 cases appended to `tests/regression.test` (tail-only, selfdiff allowlists untouched): the leaf type error (via `try … catch .`), the 2-arg `recurse(f; cond)` form, the step-following paths under `limit`, a guarded finite step, and a plain-`recurse` regression guard. Verified against jq 1.8.1 on the JIT and `JQJIT_FORCE_INTERPRETER=1` paths, including assignment/`del` through `recurse(f)`. Full `cargo test --release` green, zero warnings.

Closes #917

🤖 Generated with [Claude Code](https://claude.com/claude-code)