### PR TITLE
fix: recurse(f) is lazy/depth-first so break ordering matches jq

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3163,14 +3163,24 @@ pub fn eval(
         }
 
         Expr::Label { var_index, body } => {
-            let label_id = {
+            // Allocate a fresh runtime label id and bind it to the label var,
+            // saving the slot's prior value. The save/restore matters when the
+            // same lexical `label $x` is dynamically re-entered — e.g. a
+            // `recurse(f)` whose `f` contains `label $x | … break $x`, which
+            // nests because the recursion is lazy/depth-first. Without the
+            // restore, a `break $x` evaluated after an inner instance exited
+            // read the inner (stale) id and unwound to the wrong label. #916
+            let (label_id, old) = {
                 let mut e = env.borrow_mut();
                 let id = e.next_label;
                 e.next_label = id + 1;
+                let old = e.get_var(*var_index);
                 e.set_var(*var_index, Value::number(id as f64));
-                id
+                (id, old)
             };
-            match eval(body, input, env, cb) {
+            let result = eval(body, input, env, cb);
+            env.borrow_mut().set_var(*var_index, old);
+            match result {
                 Err(e) => {
                     if let Some(be) = e.downcast_ref::<BreakError>() {
                         if be.0 == label_id { return Ok(true); }
@@ -4297,24 +4307,19 @@ fn eval_recurse_expr(step: &Expr, val: &Value, env: &EnvRef, cb: &mut dyn FnMut(
     if matches!(step, Expr::EachOpt { input_expr } if matches!(**input_expr, Expr::Input)) {
         eval_recurse_default(val, cb)
     } else {
-        // Custom step: use explicit stack to avoid stack overflow.
-        // Errors raised by `step` must propagate (#195) — jq emits the
-        // already-yielded values AND the type-error to stderr (exit 5).
-        // The previous `let _ = eval(...)` silently dropped them.
-        let mut work = vec![val.clone()];
-        while let Some(current) = work.pop() {
-            if !cb(current.clone())? { return Ok(false); }
-            let mut next_vals = Vec::new();
-            eval(step, current, env, &mut |next| {
-                next_vals.push(next);
-                Ok(true)
-            })?;
-            // Push in reverse so first output is processed first
-            for v in next_vals.into_iter().rev() {
-                work.push(v);
-            }
-        }
-        Ok(true)
+        // Custom step `recurse(f)` = `def r: ., (f | r); r`. The recursion is
+        // lazy and depth-first: emit the current value, then for EACH value
+        // `f` produces (in order) immediately recurse into it before pulling
+        // the next one. Buffering all of `f`'s outputs first (the old
+        // explicit-stack approach) evaluated `f` breadth-first, so a
+        // `break $label` / error raised by a *later* generator alternative
+        // inside `f` fired before an *earlier* alternative's subtree ran —
+        // truncating output (#916). Errors raised by `step` still propagate
+        // (#195). `stacker::maybe_grow` guards deep recursion.
+        if !cb(val.clone())? { return Ok(false); }
+        eval(step, val.clone(), env, &mut |next| {
+            stacker::maybe_grow(64 * 1024, 1024 * 1024, || eval_recurse_expr(step, &next, env, cb))
+        })
     }
 }
 

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -12757,3 +12757,23 @@ try ([path(recurse(.a; true))]) catch .
 [path(recurse)]
 {"a":{"b":9},"c":7}
 [[],["a"],["a","b"],["c"]]
+
+# #916: recurse(f) is lazy/depth-first; an outer break fires after the earlier subtree
+[label $o | recurse(if . < 3 then (.+1, (if .==1 then break $o else empty end)) else empty end)]
+0
+[0,1,2,3]
+
+# #916: same for the 2-arg recurse(f; cond) form
+[label $o | recurse(if .==1 then (.+1, break $o) else .+1 end; . < 4)]
+0
+[0,1,2,3]
+
+# #916: a label inside f is re-entered per level; each break targets its own instance
+[label $a | recurse(if . < 5 then (label $b | (.+1, break $b)) else empty end)]
+0
+[0,1,2,3,4,5]
+
+# #916: recurse(f) ordering unchanged when no break is involved (regression guard)
+[recurse(if . < 3 then .+1 else empty end)]
+0
+[0,1,2,3]


### PR DESCRIPTION
## Summary

`recurse(f)` buffered all of `f`'s outputs before recursing, evaluating `f` breadth-first. A `break $label` (or error) from a *later* generator alternative inside `f` fired before an *earlier* alternative's depth-first subtree ran, truncating output.

```
$ echo 0 | jq     -c '[label $o | recurse(if . < 3 then (.+1, (if .==1 then break $o else empty end)) else empty end)]'
[0,1,2,3]
$ echo 0 | jq-jit -c '…'   # before: [0,1]   → after: [0,1,2,3]
```

The hand-expanded `def r: ., (f|r); r` already agreed with jq, proving the divergence was the `recurse(f)` fast path, not the semantics. Also affected the 2-arg `recurse(f; cond)` form.

## Fix

Make the custom-step recursion **lazy and depth-first**: emit the current value, then for each value `f` yields (in order) recurse immediately before pulling the next. `stacker::maybe_grow` guards depth; step errors still propagate (#195).

This lazy nesting exposed a latent bug in `Expr::Label`: the label var slot was overwritten with the fresh runtime id but **never restored**. A `label $x` inside `f` is dynamically re-entered once per recursion level, so after an inner instance exited a stale id was left in the slot and a later `break $x` unwound to the wrong label. The `Label` arm now saves/restores the slot around its body — this only changes behaviour when a label is dynamically re-entered (the broken case). `Expr::Label` comes only from an explicit `label $x` (limit/first/while use dedicated nodes), so it is not a hot path.

## Tests

4 cases appended to `tests/regression.test` (tail-only): both issue repros, a nested-inner-label case (`break $b` inside `f`), and a no-break ordering guard. Verified against jq 1.8.1 (JIT and `JQJIT_FORCE_INTERPRETER=1`), plus label/break/limit/first regressions. Full `cargo test --release` green, zero warnings.

Closes #916

🤖 Generated with [Claude Code](https://claude.com/claude-code)