### PR TITLE
fix: track input_filename source instead of hardcoded "<stdin>"

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -39,6 +39,19 @@ fn json_inputs_with_lines(content: &str) -> Result<Vec<(Value, u64)>, String> {
     Ok(out)
 }
 
+/// Tag `(value, line)` queue entries with their source filename, producing the
+/// `(value, line, filename)` entries `input`/`inputs` need so `input_filename`
+/// reports the right source as a filter pulls across the stream (#926).
+fn tag_filename(
+    entries: Vec<(jq_jit::value::Value, u64)>,
+    filename: &std::rc::Rc<str>,
+) -> Vec<jq_jit::eval::InputEntry> {
+    entries
+        .into_iter()
+        .map(|(v, line)| (v, line, Some(std::rc::Rc::clone(filename))))
+        .collect()
+}
+
 /// Raw (`-R`) input lines paired with their 1-based line numbers (#855).
 /// Split raw (`-R`) input into lines the way jq does: on `\n` ONLY, keeping any
 /// trailing `\r` as line content (so a CRLF file yields `"a\r"`). Rust's
@@ -3563,31 +3576,34 @@ fn real_main() {
     if null_input {
         // Pre-read inputs for `input`/`inputs` builtins
         if filter.uses_inputs() {
-            let mut inputs_values: Vec<(Value, u64)> = Vec::new();
+            let mut inputs_values: Vec<jq_jit::eval::InputEntry> = Vec::new();
             if files.is_empty() {
                 // Read from stdin
+                let stdin_name: std::rc::Rc<str> = std::rc::Rc::from("<stdin>");
                 let mut input_str = String::new();
                 io::stdin().lock().read_to_string(&mut input_str).unwrap_or(0);
                 if raw_input {
-                    inputs_values.extend(raw_inputs_with_lines(&input_str));
+                    inputs_values.extend(tag_filename(raw_inputs_with_lines(&input_str), &stdin_name));
                 } else {
                     match json_inputs_with_lines(&input_str) {
-                        Ok(vs) => inputs_values.extend(vs),
+                        Ok(vs) => inputs_values.extend(tag_filename(vs, &stdin_name)),
                         Err(e) => { eprintln!("jq: error (at <stdin>:0): {}", e); process::exit(2); }
                     }
                 }
             } else {
-                // Read from files
+                // Read from files — each document carries its own source path so
+                // `input_filename` reflects the file the value came from (#926).
                 for file in &files {
+                    let fname: std::rc::Rc<str> = std::rc::Rc::from(file.as_str());
                     let content = match std::fs::read_to_string(file) {
                         Ok(c) => c,
                         Err(e) => { eprintln!("jq: error: Could not open file {}: {}", file, e); process::exit(2); }
                     };
                     if raw_input {
-                        inputs_values.extend(raw_inputs_with_lines(&content));
+                        inputs_values.extend(tag_filename(raw_inputs_with_lines(&content), &fname));
                     } else {
                         match json_inputs_with_lines(&content) {
-                            Ok(vs) => inputs_values.extend(vs),
+                            Ok(vs) => inputs_values.extend(tag_filename(vs, &fname)),
                             Err(e) => { eprintln!("jq: error (at {}:0): {}", file, e); process::exit(2); }
                         }
                     }
@@ -3603,17 +3619,18 @@ fn real_main() {
         // remaining stdin value (#196). Pre-load everything into the inputs
         // queue, then drain the queue while both sites pull through the same
         // `read_next_input`.
-        let inputs_values: Vec<(Value, u64)> = if raw_input {
+        let stdin_name: std::rc::Rc<str> = std::rc::Rc::from("<stdin>");
+        let inputs_values: Vec<jq_jit::eval::InputEntry> = if raw_input {
             let mut buf = String::new();
             if let Err(e) = io::stdin().lock().read_to_string(&mut buf) {
                 eprintln!("jq: error reading input: {}", e);
                 process::exit(2);
             }
-            raw_inputs_with_lines(&buf)
+            tag_filename(raw_inputs_with_lines(&buf), &stdin_name)
         } else {
             let input_str = stdin_data.unwrap_or_default();
             match json_inputs_with_lines(&input_str) {
-                Ok(vs) => vs,
+                Ok(vs) => tag_filename(vs, &stdin_name),
                 Err(e) => { eprintln!("jq: error (at <stdin>:0): {}", e); process::exit(2); }
             }
         };
@@ -3627,6 +3644,8 @@ fn real_main() {
         jq_jit::eval::clear_inputs_queue();
     } else if files.is_empty() {
         // Read from stdin
+        // `input_filename` reports "<stdin>" for the stdin stream (#926).
+        jq_jit::eval::set_input_filename(Some(std::rc::Rc::from("<stdin>")));
         let stdin = io::stdin();
         if raw_input {
             if slurp {
@@ -12675,6 +12694,14 @@ fn real_main() {
         // Process files
         let mut slurp_values: Vec<Value> = Vec::new();
         for file in &files {
+            // `input_filename` reports the source path of the current input;
+            // "-" reads stdin and reports "<stdin>" (#926). For `--slurp`, all
+            // files fold into one document and jq reports the LAST source —
+            // setting it per file leaves the last value in place for the single
+            // post-loop `process_input`.
+            jq_jit::eval::set_input_filename(Some(std::rc::Rc::from(
+                if file == "-" { "<stdin>" } else { file.as_str() },
+            )));
             // Handle "-" as stdin
             if file == "-" {
                 let mut s = String::new();

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -57,8 +57,14 @@ pub type EnvRef = Rc<RefCell<Env>>;
 // Pre-populated by CLI before eval/JIT execution. Per-thread to keep
 // `cargo test` parallel runs honest — see `value::OBJMAP_POOL`.
 thread_local! {
-    static INPUTS_STATE: RefCell<(Vec<(Value, u64)>, usize)> = const { RefCell::new((Vec::new(), 0)) };
+    static INPUTS_STATE: RefCell<(Vec<InputEntry>, usize)> = const { RefCell::new((Vec::new(), 0)) };
 }
+
+/// A queued document for `input`/`inputs`: the value, the `input_line_number`
+/// jq reports after consuming it (#855), and the source filename for
+/// `input_filename` (#926; `None` => stdin-less null, but the CLI always
+/// supplies "<stdin>" or a file path so this is `Some` in practice).
+pub type InputEntry = (Value, u64, Option<std::rc::Rc<str>>);
 
 // Per-thread 1-indexed line number for `input_line_number`. The CLI updates
 // it before executing the filter on each input; jq defines it as the count
@@ -67,6 +73,16 @@ thread_local! {
 // line sees the same number.
 thread_local! {
     static INPUT_LINE_STATE: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+}
+
+// Per-thread filename reported by `input_filename` (#926). `None` means no
+// input source has been consumed yet — jq returns `null` in that case (e.g.
+// `-n` mode before the first `input`). The CLI sets it to the file path for a
+// named file argument, or "<stdin>" for the stdin stream, as each source is
+// read. `read_next_input` advances it alongside the line counter so a filter
+// that pulls across a file boundary via `input` sees the right source.
+thread_local! {
+    static INPUT_FILENAME_STATE: RefCell<Option<std::rc::Rc<str>>> = const { RefCell::new(None) };
 }
 
 /// Set the line number reported by `input_line_number` for the current input.
@@ -79,11 +95,26 @@ pub fn get_input_line_number() -> u64 {
     INPUT_LINE_STATE.with(|c| c.get())
 }
 
+/// Set the filename reported by `input_filename` for the current input source
+/// (`None` => jq's `null`, before any input is consumed). See #926.
+pub fn set_input_filename(name: Option<std::rc::Rc<str>>) {
+    INPUT_FILENAME_STATE.with_borrow_mut(|c| *c = name);
+}
+
+/// Read the current `input_filename` value as a jq `Value` (`null` until an
+/// input source has been consumed, otherwise the source path string).
+pub fn get_input_filename() -> Value {
+    INPUT_FILENAME_STATE.with_borrow(|c| match c {
+        Some(name) => Value::from_str(name),
+        None => Value::Null,
+    })
+}
+
 /// Set the inputs queue for `input`/`inputs` builtins. Each entry pairs the
 /// document value with the `input_line_number` jq reports after consuming it
 /// (#855): reading a document via `input`/`inputs` advances the counter, just
 /// like the main per-document loop.
-pub fn set_inputs_queue(values: Vec<(Value, u64)>) {
+pub fn set_inputs_queue(values: Vec<InputEntry>) {
     INPUTS_STATE.with_borrow_mut(|state| {
         state.0 = values;
         state.1 = 0;
@@ -111,8 +142,9 @@ pub fn read_next_input() -> Option<Value> {
         }
     });
     match next {
-        Some((v, line)) => {
+        Some((v, line, filename)) => {
             set_input_line_number(line);
+            set_input_filename(filename);
             Some(v)
         }
         None => None,
@@ -6843,6 +6875,9 @@ fn eval_call_builtin(name: &str, args: &[Expr], input: Value, env: &EnvRef, cb: 
     match (name, args.len()) {
         ("input_line_number", 0) => {
             return cb(Value::number(get_input_line_number() as f64));
+        }
+        ("input_filename", 0) => {
+            return cb(get_input_filename());
         }
         ("toboolean", 0) => {
             return cb(rt_toboolean(&input)?);

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -7947,6 +7947,10 @@ extern "C" fn jit_rt_call_builtin(dst: *mut Value, name_ptr: *const u8, name_len
             std::ptr::write(dst, Value::number(crate::eval::get_input_line_number() as f64));
             return 0;
         }
+        if name == "input_filename" {
+            std::ptr::write(dst, crate::eval::get_input_filename());
+            return 0;
+        }
         if name == "__env__" {
             // Cache env object — environment is constant during execution.
             thread_local! {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3553,13 +3553,12 @@ impl Parser {
                 Ok(Expr::CallBuiltin { name: "tostream".to_string(), args: vec![] })
             }
             "input_filename" => {
-                // jq emits "<stdin>" for the default stdin input source
-                // (and the file path when one is specified). jq-jit reads
-                // exclusively from stdin and does not plumb file paths
-                // through the pipeline, so always return "<stdin>" — this
-                // matches jq for the common stdin pipeline; in `-n` mode
-                // jq would return null, which is a known divergence.
-                Ok(Expr::Literal(Literal::Str("<stdin>".to_string())))
+                // Resolved at eval/JIT time from the current input's filename
+                // state (set by the CLI as each input source is consumed): the
+                // file path for a named file argument, "<stdin>" for the stdin
+                // stream, and null before any input has been read (e.g. `-n`
+                // mode before the first `input`). See #926.
+                Ok(Expr::CallBuiltin { name: "input_filename".to_string(), args: vec![] })
             }
             _ => {
                 // User defs and filter parameters were already resolved at the

--- a/tests/input_filename.rs
+++ b/tests/input_filename.rs
@@ -1,0 +1,115 @@
+//! Issue #926: `input_filename` must report the source of the current input —
+//! the file path for a named file argument, "<stdin>" for the stdin stream,
+//! and `null` before any input has been consumed (e.g. `-n` mode before the
+//! first `input`). It was previously hardcoded to the literal "<stdin>".
+//!
+//! These behaviours depend on file arguments and `-n` mode, which the 3-line
+//! `regression.test` harness (single stdin document) cannot drive, so we shell
+//! out and verify against the expectations captured from jq 1.8.1.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn jq_jit() -> &'static str {
+    env!("CARGO_BIN_EXE_jq-jit")
+}
+
+/// Run with explicit file arguments (no stdin).
+fn run_files(args: &[&str]) -> String {
+    let out = Command::new(jq_jit())
+        .args(args)
+        .stdin(Stdio::null())
+        .output()
+        .expect("failed to spawn jq-jit");
+    String::from_utf8(out.stdout).expect("non-utf8 stdout").trim_end().to_string()
+}
+
+/// Run feeding `stdin`, returning trimmed stdout.
+fn run_stdin(args: &[&str], stdin: &str) -> String {
+    let mut child = Command::new(jq_jit())
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn jq-jit");
+    child.stdin.take().unwrap().write_all(stdin.as_bytes()).unwrap();
+    let out = child.wait_with_output().expect("wait failed");
+    String::from_utf8(out.stdout).expect("non-utf8 stdout").trim_end().to_string()
+}
+
+fn write_tmp(name: &str, content: &str) -> String {
+    let mut path = std::env::temp_dir();
+    path.push(format!("jqjit_ifn_{}_{}", std::process::id(), name));
+    std::fs::write(&path, content).unwrap();
+    path.to_str().unwrap().to_string()
+}
+
+#[test]
+fn stdin_reports_stdin_literal() {
+    assert_eq!(run_stdin(&["-c", "input_filename"], "1"), "\"<stdin>\"");
+}
+
+#[test]
+fn null_input_before_read_is_null() {
+    assert_eq!(run_stdin(&["-cn", "input_filename"], "null"), "null");
+}
+
+#[test]
+fn single_file_reports_its_path() {
+    let a = write_tmp("a", "1\n");
+    assert_eq!(run_files(&["-c", "input_filename", &a]), format!("{:?}", a));
+}
+
+#[test]
+fn two_files_report_their_respective_paths() {
+    let a = write_tmp("two_a", "1\n");
+    let b = write_tmp("two_b", "2\n");
+    let expected = format!("{:?}\n{:?}", a, b);
+    assert_eq!(run_files(&["-c", "input_filename", &a, &b]), expected);
+}
+
+#[test]
+fn null_input_with_file_is_null_until_first_read() {
+    let a = write_tmp("nfa", "1\n");
+    assert_eq!(run_files(&["-cn", "input_filename", &a]), "null");
+}
+
+#[test]
+fn null_input_filename_follows_first_read() {
+    let a = write_tmp("nffa", "1\n");
+    assert_eq!(run_files(&["-cn", "input | input_filename", &a]), format!("{:?}", a));
+}
+
+#[test]
+fn input_filename_tracks_source_across_file_boundary() {
+    let a = write_tmp("xb_a", "1\n");
+    let b = write_tmp("xb_b", "2\n");
+    // null (no read), then read 1 from a, then read 2 from b — the filename
+    // tracks the source of the document the cursor last consumed.
+    let expected = format!("[null,1,{:?},2,{:?}]", a, b);
+    assert_eq!(
+        run_files(&["-cn", "[input_filename, input, input_filename, input, input_filename]", &a, &b]),
+        expected
+    );
+}
+
+#[test]
+fn multi_document_file_reports_same_path_each_time() {
+    let m = write_tmp("multi", "1\n2\n3\n");
+    let expected = format!("{0:?}\n{0:?}\n{0:?}", m);
+    assert_eq!(run_files(&["-c", "input_filename", &m]), expected);
+}
+
+#[test]
+fn slurp_two_files_reports_last_source() {
+    // --slurp folds every file into one document; jq reports the LAST source.
+    let a = write_tmp("slurp_a", "1\n");
+    let b = write_tmp("slurp_b", "2\n");
+    assert_eq!(run_files(&["-c", "input_filename", "--slurp", &a, &b]), format!("{:?}", b));
+}
+
+#[test]
+fn dash_argument_reports_stdin() {
+    assert_eq!(run_stdin(&["-c", "input_filename", "-"], "9"), "\"<stdin>\"");
+}

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -12817,3 +12817,8 @@ try ([path(foreach .k[] as $x (.a; .; .))]) catch .
 [path(foreach .[] as $x (0; .; $x))]
 [10,20]
 [[0],[1]]
+
+# #926: input_filename reports "<stdin>" for the stdin stream (file-arg/-n cases in tests/input_filename.rs)
+input_filename
+1
+"<stdin>"


### PR DESCRIPTION
## Summary

`input_filename` always returned the literal string `"<stdin>"` because it was inlined at parse time, ignoring file arguments and `-n` mode. It now resolves at eval/JIT time from per-input filename state the CLI maintains as each source is consumed.

| Invocation | jq 1.8.1 | before | after |
|---|---|---|---|
| `input_filename a.json` | `"a.json"` | `"<stdin>"` | `"a.json"` |
| `input_filename a.json b.json` | `"a.json"`,`"b.json"` | `"<stdin>"`×2 | `"a.json"`,`"b.json"` |
| `-n input_filename` | `null` | `"<stdin>"` | `null` |
| `-n 'input \| input_filename' a.json` | `"a.json"` | `"<stdin>"` | `"a.json"` |
| `input_filename` (stdin) | `"<stdin>"` | `"<stdin>"` | `"<stdin>"` |
| `--slurp ... a.json b.json` | `"b.json"` | `"<stdin>"` | `"b.json"` |

## Approach

- Parser emits `input_filename` as a runtime `CallBuiltin` (like `input_line_number`) instead of a constant string literal.
- A thread-local filename slot in `eval.rs` (`None` ⇒ jq's `null`) is read by the eval and JIT dispatch.
- The `input`/`inputs` queue entries widen from `(value, line)` to `(value, line, filename)`, so `read_next_input` advances the reported source alongside the line counter — a filter pulling across a file boundary via `input` sees the right file.
- The CLI sets the slot to each file's path (or `"<stdin>"` for the stdin stream / `-`) as it processes inputs; `--slurp` leaves the last file's path in place for the single post-loop evaluation.

## Testing

- Verified against jq 1.8.1 on both the JIT and `JQJIT_FORCE_INTERPRETER=1` paths.
- `tests/input_filename.rs` (new): file-argument, multi-file, `-n`, cross-file-`input`, multi-document, slurp, and `-`/stdin cases (the 3-line `regression.test` harness can only drive a single stdin document).
- `regression.test`: stdin case pinned.
- Full suite (`cargo test --release`) green; zero build warnings.

Closes #926

🤖 Generated with [Claude Code](https://claude.com/claude-code)