### PR TITLE
fix: 2-arg foreach over a value generator yields the UPDATE path in path mode

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -6689,7 +6689,16 @@ fn eval_foreach_valuegen_path(
                                     cb(Value::Arr(Rc::new(comb)))
                                 })
                             } else {
-                                bail!("__pathexpr_result__:{}", crate::value::value_to_json(&nbase));
+                                // 2-arg `foreach gen as $x (init; update)` over a
+                                // value-generator source yields UPDATE each step,
+                                // so with a PATH-threaded accumulator the output is
+                                // the UPDATE path (`path(foreach (1,2) as $x (.;.))`
+                                // → `[],[]`; `path(foreach range(1) as $x (.;.a))`
+                                // → `["a"]`). The old code bailed as if the
+                                // accumulator were rootless, which only holds for
+                                // the value-threaded (rootless-INIT) branch below.
+                                // #915
+                                cb(np.clone())
                             };
                             env.borrow_mut().vars[ai as usize] = old_acc2;
                             let c = ec?;

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -12822,3 +12822,18 @@ try ([path(foreach .k[] as $x (.a; .; .))]) catch .
 input_filename
 1
 "<stdin>"
+
+# #915: 2-arg foreach over a value-generator source with a path-valued accumulator yields the UPDATE path
+[path(foreach (1,2) as $x (.;.))]
+{"a":1}
+[[],[]]
+
+# #915: 2-arg foreach value-generator, navigating UPDATE extends the accumulator path
+[path(foreach range(1) as $x (.;.a))]
+{"a":1}
+[["a"]]
+
+# #915: 2-arg foreach value-generator, path-valued INIT threads across steps
+[path(foreach range(2) as $i (.a; .))]
+{"a":1}
+[["a"],["a"]]


### PR DESCRIPTION
## Summary

In `path()`/assignment context, a 2-arg `foreach gen as \$x (init; update)` whose source is a **value generator** (`range`, a literal stream, `empty`) and whose INIT is **path-valued** threads the accumulator as a PATH. Such a foreach yields UPDATE each step, so its path output is the UPDATE path. The path-threaded branch instead bailed with the rootless-accumulator sentinel — which only holds for the value-threaded (rootless-INIT, `nth(n; range)`) branch.

| Filter (input `{"a":1}`) | jq 1.8.1 | before | after |
|---|---|---|---|
| `path(foreach (1,2) as $x (.;.))` | `[],[]` | error | `[],[]` |
| `path(foreach range(1) as $x (.;.a))` | `["a"]` | error | `["a"]` |
| `path(foreach range(2) as $i (.a; .))` | `["a"],["a"]` | error | `["a"],["a"]` |

## Fix

Emit the UPDATE path (already computed as `np`, extending the accumulator path) when EXTRACT is absent, in the PATH-threaded branch of `eval_foreach_valuegen_path`. The value-threaded branch (rootless INIT) and the 3-arg (EXTRACT present) branch are untouched, so:

- the `nth(n; range)` → "result N" shape (#839) is preserved,
- bare-`$x` element forwarding (#711) is preserved,
- 3-arg valuegen path-threading (`path(foreach range(2) as $i (.a;.;.))` → `["a"],["a"]`) is preserved.

## Scope

This is the **value-generator half** of #915. The navigating-source accumulator-provenance cases (rootless-INIT 3-arg silent corruption under `|=`, and the 2-arg navigating-UPDATE case) remain open — they are entangled with the #711 bare-`$x` forwarding (rootless INIT is shared by the `nth(n; .[])` desugar, where `$x` must forward the element path rather than bail) and need the deeper foreach-path rework tracked in #915.

## Testing

- Verified against jq 1.8.1 on both the JIT and `JQJIT_FORCE_INTERPRETER=1` paths, including the #711/#839 guards.
- 3 cases pinned in `regression.test` (tail-appended; self-diff allowlists undisturbed).
- Full suite (`cargo test --release`) green; zero build warnings.

Refs #915

🤖 Generated with [Claude Code](https://claude.com/claude-code)