### PR TITLE
docs: record regex $/^ anchor divergence as an accepted limitation

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -329,6 +329,18 @@ self.emit(JitOp::TypeCmpBranch {
 
 `else_label` 側は `flatten_scalar` で cond/update をセマンティックに評価する generic path に逃がす。cross-type 比較（`"hello" > 5` = true）を honour するのはそこだけ。新しい f64 fused path を書く時は必ずこの guard を付ける。タグ値は `src/value.rs` の `TAG_*` 定数。
 
+### regex の `$` / `^` アンカーは end-of-text のみ（既知の非互換・再起票しない / #820）
+
+jq（Oniguruma）の `$` は Perl 流で「文字列末尾 **または** 末尾改行 1 個の直前」にマッチする（内部改行の前には当たらない）。`^` も対称に始端のみ。jq-jit は Rust `regex` クレートを使っており、その `$` は **end-of-text のみ**、`(?m)$` は **全改行の前**（広すぎ）で、どちらも jq に一致しない。正攻法の lookahead 書き換え `$`→`(?=\n?\z)` は `regex` クレートが lookaround 非対応のため表現できず、消費型 `\n?\z` はゼロ幅でなくなりオフセット/`sub`/`gsub` を壊すので不可。
+
+```
+"a\n" | test("a$")        jq=true        jit=false
+"hello\n" | sub("o$";"0") jq="hell0\n"   jit="hello\n"
+"a\nb\n" | gsub("$";"X")  jq="a\nbX\nX"  jit="a\nb\nX"
+```
+
+単一根因（`$` 既定セマンティクス）が全 regex ビルトイン（`test`/`match`/`sub`/`gsub`/`scan`/`splits`/`capture`）に波及する。クリーンな修正は lookaround 対応エンジン（例 `fancy-regex`）への載せ替えだが、`regex` クレートの **線形時間保証（ReDoS 耐性）を全 regex 経路で手放す** all-or-nothing な設計判断になり、エンジン構文拒否を追う #727 と一体で検討すべき。意図的トレードオフとして **据え置き（#820 を wontfix で close 済）**。bug sweep の regex レンズでこの `$`/`^` 差異を見つけても **再起票しない**。差異の実害は haystack に末尾改行があるケースに限られ、`^…$` 全体マッチの最頻用法では出ない。
+
 ---
 
 ## 4. 典型的なデバッグの流れ


### PR DESCRIPTION
## Summary

Documents the regex `$`/`^` anchor divergence (#820) as a deliberate, accepted limitation in the maintainer notes, so the differential regex lens does not re-file it during bug sweeps.

## Why accepted (not fixed)

jq (Oniguruma) `$` is Perl-style — matches end-of-text **or** just before a single trailing newline. The Rust `regex` crate's `$` matches end-of-text only; `(?m)$` over-matches every interior newline. Neither matches jq, and the natural translation `$`→`(?=\n?\z)` needs lookaround, which the `regex` crate does not support (a consuming rewrite would corrupt offsets / `sub`/`gsub`).

The only principled fix is migrating to a lookaround-capable engine (e.g. `fancy-regex`), which would trade the crate's **linear-time, ReDoS-resistant guarantee across every regex builtin** (`test`/`match`/`sub`/`gsub`/`scan`/`splits`/`capture`) for backtracking. That is an architectural decision to coordinate with the engine-syntax work in #727, not a localized bug fix. Accepted as-is.

Doc-only change.

Refs #820 (closed as wontfix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)