### PR TITLE
fix(jit): error on type-mismatched index in reduce in-place update-assign

### DIFF
--- a/src/jit.rs
+++ b/src/jit.rs
@@ -966,7 +966,13 @@ impl Flattener {
             // null in dst leaks out — e.g. `.[0]|=. | .a==1` returned null instead
             // of erroring once the surrounding _modify pushed it onto the JIT
             // path (#809).
-            JitOp::FieldBinopConst { .. } | JitOp::FieldBinopField { .. }
+            JitOp::FieldBinopConst { .. } | JitOp::FieldBinopField { .. } |
+            // The reduce in-place update/assign navigation: a type-mismatched
+            // index (string key on array, number key on object, any key on a
+            // scalar) sets the error flag instead of silently navigating to
+            // null, so the accumulator update aborts / is caught by an enclosing
+            // try rather than masking the index type error (#964).
+            JitOp::PathExtract { .. }
         );
         self.ops.push(op);
         if is_fallible {
@@ -7595,9 +7601,28 @@ extern "C" fn jit_rt_path_extract(element: *mut Value, container: *mut Value, ke
                 }
                 0
             }
-            _ => {
+            // jq permits indexing null with any key, yielding null — keep the
+            // in-place update fast path lenient here so a null-valued cell
+            // navigates the same as the generic eval / setpath path.
+            (Value::Null, _) => {
                 std::ptr::write(element, Value::Null);
                 0
+            }
+            // Every other (container, key) pair is a type error in jq (e.g.
+            // a string key on an array, a number key on an object, or any key
+            // on a scalar). The generic eval / setpath path raises it; the
+            // reduce in-place update-assign fast path previously swallowed it
+            // by writing null and no-op'ing the writeback, masking index type
+            // errors inside a reduce accumulator update (#964). Propagate jq's
+            // wording so the JIT aborts the update like setpath/`=`/foreach do.
+            (other, key_ref) => {
+                set_jit_error(format!(
+                    "Cannot index {} with {}",
+                    other.type_name(),
+                    crate::runtime::index_err_desc(key_ref)
+                ));
+                std::ptr::write(element, Value::Null);
+                GEN_ERROR
             }
         }
     }
@@ -9976,6 +10001,10 @@ impl JitCompiler {
                         let e = slot_addr(&mut b, *element);
                         let c = slot_addr(&mut b, *container);
                         let k = slot_addr(&mut b, *key);
+                        // Returns GEN_ERROR + sets env.error_flag on a type
+                        // mismatch (#964). The flag is propagated by the
+                        // CheckError/JumpIfError that `emit()` auto-attaches to
+                        // this op (registered fallible), so the result is unused.
                         b.ins().call(rt["path_extract"], &[e, c, k]);
                     }
                     JitOp::PathInsert { container, key, val } => {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2556,7 +2556,7 @@ fn slice_indices(slice_spec: &crate::value::ObjMap, len: i64) -> (usize, usize) 
 
 /// Match jq 1.8.1's "Cannot index X with Y" wording for the Y side.
 /// Numbers omit the value; strings keep the quoted content; others show the type name.
-fn index_err_desc(key: &Value) -> String {
+pub fn index_err_desc(key: &Value) -> String {
     match key {
         Value::Str(s) => format!("string \"{}\"", s),
         Value::Num(_, _) => "number".to_string(),

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -4207,3 +4207,7 @@ null
 
 [5e-324 * 1] | @csv
 null
+
+# #964: reduce in-place update-assign must not mask index type errors
+try (reduce .[] as $x (.; .sum += $x)) catch .
+[1,2,3]

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -12857,3 +12857,23 @@ try ((foreach .[] as $x (0; .+$x; .)) |= 99) catch .
 [path(foreach .[] as $x (0; .; $x))]
 {"a":{"b":2},"c":3}
 [["a"],["c"]]
+
+# #964: reduce in-place update-assign must not mask index type errors (string key on array)
+try (reduce .[] as $x (.; .sum += $x)) catch .
+[1,2,3]
+"Cannot index array with string \"sum\""
+
+# #964: reduce in-place update-assign masking (number key on object)
+try (reduce 0 as $k (.; .[$k] += 1)) catch .
+{"x":0}
+"Cannot index object with number"
+
+# #964: masked error in a multi-level reduce update (.bad.k on an array element)
+try (reduce .[] as $x ({"ok":0,"bad":[1]}; .ok += $x | .bad.k += $x)) catch .
+[10,20]
+"Cannot index array with string \"k\""
+
+# #964: an inner try inside the reduce body still catches the per-iteration error
+reduce .[] as $x (.; try (.sum += $x) catch "ERR")
+[1,2,3]
+"ERR"


### PR DESCRIPTION
## Summary

Inside a `reduce` accumulator body, an update-assignment (`+=` / `-=` / `*=` / `/=` / `//=` / `|=`) whose path indexes a wrong-type container silently **swallowed** the index type error jq raises. The accumulator was returned unchanged (or, for `-=`/`*=`/`/=`, a wrong `null and number` arithmetic error surfaced). The strongest variant silently produced a wrong document — a valid update applied while the invalid one was swallowed.

```
$ echo '[1,2,3]' | jq     -c 'reduce .[] as $x (.; .sum += $x)'
jq: error: Cannot index array with string "sum"
$ echo '[1,2,3]' | jq-jit -c 'reduce .[] as $x (.; .sum += $x)'   # before
[1,2,3]
```

## Root cause

The reduce in-place update/assign fast path (`emit_inplace_update_on_slot` / `emit_reduce_assign`) navigates each path component via `jit_rt_path_extract`, whose catch-all arm wrote `Null` for any type-mismatched `(container, key)` pair instead of jq's type-checked index. The `+=` then proceeded on `null` and the writeback no-op'd. The generic interpreter path (`JQJIT_FORCE_INTERPRETER=1`) and the same update outside `reduce` both error correctly — only the JIT in-place fast path masked it. This is the path-guard invariant gap documented in `docs/maintenance.md`.

## Fix

- `jit_rt_path_extract` now propagates jq's `Cannot index <type> with <key>` wording via `set_jit_error`. Indexing `null` stays lenient (jq permits it).
- `JitOp::PathExtract` is registered as fallible in `emit()`, so the standard error propagation is attached automatically: a `CheckError` jump to the catch handler when inside a `try`, otherwise `ReturnError`. This makes the error catchable by an enclosing `try` (verified jq parity).
- `runtime::index_err_desc` is exposed to reuse the exact key-side wording.

After the fix, jq, the JIT path, and the interpreter path all agree, including `try`/`catch` propagation.

## Tests

- `tests/regression.test`: four cases (string-key-on-array, number-key-on-object, multi-level nested update, and an inner `try` inside the reduce body that still catches per-iteration).
- `tests/differential/corpus.test`: one differential case against system jq.
- Full suite green (`cargo test --release`, 0 failures), zero build warnings.

Closes #964