### PR TITLE
fix(jit): correct trim/ltrim/rtrim opcode mapping under |= apply route

### DIFF
--- a/src/jit.rs
+++ b/src/jit.rs
@@ -7347,13 +7347,18 @@ extern "C" fn jit_rt_unaryop(dst: *mut Value, op: i32, input: *const Value) -> i
                 .duration_since(std::time::UNIX_EPOCH).unwrap().as_secs_f64()));
             return 0;
         }
-        // Fast path: ltrimstr/rtrimstr/trim (op 40/41/42) — null-arg form trims whitespace
+        // Fast path: trim/ltrim/rtrim (op 40/41/42 — see `unaryop_from_i32`)
+        // strip whitespace. The opcodes are Trim=40, Ltrim=41, Rtrim=42, so the
+        // map must be trim→`trim`, ltrim→`trim_start`, rtrim→`trim_end`. It was
+        // previously scrambled (40→trim_start, 41→trim_end, 42→trim), which only
+        // surfaced on the JIT `|=`/_modify apply route — standalone trim uses a
+        // different path — degenerating `ltrim`/`trim` to `rtrim` there (#963).
         if op >= 40 && op <= 42 {
             if let Value::Str(s) = &*input {
                 let r = match op {
-                    40 => s.trim_start(),
-                    41 => s.trim_end(),
-                    42 => s.trim(),
+                    40 => s.trim(),
+                    41 => s.trim_start(),
+                    42 => s.trim_end(),
                     _ => unreachable!(),
                 };
                 std::ptr::write(dst, Value::from_str(r));

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -4211,3 +4211,7 @@ null
 # #964: reduce in-place update-assign must not mask index type errors
 try (reduce .[] as $x (.; .sum += $x)) catch .
 [1,2,3]
+
+# #963: trim family under |= must not scramble leading/trailing stripping
+[(.a|=ltrim), (.a|=rtrim), (.a|=trim)]
+{"a":" hi "}

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -12877,3 +12877,23 @@ try (reduce .[] as $x ({"ok":0,"bad":[1]}; .ok += $x | .bad.k += $x)) catch .
 reduce .[] as $x (.; try (.sum += $x) catch "ERR")
 [1,2,3]
 "ERR"
+
+# #963: ltrim under |= strips leading whitespace (was degenerating to rtrim)
+.a |= ltrim
+{"a":" hi "}
+{"a":"hi "}
+
+# #963: rtrim under |= strips trailing whitespace only
+.a |= rtrim
+{"a":" hi "}
+{"a":" hi"}
+
+# #963: trim under |= strips both ends (leading ASCII space was kept)
+.a |= trim
+{"a":" hi "}
+{"a":"hi"}
+
+# #963: ltrim on root under |= strips leading ASCII whitespace
+. |= ltrim
+" hi"
+"hi"


### PR DESCRIPTION
## Summary

`trim` / `ltrim` applied under update-assignment (`|=` / `_modify`) failed to strip leading ASCII whitespace: `.a |= trim` on `" hi "` kept the leading space, and `. |= ltrim` was a no-op on a leading space (degenerating to `rtrim`). Standalone `trim`/`ltrim`/`rtrim` were correct — only the update route was wrong.

```
$ echo '{"a":" hi "}' | jq     -c '.a |= trim'
{"a":"hi"}
$ echo '{"a":" hi "}' | jq-jit -c '.a |= trim'   # before
{"a":"hi "}
```

## Root cause

The JIT unaryop fast path for the null-arg trim family mapped the opcodes to the wrong operations: `40→trim_start, 41→trim_end, 42→trim`. The opcodes are `Trim=40, Ltrim=41, Rtrim=42` (`unaryop_from_i32`), so the correct map is `40→trim, 41→trim_start, 42→trim_end`. The scramble only surfaced on the JIT `|=` / `_modify` apply route; standalone trim reaches a different path. Leading non-ASCII whitespace (NBSP, ideographic space) was stripped via another mechanism while a pure-ASCII leading run survived — the tell-tale of the scrambled ASCII fast path.

## Fix

Reorder the match to match `runtime`/`eval_unaryop` semantics (`ltrim`=`trim_start`, `rtrim`=`trim_end`, `trim`=`trim`). jq, the JIT path, and the interpreter path now agree across the whole family, standalone and under `|=`, including non-ASCII whitespace.

## Tests

- `tests/regression.test`: four cases pinning `ltrim`/`rtrim`/`trim` under `|=` and `ltrim` on the root.
- `tests/differential/corpus.test`: one differential case against system jq.
- Full suite green (`cargo test --release`), zero warnings.

Closes #963