### PR TITLE
fix(eval): make trim builtins path-transparent under path()/|=/del

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -5501,6 +5501,40 @@ fn source_nav_error(source: &Expr, input: &Value, env: &EnvRef) -> anyhow::Error
     anyhow::anyhow!("Invalid path expression near {}", tail)
 }
 
+/// Lower the path-transparent `*str` trim builtins to their jq slice
+/// definitions so the existing slice-path machinery produces jq's paths:
+///   `ltrimstr($x)` → `if startswith($x) then .[($x|length):] else . end`
+///   `rtrimstr($x)` → `if endswith($x)   then .[:-($x|length)] else . end`
+///   `trimstr($x)`  → `ltrimstr($x) | rtrimstr($x)`
+/// A no-match yields the identity path `[]`; a match yields the slice path
+/// (`[{start,end}]`), which `|=`/`=` reject with "Cannot update string slices"
+/// and `del` removes — exactly as jq does (#962). The startswith/endswith
+/// condition raises jq's "… requires string inputs" on a non-string input or
+/// argument. `$x` (`arg`) is evaluated against the same input as the builtin,
+/// matching `def`-bound semantics; it is referenced twice, so a generator
+/// argument (vanishingly rare in a path expression) is re-evaluated.
+fn lower_trimstr_path(name: &str, arg: &Expr) -> Expr {
+    let len_of_arg = || Expr::UnaryOp { op: crate::ir::UnaryOp::Length, operand: Box::new(arg.clone()) };
+    match name {
+        "ltrimstr" => Expr::IfThenElse {
+            cond: Box::new(Expr::CallBuiltin { name: "startswith".to_string(), args: vec![arg.clone()] }),
+            then_branch: Box::new(Expr::Slice { expr: Box::new(Expr::Input), from: Some(Box::new(len_of_arg())), to: None }),
+            else_branch: Box::new(Expr::Input),
+        },
+        "rtrimstr" => Expr::IfThenElse {
+            cond: Box::new(Expr::CallBuiltin { name: "endswith".to_string(), args: vec![arg.clone()] }),
+            then_branch: Box::new(Expr::Slice { expr: Box::new(Expr::Input), from: None, to: Some(Box::new(Expr::Negate { operand: Box::new(len_of_arg()) })) }),
+            else_branch: Box::new(Expr::Input),
+        },
+        // `trimstr` is `ltrimstr | rtrimstr`: a left match then a right match
+        // compose into a two-component slice path, exactly as jq emits.
+        _ => Expr::Pipe {
+            left: Box::new(lower_trimstr_path("ltrimstr", arg)),
+            right: Box::new(lower_trimstr_path("rtrimstr", arg)),
+        },
+    }
+}
+
 fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) -> GenResult) -> GenResult {
     match expr {
         Expr::Input => {
@@ -6269,6 +6303,33 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
         Expr::UnaryOp { op: crate::ir::UnaryOp::All, operand } => {
             let gen = Expr::Each { input_expr: operand.clone() };
             eval_any_all_path(&gen, &Expr::Input, false, input, env, cb)
+        }
+        // The `*str` trim builtins are jq-defined slice expressions, so they are
+        // path-transparent: lower to that definition and reuse the slice-path
+        // machinery (no-match → identity `[]`, match → slice path). #962
+        Expr::CallBuiltin { name, args }
+            if args.len() == 1 && matches!(name.as_str(), "ltrimstr" | "rtrimstr" | "trimstr") =>
+        {
+            let lowered = lower_trimstr_path(name, &args[0]);
+            eval_path(&lowered, input, env, cb)
+        }
+        // The whitespace trim builtins (`trim`/`ltrim`/`rtrim`) are value-
+        // producing C builtins: jq keeps the path only when the result is the
+        // input unchanged (identity path `[]`); any actual trim has no path and
+        // surfaces "Invalid path expression with result <trimmed>". #962
+        Expr::UnaryOp { op, operand }
+            if matches!(op, crate::ir::UnaryOp::Trim | crate::ir::UnaryOp::Ltrim | crate::ir::UnaryOp::Rtrim) =>
+        {
+            let root = input.clone();
+            eval_path(operand, input, env, &mut |base_path| {
+                let base_val = crate::runtime::rt_getpath(&root, &base_path).unwrap_or(Value::Null);
+                let trimmed = eval_unaryop(*op, &base_val)?;
+                if trimmed == base_val {
+                    cb(base_path)
+                } else {
+                    bail!("__pathexpr_result__:{}", crate::value::value_to_json(&trimmed))
+                }
+            })
         }
         _ => {
             // Non-path-safe expression: evaluate, then accept the value as

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -4223,3 +4223,11 @@ try (reduce .[] as $x (.; .sum += $x)) catch .
 # #956: truncate_stream null/empty-event handling vs the depth
 [(-1|truncate_stream(.)), (0|truncate_stream(.))]
 99
+
+# #962: *str / whitespace trim builtins are path-transparent
+[path(ltrimstr("q")), path(ltrimstr("a")), path(rtrimstr("c")), path(trimstr("a"))]
+"abca"
+
+# #962: trim no-op under |= vs object navigation
+(.x |= trim)
+{"x":" hi "}

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -12927,3 +12927,58 @@ reduce .[] as $x (.; try (.sum += $x) catch "ERR")
 [-1|truncate_stream([])]
 99
 [[null]]
+
+# #962: ltrimstr no-match yields the identity path []
+path(ltrimstr("q"))
+"abc"
+[]
+
+# #962: ltrimstr match yields a slice path (jq-defined slice builtin)
+path(ltrimstr("a"))
+"abc"
+[{"start":1,"end":null}]
+
+# #962: rtrimstr match yields a trailing slice path
+path(rtrimstr("c"))
+"abc"
+[{"start":null,"end":-1}]
+
+# #962: trimstr match composes two slice components (ltrimstr | rtrimstr)
+path(trimstr("a"))
+"abca"
+[{"start":1,"end":null},{"start":null,"end":-1}]
+
+# #962: ltrimstr no-match under |= updates the whole value (identity path)
+ltrimstr("x") |= "Z"
+"abc"
+"Z"
+
+# #962: trim no-op under |= updates (whitespace-free input keeps identity path)
+trim |= "Z"
+"abc"
+"Z"
+
+# #962: trim that actually strips has no path -> invalid path expression
+try (trim|="Z") catch .
+" hi "
+"Invalid path expression with result \"hi\""
+
+# #962: del over a no-match *str trim removes nothing-indexable -> null
+del(ltrimstr("q"))
+"abc"
+null
+
+# #962: |= over a matched *str slice rejects like any string slice
+try (ltrimstr("a")|="Z") catch .
+"abc"
+"Cannot update string slices"
+
+# #962: trim is path-transparent through object navigation under |=
+.x |= trim
+{"x":" hi "}
+{"x":"hi"}
+
+# #962: trim no-op navigates to a valid path
+path(.x | trim)
+{"x":"hi"}
+["x"]


### PR DESCRIPTION
## Summary

`ltrimstr` / `rtrimstr` / `trimstr` / `ltrim` / `rtrim` / `trim` are path expressions in jq, but jq-jit's native fast paths dropped path provenance, so using one as a path expression (`path()`, the LHS of `|=`/`=`, or inside `del`) errored `Invalid path expression`.

```
$ echo '"abc"' | jq     -c 'path(ltrimstr("q"))'
[]
$ echo '"abc"' | jq-jit -c 'path(ltrimstr("q"))'   # before
jq: error: Invalid path expression with result "abc"
```

## Fix

Two distinct jq behaviors, both handled in `eval_path` (value-context native fast paths untouched):

- **`*str` variants** are jq-defined slice expressions. Lower them to that definition (`ltrimstr($x)` → `if startswith($x) then .[($x|length):] else . end`, `rtrimstr($x)` → `if endswith($x) then .[:-($x|length)] else . end`, `trimstr($x)` → `ltrimstr($x) | rtrimstr($x)`) and reuse the existing slice-path machinery. A no-match yields the identity path `[]`; a match yields the slice path `[{start,end}]`, which `|=`/`=` reject with "Cannot update string slices" and `del` removes — exactly as jq. The `startswith`/`endswith` condition reproduces jq's "… requires string inputs" on a non-string input/argument.
- **Whitespace variants** (`trim`/`ltrim`/`rtrim`) are value-producing C builtins: jq keeps the path only when the result is the input unchanged (identity `[]`); any actual trim has no path → `Invalid path expression with result <trimmed>`.

## Verification

jq-parity confirmed across the whole family for `path()`/`|=`/`del`, through object navigation, including the matched-slice path (`[{"start":1,"end":null}]`), the "Cannot update string slices" `|=` case, and non-string-input errors — against both jq 1.8.1 and the interpreter path.

## Tests

- `tests/regression.test`: eleven cases (no-match identity, match slice paths, `trimstr` two-component path, `|=`/`del`/navigation, and the trim-occurs invalid-path case).
- `tests/differential/corpus.test`: two differential cases against system jq.
- Full suite green (`cargo test --release`), zero warnings.

Closes #962