### PR TITLE
fix(eval): validate @urid input like jq (malformed escapes, raw non-ASCII)

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -4616,23 +4616,48 @@ pub fn eval_format(name: &str, val: &Value) -> Result<String> {
             Ok(r)
         }
         "urid" => {
+            // jq validates `@urid` input (#961): a `%` must be followed by two
+            // hex digits, and a maximal run of consecutive `%XX` escapes must
+            // decode to valid UTF-8 — a malformed escape (`%`, `%4`, `%GG`) or
+            // an ill-formed escaped byte sequence (`%80`, `%C3`, `%C0%80`) is a
+            // hard `"string (X) is not a valid uri encoding"` error. A *raw*
+            // (non-escaped) input byte ≥ 0x80 is instead replaced per-byte with
+            // U+FFFD (so `"é"` → two U+FFFD), and raw ASCII passes through.
             let bytes = s.as_bytes();
-            let mut decoded = Vec::new();
+            let uri_err = || anyhow::anyhow!(
+                "string ({}) is not a valid uri encoding",
+                crate::value::value_to_json(&Value::from_str(&s))
+            );
+            // Validate + flush the pending escaped-byte run as UTF-8.
+            let flush = |esc: &mut Vec<u8>, out: &mut String| -> Result<()> {
+                if !esc.is_empty() {
+                    match std::str::from_utf8(esc) {
+                        Ok(decoded) => out.push_str(decoded),
+                        Err(_) => return Err(uri_err()),
+                    }
+                    esc.clear();
+                }
+                Ok(())
+            };
+            let mut out = String::with_capacity(s.len());
+            let mut esc: Vec<u8> = Vec::new();
             let mut i = 0;
             while i < bytes.len() {
-                if bytes[i] == b'%' && i + 2 < bytes.len() {
-                    let hi = hex_val(bytes[i+1]);
-                    let lo = hex_val(bytes[i+2]);
-                    if let (Some(h), Some(l)) = (hi, lo) {
-                        decoded.push(h * 16 + l);
-                        i += 3;
-                        continue;
+                if bytes[i] == b'%' {
+                    match (bytes.get(i + 1).copied().and_then(hex_val),
+                           bytes.get(i + 2).copied().and_then(hex_val)) {
+                        (Some(h), Some(l)) => { esc.push(h * 16 + l); i += 3; }
+                        _ => return Err(uri_err()),
                     }
+                } else {
+                    flush(&mut esc, &mut out)?;
+                    let b = bytes[i];
+                    if b < 0x80 { out.push(b as char); } else { out.push('\u{FFFD}'); }
+                    i += 1;
                 }
-                decoded.push(bytes[i]);
-                i += 1;
             }
-            Ok(String::from_utf8_lossy(&decoded).into_owned())
+            flush(&mut esc, &mut out)?;
+            Ok(out)
         }
         "sh" => format_sh(val),
         "base64" => {

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -4231,3 +4231,11 @@ try (reduce .[] as $x (.; .sum += $x)) catch .
 # #962: trim no-op under |= vs object navigation
 (.x |= trim)
 {"x":" hi "}
+
+# #961: @urid validates malformed escapes / raw non-ASCII (error via try/catch)
+[("%C3%A9","%41","caf%C3%A9","é") | try @urid catch "ERR:\(.)"]
+null
+
+# #961: @urid hard-errors on a malformed percent escape
+try @urid catch .
+"%GG"

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -12982,3 +12982,38 @@ try (ltrimstr("a")|="Z") catch .
 path(.x | trim)
 {"x":"hi"}
 ["x"]
+
+# #961: @urid passes valid percent-escapes through
+@urid
+"%C3%A9"
+"é"
+
+# #961: @urid errors on a non-hex percent escape
+try @urid catch .
+"%GG"
+"string (\"%GG\") is not a valid uri encoding"
+
+# #961: @urid errors on a truncated percent escape
+try @urid catch .
+"%4"
+"string (\"%4\") is not a valid uri encoding"
+
+# #961: @urid errors when an escape decodes to invalid UTF-8
+try @urid catch .
+"%80"
+"string (\"%80\") is not a valid uri encoding"
+
+# #961: @urid errors on an overlong escaped sequence
+try @urid catch .
+"%C0%80"
+"string (\"%C0%80\") is not a valid uri encoding"
+
+# #961: @urid replaces a raw non-ASCII input byte per-byte with U+FFFD
+@urid
+"é"
+"��"
+
+# #961: @urid raw ASCII passes through, escaped non-ASCII decodes
+@urid
+"caf%C3%A9"
+"café"


### PR DESCRIPTION
## Summary

`@urid` (URI-decode) was missing all input validation: jq 1.8.1 errors on malformed percent-escapes and on escaped sequences that decode to invalid UTF-8, while jq-jit passed the input through (or lossily substituted U+FFFD).

```
$ echo '"%GG"' | jq     -c '@urid'
jq: error: string ("%GG") is not a valid uri encoding
$ echo '"%GG"' | jq-jit -c '@urid'   # before
"%GG"
```

## Fix

Match jq's algorithm:

- A `%` must be followed by **two hex digits** — `%`, `%4`, `%GG`, `%2g`, `100%` all error.
- A maximal run of consecutive `%XX` escapes must decode to **valid UTF-8** — `%80` (lone continuation), `%C3` (truncated lead), `%C0%80` (overlong), and surrogates all error.
- Errors use jq's wording: `string (X) is not a valid uri encoding`.
- A **raw** (non-escaped) input byte ≥ 0x80 is replaced **per-byte** with U+FFFD (so `"é"` → two U+FFFD), and raw ASCII passes through unchanged.

## Verification

jq-parity confirmed across valid input (`%C3%A9` → `é`, `%41` → `A`), every malformed-escape / invalid-UTF-8 shape, escape-run boundaries (`%C3a%A9`, `%41%80`), and raw non-ASCII — against both jq 1.8.1 and the interpreter path, error wording included.

## Tests

- `tests/regression.test`: seven cases (valid decode, four error shapes via `try/catch`, raw-non-ASCII FFFD, mixed raw/escaped).
- `tests/differential/corpus.test`: two differential cases against system jq.
- Full suite green (`cargo test --release`), zero warnings.

Closes #961