### PR TITLE
fix(cli): treat --args/--jsonargs as mode flags, not terminal separators

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -2346,9 +2346,49 @@ fn real_main() {
         }
     }
 
+    // `--args` / `--jsonargs` are *mode* flags, not terminal separators (#957):
+    // after one, jq keeps parsing option flags and only collects non-flag tokens
+    // as positional arguments. `args_mode` is None until one is seen, then
+    // Some(false) for `--args` (string positionals) / Some(true) for `--jsonargs`
+    // (JSON positionals). A bare `--` ends option parsing entirely.
+    let mut args_mode: Option<bool> = None;
+    let mut end_of_options = false;
+
+    // Push one operand (a non-option token, or any token after `--`). The first
+    // such token always fills the filter slot — even in args mode, jq treats
+    // `jq -n --args a b` as filter `a` with positional `b`. Once the filter is
+    // set, a `--args`/`--jsonargs` mode routes operands to positional string /
+    // JSON args; otherwise they are input files.
+    macro_rules! push_operand {
+        ($s:expr) => {{
+            let s: &str = $s;
+            if filter_str.is_none() {
+                filter_str = Some(s.to_string());
+            } else {
+                match args_mode {
+                    Some(true) => match json_to_value(s) {
+                        Ok(val) => positional_args.push(val),
+                        Err(e) => {
+                            eprintln!("jq: Invalid JSON text passed to --jsonargs: {}", e);
+                            process::exit(2);
+                        }
+                    },
+                    Some(false) => positional_args.push(Value::from_str(s)),
+                    None => files.push(s.to_string()),
+                }
+            }
+        }};
+    }
+
     let mut i = 0;
     while i < expanded_args.len() {
         let arg = &expanded_args[i];
+        // Past a `--`, every remaining token is an operand — no option parsing.
+        if end_of_options {
+            push_operand!(arg.as_str());
+            i += 1;
+            continue;
+        }
         match arg.as_str() {
             "-c" | "--compact-output" => { compact = true; tab = false; }
             "-r" | "--raw-output" => raw_output = true,
@@ -2471,30 +2511,12 @@ fn real_main() {
                     lib_dirs.push(expanded_args[i].clone());
                 }
             }
-            "--args" => {
-                // Remaining arguments are positional string args
-                i += 1;
-                while i < expanded_args.len() {
-                    positional_args.push(Value::from_str(&expanded_args[i]));
-                    i += 1;
-                }
-                break;
-            }
-            "--jsonargs" => {
-                // Remaining arguments are positional JSON args
-                i += 1;
-                while i < expanded_args.len() {
-                    match json_to_value(&expanded_args[i]) {
-                        Ok(val) => positional_args.push(val),
-                        Err(e) => {
-                            eprintln!("jq: Invalid JSON text passed to --jsonargs: {}", e);
-                            process::exit(2);
-                        }
-                    }
-                    i += 1;
-                }
-                break;
-            }
+            // Mode flags: subsequent non-option tokens are collected as
+            // positional string / JSON args, while option flags keep parsing.
+            "--args" => { args_mode = Some(false); }
+            "--jsonargs" => { args_mode = Some(true); }
+            // End of options: every remaining token is an operand.
+            "--" => { end_of_options = true; }
             "--slurpfile" => {
                 if i + 2 < expanded_args.len() {
                     let name = expanded_args[i + 1].clone();
@@ -2547,16 +2569,15 @@ fn real_main() {
                 eprintln!("jq: Unknown option: {}", s);
                 process::exit(2);
             }
-            s if s.starts_with('-') && s != "-" && filter_str.is_some() => {
+            // An unknown `-`-prefixed flag errors once the filter is set or a
+            // `--args`/`--jsonargs` mode is active (jq still rejects stray flags
+            // in args mode rather than collecting them as positionals). #957
+            s if s.starts_with('-') && s != "-" && (filter_str.is_some() || args_mode.is_some()) => {
                 eprintln!("jq: Unknown option: {}", s);
                 process::exit(2);
             }
             _ => {
-                if filter_str.is_none() {
-                    filter_str = Some(arg.clone());
-                } else {
-                    files.push(arg.clone());
-                }
+                push_operand!(arg.as_str());
             }
         }
         i += 1;

--- a/tests/cli_args_mode.rs
+++ b/tests/cli_args_mode.rs
@@ -1,0 +1,84 @@
+//! Issue #957: `--args` / `--jsonargs` are *mode* flags, not terminal
+//! separators. After one, jq keeps parsing option flags (tokens starting with
+//! `-`) and only collects non-flag tokens as positional arguments; a bare `--`
+//! ends option parsing entirely. jq-jit previously swallowed everything after
+//! `--args` into `$ARGS.positional` and stopped parsing options.
+//!
+//! These exercise CLI argument parsing, which the 3-line regression harness
+//! cannot express, so shell out to the binary.
+
+use std::process::Command;
+
+fn run(args: &[&str]) -> (String, bool) {
+    let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
+    let out = Command::new(jq_jit)
+        .args(args)
+        .output()
+        .expect("failed to spawn jq-jit");
+    (
+        String::from_utf8_lossy(&out.stdout).trim_end().to_string(),
+        out.status.success(),
+    )
+}
+
+#[test]
+fn args_keeps_parsing_option_flags() {
+    // `--arg a 1` after `--args x y` is still parsed as a named arg.
+    let (out, ok) = run(&["-cn", "$ARGS", "--args", "x", "y", "--arg", "a", "1"]);
+    assert!(ok);
+    assert_eq!(out, r#"{"positional":["x","y"],"named":{"a":"1"}}"#);
+}
+
+#[test]
+fn args_consumes_n_flag_not_as_positional() {
+    let (out, ok) = run(&["-cn", "$ARGS.positional", "--args", "a", "-n", "b"]);
+    assert!(ok);
+    assert_eq!(out, r#"["a","b"]"#);
+}
+
+#[test]
+fn args_unknown_flag_errors() {
+    // A stray `-y` in args mode is an unknown option, not a positional.
+    let (_out, ok) = run(&["-cn", "$ARGS.positional", "--args", "x", "-y"]);
+    assert!(!ok, "stray -y in args mode must error");
+}
+
+#[test]
+fn args_double_dash_ends_option_parsing() {
+    // After `--`, `-n` is a positional, not the null-input flag.
+    let (out, ok) = run(&["-cn", "$ARGS.positional", "--args", "--", "a", "-n"]);
+    assert!(ok);
+    assert_eq!(out, r#"["a","-n"]"#);
+}
+
+#[test]
+fn jsonargs_consumes_n_flag() {
+    let (out, ok) = run(&["-cn", "$ARGS.positional", "--jsonargs", "1", "-n", "2"]);
+    assert!(ok);
+    assert_eq!(out, "[1,2]");
+}
+
+#[test]
+fn jsonargs_keeps_parsing_named_args() {
+    let (out, ok) = run(&["-cn", "$ARGS", "--jsonargs", "1", "2", "--argjson", "z", "3"]);
+    assert!(ok);
+    assert_eq!(out, r#"{"positional":[1,2],"named":{"z":3}}"#);
+}
+
+#[test]
+fn first_operand_in_args_mode_is_the_filter() {
+    // With no filter before `--args`, the first non-option token fills the
+    // filter slot; subsequent tokens are positionals. `.x` is the program.
+    let (out, ok) = run(&["-cn", "--args", "$ARGS.positional", "extra"]);
+    assert!(ok);
+    assert_eq!(out, r#"["extra"]"#);
+}
+
+#[test]
+fn bare_double_dash_is_end_of_options_without_args_mode() {
+    // `--` with no args mode just ends option parsing; remaining tokens are
+    // the filter / input files, not an "Unknown option" error.
+    let (out, ok) = run(&["-cn", "--", "1+1"]);
+    assert!(ok);
+    assert_eq!(out, "2");
+}


### PR DESCRIPTION
## Summary

`--args` / `--jsonargs` greedily swallowed **everything** after them into `$ARGS.positional` and stopped parsing options. In jq 1.8.1 they are *mode* flags: after one, jq keeps parsing option flags and only collects non-flag tokens as positional arguments.

```
$ jq     -cn '$ARGS' --args x y --arg a 1
{"positional":["x","y"],"named":{"a":"1"}}
$ jq-jit -cn '$ARGS' --args x y --arg a 1   # before
{"positional":["x","y","--arg","a","1"],"named":{}}
```

## Fix

Replace the swallow/`break` with an `args_mode` state (string vs JSON positionals) and continue the option loop:

- Option flags after `--args` (`--arg`, `-n`, `--argjson`, …) keep parsing normally.
- A non-option token fills the **filter** slot first — jq parses `jq -n --args a b` as filter `a`, positional `b` — then becomes a positional once the filter is set.
- A bare `--` ends option parsing (remaining tokens are operands), fixing both `--args -- a -n` → `["a","-n"]` and the standalone `jq -c '.x' -- file.json` case that previously errored "Unknown option: --".
- A stray unknown `-`-flag in args mode errors (`--args x -y` → "Unknown option") instead of being collected as a positional.

## Verification

jq-parity confirmed for exact `$ARGS` contents and error behavior across all the issue's cases (`--args x y --arg a 1`, `--args a -n b`, `--args x -y`, `--args -- a -n`, `--jsonargs 1 -n 2`, `--jsonargs 1 2 --argjson z 3`), plus the no-filter / first-operand-is-filter and file-input cases.

## Tests

- `tests/cli_args_mode.rs`: eight CLI integration tests (shelling out to the binary).
- Full suite green (`cargo test --release`), zero warnings.

Closes #957