### PR TITLE
fix(cli): accept non-identifier --arg/--argjson names into $ARGS.named

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -2478,11 +2478,12 @@ fn real_main() {
             }
             "--arg" => {
                 if i + 2 < expanded_args.len() {
+                    // jq accepts ANY name (e.g. `1bad`, `a-b`, `c.d`, empty) and
+                    // stores it in $ARGS.named; a non-identifier simply cannot be
+                    // referenced as a bare `$name`. The bare binding below is
+                    // gated on `is_valid_var_name`, so no validation is needed
+                    // here — rejecting was an over-strict compat gap (#958).
                     let name = expanded_args[i + 1].clone();
-                    if !is_valid_var_name(&name) {
-                        eprintln!("jq: error: arg name `{}` is not a valid identifier", name);
-                        process::exit(2);
-                    }
                     let val = Value::from_str(&expanded_args[i + 2]);
                     arg_vars.push((name, val));
                     i += 2;
@@ -2491,10 +2492,6 @@ fn real_main() {
             "--argjson" => {
                 if i + 2 < expanded_args.len() {
                     let name = expanded_args[i + 1].clone();
-                    if !is_valid_var_name(&name) {
-                        eprintln!("jq: error: arg name `{}` is not a valid identifier", name);
-                        process::exit(2);
-                    }
                     match json_to_value(&expanded_args[i + 2]) {
                         Ok(val) => argjson_vars.push((name, val)),
                         Err(e) => {
@@ -2612,13 +2609,18 @@ fn real_main() {
     // Prepend --arg / --argjson / $ARGS bindings to the filter expression
     let filter_str = {
         let mut prefix = String::new();
+        // Only identifier names can be bound as a bare `$name` (a non-identifier
+        // would be a syntax error in the prefix). Non-identifier names still
+        // reach the filter through $ARGS.named below, matching jq. #958
         for (name, val) in &arg_vars {
+            if !is_valid_var_name(name) { continue; }
             prefix.push_str(&value_to_json_precise(val));
             prefix.push_str(" as $");
             prefix.push_str(name);
             prefix.push_str(" | ");
         }
         for (name, val) in &argjson_vars {
+            if !is_valid_var_name(name) { continue; }
             prefix.push_str(&value_to_json_precise(val));
             prefix.push_str(" as $");
             prefix.push_str(name);
@@ -2633,20 +2635,22 @@ fn real_main() {
             }
             args_json.push_str("],\"named\":{");
             let mut first = true;
+            // JSON-encode the name as a string key so arbitrary arg names jq
+            // accepts (`1bad`, `a-b`, and names containing `"`/`\`) produce a
+            // valid $ARGS.named object rather than corrupting the embedded
+            // JSON. #958
             for (name, val) in &arg_vars {
                 if !first { args_json.push(','); }
                 first = false;
-                args_json.push('"');
-                args_json.push_str(name);
-                args_json.push_str("\":");
+                args_json.push_str(&value_to_json_precise(&Value::from_str(name)));
+                args_json.push(':');
                 args_json.push_str(&value_to_json_precise(val));
             }
             for (name, val) in &argjson_vars {
                 if !first { args_json.push(','); }
                 first = false;
-                args_json.push('"');
-                args_json.push_str(name);
-                args_json.push_str("\":");
+                args_json.push_str(&value_to_json_precise(&Value::from_str(name)));
+                args_json.push(':');
                 args_json.push_str(&value_to_json_precise(val));
             }
             args_json.push_str("}}");

--- a/tests/cli_args_mode.rs
+++ b/tests/cli_args_mode.rs
@@ -82,3 +82,50 @@ fn bare_double_dash_is_end_of_options_without_args_mode() {
     assert!(ok);
     assert_eq!(out, "2");
 }
+
+// Issue #958: jq accepts ANY --arg/--argjson name into $ARGS.named (including
+// non-identifiers); only a valid identifier is also reachable as a bare $name.
+// jq-jit previously rejected every non-identifier name with a fatal error.
+
+#[test]
+fn arg_accepts_non_identifier_name_into_args_named() {
+    let (out, ok) = run(&["-cn", "$ARGS.named", "--arg", "1bad", "hello"]);
+    assert!(ok, "non-identifier --arg name must be accepted");
+    assert_eq!(out, r#"{"1bad":"hello"}"#);
+}
+
+#[test]
+fn arg_non_identifier_name_reachable_via_args_named_index() {
+    let (out, ok) = run(&["-cn", r#"$ARGS.named["a-b"]"#, "--arg", "a-b", "1"]);
+    assert!(ok);
+    assert_eq!(out, r#""1""#);
+}
+
+#[test]
+fn argjson_accepts_dotted_name() {
+    let (out, ok) = run(&["-cn", r#"$ARGS.named["c.d"]"#, "--argjson", "c.d", "5"]);
+    assert!(ok);
+    assert_eq!(out, "5");
+}
+
+#[test]
+fn arg_accepts_empty_name() {
+    let (out, ok) = run(&["-cn", "$ARGS.named", "--arg", "", "x"]);
+    assert!(ok);
+    assert_eq!(out, r#"{"":"x"}"#);
+}
+
+#[test]
+fn arg_name_with_special_chars_is_json_escaped() {
+    // A name containing a quote must produce a valid $ARGS.named object.
+    let (out, ok) = run(&["-cn", "$ARGS.named", "--arg", "a\"b", "x"]);
+    assert!(ok);
+    assert_eq!(out, r#"{"a\"b":"x"}"#);
+}
+
+#[test]
+fn valid_identifier_name_still_bound_as_bare_variable() {
+    let (out, ok) = run(&["-cn", "$a", "--arg", "a", "7"]);
+    assert!(ok);
+    assert_eq!(out, r#""7""#);
+}


### PR DESCRIPTION
## Summary

jq accepts **any** `--arg` / `--argjson` name (including non-identifiers like `1bad`, `a-b`, `c.d`, or empty) and stores it in `$ARGS.named`, reachable via `$ARGS.named["1bad"]`; a non-identifier simply cannot be referenced as a bare `$name`. jq-jit rejected every non-identifier name with a fatal error at bind time — over-strict, and inconsistent with `--slurpfile`/`--rawfile`, which already accepted them.

```
$ jq     -cn '$ARGS.named' --arg 1bad hello
{"1bad":"hello"}
$ jq-jit -cn '$ARGS.named' --arg 1bad hello   # before
jq: error: arg name `1bad` is not a valid identifier      (exit 2)
```

## Fix

- Drop the bind-time `is_valid_var_name` rejection for `--arg`/`--argjson`.
- Gate only the bare `<val> as $name |` prefix on `is_valid_var_name` (a non-identifier there would be a syntax error), so non-identifier names still reach the filter through `$ARGS.named`.
- JSON-encode the `$ARGS.named` key so names containing `"` or `\` (which jq also accepts) produce a valid object instead of corrupting the embedded JSON.

## Verification

jq-parity confirmed for `1bad`/`a-b`/`c.d`/empty/quote/backslash names, the `$ARGS.named[...]` index access, and the unchanged bare `$name` binding for valid identifiers.

## Tests

- `tests/cli_args_mode.rs`: six new CLI integration tests.
- Full suite green (`cargo test --release`), zero warnings.

Closes #958