### PR TITLE
fix(runtime): propagate a NaN exponent through scalb instead of truncating

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -473,11 +473,20 @@ pub fn call_builtin(name: &str, args: &[Value]) -> Result<Value> {
             _ => bail!("{} number required", errdesc(if !matches!(a, Value::Num(..)) { a } else { b })),
         }),
         "scalb" => ternary_arg(args, |a, b| match (a, b) {
-            // C scalb / jq truncate the exponent to an integer: x * 2^trunc(n).
-            // `2f64.powf(n)` honoured the fraction (scalb(1; 0.5) → √2 instead
-            // of 1). Use scalbn with the truncated exponent, matching the
-            // sibling scalbln/ldexp (`f64 as i32` truncates toward zero) (#812).
-            (Value::Num(x, _), Value::Num(y, _)) => Ok(Value::number(libm::scalbn(*x, *y as i32))),
+            // C scalb / jq truncate a *finite* fractional exponent to an
+            // integer: x * 2^trunc(n) (scalb(1; 0.5) → 1, not √2) (#812). But a
+            // NaN exponent propagates to NaN per IEEE `scalb(x, y)` — truncating
+            // it to 0 (`f64::NAN as i32 == 0`) wrongly returned `x` unchanged
+            // (#960). The sibling ldexp/scalbln take an integer exponent and
+            // legitimately truncate NaN→0, so only scalb propagates. ±inf
+            // exponents already match jq via scalbn's saturating cast.
+            (Value::Num(x, _), Value::Num(y, _)) => {
+                if y.is_nan() {
+                    Ok(Value::number(f64::NAN))
+                } else {
+                    Ok(Value::number(libm::scalbn(*x, *y as i32)))
+                }
+            }
             _ => bail!("{} number required", errdesc(if !matches!(a, Value::Num(..)) { a } else { b })),
         }),
         // Additional libc binary wrappers (#473).

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -13017,3 +13017,18 @@ try @urid catch .
 @urid
 "caf%C3%A9"
 "café"
+
+# #960: scalb propagates a NaN exponent to NaN (ldexp/scalbln truncate NaN->0)
+[ldexp(1;nan), scalbln(1;nan), scalb(1;nan)]
+null
+[1,1,null]
+
+# #960: scalb(x; nan) is NaN regardless of x
+scalb(5;nan)|isnan
+null
+true
+
+# #960: scalb still truncates a finite fractional exponent (#812 unchanged)
+[scalb(1;0.5), scalb(3;1.5)]
+null
+[1,6]


### PR DESCRIPTION
## Summary

`scalb(x; nan)` truncated the NaN exponent to `0` and returned `x` unchanged, but jq's `scalb` uses libm's IEEE double-argument `scalb(x, y)` where a NaN exponent propagates to a NaN result (serialized as `null`).

```
$ echo null | jq     -c '[ldexp(1;nan), scalbln(1;nan), scalb(1;nan)]'
[1,1,null]
$ echo null | jq-jit -c '[ldexp(1;nan), scalbln(1;nan), scalb(1;nan)]'   # before
[1,1,1]
```

## Root cause

`scalb` was implemented as `scalbn(x, y as i32)`; `f64::NAN as i32 == 0`, so the NaN exponent became `scalbn(x, 0) == x`. Residual of #812 (which made jit truncate scalb's *fractional* exponent) — the truncation must not apply to a NaN exponent.

## Fix

Special-case a NaN exponent to return NaN. Finite fractional exponents still truncate (`scalb(1; 0.5)` → `1`), and ±inf exponents already match jq via `scalbn`'s saturating cast. The sibling `ldexp`/`scalbln` take an integer exponent and legitimately truncate NaN→0, so they are unchanged.

## Tests

- `tests/regression.test`: three cases (the NaN family vs ldexp/scalbln, `scalb(x;nan)|isnan`, and the unchanged fractional truncation). These are jit-deterministic (the libm crate, not system libm) so the macOS-pinned values hold on every platform. The `ldexp`/`scalbln` NaN→0 truncation is libc-dependent for *system* jq, so it is deliberately not added to the differential corpus.
- Full suite green (`cargo test --release`), zero warnings.

Closes #960