### PR TITLE
fix(eval): validate $x-anchored foreach navigation against the document

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -5374,22 +5374,46 @@ thread_local! {
     // foreach raises the depth, so ordinary path expressions are unaffected.
     // #915
     static FOREACH_ROOTLESS: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
+
+    // Document root for the active rootless navigating-source `foreach`
+    // extract/update, pushed in lockstep with `FOREACH_ROOTLESS`. A
+    // `$x`-anchored navigation (`$x.k`, `$x[i]`) forwards the element's source
+    // path, which is *document*-relative — so its key must be validated against
+    // the document the element lives in, not the rootless accumulator. Resolving
+    // it against the accumulator lenient-nulled a non-indexable element and let
+    // an invalid navigation slip through. #953
+    static FOREACH_DOC_ROOT: RefCell<Vec<Value>> = const { RefCell::new(Vec::new()) };
 }
 
 /// RAII guard that marks the current `eval_path` input as a rootless `foreach`
-/// accumulator for its lifetime (see [`FOREACH_ROOTLESS`]). Restores the prior
-/// depth on drop, so early returns / error propagation can't leak the state.
+/// accumulator for its lifetime (see [`FOREACH_ROOTLESS`]) and records the
+/// document root for `$x`-anchored key validation (see [`FOREACH_DOC_ROOT`]).
+/// Restores the prior state on drop, so early returns / error propagation can't
+/// leak it.
 struct RootlessAccGuard;
 impl RootlessAccGuard {
-    fn enter() -> Self {
+    fn enter(doc_root: Value) -> Self {
         FOREACH_ROOTLESS.with(|c| c.set(c.get() + 1));
+        FOREACH_DOC_ROOT.with(|s| s.borrow_mut().push(doc_root));
         RootlessAccGuard
     }
 }
 impl Drop for RootlessAccGuard {
     fn drop(&mut self) {
         FOREACH_ROOTLESS.with(|c| c.set(c.get().saturating_sub(1)));
+        FOREACH_DOC_ROOT.with(|s| { s.borrow_mut().pop(); });
     }
+}
+
+/// The document root of the innermost active rootless navigating-source
+/// `foreach` extract/update, or `None` when not inside one. Used to validate a
+/// `$x`-anchored navigation's key against the document rather than the rootless
+/// accumulator (#953).
+fn rootless_doc_root() -> Option<Value> {
+    if FOREACH_ROOTLESS.with(|c| c.get()) == 0 {
+        return None;
+    }
+    FOREACH_DOC_ROOT.with(|s| s.borrow().last().cloned())
 }
 
 thread_local! {
@@ -5595,7 +5619,18 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
                         // current path can't accept the key type (issue #46).
                         // Only objects (with string keys), arrays (with number
                         // keys), and null (a no-op) are valid bases.
-                        let base_val = crate::runtime::rt_getpath(&input_for_check, bp).unwrap_or(Value::Null);
+                        //
+                        // In a rootless navigating-source `foreach` extract/
+                        // update, any base path reaching here is `$x`-anchored:
+                        // a `.`-anchored navigation bails the rootless sentinel
+                        // via the `Input` arm before producing a path. That path
+                        // is document-relative, so validate the key against the
+                        // document the element lives in — resolving it against
+                        // the rootless accumulator lenient-nulled a non-indexable
+                        // element and accepted an invalid navigation (#953).
+                        let base_val = rootless_doc_root()
+                            .map(|doc| crate::runtime::rt_getpath(&doc, bp).unwrap_or(Value::Null))
+                            .unwrap_or_else(|| crate::runtime::rt_getpath(&input_for_check, bp).unwrap_or(Value::Null));
                         match (&base_val, &key) {
                             (Value::Obj(_), Value::Str(_)) => {}
                             (Value::Arr(_), Value::Num(_, _)) => {}
@@ -6183,7 +6218,7 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
                         // `.`/`.k` surfaces "result <acc>"/"near attempt …", a
                         // `$x` still forwards the element path. #915
                         let r = {
-                            let _rootless = RootlessAccGuard::enter();
+                            let _rootless = RootlessAccGuard::enter(input.clone());
                             eval_path(extract_expr, new_acc.clone(), env, cb)
                         };
                         FOREACH_PATH_BIND.with(|s| { s.borrow_mut().pop(); });
@@ -6751,7 +6786,7 @@ fn eval_foreach_nav_noextract_path(
             // accumulator-anchored UPDATE (`.`, `.k`) is an invalid path
             // expression while a `$x`-anchored one forwards the element path. #915
             let r = {
-                let _rootless = RootlessAccGuard::enter();
+                let _rootless = RootlessAccGuard::enter(input.clone());
                 eval_path(update, acc_val, env, &mut |upd_path| {
                     // The update result threads as the next accumulator value.
                     acc = crate::runtime::rt_getpath(input, &upd_path).unwrap_or(Value::Null);

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -4239,3 +4239,7 @@ null
 # #961: @urid hard-errors on a malformed percent escape
 try @urid catch .
 "%GG"
+
+# #953: $x-anchored navigation in a navigating-source foreach is document-rooted
+[path(foreach .[] as $x (0; .; $x.b))]
+{"a":{"b":2},"c":{"b":9}}

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -13032,3 +13032,24 @@ true
 [scalb(1;0.5), scalb(3;1.5)]
 null
 [1,6]
+
+# #953: $x-anchored navigation in a navigating-source foreach validates the key
+# against the document the element lives in, not the rootless accumulator
+try [path(foreach .[] as $x (0; .; $x.b))] catch .
+{"a":{"b":2},"c":3}
+"Cannot index number with string \"b\""
+
+# #953: when every element is indexable the $x-anchored paths are document-rooted
+[path(foreach .[] as $x (0; .; $x.b))]
+{"a":{"b":2},"c":{"b":9}}
+[["a","b"],["c","b"]]
+
+# #953: $x[i] index validation likewise checks the document element's type
+try [path(foreach .[] as $x (0; .; $x[0]))] catch .
+{"a":[1],"c":3}
+"Cannot index number with number"
+
+# #953: a bare $x still forwards the element spine (unchanged, #711/#915)
+[path(foreach .[] as $x (0; .; $x))]
+{"a":{"b":2},"c":3}
+[["a"],["c"]]


### PR DESCRIPTION
## Summary

In `path()` context, a `$x`-anchored navigation (`$x.k`, `$x[i]`) inside a `foreach` over a navigating source validated the key against the **accumulator** value instead of the **document** value the element actually lives in. A navigation jq rejects (the element is not indexable) was therefore silently accepted and a bogus path produced.

```
$ echo '{"a":{"b":2},"c":3}' | jq     -c '[path(foreach .[] as $x (0; .; $x.b))]'
jq: error: Cannot index number with string "b"
$ echo '{"a":{"b":2},"c":3}' | jq-jit -c '[path(foreach .[] as $x (0; .; $x.b))]'   # before
[["a","b"],["c","b"]]
```

## Root cause

The navigating-source `foreach` EXTRACT/UPDATE runs via `eval_path(expr, accumulator, …)`, so the accumulator is the `eval_path` root. A `$x`-anchored path is document-relative, but `Expr::Index`'s key-validation read the base value with `rt_getpath(accumulator, base_path)`. With a rootless accumulator (`0`), that getpath is `null`, and `null` accepts a string key, so the invalid navigation slipped through.

## Fix

Thread the document root through `RootlessAccGuard` (pushed in lockstep with the rootless depth) and validate the `Index` key against it when rootless. In that state, any base path reaching the validation is necessarily `$x`-anchored — a `.`-anchored navigation bails the rootless sentinel via the `Input` arm before producing a path — so the document root is the correct base for all of them. Accumulator-anchored navigations stay rootless.

This splits out the last sub-case of #915; the navigating-source vs body/extract provenance inversions were fixed in #951/#952.

## Verification

jq-parity confirmed (value and error wording) for `$x.k` / `$x[i]` / `$x.b.c` on indexable and non-indexable elements, against both jq 1.8.1 and the interpreter path, plus a regression sweep over the related `foreach`/`reduce` path cases (#711/#915/#951/#952) — no regressions.

## Tests

- `tests/regression.test`: four cases (non-indexable element error, all-indexable document-rooted paths, `$x[i]` index validation, unchanged bare `$x`).
- `tests/differential/corpus.test`: one differential case against system jq.
- Full suite green (`cargo test --release`), zero warnings.

Closes #953