### PR TITLE
fix(from_entries): drop spurious key_ key alias

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1896,9 +1896,11 @@ fn rt_from_entries(v: &Value) -> Result<Value> {
             for entry in a.iter() {
                 match entry {
                     Value::Obj(ObjInner(o)) => {
-                        // jq resolves the key via `.key // .key_ // .Key // .name // .Name`
+                        // jq 1.8.1 resolves the key via `.key // .Key // .name // .Name`
                         // — `//` skips null/false — and errors when the resolved key is
-                        // not a string. Matches jq 1.8.1 wording.
+                        // not a string. (`key_`, `.k`, `.K`, `.N` are NOT aliases in
+                        // 1.8.1; `key_` previously here made jq-jit accept entries jq
+                        // rejects and pick the wrong key — #976.)
                         let pick_truthy = |name: &str| -> Option<&Value> {
                             match o.get(name) {
                                 Some(v) if !matches!(v, Value::Null | Value::False) => Some(v),
@@ -1906,7 +1908,6 @@ fn rt_from_entries(v: &Value) -> Result<Value> {
                             }
                         };
                         let key = pick_truthy("key")
-                            .or_else(|| pick_truthy("key_"))
                             .or_else(|| pick_truthy("Key"))
                             .or_else(|| pick_truthy("name"))
                             .or_else(|| pick_truthy("Name"))

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -13053,3 +13053,18 @@ try [path(foreach .[] as $x (0; .; $x[0]))] catch .
 [path(foreach .[] as $x (0; .; $x))]
 {"a":{"b":2},"c":3}
 [["a"],["c"]]
+
+# #976: from_entries does not treat key_ as a key alias (jq errors -> null key)
+try from_entries catch .
+[{"key_":"x","value":1}]
+"Cannot use null (null) as object key"
+
+# #976: with a real alias present, key_ does not override it
+from_entries
+[{"key_":"K_","name":"NAME","value":1}]
+{"NAME":1}
+
+# #976: Key is a genuine alias and wins over a spurious key_ field
+from_entries
+[{"key_":"K_","Key":"K","value":1}]
+{"K":1}


### PR DESCRIPTION
## Summary

jq 1.8.1's `from_entries` key-alias chain is `.key, .Key, .name, .Name` (value: `.value, .Value`). jq-jit additionally accepted `key_` ahead of the real aliases, so it both accepted entries jq rejects and picked the wrong key when several fields were present.

Verified against jq 1.8.1: `key_`, `.k`, `.K`, `.N`, `.v` are **not** aliases (the chain claimed in the issue was inaccurate — only `key`/`Key`/`name`/`Name` + `value`/`Value` are recognized). Removing `key_` makes jq-jit's chain match exactly.

## Behavior

```
$ echo '[{"key_":"x","value":1}]' | jq-jit -c 'from_entries'
jq: error: Cannot use null (null) as object key   # was {"x":1}
$ echo '[{"key_":"K_","name":"NAME","value":1}]' | jq-jit -c 'from_entries'
{"NAME":1}                                          # was {"K_":1}
```

## Tests

Added 3 regression cases. Full suite passes, zero warnings.

Closes #976

🤖 Generated with [Claude Code](https://claude.com/claude-code)