### PR TITLE
fix(halt_error): clamp negative exit code to 0

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -7080,6 +7080,11 @@ fn eval_call_builtin(name: &str, args: &[Expr], input: Value, env: &EnvRef, cb: 
         ("halt_error", 1) => {
             return eval(&args[0], input.clone(), env, &mut |code_val| {
                 let code = match &code_val {
+                    // jq clamps any negative halt_error code to 0 (still emitting
+                    // the stderr payload); without this, `n as i32` -> the OS
+                    // truncates to `n & 0xff`, so halt_error(-1) wrongly exits 255
+                    // instead of 0 (#979).
+                    Value::Num(n, _) if *n < 0.0 => 0,
                     Value::Num(n, _) => *n as i32,
                     _ => bail!(
                         "{} halt_error/1: number required",

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -13068,3 +13068,8 @@ from_entries
 from_entries
 [{"key_":"K_","Key":"K","value":1}]
 {"K":1}
+
+# #979: halt_error with a negative code clamps the process exit status to 0 (was 255)
+halt_error(-1)
+null
+


### PR DESCRIPTION
## Summary

jq clamps any negative `halt_error(n)` exit code to `0` (while still emitting the stderr payload). jq-jit cast `n as i32` and let the OS truncate to `n & 0xff`, so `halt_error(-1)` exited **255** instead of 0.

```
$ printf null | jq-jit 'halt_error(-1)'; echo $?
0   # was 255
```

Verified across `-1 -2 -255 -256 -257 -1.5` (all → 0, matching jq) and that positive / `>=256` codes are unaffected (both wrap mod 256 via the OS).

## Tests

Added a regression case (`halt_error(-1)` on `null` → empty stdout, exit 0; previously the harness saw `<exit code 255>`). Full suite passes, zero warnings.

Closes #979

🤖 Generated with [Claude Code](https://claude.com/claude-code)