### PR TITLE
fix(cli): reject embedded NUL under --raw-output0

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -284,6 +284,11 @@ fn is_valid_var_name(name: &str) -> bool {
     bytes.all(|b| b == b'_' || b.is_ascii_alphanumeric())
 }
 
+/// jq's error when a string with an embedded NUL is dumped under
+/// `--raw-output0` (NUL is the record separator there). See #980.
+const RAW_OUTPUT0_NUL_ERR: &str =
+    "Cannot dump a string containing NUL with --raw-output0 option";
+
 fn print_jq_error(msg: &str) {
     let line = jq_jit::eval::get_input_line_number();
     if let Some(jq_msg) = msg.strip_prefix("__jqerror__:") {
@@ -3552,6 +3557,11 @@ fn real_main() {
                     let _ = write_value_compact_ext(out, result, sort_keys);
                 } else {
                     let formatted = format_value(result);
+                    if raw_output0 && formatted.as_bytes().contains(&0) {
+                        print_jq_error(RAW_OUTPUT0_NUL_ERR);
+                        *had_error = true;
+                        return Ok(true);
+                    }
                     let _ = write!(out, "{}", formatted);
                 }
             } else if compact && !raw_output {
@@ -3560,6 +3570,16 @@ fn real_main() {
                 let _ = write_value_pretty_line_color(out, result, indent_n, tab, sort_keys, color_output);
             } else {
                 let formatted = format_value(result);
+                // --raw-output0 reserves NUL as the record separator, so jq
+                // refuses to dump a (raw) string whose content contains an
+                // embedded NUL and errors instead (#980). Non-string outputs
+                // are JSON-encoded even under -r (NUL escaped to U+0000), so
+                // this only fires for genuine raw-string NUL content.
+                if raw_output0 && formatted.as_bytes().contains(&0) {
+                    print_jq_error(RAW_OUTPUT0_NUL_ERR);
+                    *had_error = true;
+                    return Ok(true);
+                }
                 let _ = out.write_all(formatted.as_bytes());
                 // --raw-output0 (#210): use NUL as record separator so the
                 // stream is xargs -0 -friendly. -r alone keeps the newline.

--- a/tests/raw_output0_nul_guard.rs
+++ b/tests/raw_output0_nul_guard.rs
@@ -1,0 +1,86 @@
+//! Issue #980: under `--raw-output0`, jq refuses to emit a string whose content
+//! contains an embedded NUL (NUL is the output record separator there) and
+//! errors `Cannot dump a string containing NUL with --raw-output0 option`
+//! (exit 5). jq-jit previously wrote the NUL bytes through with exit 0.
+//!
+//! The guard is specific to `--raw-output0`: plain `-r` and `-j` (without
+//! `--raw-output0`) must still pass NUL through. `regression.test` /
+//! `corpus.test` can't cover this (CLI flag + exit-code + stderr), so shell
+//! out and inspect the raw bytes/status instead.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+struct Run {
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
+    code: i32,
+}
+
+fn run(args: &[&str], input: &str) -> Run {
+    let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
+    let mut child = Command::new(jq_jit)
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn jq-jit");
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(input.as_bytes())
+        .unwrap();
+    let out = child.wait_with_output().expect("wait failed");
+    Run {
+        stdout: out.stdout,
+        stderr: out.stderr,
+        code: out.status.code().unwrap_or(-1),
+    }
+}
+
+// `"AA==" | @base64d` decodes to a single NUL byte.
+const NUL_FILTER: &str = "\"AA==\" | @base64d";
+
+#[test]
+fn raw_output0_rejects_embedded_nul() {
+    let r = run(&["--raw-output0", NUL_FILTER], "null");
+    assert_eq!(r.code, 5, "should exit 5 like jq");
+    assert!(r.stdout.is_empty(), "no NUL bytes should be written");
+    assert_eq!(
+        String::from_utf8_lossy(&r.stderr).trim_end(),
+        "jq: error (at <stdin>:0): Cannot dump a string containing NUL with --raw-output0 option"
+    );
+}
+
+#[test]
+fn raw_output0_join_output_also_rejects_nul() {
+    // `-j --raw-output0` still applies the NUL-content guard in jq.
+    let r = run(&["-j", "--raw-output0", NUL_FILTER], "null");
+    assert_eq!(r.code, 5);
+    assert!(r.stdout.is_empty());
+}
+
+#[test]
+fn raw_output0_passes_non_nul_string() {
+    let r = run(&["--raw-output0", "\"hello\""], "null");
+    assert_eq!(r.code, 0);
+    assert_eq!(r.stdout, b"hello\0");
+}
+
+#[test]
+fn plain_raw_output_passes_nul_through() {
+    // `-r` alone has no NUL guard: the byte goes through, then a newline.
+    let r = run(&["-r", NUL_FILTER], "null");
+    assert_eq!(r.code, 0);
+    assert_eq!(r.stdout, b"\0\n");
+}
+
+#[test]
+fn join_output_passes_nul_through() {
+    // `-j` alone (no --raw-output0) passes NUL through with no separator.
+    let r = run(&["-j", NUL_FILTER], "null");
+    assert_eq!(r.code, 0);
+    assert_eq!(r.stdout, b"\0");
+}


### PR DESCRIPTION
## Summary

Under `--raw-output0`, NUL is the output record separator, so jq refuses to emit a string whose content contains an embedded NUL and errors `Cannot dump a string containing NUL with --raw-output0 option` (exit 5). jq-jit had no such guard and wrote the NUL bytes through with exit 0.

```
$ printf null | jq-jit --raw-output0 '"AA==" | @base64d'; echo $?
jq: error (at <stdin>:0): Cannot dump a string containing NUL with --raw-output0 option
5   # was: wrote 0x00, exit 0
```

The guard is specific to `--raw-output0`: plain `-r` and `-j` (without `--raw-output0`) still pass NUL through, and non-string outputs are JSON-encoded (NUL escaped) so they never trip it. Verified all combinations against jq 1.8.1.

## Tests

New integration test `tests/raw_output0_nul_guard.rs` (5 cases: NUL rejection, `-j --raw-output0` rejection, non-NUL passthrough, `-r`/`-j` NUL passthrough). Full suite passes, zero warnings.

Closes #980

🤖 Generated with [Claude Code](https://claude.com/claude-code)