### PR TITLE
fix(IN): short-circuit the source generator in IN/2

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4328,57 +4328,27 @@ impl Parser {
                     }),
                 })
             }
-            // IN/2: jq's `IN(src; s)` is `any(src == s; .)` — BOTH `src` and the
-            // candidate set `s` are evaluated against the original input. The old
-            // desugar fed the candidate set the reduce accumulator (the update's
-            // `.`), so `IN(1; .[])` iterated `false` and `IN(false; .)` compared
-            // against the accumulator. Bind the original input as `$dot` and pipe
-            // the candidate set from it: #846
-            //   . as $dot
-            //   | reduce src as $x (false;
-            //       . or (first(($dot | s) | if . == $x then true else empty) // false))
+            // IN/2: jq defines `def IN(src; s): any(src == s; .);`. Lower
+            // straight to the short-circuiting `any` over the cartesian
+            // comparison of the two generators. Both `src` and the candidate
+            // set `s` are evaluated against the same input `.` (the `==`
+            // operands share it), matching jq, and `any` stops at the first
+            // match. A prior reduce-based desugar drained `src` fully even
+            // after a match — hanging on an infinite source and surfacing
+            // later errors past the first hit (#984). The candidate-set vs
+            // accumulator issue (#846) and IN/1 membership (#847) both fall
+            // out of the jq definition without the extra `$dot` plumbing.
             ("IN", 2) => {
                 let mut args = args.into_iter();
                 let src = args.next().unwrap();
                 let s = args.next().unwrap();
-                let dot_var = self.scope.alloc_var("__in2_dot__");
-                let x_var = self.scope.alloc_var("__in2_x__");
-                let acc_var = self.scope.alloc_var("__in2_acc__");
-                let in_check = Expr::Alternative {
-                    primary: Box::new(Expr::Limit {
-                        count: Box::new(Expr::Literal(Literal::Num(1.0, None))),
-                        generator: Box::new(Expr::Pipe {
-                            left: Box::new(Expr::Pipe {
-                                left: Box::new(Expr::LoadVar { var_index: dot_var }),
-                                right: Box::new(s),
-                            }),
-                            right: Box::new(Expr::IfThenElse {
-                                cond: Box::new(Expr::BinOp {
-                                    op: BinOp::Eq,
-                                    lhs: Box::new(Expr::Input),
-                                    rhs: Box::new(Expr::LoadVar { var_index: x_var }),
-                                }),
-                                then_branch: Box::new(Expr::Literal(Literal::True)),
-                                else_branch: Box::new(Expr::Empty),
-                            }),
-                        }),
+                Ok(Expr::AnyShort {
+                    generator: Box::new(Expr::BinOp {
+                        op: BinOp::Eq,
+                        lhs: Box::new(src),
+                        rhs: Box::new(s),
                     }),
-                    fallback: Box::new(Expr::Literal(Literal::False)),
-                };
-                Ok(Expr::LetBinding {
-                    var_index: dot_var,
-                    value: Box::new(Expr::Input),
-                    body: Box::new(Expr::Reduce {
-                        source: Box::new(src),
-                        init: Box::new(Expr::Literal(Literal::False)),
-                        var_index: x_var,
-                        acc_index: acc_var,
-                        update: Box::new(Expr::BinOp {
-                            op: BinOp::Or,
-                            lhs: Box::new(Expr::Input),
-                            rhs: Box::new(in_check),
-                        }),
-                    }),
+                    predicate: Box::new(Expr::Input),
                 })
             }
             // INDEX/1: INDEX(idx_expr) = INDEX(.[]; idx_expr).

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -13107,3 +13107,18 @@ null
 {"ab":1}
 null
 {"a\u007fb":1}
+
+# #984: IN/2 short-circuits its source generator at the first match (no drain)
+IN(2, error("x"); 2)
+null
+true
+
+# #984: IN/2 stops consuming src once a match is found (select idiom)
+[.[] | select(.x | IN(1, error; 1))]
+[{"x":1},{"x":9}]
+[{"x":1},{"x":9}]
+
+# #984: IN/2 still returns false when no source value matches
+IN(1, 2, 3; 9)
+null
+false


### PR DESCRIPTION
## Summary

jq defines `def IN(src; s): any(src == s; .);`, which stops at the first match. jq-jit desugared `IN/2` to a `reduce` over `src`, which fully drains `src` even after a match — **hanging** on an infinite/long source once a match exists, and surfacing later errors past the first hit.

```
$ echo null | jq-jit -c 'IN(2, error("x"); 2)'
true                       # was: jq: error: x (drained past the match)
$ echo null | timeout 3 jq-jit -c 'IN(1, range(1e18); 1)'; echo $?
true / 0                   # was: hang / rc 124
```

## Fix

Lower `IN/2` straight to the short-circuiting `any` (`AnyShort`) over the cartesian comparison `src == s` — exactly jq's builtin definition. Both operands share the same input `.`, so the candidate-set-vs-input behavior (#846) and IN/1 membership (#847) fall out without the extra `$dot`/`reduce` plumbing.

Verified ~20 IN/1 and IN/2 differential cases against jq 1.8.1 (membership, empty src/candidate, piped input, short-circuit, no-match) all match.

## Tests

Added 3 regression cases. Full suite passes, zero warnings.

Closes #984

🤖 Generated with [Claude Code](https://claude.com/claude-code)