### PR TITLE
fix(eval): nest multi-arg builtin generator args rightmost-outer

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -7196,8 +7196,14 @@ fn eval_call_builtin(name: &str, args: &[Expr], input: Value, env: &EnvRef, cb: 
         }
         _ => {}
     }
-    // Default: evaluate args as generators and call runtime with input + args
-    eval_call_builtin_args(name, args, 0, vec![input.clone()], input, env, cb)
+    // Default: evaluate args as generators and call runtime with input + args.
+    // `collected[0]` is the input; `collected[1+i]` is the value of `args[i]`.
+    // jq nests multi-argument builtin generators rightmost-outer (the last
+    // argument is the outer loop), so bind the arguments right-to-left. The
+    // values land in the same positions — only the stream order changes (#978).
+    let mut collected = vec![Value::Null; args.len() + 1];
+    collected[0] = input.clone();
+    eval_call_builtin_args(name, args, args.len(), collected, input, env, cb)
 }
 
 /// Yield each Cartesian-product combination of an array of arrays, in
@@ -7666,14 +7672,20 @@ fn eval_fromcsvh_with_headers(input: &Value, headers_val: &Value, is_tsv: bool, 
     Ok(true)
 }
 
-fn eval_call_builtin_args(name: &str, args: &[Expr], idx: usize, collected: Vec<Value>, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) -> GenResult) -> GenResult {
-    if idx >= args.len() {
+// `remaining` counts arguments not yet bound, from the right: the first call
+// binds `args[remaining-1]` (the rightmost argument, the outer loop), and each
+// nested level binds the next-earlier argument. `collected[0]` holds the input
+// and `collected[1+i]` the value of `args[i]`, so the values stay in argument
+// order regardless of the (rightmost-outer) nesting direction. See #978.
+fn eval_call_builtin_args(name: &str, args: &[Expr], remaining: usize, collected: Vec<Value>, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) -> GenResult) -> GenResult {
+    if remaining == 0 {
         return cb(crate::runtime::call_builtin(name, &collected)?);
     }
+    let idx = remaining - 1;
     eval(&args[idx], input.clone(), env, &mut |val| {
         let mut next = collected.clone();
-        next.push(val);
-        eval_call_builtin_args(name, args, idx + 1, next, input.clone(), env, cb)
+        next[idx + 1] = val;
+        eval_call_builtin_args(name, args, remaining - 1, next, input.clone(), env, cb)
     })
 }
 

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -13122,3 +13122,18 @@ true
 IN(1, 2, 3; 9)
 null
 false
+
+# #978: multi-arg math builtins nest generator args rightmost-outer (like jq)
+[pow(10,20; 1,2)]
+null
+[10,20,100,400]
+
+# #978: 3-arg fma nests rightmost-outer across all three generator args
+[fma(1,2; 10,20; 100,200)]
+null
+[110,120,120,140,210,220,220,240]
+
+# #978: ldexp generator args also nest rightmost-outer
+[ldexp(1,3; 0,4)]
+null
+[1,3,16,48]


### PR DESCRIPTION
## Summary

jq evaluates a builtin call `f(a; b)` with the **rightmost** argument as the **outer** loop. jq-jit's default builtin argument dispatch iterated left-to-right (leftmost-outer), so multi-arg math builtins (`pow/2`, `atan2/2`, `fma/3`, `hypot/2`, `ldexp/2`, `copysign/2`, `fmin/2`, `fmax/2`, `fdim/2`, `nextafter/2`, …) called with generator arguments produced correct values in the wrong stream order.

```
$ echo null | jq-jit -c '[pow(10,20; 1,2)]'
[10,20,100,400]    # was [10,100,20,400]
$ echo null | jq-jit -c '[fma(1,2; 10,20; 100,200)]'
[110,120,120,140,210,220,220,240]   # was reversed nesting
```

## Fix

Bind the arguments right-to-left in `eval_call_builtin_args` (rightmost argument outermost). The values still land in argument order — only the stream order changes — so this is order-only and affects no single-arg or single-valued call. Full suite passes with no expected-value churn.

## Tests

Added 3 regression cases (`pow/2`, `fma/3`, `ldexp/2`). Zero warnings.

Closes #978

🤖 Generated with [Claude Code](https://claude.com/claude-code)