### PR TITLE
fix(eval): nest regex 2-arg generator args rightmost-outer

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3725,9 +3725,11 @@ pub fn eval(
         }
 
         Expr::RegexTest { input_expr, re, flags } => {
+            // jq nests the 2-arg `test(re; flags)` generator args rightmost-outer:
+            // `flags` is the outer loop, `re` the inner one (#983).
             eval(input_expr, input.clone(), env, &mut |s| {
-                eval(re, input.clone(), env, &mut |re_val| {
-                    eval(flags, input.clone(), env, &mut |fv| {
+                eval(flags, input.clone(), env, &mut |fv| {
+                    eval(re, input.clone(), env, &mut |re_val| {
                         cb(crate::runtime::call_builtin("test", &[s.clone(), re_val.clone(), fv.clone()])?)
                     })
                 })
@@ -3735,9 +3737,10 @@ pub fn eval(
         }
 
         Expr::RegexMatch { input_expr, re, flags } => {
+            // Rightmost-outer nesting: `flags` outer, `re` inner (#983).
             eval(input_expr, input.clone(), env, &mut |s| {
-                eval(re, input.clone(), env, &mut |re_val| {
-                    eval(flags, input.clone(), env, &mut |fv| {
+                eval(flags, input.clone(), env, &mut |fv| {
+                    eval(re, input.clone(), env, &mut |re_val| {
                         match crate::runtime::call_builtin("match", &[s.clone(), re_val.clone(), fv.clone()]) {
                             Ok(v) => {
                                 // "g" flag: match returns array of all matches
@@ -3769,9 +3772,10 @@ pub fn eval(
         }
 
         Expr::RegexCapture { input_expr, re, flags } => {
+            // Rightmost-outer nesting: `flags` outer, `re` inner (#983).
             eval(input_expr, input.clone(), env, &mut |s| {
-                eval(re, input.clone(), env, &mut |re_val| {
-                    eval(flags, input.clone(), env, &mut |fv| {
+                eval(flags, input.clone(), env, &mut |fv| {
+                    eval(re, input.clone(), env, &mut |re_val| {
                         let global = matches!(&fv, Value::Str(f) if f.as_str().contains('g'));
                         match crate::runtime::call_builtin("capture", &[s.clone(), re_val.clone(), fv.clone()]) {
                             Ok(v) => {

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -13137,3 +13137,18 @@ null
 [ldexp(1,3; 0,4)]
 null
 [1,3,16,48]
+
+# #983: test/2 nests its (regex; flags) generator args rightmost-outer
+"a" | [test(("a","b"); ("","i"))]
+null
+[true,false,true,false]
+
+# #983: match/2 likewise nests flags as the outer loop
+"ab" | [match(("a","b"); ("","g")) | .string]
+null
+["a","b","a","b"]
+
+# #983: capture/2 likewise nests flags as the outer loop
+"ab" | [capture(("(?<x>a)","(?<y>b)"); ("","g"))]
+null
+[{"x":"a"},{"y":"b"},{"x":"a"},{"y":"b"}]


### PR DESCRIPTION
## Summary

`test/2`, `match/2`, and `capture/2` nested their `(regex; flags)` generator arguments **leftmost-outer** (regex outer), while jq nests them **rightmost-outer** (flags outer). The values were identical — only the output stream order diverged. This is the regex-family counterpart of #978 (math builtins), in the separate `_match_impl` dispatch.

```
$ echo '"a"' | jq-jit -c '[test(("a","b"); ("","i"))]'
[true,false,true,false]   # was [true,true,false,false]
```

## Fix

Swap the eval nesting so `flags` is the outer loop and `re` the inner one in all three arms (call-order of `call_builtin` args unchanged). `scan/2`/`splits/2`/`sub/3` bind differently and already match jq (verified), so they are left unchanged.

## Tests

Added 3 regression cases (`test/2`, `match/2`, `capture/2`). Full suite passes, zero warnings.

Closes #983

🤖 Generated with [Claude Code](https://claude.com/claude-code)