### PR TITLE
fix(parser): reject ?// outside destructuring-alternative position

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2278,14 +2278,14 @@ impl Parser {
         // stay below the `//` rung — read parse_add directly. The `//`
         // operator is handled at parse_alt_top above parse_assign.
         let mut expr = self.parse_add()?;
-        // Check for ?// (alternative destructuring)
-        while self.at(&Token::AltDestructure) {
-            self.advance();
-            let right = self.parse_add()?;
-            expr = Expr::AlternativeDestructure {
-                alternatives: vec![expr, right],
-            };
-        }
+        // `?//` is NOT a general binary operator: it is the destructuring
+        // alternative separator, valid only between patterns in
+        // `EXPR as PAT ?// PAT | body` (and the `reduce`/`foreach` pattern
+        // chains). Those sites consume the token via their own pattern loops;
+        // here at expression level a `?//` is a syntax error in jq, so we must
+        // NOT consume it. Leaving it unconsumed surfaces as a parse error,
+        // matching jq instead of silently running `try LHS catch (LHS // RHS)`
+        // (#977).
         loop {
             let op = match self.current() {
                 Token::Eq => BinOp::Eq,

--- a/tests/altdestructure_bare_operator.rs
+++ b/tests/altdestructure_bare_operator.rs
@@ -1,0 +1,42 @@
+//! Issue #977: `?//` is the destructuring-alternative separator, valid only
+//! between patterns in `EXPR as PAT ?// PAT | body` (and the `reduce`/`foreach`
+//! pattern chains). jq raises a *compile* error when it appears as a bare
+//! binary operator anywhere else; jq-jit previously accepted it (running
+//! `try LHS catch (LHS // RHS)`).
+//!
+//! `regression.test` cannot cover the rejection: its harness skips programs
+//! that exit 3 (compile error). Assert directly against `Filter::with_options`,
+//! which surfaces the compile error in the CLI.
+
+use jq_jit::interpreter::Filter;
+
+fn is_compile_error(program: &str) -> bool {
+    Filter::with_options(program, &[], false).is_err()
+}
+
+fn parses(program: &str) {
+    if let Err(e) = Filter::with_options(program, &[], false) {
+        panic!("expected `{program}` to parse, got compile error: {e}");
+    }
+}
+
+#[test]
+fn bare_altdestructure_is_a_compile_error() {
+    assert!(is_compile_error("1 ?// 2"), "top-level bare ?//");
+    assert!(is_compile_error("{a: (1 ?// 2)}"), "object value");
+    assert!(is_compile_error("[1 ?// 2]"), "array element");
+    assert!(is_compile_error(".x ?// .y"), "after a field");
+    assert!(is_compile_error(r#"(.[0]) ?// "fallback""#), "parenthesized lhs");
+    assert!(is_compile_error("1 | 2 ?// 3"), "after a pipe");
+    assert!(is_compile_error("def f: 1 ?// 2; f"), "in a def body");
+}
+
+#[test]
+fn destructuring_alternative_still_parses() {
+    // The legitimate `?//` positions must keep working.
+    parses(". as [$a] ?// $a | $a");
+    parses(". as {a:$x} ?// $x | $x");
+    parses(". as [$a] ?// {a:$a} ?// $a | $a");
+    parses("reduce .[] as [$a] ?// $a (0; . + $a)");
+    parses("foreach .[] as [$a] ?// $a (0; . + $a; .)");
+}


### PR DESCRIPTION
## Summary

`?//` is the destructuring-alternative separator, valid only between patterns in `EXPR as PAT ?// PAT | body` and the `reduce`/`foreach` pattern chains. jq raises a **compile error** when it appears as a bare binary operator anywhere else, but jq-jit accepted it in expression position and ran `try LHS catch (LHS // RHS)` — so programs that are syntax errors in jq silently ran with different semantics.

```
$ echo null | jq-jit -c '1 ?// 2'
jq: error: syntax error ...   # exit 3 — was: 1 (exit 0)
```

## Fix

Remove the `?//` arm from `parse_compare` so a bare `?//` is left unconsumed and surfaces as a parse error (exit 3), matching jq. The legitimate pattern-chain sites (`parse_as_binding`, `parse_reduce`, `parse_foreach`) consume the token via their own pattern loops and are unaffected — the valid `. as [$a] ?// $a | $a` form still works.

## Tests

New `tests/altdestructure_bare_operator.rs` asserting bare `?//` is a compile error in 7 positions and that the 5 legitimate destructuring forms still parse (`regression.test` can't cover exit-3 programs). Full suite passes, zero warnings.

Closes #977

🤖 Generated with [Claude Code](https://claude.com/claude-code)