### PR TITLE
fix(eval): keep path provenance through user-def filter-arg forwarding

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -5922,12 +5922,35 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
                 cb(pv)
             })
         }
-        Expr::FuncCall { func_id, .. } => {
+        Expr::FuncCall { func_id, args } => {
             let func = env.borrow().funcs.get(*func_id).cloned();
-            if let Some(f) = func {
+            let f = match func {
+                Some(f) => f,
+                None => bail!("undefined function id {}", func_id),
+            };
+            // A path forwarded through a filter parameter (`def f(g): g; path(f(.a))`)
+            // must keep its provenance: jq treats the closure argument as
+            // path-transparent. Mirror the value-mode call by substituting the
+            // argument expressions into the body before collecting paths, so a
+            // parameter reference resolves to the path of the forwarded filter
+            // rather than evaluating to a value (which bailed "Invalid path
+            // expression with result null"). See #982.
+            if f.param_vars.is_empty() || args.is_empty() {
                 eval_path(&f.body, input, env, cb)
+            } else if contains_func_call(&f.body, *func_id) {
+                // Recursive body: rename its local bindings to fresh slots so
+                // concurrently-active frames don't share var indices (matching
+                // the value-mode recursive call path).
+                let nv_before = env.borrow().next_var;
+                let mut nv = nv_before;
+                let body = substitute_and_rename(&f.body, &f.param_vars, args, &mut nv);
+                env.borrow_mut().next_var = nv;
+                let result = eval_path(&body, input, env, cb);
+                env.borrow_mut().next_var = nv_before;
+                result
             } else {
-                bail!("undefined function id {}", func_id)
+                let body = substitute_params(&f.body, &f.param_vars, args);
+                eval_path(&body, input, env, cb)
             }
         }
         Expr::TryCatch { try_expr, catch_expr, restore_dot } => {

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -13152,3 +13152,33 @@ null
 "ab" | [capture(("(?<x>a)","(?<y>b)"); ("","g"))]
 null
 [{"x":"a"},{"y":"b"},{"x":"a"},{"y":"b"}]
+
+# #982: a path forwarded through a user-def filter arg keeps provenance under path()
+def f(g): g; path(f(.a))
+{"a":1}
+["a"]
+
+# #982: assignment through a filter-arg-forwarded path
+def f(g): g; f(.a) = 99
+{"a":1}
+{"a":99}
+
+# #982: del() through a filter-arg-forwarded path
+def f(g): g; del(f(.a))
+{"a":1,"b":2}
+{"b":2}
+
+# #982: del through a helper def that forwards a path (SQL-style idiom)
+def k(c): select(c); [del(.[] | k(.>1))]
+[1,2,3]
+[[1]]
+
+# #982: path composes across the body and the closure arg
+def f(g): .a | g; path(f(.b))
+{"a":{"b":1}}
+["a","b"]
+
+# #982: multiple filter params forward the selected path
+def f(a;b): b; path(f(.x;.y))
+{"x":1,"y":2}
+["y"]


### PR DESCRIPTION
## Summary

A path forwarded as a user-defined function's filter argument (`def f(g): g; path(f(.a))`) lost its provenance under `path()`, `=`, and `del()`. jq treats the closure argument as path-transparent, but jq-jit's path-mode `FuncCall` handler evaluated the body **without substituting the arguments**, so a parameter reference hit the value-mode default and errored `Invalid path expression with result null` — or, worse, silently produced the wrong value / dropped output for the common `del(.[] | helper(...))` idiom.

```
$ echo '{"a":1}'   | jq-jit -c 'def f(g): g; path(f(.a))'   ->  ["a"]    # was error
$ echo '{"a":1}'   | jq-jit -c 'def f(g): g; f(.a) = 99'    ->  {"a":99} # was error
$ echo '[1,2,3]'   | jq-jit -c 'def k(c): select(c); del(.[] | k(.>1))' -> [1]  # was [1,2,3]
```

## Fix

Substitute the argument expressions into the function body before collecting paths — mirroring the value-mode call — so a forwarded path resolves to its lvalue. Recursive bodies rename their local bindings to fresh slots, matching the existing value-mode recursive path. `|=`/`_modify` already took a separate (correct) lowering and are unaffected.

Verified 10 forms against jq 1.8.1 (`path`/`=`/`del`, composition across body+closure, multiple params, the SQL-style `del` idiom) all match.

## Tests

Added 6 regression cases. Full suite passes, zero warnings.

Closes #982

🤖 Generated with [Claude Code](https://claude.com/claude-code)