### PR TITLE
fix(path): make debug/stderr path-transparent

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -6418,6 +6418,26 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
                 }
             })
         }
+        // `debug`/`stderr` are path-transparent: they emit their side-effect
+        // line on stderr but forward the value and the incoming path unchanged
+        // (identity path `[]`), so `path()`/`=`/`|=`/`del` through a debugging
+        // insertion keep working. Mirror the value arms above but yield the
+        // identity path instead of the value. #997
+        Expr::Debug { expr: de } => {
+            eval(de, input.clone(), env, &mut |val| {
+                eprintln!("[\"DEBUG:\",{}]", crate::value::value_to_json_tojson(&val));
+                cb(Value::Arr(Rc::new(vec![])))
+            })
+        }
+        Expr::Stderr { expr: se } => {
+            eval(se, input.clone(), env, &mut |val| {
+                match &val {
+                    Value::Str(s) => eprint!("{}", s.as_str()),
+                    _ => eprint!("{}", crate::value::value_to_json_tojson(&val)),
+                }
+                cb(Value::Arr(Rc::new(vec![])))
+            })
+        }
         _ => {
             // Non-path-safe expression: evaluate, then accept the value as
             // the empty path `[]` if it is one of `null`/`true`/`false` and

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -13182,3 +13182,23 @@ def f(g): .a | g; path(f(.b))
 def f(a;b): b; path(f(.x;.y))
 {"x":1,"y":2}
 ["y"]
+
+# #997: debug is path-transparent (= / |= / del / path)
+debug = 9
+5
+9
+
+# #997: path() through debug forwards the incoming path
+path(.a | debug)
+{"a":5}
+["a"]
+
+# #997: del() through debug keeps path tracking
+del(.a | debug | .b)
+{"a":{"b":5},"c":1}
+{"a":{},"c":1}
+
+# #997: stderr is path-transparent too
+(.a | stderr | .b) = 9
+{"a":{"b":5}}
+{"a":{"b":9}}


### PR DESCRIPTION
## Summary

`debug` and `stderr` are identity-on-path in jq — they emit their side-effect line on stderr but forward both the value and the incoming path register unchanged. jq-jit only implemented value-context arms, so a path flowing through `debug`/`stderr` hit the generic non-path fallback and raised `Invalid path expression`, breaking `path()` / `=` / `|=` / `del`.

```
$ echo 5 | jq-jit -c 'debug = 9'      # before: error; jq: 9
$ echo '{"a":5}' | jq-jit -c 'path(.a | debug)'   # before: error; jq: ["a"]
```

## Fix

Add `eval_path` arms for `Expr::Debug` / `Expr::Stderr` mirroring the value arms, but yielding the identity path `[]` after the side effect — the same mechanism that made the trim builtins transparent in #962.

## Tests

- 4 regression cases in `tests/regression.test` (`debug = 9`, `path(.a|debug)`, `del(.a|debug|.b)`, `(.a|stderr|.b)=9`), all cross-checked against jq 1.8.1.
- Full suite passes, zero warnings.

Closes #997

🤖 Generated with [Claude Code](https://claude.com/claude-code)