### PR TITLE
fix(path): stop double-evaluating F in invalid path(P|F) error

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -5724,7 +5724,14 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
             }
         }
         Expr::Pipe { left, right } => {
+            // Track whether LEFT produced a path: if so, a `__pathexpr_result__`
+            // sentinel below came from RIGHT applied to a real `mid` value, so
+            // its json IS the offending value already — reporting it directly
+            // avoids re-running RIGHT on it (which double-applies a non-path
+            // transform: `path(.a | . + 2)` reported 9 instead of 7). #1005
+            let left_pathed = std::cell::Cell::new(false);
             let result = eval_path(left, input.clone(), env, &mut |lp| {
+                left_pathed.set(true);
                 let mid = crate::runtime::rt_getpath(&input, &lp).unwrap_or(Value::Null);
                 eval_path(right, mid.clone(), env, &mut |rp| {
                     let mut p = match &lp { Value::Arr(a)=>a.as_ref().clone(), _=>vec![] };
@@ -5736,6 +5743,11 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
                 Err(e) => {
                     let msg = format!("{}", e);
                     if let Some(json) = msg.strip_prefix("__pathexpr_result__:") {
+                        if left_pathed.get() {
+                            // Sentinel originates from RIGHT on a navigated value;
+                            // json is the already-computed result. Don't re-eval.
+                            bail!("Invalid path expression with result {}", trunc_path_dump(json));
+                        }
                         match right.as_ref() {
                             Expr::Index { key, .. } | Expr::IndexOpt { key, .. } => {
                                 let mut key_val = Value::Null;

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -13202,3 +13202,18 @@ del(.a | debug | .b)
 (.a | stderr | .b) = 9
 {"a":{"b":5}}
 {"a":{"b":9}}
+
+# #1005: invalid path(P|F) reports F applied once, not twice
+try path(.a | . + 2) catch .
+{"a":1}
+"Invalid path expression with result 3"
+
+# #1005: non-idempotent F is not double-applied in the error value
+try path(.a | [.]) catch .
+{"a":1}
+"Invalid path expression with result [1]"
+
+# #1005: object-wrapping F reported once
+try path(.a | {x:.}) catch .
+{"a":1}
+"Invalid path expression with result {\"x\":1}"


### PR DESCRIPTION
## Summary

When `path(P | F)` is invalid because `F` is not a path expression, the `Invalid path expression with result N` message embedded a value with `F` applied **twice**.

```
$ echo '{"a":5}' | jq-jit -c 'path(.a | . + 2)'   # before: result 9; jq: result 7
$ echo '{"a":1}' | jq-jit -c 'path(.a | [.])'     # before: result [[1]]; jq: result [1]
```

## Root cause

In the `Pipe` arm of `eval_path`, when `P` produces a real path, the inner `eval_path(F, mid)` already bails the `__pathexpr_result__` sentinel carrying `F(mid)`. The error handler then mistook that json for "the value the left side produced" and re-ran `F` on it (the #839 rootless-left path), doubling non-idempotent `F`.

## Fix

Track whether the left side produced a path. If so, the sentinel already holds the offending value — report it directly without re-evaluating `F`. The rootless-left case keeps the existing #839 navigate-detection logic.

## Tests

3 regression cases (`. + 2`, `[.]`, `{x:.}`), cross-checked against jq 1.8.1. Full suite passes, zero warnings.

Closes #1005

🤖 Generated with [Claude Code](https://claude.com/claude-code)