### PR TITLE
fix(remap): bail object-construct .field|length on a boolean

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -1463,6 +1463,14 @@ fn resolved_would_error(
             }
             true
         }
+        // `.field | length`: jq's `length` is defined for null (0), strings
+        // (codepoints), arrays/objects (count), and numbers (abs), but raises
+        // `<type> has no length` for booleans. The inline emitter falls through
+        // to a `null` literal for booleans, masking that error — bail so the
+        // generic path raises it. Surfaced by the metamorphic harness as
+        // `{a: (.b | length)}` on `{"b":false}` emitting `{"a":null}` while
+        // `.b | length` (and every non-object-construct path) errors.
+        ResolvedRemap::FieldLength(idx) => matches!(bytes_of(*idx).first(), Some(b't') | Some(b'f')),
         ResolvedRemap::FieldStringCase(idx, _) => str_domain(*idx),
         ResolvedRemap::FieldStrBuiltin(idx, _, _) => str_domain(*idx),
         ResolvedRemap::FieldSplitJoin(idx, _, _) => str_domain(*idx),

--- a/tests/objconstruct_length_boolean.rs
+++ b/tests/objconstruct_length_boolean.rs
@@ -1,0 +1,61 @@
+//! The object-construct computed-remap fast path for `{key: (.field | length)}`
+//! must not mask jq's `<type> has no length` error when the field value is a
+//! boolean. The inline emitter coerced booleans to a `null` literal, so
+//! `{a: (.b | length)}` on `{"b":false}` emitted `{"a":null}` while every other
+//! path (`.b | length`, `[.b|length]`, `reduce …`) correctly errored.
+//!
+//! Surfaced by the metamorphic equivalence harness (error-class mismatch
+//! between the object-construct path and the generic path). The regression-test
+//! harness only compares stdout (an error and the pre-fix silent-null both pass
+//! some checks), so assert the process exit status here.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn run(filter: &str, stdin: &str) -> (String, bool) {
+    let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
+    let mut child = Command::new(jq_jit)
+        .args(["-c", filter])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn jq-jit");
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(stdin.as_bytes())
+        .unwrap();
+    let out = child.wait_with_output().expect("wait failed");
+    (
+        String::from_utf8_lossy(&out.stdout).trim_end().to_string(),
+        out.status.success(),
+    )
+}
+
+#[test]
+fn boolean_field_length_errors_in_object_construct() {
+    for input in [r#"{"b":false}"#, r#"{"b":true}"#] {
+        let (out, ok) = run("{a: (.b | length)}", input);
+        assert!(!ok, "expected `{{a:.b|length}}` on `{input}` to error, got {out:?}");
+        assert!(out.is_empty(), "expected no stdout for `{input}`, got {out:?}");
+    }
+}
+
+#[test]
+fn lengthable_field_types_still_fast_path() {
+    let cases = [
+        (r#"{"b":5}"#, r#"{"a":5}"#),
+        (r#"{"b":-3}"#, r#"{"a":3}"#),
+        (r#"{"b":null}"#, r#"{"a":0}"#),
+        (r#"{"b":"hi"}"#, r#"{"a":2}"#),
+        (r#"{"b":[1,2,3]}"#, r#"{"a":3}"#),
+        (r#"{"b":{"x":1}}"#, r#"{"a":1}"#),
+    ];
+    for (input, expected) in cases {
+        let (out, ok) = run("{a: (.b | length)}", input);
+        assert!(ok, "expected success for `{input}`");
+        assert_eq!(out, expected, "for input `{input}`");
+    }
+}


### PR DESCRIPTION
## Summary

The computed-remap fast path's `FieldLength` emitter coerces any value without a jq length to a `null` literal. For booleans this masked jq's `<type> has no length` error:

```
$ echo '{"b":false}' | jq-jit -c '{a: (.b | length)}'   # before: {"a":null}; jq: error
$ echo '{"b":false}' | jq-jit -c '.b | length'           # error (correct)
$ echo '{"b":false}' | jq-jit -c '[.b|length]'           # error (correct)
```

The object-construct path disagreeing with every other path is an **internal inconsistency** the metamorphic equivalence harness flags as an error-class mismatch (`[gen]|add ≡ reduce …` and `[f]|.[] ≡ f`), which made `tests/metamorphic.rs` intermittently red.

## Fix

Add a `FieldLength` arm to `resolved_would_error` that bails when the field value is a boolean, routing the record through the generic interpreter so it raises jq's error. `null` (0), strings, arrays, objects, and numbers (abs) keep the fast path.

## Tests

- New `tests/objconstruct_length_boolean.rs`: bare `{a:(.b|length)}` errors on boolean input (nonzero exit, empty stdout) and still fast-paths all lengthable types.
- Metamorphic harness now stable (3× 256-case runs green).
- Full suite passes, zero warnings.

Found by the metamorphic equivalence harness (no filed issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)