### PR TITLE
fix(fast-path): stop select(.field|length CMP N) masking the index error

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -4977,6 +4977,21 @@ fn real_main() {
                                 }
                                 compact_buf.push(b'\n');
                             }
+                        } else {
+                            // Field not located by the object scanner: either a
+                            // non-object input (jq raises `Cannot index <type>
+                            // with string`) or an object missing the field
+                            // (`.field` = null, `null|length` = 0). The raw path
+                            // silently dropping these masked the type error on
+                            // non-objects (#998). Defer to the JIT, which raises
+                            // the error or applies the length-0 comparison.
+                            let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                            if compact_buf.len() >= 1 << 17 {
+                                let _ = out.write_all(&compact_buf);
+                                compact_buf.clear();
+                            }
+                            return Ok(());
                         }
                         if compact_buf.len() >= 1 << 17 {
                             let _ = out.write_all(&compact_buf);
@@ -13995,6 +14010,18 @@ fn real_main() {
                             }
                             compact_buf.push(b'\n');
                         }
+                    } else {
+                        // Non-object input (jq raises `Cannot index <type> with
+                        // string`) or object missing the field (`null|length`=0).
+                        // Defer to the JIT instead of silently dropping, which
+                        // masked the type error on non-objects (#998).
+                        let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
+                        process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+                        if compact_buf.len() >= 1 << 17 {
+                            let _ = out.write_all(&compact_buf);
+                            compact_buf.clear();
+                        }
+                        return Ok(());
                     }
                     if compact_buf.len() >= 1 << 17 {
                         let _ = out.write_all(&compact_buf);

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -13217,3 +13217,13 @@ try path(.a | [.]) catch .
 try path(.a | {x:.}) catch .
 {"a":1}
 "Invalid path expression with result {\"x\":1}"
+
+# #998: select(.field|length CMP N) on a non-object raises the index type error
+try select(.a | length > 0) catch .
+5
+"Cannot index number with string \"a\""
+
+# #998: object missing the field compares length against 0
+select(.a | length == 0)
+{"b":1}
+{"b":1}

--- a/tests/select_length_cmp_nonobject.rs
+++ b/tests/select_length_cmp_nonobject.rs
@@ -1,0 +1,78 @@
+//! Issue #998: the fused `select(.field | length CMP const)` raw fast path
+//! must not mask the index type error on non-object inputs. jq raises
+//! `Cannot index <type> with string` when `.field` is applied to a
+//! non-object; jq-jit's raw scanner silently emitted nothing (exit 0).
+//!
+//! The regression-test harness only compares stdout (an error case and the
+//! pre-fix silent-drop both produce empty stdout), so it can't distinguish
+//! the masking — assert the process exit status here instead.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn run(filter: &str, stdin: &str) -> (String, bool) {
+    let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
+    let mut child = Command::new(jq_jit)
+        .args(["-c", filter])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn jq-jit");
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(stdin.as_bytes())
+        .unwrap();
+    let out = child.wait_with_output().expect("wait failed");
+    (
+        String::from_utf8_lossy(&out.stdout).trim_end().to_string(),
+        out.status.success(),
+    )
+}
+
+#[test]
+fn nonobject_input_raises_index_error() {
+    // Every comparison operator and every non-object input must error,
+    // matching jq's `Cannot index <type> with string`.
+    for op in [">", "<", "==", ">=", "<=", "!="] {
+        let filter = format!("select(.a | length {op} 0)");
+        for input in ["5", "\"s\"", "true", "[1]"] {
+            let (out, ok) = run(&filter, input);
+            assert!(
+                !ok,
+                "expected `{filter}` on `{input}` to error, got success with {out:?}"
+            );
+            assert!(out.is_empty(), "expected no stdout for `{filter}` on `{input}`");
+        }
+    }
+}
+
+#[test]
+fn null_input_does_not_error() {
+    // `null | .a` is `null` in jq, so `null | length` is 0 and the select
+    // simply produces nothing — it must not raise a type error.
+    let (out, ok) = run("select(.a | length > 0)", "null");
+    assert!(ok, "expected null input to succeed, got error");
+    assert!(out.is_empty(), "expected no output for null input, got {out:?}");
+}
+
+#[test]
+fn object_missing_field_compares_against_zero() {
+    // An object missing the field has `.field == null`, `null | length == 0`,
+    // so `== 0` passes and the whole object is emitted.
+    let (out, ok) = run("select(.a | length == 0)", r#"{"b":1}"#);
+    assert!(ok, "expected success");
+    assert_eq!(out, r#"{"b":1}"#);
+}
+
+#[test]
+fn string_field_fast_path_still_works() {
+    let (out, ok) = run("select(.a | length > 3)", r#"{"a":"hello"}"#);
+    assert!(ok);
+    assert_eq!(out, r#"{"a":"hello"}"#);
+    let (out, ok) = run("select(.a | length > 3)", r#"{"a":"hi"}"#);
+    assert!(ok);
+    assert!(out.is_empty());
+}


### PR DESCRIPTION
## Summary

The fused `select(.field | length CMP const)` raw fast path located the field with `json_object_get_field_raw`; when that returned `None` it silently dropped the record:

```
$ echo 5 | jq-jit -c 'select(.a | length > 0)'   # before: empty, exit 0; jq: Cannot index number with string "a"
```

For a non-object input the `Cannot index <type> with string` type error was swallowed; for an object missing the field it skipped instead of comparing against `null | length = 0`.

## Fix

Add an `else` arm to both apply sites (file + stdin) that defers to the generic interpreter when the field isn't located: it raises the type error on non-objects (and `null` input still no-ops, matching jq), and applies the length-0 comparison for an object missing the field.

## Tests

- New `tests/select_length_cmp_nonobject.rs`: non-object errors across all operators/types, `null` no-error, object-missing-field `==0` emits, string field still fast-paths.
- 2 regression cases. Full suite passes, zero warnings.

Closes #998

🤖 Generated with [Claude Code](https://claude.com/claude-code)