### PR TITLE
fix(fast-path): stop .field|=ascii_*case corrupting compact stdout

### DIFF
--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -3388,9 +3388,17 @@ pub fn apply_field_update_case_raw(
     is_upcase: bool,
     buf: &mut Vec<u8>,
 ) -> RawApplyOutcome {
+    // `json_object_update_field_case` appends the object prefix (`{`, the key,
+    // and copied values) to `buf` as it scans, and only returns false once it
+    // discovers the target value isn't a string. In `-c` mode `buf` is the
+    // shared output buffer, so those partial bytes (`{"a":5`) leak to stdout
+    // ahead of the generic path's error. Roll `buf` back to its pre-attempt
+    // length on Bail so nothing is emitted before the re-run errors. #996
+    let start_len = buf.len();
     if json_object_update_field_case(raw, 0, field, is_upcase, buf) {
         RawApplyOutcome::Emit
     } else {
+        buf.truncate(start_len);
         RawApplyOutcome::Bail
     }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -3581,7 +3581,11 @@ pub fn json_object_update_field_case(
         while i < b.len() && matches!(b[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
     }
     if !found { return false; }
-    buf.extend_from_slice(b"}\n");
+    // Terminate with `}` only (no trailing newline), matching the sibling
+    // `json_object_update_field_*` helpers — the apply site adds the record's
+    // `\n`. Emitting `}\n` here let the compact apply arm's own `\n` push double
+    // it, so `.field |= ascii_upcase` printed a stray blank line per record. #996
+    buf.push(b'}');
     true
 }
 

--- a/tests/case_update_output.rs
+++ b/tests/case_update_output.rs
@@ -1,0 +1,66 @@
+//! Issue #996: the top-level `.field |= ascii_upcase` / `ascii_downcase` raw
+//! fast path produced byte-incorrect stdout that the line-normalizing
+//! regression harness can't see:
+//!
+//!   1. On a non-string field value it leaked the partial, unterminated object
+//!      prefix (`{"a":5`) to stdout before erroring (the value-side helper
+//!      appends bytes as it scans, then bails when the value isn't a string).
+//!   2. On every successful record it emitted a stray blank line — the helper
+//!      terminated with `}\n` while the compact apply arm pushed its own `\n`.
+//!
+//! These assert the exact stdout bytes, so they catch both regressions.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn run_bytes(filter: &str, stdin: &str) -> (Vec<u8>, bool) {
+    let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
+    let mut child = Command::new(jq_jit)
+        .args(["-c", filter])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn jq-jit");
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(stdin.as_bytes())
+        .unwrap();
+    let out = child.wait_with_output().expect("wait failed");
+    (out.stdout, out.status.success())
+}
+
+#[test]
+fn successful_update_has_no_stray_blank_line() {
+    let (out, ok) = run_bytes(".a |= ascii_upcase", r#"{"a":"hi"}"#);
+    assert!(ok);
+    assert_eq!(out, b"{\"a\":\"HI\"}\n", "exactly one trailing newline");
+
+    let (out, ok) = run_bytes(".a |= ascii_downcase", r#"{"a":"HELLO"}"#);
+    assert!(ok);
+    assert_eq!(out, b"{\"a\":\"hello\"}\n");
+}
+
+#[test]
+fn nonstring_value_leaks_nothing_to_stdout() {
+    for input in [r#"{"a":5}"#, r#"{"a":[1]}"#, r#"{"a":{}}"#, r#"{"a":null}"#, r#"{"a":true}"#] {
+        let (out, ok) = run_bytes(".a |= ascii_upcase", input);
+        assert!(!ok, "expected error on `{input}`");
+        assert!(
+            out.is_empty(),
+            "expected no stdout for `{input}`, got {:?}",
+            String::from_utf8_lossy(&out)
+        );
+    }
+}
+
+#[test]
+fn multi_record_stream_no_blank_lines_and_no_leak() {
+    // First and third records succeed; the middle errors. jq writes only the
+    // two valid objects (the stream continues past the error), each on its own
+    // line with no blank lines and no partial prefix from the error record.
+    let (out, _ok) = run_bytes(".a |= ascii_upcase", "{\"a\":\"hi\"}\n{\"a\":5}\n{\"a\":\"yo\"}");
+    assert_eq!(out, b"{\"a\":\"HI\"}\n{\"a\":\"YO\"}\n");
+}

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -13227,3 +13227,13 @@ try select(.a | length > 0) catch .
 select(.a | length == 0)
 {"b":1}
 {"b":1}
+
+# #996: .field |= ascii_upcase emits exactly one line (no stray trailing blank)
+.a |= ascii_upcase
+{"a":"hi"}
+{"a":"HI"}
+
+# #996: ascii_downcase update single line
+.a |= ascii_downcase
+{"a":"HELLO"}
+{"a":"hello"}


### PR DESCRIPTION
## Summary

The top-level `.field |= ascii_upcase` / `ascii_downcase` raw fast path wrote two kinds of byte-incorrect output to stdout, both invisible to the line-normalizing regression harness:

**1. Partial leak (the filed bug).** `json_object_update_field_case` appends the object prefix (`{`, key, copied values) to the shared output buffer as it scans, and only returns false once it discovers the target value isn't a string. In `-c` mode that left `{"a":5` on stdout before the generic re-run errored:

```
$ printf '{"a":5}' | jq-jit -c '.a |= ascii_upcase' 2>/dev/null | xxd
00000000: 7b22 6122 3a35    {"a":5        # 6 leaked bytes; jq writes nothing
```

**2. Stray blank line (found alongside).** The helper terminated with `}\n` while the compact apply arm pushes its own `\n`, doubling it — every *successful* record got a trailing blank line (`{"a":"HI"}\n\n`).

## Fix

1. `apply_field_update_case_raw` truncates the buffer back to its pre-attempt length on Bail, so nothing leaks before the generic path errors.
2. The helper now terminates with `}` only, matching the sibling `json_object_update_field_*` helpers (the apply site owns the record newline). The pretty path already stripped the helper's `\n`, so it stays correct.

Output is now byte-identical to jq for compact, pretty, single/multi-record streams, and the bracket/paren spellings.

## Tests

New `tests/case_update_output.rs` asserts exact stdout bytes (the regression harness filters blank lines, so it can't see either symptom): no stray blank line, no partial leak on any non-string type, clean multi-record stream. Plus 2 regression cases. Full suite green, zero warnings.

Closes #996

🤖 Generated with [Claude Code](https://claude.com/claude-code)