### PR TITLE
fix(parser): reject empty and trailing-comma destructuring patterns

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1884,22 +1884,42 @@ impl Parser {
             }
             Token::LBracket => {
                 self.advance();
+                // jq's grammar requires at least one sub-pattern and forbids a
+                // trailing comma: `. as []` and `. as [$a,]` are syntax errors
+                // (unlike object/array *construction*, which allows neither an
+                // empty list error nor — for construction — a trailing comma).
+                // The old `while` loop accepted both. #999
+                if self.at(&Token::RBracket) {
+                    bail!("syntax error, unexpected ']', expecting BINDING or '[' or '{{'");
+                }
                 let mut pats = Vec::new();
-                while !self.at(&Token::RBracket) && !self.at_eof() {
+                loop {
                     pats.push(self.parse_pattern()?);
                     if !self.eat(&Token::Comma) { break; }
+                    if self.at(&Token::RBracket) {
+                        bail!("syntax error, unexpected ']', expecting BINDING or '[' or '{{'");
+                    }
                 }
                 self.expect(&Token::RBracket)?;
                 Ok(Pattern::Array(pats))
             }
             Token::LBrace => {
                 self.advance();
+                // jq requires at least one key pattern and forbids a trailing
+                // comma: `. as {}` and `. as {a:$x,}` / `. as {$a,}` are syntax
+                // errors. #999
+                if self.at(&Token::RBrace) {
+                    bail!("syntax error, unexpected '}}'");
+                }
                 let mut pats = Vec::new();
-                while !self.at(&Token::RBrace) && !self.at_eof() {
+                loop {
                     // {key: $var} or {$var} (shorthand)
                     let (key, pat) = self.parse_obj_pattern_pair()?;
                     pats.push((key, pat));
                     if !self.eat(&Token::Comma) { break; }
+                    if self.at(&Token::RBrace) {
+                        bail!("syntax error, unexpected '}}'");
+                    }
                 }
                 self.expect(&Token::RBrace)?;
                 Ok(Pattern::Object(pats))

--- a/tests/destructure_pattern_strict.rs
+++ b/tests/destructure_pattern_strict.rs
@@ -1,0 +1,64 @@
+//! Issue #999: the destructuring-pattern parser over-accepted empty patterns
+//! (`. as []`, `. as {}`) and trailing commas (`. as [$a,]`, `. as {a:$x,}`,
+//! `. as {$a,}`) that jq's grammar rejects as compile errors. These are
+//! compile-time syntax errors (exit 3), which the diff/regression harnesses
+//! skip, so assert acceptance/rejection at the process level here.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+/// Returns true if jq-jit *compiled* the program (it may still fail at
+/// runtime). jq/jq-jit use exit code 3 for compile errors, so rejection is
+/// exactly exit 3 — a runtime type error (exit 5) still counts as accepted,
+/// since the pattern was syntactically valid.
+fn accepts(filter: &str) -> bool {
+    let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
+    let mut child = Command::new(jq_jit)
+        .args(["-c", filter])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn jq-jit");
+    child.stdin.take().unwrap().write_all(b"[1,2]").unwrap();
+    let code = child.wait_with_output().expect("wait failed").status.code();
+    code != Some(3)
+}
+
+#[test]
+fn rejects_empty_and_trailing_comma_patterns() {
+    let bad = [
+        r#". as [] | "ok""#,
+        r#". as {} | "ok""#,
+        r#". as [$a,] | $a"#,
+        r#". as [$a,$b,] | $a"#,
+        r#". as {a:$x,} | $x"#,
+        r#". as {$a,} | $a"#,
+        r#". as {a:{}} | "ok""#,
+        r#". as {a:[]} | "ok""#,
+        r#"reduce .[] as {} (0; .)"#,
+        r#"reduce .[] as [] (0; .)"#,
+        r#"foreach .[] as [$a,] (0; .; .)"#,
+    ];
+    for f in bad {
+        assert!(!accepts(f), "expected jq-jit to reject `{f}`");
+    }
+}
+
+#[test]
+fn still_accepts_valid_patterns() {
+    let good = [
+        r#"[1,2] as [$a,$b] | $a"#,
+        r#"{"a":1} as {a:$x} | $x"#,
+        r#"{"a":1} as {$a} | $a"#,
+        r#"[[1]] as [[$a]] | $a"#,
+        r#"{"a":[1]} as {a:[$x]} | $x"#,
+        r#"[1] as [$a] ?// $a | $a"#,
+        r#"{"a":1,"b":2} as {a:$x,b:$y} | $x"#,
+        r#"foreach .[] as [$a] (0; .; .)"#,
+        r#"reduce .[] as [$a] (0; .)"#,
+    ];
+    for f in good {
+        assert!(accepts(f), "expected jq-jit to accept `{f}`");
+    }
+}


### PR DESCRIPTION
## Summary

jq's grammar requires a destructuring pattern to contain at least one binding and forbids a trailing comma, so these are compile errors in jq but jq-jit accepted them:

```
. as []        . as {}        . as [$a,]        . as {a:$x,}        . as {$a,}
. as {a:{}}    . as {a:[]}    reduce .[] as {} (...)
```

The pattern parser's element loops accepted all of them: the `while !at(close)` guard let an empty list through, and `if !eat(Comma) { break }` swallowed a trailing comma before the closing bracket.

## Fix

Reject an immediately-closing bracket (empty pattern) and a comma-then-closing-bracket (trailing comma) in both the array and object pattern branches of `parse_pattern`, emitting jq's syntax-error wording (`unexpected ']', expecting BINDING or '[' or '{'` / `unexpected '}'`). This also covers the `reduce`/`foreach` pattern position, which shares `parse_pattern`.

## Tests

New `tests/destructure_pattern_strict.rs` (these are compile errors / exit 3, which the diff & regression harnesses skip): rejects the empty/trailing-comma forms across array, object, shorthand, nested, and reduce/foreach contexts; still accepts all valid patterns including `?//` alternatives. Full suite green, zero warnings.

Closes #999

🤖 Generated with [Claude Code](https://claude.com/claude-code)