### PR TITLE
fix(io): reject adjacent tokens in the main-loop document reader

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -911,11 +911,17 @@ where F: FnMut(usize, usize) -> Result<()> {
             cb(pos, end)?;
             return json_stream_ndjson(bytes, end + 1, cb);
         }
+        // The default main-loop document reader (`jq .`) is this raw streamer,
+        // not `json_stream` — so it needs the same adjacent-token guard #854
+        // added there. Without it `nullnull` / `true1` / `truefalse` split into
+        // separate documents instead of erroring like jq. #1000
+        reject_adjacent_word_token(bytes, end)?;
         cb(pos, end)?;
         pos = ws_after;
     }
     while pos < bytes.len() {
         let end = skip_json_value(bytes, pos)?;
+        reject_adjacent_word_token(bytes, end)?;
         cb(pos, end)?;
         pos = skip_ws(bytes, end);
     }

--- a/tests/input_tokenizer_adjacent.rs
+++ b/tests/input_tokenizer_adjacent.rs
@@ -10,10 +10,10 @@
 use std::io::Write;
 use std::process::{Command, Stdio};
 
-fn run_inputs(stdin: &str) -> (String, bool) {
+fn run_with_args(args: &[&str], stdin: &str) -> (String, bool) {
     let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
     let mut child = Command::new(jq_jit)
-        .args(["-cn", "[inputs]"])
+        .args(args)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
@@ -30,6 +30,16 @@ fn run_inputs(stdin: &str) -> (String, bool) {
         String::from_utf8_lossy(&out.stdout).trim_end().to_string(),
         out.status.success(),
     )
+}
+
+fn run_inputs(stdin: &str) -> (String, bool) {
+    run_with_args(&["-cn", "[inputs]"], stdin)
+}
+
+/// The default main-loop document reader (plain `jq .`) — a separate raw
+/// streamer from the `inputs` builtin (#1000).
+fn run_main_loop(stdin: &str) -> (String, bool) {
+    run_with_args(&["-c", "."], stdin)
 }
 
 #[test]
@@ -59,6 +69,37 @@ fn well_separated_and_structural_values_ok() {
     for (input, expected) in cases {
         let (out, ok) = run_inputs(input);
         assert!(ok, "expected `{input}` to parse");
+        assert_eq!(out, expected, "for input `{input}`");
+    }
+}
+
+/// #1000: the plain `jq .` main-loop reader (a different code path from
+/// `inputs`) must also reject adjacent word/number tokens instead of splitting
+/// them into separate documents.
+#[test]
+fn main_loop_rejects_adjacent_word_tokens() {
+    for bad in [
+        "nullnull", "truefalse", "true1", "1true", "false0", "false-1", "1-2", "1.2.3",
+    ] {
+        let (out, ok) = run_main_loop(bad);
+        assert!(!ok, "expected main loop to reject `{bad}`, got {out:?}");
+    }
+}
+
+#[test]
+fn main_loop_keeps_structural_and_separated_values() {
+    let cases = [
+        ("{}{}", "{}\n{}"),
+        ("[1][2]", "[1]\n[2]"),
+        (r#""a""b""#, "\"a\"\n\"b\""),
+        (r#""a"-1"#, "\"a\"\n-1"),
+        ("[1]-2", "[1]\n-2"),
+        ("1 2", "1\n2"),
+        ("1\n2\n", "1\n2"),
+    ];
+    for (input, expected) in cases {
+        let (out, ok) = run_main_loop(input);
+        assert!(ok, "expected main loop to accept `{input}`");
         assert_eq!(out, expected, "for input `{input}`");
     }
 }


### PR DESCRIPTION
## Summary

#854 added `reject_adjacent_word_token` to `json_stream` / `json_stream_offsets` (the `inputs` builtin path), but not to `json_stream_raw`, which is the **default `jq .` main-loop document reader**. So the residual:

```
$ printf 'nullnull' | jq-jit -c '.'      # before: null / null (split); jq: Invalid literal
$ printf 'true1'    | jq-jit -c '.'      # before: true / 1
```

Same for `1true`, `truefalse`, `false0`, `false-1`, `1-2`.

## Fix

Apply the existing guard after each top-level value in `json_stream_raw`'s non-NDJSON path (the first value and the trailing loop). Self-delimiting structural/string values (`{}{}`, `[1][2]`, `"a""b"`, `"a"-1`, `[1]-2`) and whitespace-separated documents stay valid.

The clean-NDJSON line scanner (entered only when the first value ends exactly at a newline) is deliberately left untouched to avoid adding a per-line parse to that hot path. (Note: a within-line jam in already-clean NDJSON, e.g. `null\nnullnull`, still emits the unsplit-but-invalid line rather than erroring — a separate, perf-sensitive concern not covered here.)

## Tests

Extended `tests/input_tokenizer_adjacent.rs` with a `-c '.'` main-loop variant (the issue explicitly noted the existing test only covered `-cn '[inputs]'`): rejects the adjacent forms, keeps structural/separated values. Full suite green, zero warnings.

Closes #1000

🤖 Generated with [Claude Code](https://claude.com/claude-code)