### PR TITLE
fix(cli): accept attached -L<path> library-path form

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -2521,6 +2521,12 @@ fn real_main() {
                     lib_dirs.push(expanded_args[i].clone());
                 }
             }
+            // GNU-style attached short option `-L<path>` (no space), which jq
+            // accepts alongside the separated `-L <path>`. Everything after the
+            // `-L` in the same token is the path. #1001
+            s if s.starts_with("-L") => {
+                lib_dirs.push(s[2..].to_string());
+            }
             // Mode flags: subsequent non-option tokens are collected as
             // positional string / JSON args, while option flags keep parsing.
             "--args" => { args_mode = Some(false); }

--- a/tests/cli_attached_library_path.rs
+++ b/tests/cli_attached_library_path.rs
@@ -1,0 +1,57 @@
+//! Issue #1001: jq-jit must accept the GNU-style attached short-option form
+//! `-L<path>` (no space) for the module library path, like jq, in addition to
+//! the separated `-L <path>` / `--library-path <path>` forms.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn run(args: &[&str], cwd: Option<&std::path::Path>) -> (String, bool) {
+    let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
+    let mut cmd = Command::new(jq_jit);
+    cmd.args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+    if let Some(dir) = cwd {
+        cmd.current_dir(dir);
+    }
+    let mut child = cmd.spawn().expect("failed to spawn jq-jit");
+    child.stdin.take().unwrap().write_all(b"null").unwrap();
+    let out = child.wait_with_output().expect("wait failed");
+    (
+        String::from_utf8_lossy(&out.stdout).trim_end().to_string(),
+        out.status.success(),
+    )
+}
+
+#[test]
+fn attached_and_separated_library_path_forms() {
+    let dir = std::env::temp_dir().join(format!("jqjit_l_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("m.jq"), "def greet: \"hi\";").unwrap();
+    let dir_s = dir.to_str().unwrap();
+    let prog = "import \"m\" as m; m::greet";
+
+    // Attached `-L<path>` (the bug).
+    let attached = format!("-L{dir_s}");
+    let (out, ok) = run(&[&attached, "-c", prog], None);
+    assert!(ok, "attached -L<path> failed: {out:?}");
+    assert_eq!(out, "\"hi\"");
+
+    // Separated `-L <path>` still works.
+    let (out, ok) = run(&["-L", dir_s, "-c", prog], None);
+    assert!(ok, "separated -L <path> failed");
+    assert_eq!(out, "\"hi\"");
+
+    // Long `--library-path <path>` still works.
+    let (out, ok) = run(&["--library-path", dir_s, "-c", prog], None);
+    assert!(ok, "--library-path failed");
+    assert_eq!(out, "\"hi\"");
+
+    // Attached relative `-L.` resolved against the cwd.
+    let (out, ok) = run(&["-L.", "-c", prog], Some(&dir));
+    assert!(ok, "attached -L. failed: {out:?}");
+    assert_eq!(out, "\"hi\"");
+
+    std::fs::remove_dir_all(&dir).ok();
+}


### PR DESCRIPTION
## Summary

jq accepts both the separated `-L <path>` and the GNU-style **attached** `-L<path>` (no space). jq-jit only matched the exact `-L` token, so the attached form fell through and was treated as the filter program:

```
$ echo null | jq-jit -L/tmp -c 'import "m" as m; m::greet'   # before: L/0 is not defined
```

## Fix

Add a match arm for any `-L`-prefixed token that takes the remainder (`s[2..]`) as the library path. The explicit `-L` / `--library-path` arms come first so the separated and long forms are unchanged; `--library-path` starts with `--` so it doesn't collide. A bare `.L`-style filter is a positional (not a `-L` flag) and is unaffected.

## Tests

New `tests/cli_attached_library_path.rs`: attached `-L<path>`, attached relative `-L.` (resolved against cwd), separated `-L <path>`, and `--library-path <path>` all import a module successfully. Full suite green, zero warnings.

Closes #1001

🤖 Generated with [Claude Code](https://claude.com/claude-code)