### PR TITLE
fix(module): read JSON data modules as a value sequence

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1263,8 +1263,27 @@ impl Parser {
                 let json_path = self.resolve_data_module(&path, search_path.as_deref())?;
                 let json_content = std::fs::read_to_string(&json_path)
                     .map_err(|e| anyhow::anyhow!("Cannot load data module '{}': {}", path, e))?;
-                // Data modules are wrapped in an array per jq convention
-                let array_json = format!("[{}]", json_content.trim());
+                // A data module is a JSON *text sequence*: jq reads every
+                // whitespace-separated value in the file and binds the array of
+                // them (`1 2` → [1,2], `42` → [42], empty → []). The old code
+                // wrapped the raw content in `[...]`, which `fromjson` then
+                // rejected for any multi-value file (`[1 2]`). Split the file
+                // into its top-level values and join them with commas so the
+                // array JSON is well-formed, preserving each value's original
+                // bytes (number formatting etc.). #1002
+                let mut ranges: Vec<(usize, usize)> = Vec::new();
+                crate::value::json_stream_offsets(&json_content, |_v, s, e| {
+                    ranges.push((s, e));
+                    Ok(())
+                })
+                .map_err(|e| anyhow::anyhow!("Cannot parse data module '{}': {}", path, e))?;
+                let mut array_json = String::with_capacity(json_content.len() + 2);
+                array_json.push('[');
+                for (idx, (s, e)) in ranges.iter().enumerate() {
+                    if idx > 0 { array_json.push(','); }
+                    array_json.push_str(&json_content[*s..*e]);
+                }
+                array_json.push(']');
                 let value_expr = Expr::Literal(Literal::Str(array_json));
                 // Parse at runtime via fromjson
                 let fromjson_expr = Expr::CallBuiltin {

--- a/tests/data_module_multivalue.rs
+++ b/tests/data_module_multivalue.rs
@@ -1,0 +1,48 @@
+//! Issue #1002: a JSON data module (`import "name" as $var;`) is a JSON text
+//! *sequence* — jq reads every whitespace-separated value in the file and binds
+//! the array of them. jq-jit wrapped the raw file content in `[...]` and let
+//! `fromjson` choke on any multi-value file (`[1 2]`). Verify the array binding
+//! across single, multi, object, empty, and nested-array files.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn import_var(dir: &std::path::Path, module: &str) -> (String, bool) {
+    let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
+    let prog = format!("import \"{module}\" as $d; $d");
+    let mut child = Command::new(jq_jit)
+        .args(["-L", dir.to_str().unwrap(), "-c", &prog])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn jq-jit");
+    child.stdin.take().unwrap().write_all(b"null").unwrap();
+    let out = child.wait_with_output().expect("wait failed");
+    (
+        String::from_utf8_lossy(&out.stdout).trim_end().to_string(),
+        out.status.success(),
+    )
+}
+
+#[test]
+fn data_module_binds_array_of_all_values() {
+    let dir = std::env::temp_dir().join(format!("jqjit_data_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let cases = [
+        ("two", "1 2", "[1,2]"),
+        ("one", "42", "[42]"),
+        ("objs", "{\"a\":1}\n{\"b\":2}\n", r#"[{"a":1},{"b":2}]"#),
+        ("empty", "", "[]"),
+        ("arr", "[1,2,3]", "[[1,2,3]]"),
+        ("mix", "1 2 3\n4", "[1,2,3,4]"),
+        ("strs", "\"x\"\n\"y\"", r#"["x","y"]"#),
+    ];
+    for (name, content, expected) in cases {
+        std::fs::write(dir.join(format!("{name}.json")), content).unwrap();
+        let (out, ok) = import_var(&dir, name);
+        assert!(ok, "import of `{name}` failed: {out:?}");
+        assert_eq!(out, expected, "data module `{name}` (content {content:?})");
+    }
+    std::fs::remove_dir_all(&dir).ok();
+}


### PR DESCRIPTION
## Summary

A data module (`import "name" as $var;`) is a JSON text *sequence*: jq reads every whitespace-separated value in the file and binds the array of them.

```
$ printf '1 2' > two.json
$ echo null | jq-jit -L. -c 'import "two" as $d; $d'
# before: error "Expected separator between values (while parsing '[1 2]')"; jq: [1,2]
```

jq-jit wrapped the raw file content in `[...]` and deferred to `fromjson`, so any multi-value file produced `[1 2]` and failed.

## Fix

Split the file into its top-level JSON values with `json_stream_offsets` and join them with commas, preserving each value's original bytes, so the constructed array JSON is well-formed for every file shape (single, multi, objects, nested array, empty).

## Tests

New `tests/data_module_multivalue.rs`, cross-checked against jq 1.8.1: `1 2`→`[1,2]`, `42`→`[42]`, two objects→array, empty→`[]`, `[1,2,3]`→`[[1,2,3]]`, mixed whitespace/newline→flat array, strings. Full suite green, zero warnings.

Closes #1002

🤖 Generated with [Claude Code](https://claude.com/claude-code)