### PR TITLE
fix(module): honor {search} metadata and reflect -L in get_search_list

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -7122,6 +7122,31 @@ fn eval_call_builtin(name: &str, args: &[Expr], input: Value, env: &EnvRef, cb: 
         ("input_filename", 0) => {
             return cb(get_input_filename());
         }
+        ("get_search_list", 0) => {
+            // jq reports the *effective* search list: the `-L` dirs (canonical-
+            // ised via realpath when they resolve, else kept as given) when any
+            // are present, otherwise the compile-time defaults. The static
+            // builtin ignored `-L` entirely. #1003
+            let dirs = env.borrow().lib_dirs.clone();
+            let list: Vec<Value> = if dirs.is_empty() {
+                vec![
+                    Value::from_str("~/.jq"),
+                    Value::from_str("$ORIGIN/../lib/jq"),
+                    Value::from_str("$ORIGIN/../lib"),
+                ]
+            } else {
+                dirs.iter()
+                    .map(|d| {
+                        let canon = std::fs::canonicalize(d)
+                            .ok()
+                            .map(|p| p.to_string_lossy().into_owned())
+                            .unwrap_or_else(|| d.clone());
+                        Value::from_str(&canon)
+                    })
+                    .collect()
+            };
+            return cb(Value::Arr(Rc::new(list)));
+        }
         ("toboolean", 0) => {
             return cb(rt_toboolean(&input)?);
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1334,15 +1334,30 @@ impl Parser {
             Token::Str(s) => s,
             t => bail!("expected string after include, got {:?}", t),
         };
-        // Skip optional metadata
+        // Optional metadata — capture `{search:"..."}` (the rest is ignored).
+        // The old code skipped the whole block, dropping the search path so
+        // `include "m" {search:"dir"}` couldn't find the module. #1003
+        let mut search_path = None;
         if self.at(&Token::LBrace) {
-            while !self.at(&Token::RBrace) && !self.at_eof() { self.advance(); }
+            self.advance(); // {
+            while !self.at(&Token::RBrace) && !self.at_eof() {
+                if matches!(self.current(), Token::Ident(s) if s == "search") {
+                    self.advance(); // search
+                    if self.eat(&Token::Colon) {
+                        if let Token::Str(s) = self.advance() {
+                            search_path = Some(s);
+                        }
+                    }
+                } else {
+                    self.advance();
+                }
+            }
             if self.at(&Token::RBrace) { self.advance(); }
         }
         self.expect(&Token::Semicolon)?;
 
         // Load and parse the module without namespace prefix
-        let mod_path = self.resolve_code_module(&path, None)?;
+        let mod_path = self.resolve_code_module(&path, search_path.as_deref())?;
         self.load_code_module(&mod_path, "")?;
         Ok(())
     }
@@ -1379,7 +1394,14 @@ impl Parser {
     fn search_dirs(&self, search: Option<&str>) -> Vec<String> {
         let mut dirs: Vec<String> = Vec::new();
         if let Some(s) = search {
-            // Relative search paths - resolve relative to each lib_dir
+            // The `{search}` metadata path itself: jq honours it even with no
+            // `-L`, resolving an absolute value as-is and a relative one against
+            // the cwd (top-level) / the importing file's directory. The old code
+            // only joined it onto each `-L` dir, so with no `-L` the search path
+            // was dropped entirely and the module wasn't found. #1003
+            dirs.push(s.to_string());
+            // Also resolve it relative to each lib dir (covers a transitive
+            // module import whose own directory was pushed onto `lib_dirs`).
             for lib_dir in &self.lib_dirs {
                 let resolved = std::path::Path::new(lib_dir).join(s);
                 dirs.push(resolved.to_string_lossy().into_owned());

--- a/tests/module_search_path.rs
+++ b/tests/module_search_path.rs
@@ -1,0 +1,82 @@
+//! Issue #1003: module search-path handling was incomplete.
+//!   * The `{search:"..."}` import/include metadata was dropped (for `include`
+//!     entirely, and for `import` it was only ever joined onto `-L` dirs, so
+//!     with no `-L` it was lost), making `{search}`-resolvable modules
+//!     unfindable.
+//!   * `get_search_list` returned a static default list, ignoring `-L`.
+//!
+//! Exact default path strings and realpath canonicalisation are
+//! platform/build dependent, so the assertions compute expectations at runtime.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn run(args: &[&str]) -> (String, bool) {
+    let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
+    let mut child = Command::new(jq_jit)
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn jq-jit");
+    child.stdin.take().unwrap().write_all(b"null").unwrap();
+    let out = child.wait_with_output().expect("wait failed");
+    (
+        String::from_utf8_lossy(&out.stdout).trim_end().to_string(),
+        out.status.success(),
+    )
+}
+
+#[test]
+fn search_metadata_resolves_modules_without_dash_l() {
+    let dir = std::env::temp_dir().join(format!("jqjit_search_{}", std::process::id()));
+    let sd = dir.join("sd");
+    std::fs::create_dir_all(&sd).unwrap();
+    std::fs::write(sd.join("sm.jq"), "def g: 7;").unwrap();
+    let sd_s = sd.to_str().unwrap();
+
+    // import with absolute {search}, no -L
+    let prog = format!("import \"sm\" as s {{search:\"{sd_s}\"}}; s::g");
+    let (out, ok) = run(&["-c", &prog]);
+    assert!(ok, "import {{search}} failed: {out:?}");
+    assert_eq!(out, "7");
+
+    // include with absolute {search}, no -L
+    let prog = format!("include \"sm\" {{search:\"{sd_s}\"}}; g");
+    let (out, ok) = run(&["-c", &prog]);
+    assert!(ok, "include {{search}} failed: {out:?}");
+    assert_eq!(out, "7");
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn get_search_list_reflects_dash_l() {
+    let dir = std::env::temp_dir().join(format!("jqjit_gsl_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let dir_s = dir.to_str().unwrap();
+    // jq canonicalises a resolvable -L dir via realpath; mirror that here.
+    let canon = std::fs::canonicalize(&dir).unwrap();
+    let canon_s = canon.to_str().unwrap();
+
+    let (out, ok) = run(&["-L", dir_s, "-c", "get_search_list"]);
+    assert!(ok);
+    assert_eq!(out, format!("[\"{canon_s}\"]"));
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn get_search_list_defaults_without_dash_l() {
+    let (out, ok) = run(&["-c", "get_search_list"]);
+    assert!(ok);
+    assert_eq!(out, r#"["~/.jq","$ORIGIN/../lib/jq","$ORIGIN/../lib"]"#);
+}
+
+#[test]
+fn get_search_list_keeps_unresolvable_dash_l_verbatim() {
+    let (out, ok) = run(&["-L", "/nonexistent_zzz_jqjit", "-c", "get_search_list"]);
+    assert!(ok);
+    assert_eq!(out, r#"["/nonexistent_zzz_jqjit"]"#);
+}

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -9764,10 +9764,10 @@ tojson
 5e-324
 5E-324
 
-# Issue #614: get_search_list returns jq's static defaults
-get_search_list
+# Issue #614/#1003: get_search_list reflects the active -L dirs (harness adds 1)
+get_search_list | length
 0
-["~/.jq","$ORIGIN/../lib/jq","$ORIGIN/../lib"]
+1
 
 # Issue #614: get_jq_origin returns a string (the binary's directory)
 get_jq_origin | type


### PR DESCRIPTION
## Summary

Two module search-path gaps (#1003):

**1. `{search:"..."}` metadata ignored.**
```
$ echo null | jq-jit -c 'import "sm" as s {search:"/tmp/sd"}; s::g'   # before: Cannot find module 'sm'; jq: 7
```
For `include` the whole metadata block was skipped, dropping the search path. For `import` the path was only joined onto each `-L` dir, so with no `-L` it was never added.

**2. `get_search_list` ignored `-L`.**
```
$ echo null | jq-jit -L /tmp -c 'get_search_list'   # before: defaults; jq: ["/private/tmp"]
```

## Fix

- `search_dirs` now also adds the metadata path itself — absolute as-is, relative against the cwd / importing file's directory (in addition to the existing join onto `-L` dirs for transitive module imports). `parse_include` captures `{search}` like `parse_import`.
- `get_search_list` reports the effective list: the `-L` dirs (realpath-canonicalised when they resolve, else verbatim) when any are given, otherwise the compile-time defaults — matching jq.

## Tests

New `tests/module_search_path.rs` (computes platform-specific expectations at runtime): `{search}` import + include resolve without `-L`; `get_search_list` reflects `-L` (canonicalised), keeps an unresolvable `-L` verbatim, and returns defaults with no `-L`. The pre-existing `get_search_list` regression case (which assumed `-L` was ignored — the harness always passes `-L tests/modules`) is updated to assert `length` rather than a machine-specific absolute path. Full suite green, zero warnings.

Closes #1003

🤖 Generated with [Claude Code](https://claude.com/claude-code)