### PR TITLE
fix(module): attribute $__loc__.file to the defining module

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -828,6 +828,11 @@ pub struct Parser {
     /// allocates a deeper binding that shadows it, matching jq. See #886.
     env_var_idx: u16,
     lib_dirs: Vec<String>,
+    /// Source file these tokens came from, reported by `$__loc__.file`. The
+    /// top-level program parser uses `"<top-level>"`; a module parser uses the
+    /// module's (canonicalised) path so a `$__loc__` in a module-defined
+    /// function attributes to the module file, like jq. #1004
+    source_file: String,
     /// The `compiled_funcs` id of the function body currently being parsed, or
     /// `None` at the top level. Used to attribute a deferred unbound-variable
     /// reference to its enclosing def. #765
@@ -870,6 +875,7 @@ impl Parser {
             scope: Scope::new(),
             env_var_idx: 0,
             lib_dirs: lib_dirs.to_vec(),
+            source_file: "<top-level>".to_string(),
             current_func: None,
             deferred_unbound: Vec::new(),
             deferred_unknown_func: Vec::new(),
@@ -1434,6 +1440,12 @@ impl Parser {
         // when closure expressions reference main-scope variables.
         let mut mod_scope = Scope::new();
         mod_scope.next_var = self.scope.next_var;
+        // `$__loc__` in a module function reports the module's source path
+        // (canonicalised, matching jq's realpath). #1004
+        let mod_source_file = std::fs::canonicalize(file_path)
+            .ok()
+            .map(|p| p.to_string_lossy().into_owned())
+            .unwrap_or_else(|| file_path.to_string());
         let mut mod_parser = Parser {
             tokens,
             token_lines: mod_token_lines,
@@ -1441,6 +1453,7 @@ impl Parser {
             scope: mod_scope,
             env_var_idx: self.env_var_idx,
             lib_dirs: mod_lib_dirs,
+            source_file: mod_source_file,
             current_func: None,
             deferred_unbound: Vec::new(),
             deferred_unknown_func: Vec::new(),
@@ -2827,7 +2840,7 @@ impl Parser {
                     }
                 }
                 if name == "__loc__" {
-                    Ok(Expr::Loc { file: "<top-level>".to_string(), line: loc_line as i64 })
+                    Ok(Expr::Loc { file: self.source_file.clone(), line: loc_line as i64 })
                 } else if name == "ENV" {
                     Ok(self.resolve_env_ref())
                 } else {
@@ -2939,7 +2952,7 @@ impl Parser {
                 } else {
                     // Shorthand: {$x} = {"x": $x}
                     let val_expr = if name == "__loc__" {
-                        Expr::Loc { file: "<top-level>".to_string(), line: loc_line as i64 }
+                        Expr::Loc { file: self.source_file.clone(), line: loc_line as i64 }
                     } else if name == "ENV" {
                         self.resolve_env_ref()
                     } else {

--- a/tests/loc_module_file.rs
+++ b/tests/loc_module_file.rs
@@ -1,0 +1,76 @@
+//! Issue #1004: `$__loc__` inside a function defined in an imported/included
+//! module must report the module's source file in `.file`, not "<top-level>".
+//! The exact path is canonicalised (realpath), so the test computes the
+//! expected path at runtime; the `line` field was already correct.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn run(args: &[&str]) -> (String, bool) {
+    let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
+    let mut child = Command::new(jq_jit)
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn jq-jit");
+    child.stdin.take().unwrap().write_all(b"null").unwrap();
+    let out = child.wait_with_output().expect("wait failed");
+    (
+        String::from_utf8_lossy(&out.stdout).trim_end().to_string(),
+        out.status.success(),
+    )
+}
+
+#[test]
+fn loc_file_attributes_to_module() {
+    let dir = std::env::temp_dir().join(format!("jqjit_loc_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("w.jq"), "def w: $__loc__;").unwrap();
+    let dir_s = dir.to_str().unwrap();
+    let canon = std::fs::canonicalize(dir.join("w.jq")).unwrap();
+    let canon_s = canon.to_str().unwrap();
+    let expected = format!(r#"{{"file":"{canon_s}","line":1}}"#);
+
+    // import
+    let (out, ok) = run(&["-L", dir_s, "-c", "import \"w\" as m; m::w"]);
+    assert!(ok, "import failed: {out:?}");
+    assert_eq!(out, expected, "import module $__loc__.file");
+
+    // include
+    let (out, ok) = run(&["-L", dir_s, "-c", "include \"w\"; w"]);
+    assert!(ok, "include failed: {out:?}");
+    assert_eq!(out, expected, "include module $__loc__.file");
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn loc_file_stays_top_level_for_program() {
+    let (out, ok) = run(&["-c", "$__loc__"]);
+    assert!(ok);
+    assert_eq!(out, r#"{"file":"<top-level>","line":1}"#);
+
+    // shorthand object pattern path goes through the second Expr::Loc site
+    let (out, ok) = run(&["-c", "{$__loc__} | .__loc__"]);
+    assert!(ok);
+    assert_eq!(out, r#"{"file":"<top-level>","line":1}"#);
+}
+
+#[test]
+fn loc_line_correct_for_later_module_def() {
+    let dir = std::env::temp_dir().join(format!("jqjit_loc2_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    // `g` is defined on line 2, so $__loc__.line must be 2.
+    std::fs::write(dir.join("m2.jq"), "def f: 1;\ndef g: $__loc__;").unwrap();
+    let dir_s = dir.to_str().unwrap();
+    let canon = std::fs::canonicalize(dir.join("m2.jq")).unwrap();
+    let canon_s = canon.to_str().unwrap();
+
+    let (out, ok) = run(&["-L", dir_s, "-c", "import \"m2\" as m; m::g"]);
+    assert!(ok, "import failed: {out:?}");
+    assert_eq!(out, format!(r#"{{"file":"{canon_s}","line":2}}"#));
+
+    std::fs::remove_dir_all(&dir).ok();
+}


### PR DESCRIPTION
## Summary

`$__loc__` inside a function defined in an imported/included module reported `"file":"<top-level>"` instead of the module's source path:

```
$ printf 'def w: $__loc__;' > /tmp/w.jq
$ echo null | jq-jit -L /tmp -c 'import "w" as m; m::w'
# before: {"file":"<top-level>","line":1}; jq: {"file":"/tmp/w.jq","line":1}
```

The parser hardcoded `"<top-level>"` at both `Expr::Loc` sites and had no notion of which file it was parsing.

## Fix

Add a `source_file` field to `Parser`: the top-level program parser uses `"<top-level>"`; the module parser uses the module's canonicalised path (realpath, matching jq). Both `$__loc__` sites emit `self.source_file`. The `line` field was already correct.

## Tests

New `tests/loc_module_file.rs` (canonical path computed at runtime): `import` and `include` module defs report the module file; a later module def reports the right line; the top-level program (incl. `{$__loc__}` shorthand) stays `"<top-level>"`. Full suite green, zero warnings.

Closes #1004

🤖 Generated with [Claude Code](https://claude.com/claude-code)