### PR TITLE
fix(path): clamp NaN slice end-bound to length in setpath/getpath executor

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2549,11 +2549,19 @@ fn slice_indices(slice_spec: &crate::value::ObjMap, len: i64) -> (usize, usize) 
     // rounding the raw float first mis-placed fractional negatives like `-0.5`
     // (`(-0.5).ceil() == 0` discards the negativity, so `len` was never added).
     // This path drives slice-assign and `del(.[a:b])`. #722.
+    // A NaN bound (from the literal `nan`, or any non-integer source like
+    // `(-1)|sqrt`) follows jq's default-endpoint semantics: a NaN start opens to
+    // 0 and a NaN end opens to `len`. Guard before the `as i64` cast, which
+    // would otherwise floor NaN to 0 and collapse the end-bound to a zero-width
+    // range — silently corrupting `=`/`|=`/`+=` and object-form `del`. This
+    // mirrors the syntactic `.[a:b]` read path's `slice_index_*` helpers. #1018.
     let start = match slice_spec.get("start") {
+        Some(Value::Num(n, _)) if n.is_nan() => 0,
         Some(Value::Num(n, _)) => (if *n < 0.0 { n + lenf } else { *n }).floor() as i64,
         _ => 0,
     };
     let end = match slice_spec.get("end") {
+        Some(Value::Num(n, _)) if n.is_nan() => len,
         Some(Value::Num(n, _)) => (if *n < 0.0 { n + lenf } else { *n }).ceil() as i64,
         Some(Value::Null) | None => len,
         _ => 0,

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -13252,3 +13252,33 @@ try ((recurse(.a)) = 9) catch "caught"
 try ((while(true; .a)) |= 9) catch "caught"
 {"a":{}}
 "caught"
+
+# #1018: NaN slice end-bound clamps to array length on assign (setpath)
+.[1:(nan)] = [9]
+[1,2,3,4]
+[1,9]
+
+# #1018: NaN slice end-bound clamps to length on update (|=)
+.[1:(nan)] |= reverse
+[1,2,3,4]
+[1,4,3,2]
+
+# #1018: object-form getpath with NaN end-bound returns the tail
+getpath([{"start":1,"end":(nan)}])
+[1,2,3,4]
+[2,3,4]
+
+# #1018: object-form del with NaN end-bound deletes through the tail
+del(.[{"start":1,"end":nan}])
+[0,1,2,3,4]
+[0]
+
+# #1018: non-literal NaN source (sqrt of negative) clamps end-bound on assign
+.[1:((-1)|sqrt)] = [9]
+[1,2,3,4]
+[1,9]
+
+# #1018: NaN start-bound still clamps to 0 (regression guard)
+.[(nan):3] = [9]
+[1,2,3,4]
+[9,4]


### PR DESCRIPTION
## Summary

The shared `slice_indices` helper that backs the `setpath`/`getpath` path-register executor treated a **NaN end-bound** of a slice as a regular number. Because `NaN.ceil() as i64 == 0` in Rust, the range collapsed to zero width instead of following jq's default-endpoint semantics (a NaN end opens to the array length). Since every slice-LHS assignment (`=`, `|=`, `+=`) and the object-form path `{"start":a,"end":b}` route through this executor, the bug caused **silent data corruption** on update and a **silent no-op** on object-form `del`.

The syntactic `.[a:b]` read and `del(.[a:b])` fast paths already clamped correctly (via `slice_index_*` in `eval.rs`), so the divergence was an internal inconsistency between the read path and the write/object path.

## Fix

Guard both bounds for NaN before the `as i64` cast in `slice_indices` (`src/runtime.rs`): a NaN start opens to `0`, a NaN end opens to `len`, mirroring the read-path helpers and jq. A NaN reaches here from any non-integer numeric source (e.g. `(-1)|sqrt`), not only the literal `nan`.

## Verification

```
$ echo '[1,2,3,4]'   | jq-jit -c '.[1:(nan)] = [9]'                      # [1,9]
$ echo '[1,2,3,4]'   | jq-jit -c '.[1:(nan)] |= reverse'                 # [1,4,3,2]
$ echo '[1,2,3,4]'   | jq-jit -c 'getpath([{"start":1,"end":(nan)}])'    # [2,3,4]
$ echo '[0,1,2,3,4]' | jq-jit -c 'del(.[{"start":1,"end":nan}])'         # [0]
$ echo '[1,2,3,4]'   | jq-jit -c '.[1:((-1)|sqrt)] = [9]'                # [1,9]
$ echo '[1,2,3,4]'   | jq-jit -c '.[(nan):3] = [9]'                      # [9,4] (start guard regression)
```

All now match `jq-1.8.1`.

- Added 6 regression cases to `tests/regression.test`
- `cargo build --release`: zero warnings
- `cargo test --release`: 614 passed, 0 failed

Closes #1018

https://claude.ai/code/session_01JEEfMvvLFuBgTcWngScnrD

---
_Generated by [Claude Code](https://claude.ai/code/session_01JEEfMvvLFuBgTcWngScnrD)_