### PR TITLE
fix(datetime): render unknown strftime specifiers literally instead of panicking

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -4012,27 +4012,119 @@ fn rt_strftime(v: &Value, fmt: &Value) -> Result<Value> {
 /// the clamp doesn't shift any tested output.
 /// Rewrite `strftime` specifiers where chrono's rendering diverges from the
 /// macOS libc that jq delegates to (the project's reference, see
-/// `docs/maintenance.md`). Currently only `%x`: chrono renders it with a
-/// 2-digit year, jq's `%x` is `%m/%d/%Y` with a 4-digit year. `%%` is preserved
-/// (a literal percent, not a specifier). #763
+/// `docs/maintenance.md`):
+///
+/// - `%x`: chrono renders a 2-digit year, jq's `%x` is `%m/%d/%Y`. #763
+/// - Unknown / incomplete specifiers (`%N`, trailing `%`, `%#z`, `%4Y`, …):
+///   chrono's `Display` impl returns `Err`, which `to_string()` turns into a
+///   process-aborting panic. libc emits the conversion character literally
+///   (dropping the `%` and any consumed flags), so rewrite them to escaped
+///   literal text before chrono sees them. #710 #1020
+/// - `%E<c>` / `%O<c>` locale modifiers: chrono rejects them; in the C locale
+///   libc treats them as the unmodified specifier, so strip the modifier.
+/// - A `-`/`_`/`0` pad flag on a non-numeric specifier (`%-A`): chrono
+///   rejects it; libc ignores the flag, so drop it.
+///
+/// `%%` (a literal percent) is preserved. Fractional-second forms chrono
+/// accepts (`%.f`, `%.3f`, `%3f`, …) pass through unchanged — their rendering
+/// diverges from libc but does not panic, and is out of scope here.
 fn rewrite_strftime_compat(fmt: &str) -> std::borrow::Cow<'_, str> {
-    if !fmt.contains("%x") {
-        return std::borrow::Cow::Borrowed(fmt);
-    }
+    // Specifiers chrono's strftime formats without error for a DateTime<Tz>.
+    // `%x` is recognized but expanded per the divergence above.
+    const KNOWN: &[u8] = b"YCyqmbBhdeaAwuUWGgVjDxFvHkIlPpMSfRTXrzZc+stn";
+    // Subset chrono parses as Numeric items, where a pad flag is accepted.
+    const NUMERIC: &[u8] = b"YCyqmdewuUWGgVjHkIlMSs";
+
+    let chars: Vec<char> = fmt.chars().collect();
     let mut out = String::with_capacity(fmt.len() + 8);
-    let mut chars = fmt.chars().peekable();
-    while let Some(c) = chars.next() {
-        if c == '%' {
-            match chars.peek() {
-                Some('x') => { chars.next(); out.push_str("%m/%d/%Y"); }
-                Some('%') => { chars.next(); out.push_str("%%"); }
-                _ => out.push('%'),
-            }
-        } else {
-            out.push(c);
+    let mut changed = false;
+    let mut i = 0;
+    while i < chars.len() {
+        if chars[i] != '%' {
+            out.push(chars[i]);
+            i += 1;
+            continue;
         }
+        let mut j = i + 1;
+        // `%%`: literal percent, untouched.
+        if j < chars.len() && chars[j] == '%' {
+            out.push_str("%%");
+            i = j + 1;
+            continue;
+        }
+        // Fractional-second forms chrono accepts: %.f %.3f %.6f %.9f %3f %6f %9f.
+        let frac_len = match chars.get(j) {
+            Some('.') => match (chars.get(j + 1), chars.get(j + 2)) {
+                (Some('f'), _) => Some(2),
+                (Some('3' | '6' | '9'), Some('f')) => Some(3),
+                _ => None,
+            },
+            Some('3' | '6' | '9') if chars.get(j + 1) == Some(&'f') => Some(2),
+            _ => None,
+        };
+        if let Some(n) = frac_len {
+            out.push('%');
+            out.extend(&chars[j..j + n]);
+            i = j + n;
+            continue;
+        }
+        // Optional pad flag, then an optional E/O locale modifier.
+        let pad = match chars.get(j) {
+            Some(&p @ ('-' | '_' | '0')) => { j += 1; Some(p) }
+            _ => None,
+        };
+        if matches!(chars.get(j), Some('E' | 'O')) {
+            j += 1;
+            changed = true;
+        }
+        let Some(&conv) = chars.get(j) else {
+            // Incomplete specifier at end of input (`%`, `%-`, `%E`): libc
+            // emits the consumed flag characters literally.
+            for &c in &chars[i + 1..j] {
+                out.push(c);
+            }
+            if j == i + 1 {
+                out.push_str("%%");
+            }
+            changed = true;
+            i = j;
+            continue;
+        };
+        if conv == '%' {
+            // `%E%` / `%-%`: libc renders a literal percent and does not
+            // start a new specifier.
+            out.push_str("%%");
+            changed = true;
+            i = j + 1;
+            continue;
+        }
+        if conv == 'x' {
+            out.push_str("%m/%d/%Y");
+            changed = true;
+            i = j + 1;
+            continue;
+        }
+        if conv.is_ascii() && KNOWN.contains(&(conv as u8)) {
+            out.push('%');
+            match pad {
+                Some(p) if NUMERIC.contains(&(conv as u8)) => out.push(p),
+                Some(_) => changed = true, // pad on a fixed item: drop it
+                None => {}
+            }
+            out.push(conv);
+        } else {
+            // Unknown conversion: emit it literally, dropping the `%` and
+            // any consumed flags (libc behavior).
+            out.push(conv);
+            changed = true;
+        }
+        i = j + 1;
     }
-    std::borrow::Cow::Owned(out)
+    if changed {
+        std::borrow::Cow::Owned(out)
+    } else {
+        std::borrow::Cow::Borrowed(fmt)
+    }
 }
 
 fn format_broken(t: &BrokenTime, fmt: &str) -> String {

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -13282,3 +13282,53 @@ del(.[{"start":1,"end":nan}])
 .[(nan):3] = [9]
 [1,2,3,4]
 [9,4]
+
+# #1020: strftime unknown specifier renders literally instead of panicking
+strftime("%N")
+[1970,0,1,0,0,0,4,0]
+"N"
+
+# #1020: strftime trailing % renders a literal percent
+strftime("%")
+[1970,0,1,0,0,0,4,0]
+"%"
+
+# #1020: bare %E locale-modifier prefix renders literally
+0|gmtime|strftime("%E")
+null
+"E"
+
+# #1020: %E locale modifier strips to the unmodified specifier
+strftime("%EY")
+[2001,2,4,5,6,7,0,90]
+"2001"
+
+# #1020: %O locale modifier strips to the unmodified specifier
+strftime("%OS")
+[2001,2,4,5,6,7,0,90]
+"07"
+
+# #1020: pad flag on a non-numeric specifier drops the flag, no panic
+strftime("%-A")
+[2001,2,4,5,6,7,0,90]
+"Sunday"
+
+# #1020: unknown specifier embedded in text keeps surrounding text
+strftime("a%Nb")
+[1970,0,1,0,0,0,4,0]
+"aNb"
+
+# #1020: %% stays a literal percent before an unknown character
+strftime("%%N")
+[1970,0,1,0,0,0,4,0]
+"%N"
+
+# #1020: pad flag on a numeric specifier still applies
+strftime("%-d %0d %_d")
+[2001,2,4,5,6,7,0,90]
+"4 04  4"
+
+# #1020: epoch-input strftime path sanitizes unknown specifiers too
+strftime("%N %")
+0
+"N %"


### PR DESCRIPTION
## Summary

`strftime`/`strflocaltime` panicked with SIGABRT (exit 134) on any format string containing an unknown or incomplete conversion specifier — `%N`, a trailing `%`, bare `%E`/`%O`, `%#z`, `%4Y`, or a pad flag on a non-numeric specifier (`%-A`). chrono's `Display` impl returns `Err` for these, and the surrounding `to_string()` turned that into a process abort. This is the general residual of #710, which patched only `%z`/`%Z`.

## Fix

`rewrite_strftime_compat` (the choke point all three chrono `format()` call sites already route through) is extended into a full sanitizer that mirrors macOS libc (jq's reference) before chrono sees the format string:

- Unknown conversions emit the conversion character literally, dropping the `%` and any consumed flags: `%N` → `N`, `%4Y` → `4Y`, trailing `%` → `%`
- `%E<c>`/`%O<c>` locale modifiers strip to the bare specifier (C-locale behavior): `%EY` → `2001`, `%OS` → `07`
- A `-`/`_`/`0` pad flag on a non-numeric specifier is dropped: `%-A` → `Sunday`
- `%%`, pad flags on numeric specifiers (`%-d`/`%0d`/`%_d`), and all chrono-supported specifiers pass through unchanged
- Fractional-second forms chrono accepts (`%.f`, `%3f`, …) are left as-is — they render divergently from libc but do not panic, and stay out of scope (as does `%f`, noted in the issue)

## Verification

35-case panel against `jq-1.8.1` on macOS (`%N % %E %O %EY %OS %EN %ON %Q %-d %_d %0d a%Nb %%N %E%Y %-A %^A %#A %:z %#z %- %0 %_ %-% %4Y %-N %On …`): 34/35 exact match on the broken-down-time path, plus the epoch-input and `strflocaltime` paths. The single remaining diff is `%+` (chrono renders ISO 8601, libc renders `date(1)` form) — a pre-existing non-panicking divergence, out of scope.

- 10 regression cases appended to `tests/regression.test`
- `cargo build --release`: zero warnings
- `cargo test --release`: all 59 suites pass

Closes #1020

🤖 Generated with [Claude Code](https://claude.com/claude-code)