### PR TITLE
refactor(value): remove layout-dependent unsafe Value::tag()

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -738,10 +738,6 @@ impl Value {
         }
     }
 
-    pub fn tag(&self) -> u64 {
-        unsafe { *(self as *const Value as *const u64) }
-    }
-
     pub fn type_name(&self) -> &'static str {
         match self {
             Value::Null => "null",


### PR DESCRIPTION
## Summary

`Value::tag()` (src/value.rs:741) read the enum discriminant by reinterpreting `&Value` as `*const u64` — an unsafe block that silently depends on the compiler's discriminant layout for `Value` and would break without warning on any variant addition/reordering or niche-optimization change.

Investigation for #1032 found the method has **zero call sites** anywhere in the crate (tests and bin included). Being `pub` suppressed the `dead_code` lint, which is why it survived. The fix is therefore plain deletion: no repr pinning, no `Tag` enum, no perf consideration needed.

## Changes

- Delete `Value::tag()` (4 lines, the only layout-dependent unsafe in value.rs).

## Verification

- `cargo build --release`: zero warnings
- `cargo test --release`: all 59 suites pass (official 509, regression, differential, fuzz, selfdiff, contracts)
- Bench skipped: removal of an uncalled function, no behavior change (per workflow, routine fixes skip bench)

Part of the type-safety refactoring series (Phase 0). Next up: #1033 (index newtypes).

Closes #1032

🤖 Generated with [Claude Code](https://claude.com/claude-code)