### PR TITLE
refactor(ir): introduce VarIdx newtype for variable slot indices

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -272,12 +272,12 @@ pub struct Env {
     pub lib_dirs: Vec<String>,
     /// Closure bindings: (param_var_index, arg_expression).
     /// Used to avoid deep-cloning function bodies via substitute_params.
-    closures: Vec<(u16, Expr)>,
+    closures: Vec<(VarIdx, Expr)>,
     /// Cache for is_recursive check per func_id.
     recursive_cache: Vec<(usize, bool)>,
     /// Cache for substituted function bodies: (func_id, arg_var_indices) → substituted body.
     /// Only used when all args are LoadVar (the common case).
-    subst_cache: Vec<((usize, Vec<u16>), Rc<Expr>)>,
+    subst_cache: Vec<((usize, Vec<VarIdx>), Rc<Expr>)>,
     /// Pointer-based substitution cache: func_id → (args_ptr, substituted_body).
     /// For non-LoadVar args from stable (cached) call sites.
     subst_ptr_cache: Vec<(usize, usize, Rc<Expr>)>,
@@ -335,8 +335,8 @@ impl Env {
         // lifetime per #671 design).
     }
     #[inline(always)]
-    fn get_var(&self, idx: u16) -> Value {
-        let i = idx as usize;
+    fn get_var(&self, idx: VarIdx) -> Value {
+        let i = idx.idx();
         if i < self.vars.len() {
             // SAFETY: bounds checked above
             unsafe { self.vars.get_unchecked(i) }.clone()
@@ -345,8 +345,8 @@ impl Env {
         }
     }
     #[inline(always)]
-    fn set_var(&mut self, idx: u16, val: Value) {
-        let idx = idx as usize;
+    fn set_var(&mut self, idx: VarIdx, val: Value) {
+        let idx = idx.idx();
         if idx >= self.vars.len() { self.vars.resize(idx + 1, Value::Null); }
         // SAFETY: bounds ensured above
         unsafe { *self.vars.get_unchecked_mut(idx) = val; }
@@ -354,11 +354,11 @@ impl Env {
     /// Public setter used by the JIT runtime when it delegates complex paths
     /// back to eval — the JIT has its own var storage, so we copy the live
     /// bindings into the eval Env before dispatch.
-    pub fn seed_var(&mut self, idx: u16, val: Value) {
+    pub fn seed_var(&mut self, idx: VarIdx, val: Value) {
         self.set_var(idx, val);
     }
-    fn ensure_var(&mut self, idx: u16) {
-        let idx = idx as usize;
+    fn ensure_var(&mut self, idx: VarIdx) {
+        let idx = idx.idx();
         if idx >= self.vars.len() { self.vars.resize(idx + 1, Value::Null); }
     }
 }
@@ -367,25 +367,25 @@ impl Env {
 /// This implements jq's closure semantics: each time a param is referenced,
 /// the arg filter is re-evaluated with the current input.
 /// Uses COW: unchanged subtrees are not cloned.
-pub fn substitute_params(expr: &Expr, param_vars: &[u16], args: &[Expr]) -> Expr {
+pub fn substitute_params(expr: &Expr, param_vars: &[VarIdx], args: &[Expr]) -> Expr {
     subst_cow(expr, param_vars, args).unwrap_or_else(|| expr.clone())
 }
 
 /// Substitute params AND rename all local variable bindings (LetBinding, Reduce,
 /// Foreach, Label) to fresh indices from `next_var`. This prevents recursive calls
 /// from clobbering each other's local variables in the callback-based eval model.
-pub fn substitute_and_rename(expr: &Expr, param_vars: &[u16], args: &[Expr], next_var: &mut u16) -> Expr {
+pub fn substitute_and_rename(expr: &Expr, param_vars: &[VarIdx], args: &[Expr], next_var: &mut u16) -> Expr {
     subst_inner(expr, param_vars, args, true, next_var, &mut HashMap::new())
 }
 
 fn subst_inner(
-    expr: &Expr, pv: &[u16], args: &[Expr],
-    rename: bool, nv: &mut u16, rn: &mut HashMap<u16, u16>,
+    expr: &Expr, pv: &[VarIdx], args: &[Expr],
+    rename: bool, nv: &mut u16, rn: &mut HashMap<VarIdx, VarIdx>,
 ) -> Expr {
     macro_rules! s { ($e:expr) => { subst_inner($e, pv, args, rename, nv, rn) } }
     macro_rules! sb { ($e:expr) => { Box::new(s!($e)) } }
     macro_rules! alloc {
-        ($old:expr) => { if rename { let n = *nv; *nv += 1; rn.insert($old, n); n } else { $old } }
+        ($old:expr) => { if rename { let n = VarIdx(*nv); *nv += 1; rn.insert($old, n); n } else { $old } }
     }
     match expr {
         Expr::LoadVar { var_index } => {
@@ -610,7 +610,7 @@ pub(crate) fn append_call_args(expr: &Expr, target: usize, extra: &[Expr]) -> Ex
 
 /// COW substitution: returns None if no param vars were found (no changes needed).
 /// Avoids deep-cloning unchanged subtrees.
-fn subst_cow(expr: &Expr, pv: &[u16], args: &[Expr]) -> Option<Expr> {
+fn subst_cow(expr: &Expr, pv: &[VarIdx], args: &[Expr]) -> Option<Expr> {
     // Helpers: s returns Option, sb returns Option<Box>
     macro_rules! s { ($e:expr) => { subst_cow($e, pv, args) } }
     match expr {
@@ -1100,7 +1100,7 @@ fn expr_uses_outer_input(expr: &Expr) -> bool {
 }
 
 /// Check if an expression references a specific variable (for reduce optimization).
-pub(crate) fn expr_uses_var(expr: &Expr, target: u16) -> bool {
+pub(crate) fn expr_uses_var(expr: &Expr, target: VarIdx) -> bool {
     match expr {
         Expr::LoadVar { var_index } => *var_index == target,
         Expr::Input | Expr::Empty | Expr::Not | Expr::Env | Expr::Builtins
@@ -1286,7 +1286,7 @@ pub(crate) fn collect_func_calls(expr: &Expr, out: &mut Vec<usize>) {
 fn get_num_leaf(expr: &Expr, input: &Value, vars: &[Value]) -> Option<f64> {
     match expr {
         Expr::LoadVar { var_index } => {
-            if let Some(Value::Num(n, _)) = vars.get(*var_index as usize) {
+            if let Some(Value::Num(n, _)) = vars.get(var_index.idx()) {
                 Some(*n)
             } else { None }
         }
@@ -1350,7 +1350,7 @@ fn eval_bool_compound(expr: &Expr, input: &Value, vars: &[Value]) -> Option<bool
 /// Evaluate a boolean expression entirely via f64 arithmetic, with one variable
 /// override (avoids env borrow/store). Returns Some(true/false) or None if not applicable.
 #[inline(always)]
-fn eval_bool_numeric(expr: &Expr, vars: &[Value], override_vi: u16, override_val: f64) -> Option<bool> {
+fn eval_bool_numeric(expr: &Expr, vars: &[Value], override_vi: VarIdx, override_val: f64) -> Option<bool> {
     match expr {
         Expr::BinOp { op, lhs, rhs } => {
             let ln = get_num_leaf_override(lhs, vars, override_vi, override_val)?;
@@ -1380,12 +1380,12 @@ fn eval_bool_numeric(expr: &Expr, vars: &[Value], override_vi: u16, override_val
 
 /// Like get_num_leaf but with a variable override for one var_index.
 #[inline(always)]
-fn get_num_leaf_override(expr: &Expr, vars: &[Value], override_vi: u16, override_val: f64) -> Option<f64> {
+fn get_num_leaf_override(expr: &Expr, vars: &[Value], override_vi: VarIdx, override_val: f64) -> Option<f64> {
     match expr {
         Expr::LoadVar { var_index } => {
             if *var_index == override_vi {
                 Some(override_val)
-            } else if let Some(Value::Num(n, _)) = vars.get(*var_index as usize) {
+            } else if let Some(Value::Num(n, _)) = vars.get(var_index.idx()) {
                 Some(*n)
             } else { None }
         }
@@ -1600,7 +1600,7 @@ fn eval_one(expr: &Expr, input: &Value, env: &EnvRef) -> std::result::Result<Val
             }
         }
         Expr::LetBinding { var_index, value, body } => {
-            let vi = *var_index as usize;
+            let vi = var_index.idx();
             // Fast path: `. as $var` avoids eval_one dispatch for Input
             let val = if matches!(value.as_ref(), Expr::Input) {
                 input.clone()
@@ -2340,7 +2340,7 @@ pub fn eval(
                             let mut elems = Vec::new();
                             let gen_result = eval(gen, Value::Null, env, &mut |elem| { elems.push(elem); Ok(true) });
                             // Take array back from env (refcount should be 1 after gen drops its refs)
-                            let arr_val = std::mem::replace(&mut env.borrow_mut().vars[v_idx as usize], old);
+                            let arr_val = std::mem::replace(&mut env.borrow_mut().vars[v_idx.idx()], old);
                             gen_result?;
                             current = match arr_val {
                                 Value::Arr(rc) => {
@@ -2431,7 +2431,7 @@ pub fn eval(
                                     }
                                 }
                                 if let Some((vi, body)) = let_bind {
-                                    let old = std::mem::replace(&mut env.borrow_mut().vars[vi as usize], elem);
+                                    let old = std::mem::replace(&mut env.borrow_mut().vars[vi.idx()], elem);
                                     // jq's `all` is vacuously true when the
                                     // predicate yields no values for an
                                     // element, and false on the first falsy
@@ -2447,7 +2447,7 @@ pub fn eval(
                                             !found_falsy
                                         }
                                     };
-                                    env.borrow_mut().vars[vi as usize] = old;
+                                    env.borrow_mut().vars[vi.idx()] = old;
                                     if is_true { Ok(true) } else { all_true = false; Ok(false) }
                                 } else {
                                     // Compound bool fast path: dummy-probe at line ~1609 may
@@ -2498,7 +2498,7 @@ pub fn eval(
                                         }
                                         drop(e);
                                     }
-                                    let old = std::mem::replace(&mut env.borrow_mut().vars[vi as usize], elem);
+                                    let old = std::mem::replace(&mut env.borrow_mut().vars[vi.idx()], elem);
                                     // jq's `any` is vacuously false when the
                                     // predicate yields no values for an
                                     // element, and true on the first truthy
@@ -2514,7 +2514,7 @@ pub fn eval(
                                             found_truthy
                                         }
                                     };
-                                    env.borrow_mut().vars[vi as usize] = old;
+                                    env.borrow_mut().vars[vi.idx()] = old;
                                     if is_true { any_true = true; Ok(false) } else { Ok(true) }
                                 } else {
                                     let pred_result = eval_one(predicate, &elem, env);
@@ -2669,7 +2669,7 @@ pub fn eval(
                 let tmp_vi = *var_index;
                 if !expr_uses_outer_input(body) {
                     // Detect destructuring: body is chain of LetBinding { vi, Index(LoadVar(tmp), i) }
-                    let mut bindings: Vec<(u16, usize)> = Vec::new();
+                    let mut bindings: Vec<(VarIdx, usize)> = Vec::new();
                     let mut inner = body.as_ref();
                     while let Expr::LetBinding { var_index: vi, value: val, body: b } = inner {
                         if let Expr::Index { expr: base, key } = val.as_ref() {
@@ -2691,27 +2691,27 @@ pub fn eval(
                         // Teardown: restore all vars (1 borrow_mut).
                         let n_bind = bindings.len();
                         // Use stack storage for common 2-element case to avoid Vec allocation
-                        let mut olds_buf: [(u16, Value); 3] = [(0, Value::Null), (0, Value::Null), (0, Value::Null)];
-                        let mut olds_vec: Vec<(u16, Value)> = Vec::new();
+                        let mut olds_buf: [(VarIdx, Value); 3] = [(VarIdx(0), Value::Null), (VarIdx(0), Value::Null), (VarIdx(0), Value::Null)];
+                        let mut olds_vec: Vec<(VarIdx, Value)> = Vec::new();
                         let use_buf = n_bind <= 2;
                         let destructured = {
                             let mut e = env.borrow_mut();
-                            let old_tmp = std::mem::replace(&mut e.vars[tmp_vi as usize], input);
+                            let old_tmp = std::mem::replace(&mut e.vars[tmp_vi.idx()], input);
                             if use_buf { olds_buf[0] = (tmp_vi, old_tmp); }
                             else { olds_vec.push((tmp_vi, old_tmp)); }
-                            let rc_opt = match &e.vars[tmp_vi as usize] {
+                            let rc_opt = match &e.vars[tmp_vi.idx()] {
                                 Value::Arr(rc) => Some(rc.clone()),
                                 _ => None,
                             };
                             if let Some(rc) = rc_opt {
                                 for (i, &(vi, idx)) in bindings.iter().enumerate() {
                                     let elem = rc.get(idx).cloned().unwrap_or(Value::Null);
-                                    let old = std::mem::replace(&mut e.vars[vi as usize], elem);
+                                    let old = std::mem::replace(&mut e.vars[vi.idx()], elem);
                                     if use_buf { olds_buf[i + 1] = (vi, old); }
                                     else { olds_vec.push((vi, old)); }
                                 }
                                 drop(rc);
-                                e.vars[tmp_vi as usize] = Value::Null;
+                                e.vars[tmp_vi.idx()] = Value::Null;
                                 true
                             } else {
                                 false
@@ -2728,45 +2728,45 @@ pub fn eval(
                             if use_buf {
                                 if destructured {
                                     for i in (1..=n_bind).rev() {
-                                        let (vi, old) = std::mem::replace(&mut olds_buf[i], (0, Value::Null));
-                                        e.vars[vi as usize] = old;
+                                        let (vi, old) = std::mem::replace(&mut olds_buf[i], (VarIdx(0), Value::Null));
+                                        e.vars[vi.idx()] = old;
                                     }
                                 }
-                                e.vars[tmp_vi as usize] = std::mem::replace(&mut olds_buf[0], (0, Value::Null)).1;
+                                e.vars[tmp_vi.idx()] = std::mem::replace(&mut olds_buf[0], (VarIdx(0), Value::Null)).1;
                             } else {
                                 if destructured {
                                     while olds_vec.len() > 1 {
                                         let (vi, old) = olds_vec.pop().unwrap();
-                                        e.vars[vi as usize] = old;
+                                        e.vars[vi.idx()] = old;
                                     }
                                 }
-                                e.vars[tmp_vi as usize] = olds_vec.pop().unwrap().1;
+                                e.vars[tmp_vi.idx()] = olds_vec.pop().unwrap().1;
                             }
                         }
                         result
                     } else {
                         // No destructuring, normal path
-                        let old = std::mem::replace(&mut env.borrow_mut().vars[tmp_vi as usize], input);
+                        let old = std::mem::replace(&mut env.borrow_mut().vars[tmp_vi.idx()], input);
                         let result = eval(body, Value::Null, env, cb);
-                        env.borrow_mut().vars[tmp_vi as usize] = old;
+                        env.borrow_mut().vars[tmp_vi.idx()] = old;
                         result
                     }
                 } else {
-                    let old = std::mem::replace(&mut env.borrow_mut().vars[tmp_vi as usize], input.clone());
+                    let old = std::mem::replace(&mut env.borrow_mut().vars[tmp_vi.idx()], input.clone());
                     let result = eval(body, input, env, cb);
-                    env.borrow_mut().vars[tmp_vi as usize] = old;
+                    env.borrow_mut().vars[tmp_vi.idx()] = old;
                     result
                 }
             } else if let Ok(val) = eval_one(value, &input, env) {
                 // Scalar fast path: avoid closure + input clone
-                let vi = *var_index as usize;
+                let vi = var_index.idx();
                 let old = std::mem::replace(&mut env.borrow_mut().vars[vi], val);
                 let result = eval(body, input, env, cb);
                 env.borrow_mut().vars[vi] = old;
                 result
             } else {
                 eval(value, input.clone(), env, &mut |val| {
-                    let vi = *var_index as usize;
+                    let vi = var_index.idx();
                     let old = std::mem::replace(&mut env.borrow_mut().vars[vi], val);
                     let result = eval(body, input.clone(), env, cb);
                     env.borrow_mut().vars[vi] = old;
@@ -2875,15 +2875,15 @@ pub fn eval(
                             let acc_val = std::mem::replace(&mut acc, Value::Null);
                             let (old_var, old_acc) = {
                                 let mut e = env.borrow_mut();
-                                let ov = std::mem::replace(&mut e.vars[vi as usize], sv);
-                                let oa = std::mem::replace(&mut e.vars[ai as usize], acc_val.clone());
+                                let ov = std::mem::replace(&mut e.vars[vi.idx()], sv);
+                                let oa = std::mem::replace(&mut e.vars[ai.idx()], acc_val.clone());
                                 (ov, oa)
                             };
                             let r = eval(update, acc_val, env, &mut |new_acc| { acc = new_acc; Ok(true) });
                             {
                                 let mut e = env.borrow_mut();
-                                e.vars[ai as usize] = old_acc;
-                                e.vars[vi as usize] = old_var;
+                                e.vars[ai.idx()] = old_acc;
+                                e.vars[vi.idx()] = old_var;
                             }
                             r?;
                             Ok(true)
@@ -2915,7 +2915,7 @@ pub fn eval(
             let fused = if !acc_used_in_update {
                 if let Expr::LetBinding { var_index: tmp_vi, value, body } = update {
                     if matches!(value.as_ref(), Expr::Input) && !expr_uses_outer_input(body) {
-                        let mut bindings: Vec<(u16, usize)> = Vec::new();
+                        let mut bindings: Vec<(VarIdx, usize)> = Vec::new();
                         let mut inner = body.as_ref();
                         while let Expr::LetBinding { var_index: bvi, value: bval, body: bb } = inner {
                             if let Expr::Index { expr: base, key } = bval.as_ref() {
@@ -2944,19 +2944,19 @@ pub fn eval(
                     // Setup: store $var, destructure acc, null tmp (1 borrow_mut)
                     let (old_var, old_tmp, destructured) = {
                         let mut e = env.borrow_mut();
-                        let old_var = std::mem::replace(&mut e.vars[vi as usize], val);
-                        let old_tmp = std::mem::replace(&mut e.vars[tmp_vi as usize], acc_val);
-                        let rc_opt = match &e.vars[tmp_vi as usize] {
+                        let old_var = std::mem::replace(&mut e.vars[vi.idx()], val);
+                        let old_tmp = std::mem::replace(&mut e.vars[tmp_vi.idx()], acc_val);
+                        let rc_opt = match &e.vars[tmp_vi.idx()] {
                             Value::Arr(rc) => Some(rc.clone()),
                             _ => None,
                         };
                         if let Some(rc) = rc_opt {
                             for &(bvi, idx) in bindings {
                                 let elem = rc.get(idx).cloned().unwrap_or(Value::Null);
-                                e.vars[bvi as usize] = elem;
+                                e.vars[bvi.idx()] = elem;
                             }
                             drop(rc);
-                            e.vars[tmp_vi as usize] = Value::Null;
+                            e.vars[tmp_vi.idx()] = Value::Null;
                             (old_var, old_tmp, true)
                         } else {
                             (old_var, old_tmp, false)
@@ -2966,14 +2966,14 @@ pub fn eval(
                         eval(inner_body, Value::Null, env, &mut |new_acc| { acc = new_acc; Ok(true) })?;
                     } else {
                         // Not an array; restore tmp and run update normally
-                        env.borrow_mut().vars[tmp_vi as usize] = old_tmp;
+                        env.borrow_mut().vars[tmp_vi.idx()] = old_tmp;
                         let acc_val_for_update = env.borrow().get_var(tmp_vi);
                         eval(update, acc_val_for_update, env, &mut |new_acc| { acc = new_acc; Ok(true) })?;
                     }
                     // Teardown: restore $var (1 borrow_mut)
                     // Note: destructured bindings' old values were whatever was in env before;
                     // since we're in a reduce loop and these are scratch vars, we just restore $var.
-                    env.borrow_mut().vars[vi as usize] = old_var;
+                    env.borrow_mut().vars[vi.idx()] = old_var;
                     Ok(true)
                 })?;
                 cb(acc)
@@ -2982,7 +2982,7 @@ pub fn eval(
                 // Also detect `+= rhs` which is: LetBinding { var, value: rhs, body: Update { path: ., update: . + LoadVar(var) } }
                 let add_inplace = if let Expr::BinOp { op: BinOp::Add, lhs, rhs } = update {
                     if matches!(lhs.as_ref(), Expr::Input) && !expr_uses_outer_input(rhs) {
-                        Some((rhs.as_ref(), None::<u16>))
+                        Some((rhs.as_ref(), None::<VarIdx>))
                     } else { None }
                 } else if let Expr::LetBinding { var_index: rhs_var, value: rhs_value, body } = update {
                     // `. += rhs` pattern
@@ -3001,7 +3001,7 @@ pub fn eval(
                 } else { None };
                 if let Some((add_rhs, _temp_var)) = add_inplace {
                     eval(source, source_input, env, &mut |val| {
-                        let old_var = std::mem::replace(&mut env.borrow_mut().vars[vi as usize], val);
+                        let old_var = std::mem::replace(&mut env.borrow_mut().vars[vi.idx()], val);
                         let rhs_val = {
                             let mut r = Value::Null;
                             eval(add_rhs, Value::Null, env, &mut |v| { r = v; Ok(true) })?;
@@ -3026,16 +3026,16 @@ pub fn eval(
                                 *acc_ref = crate::runtime::rt_add(&acc_val, &rhs_val)?;
                             }
                         }
-                        env.borrow_mut().vars[vi as usize] = old_var;
+                        env.borrow_mut().vars[vi.idx()] = old_var;
                         Ok(true)
                     })?;
                     cb(acc)
                 } else {
                     eval(source, source_input, env, &mut |val| {
                         let acc_val = std::mem::replace(&mut acc, Value::Null);
-                        let old_var = std::mem::replace(&mut env.borrow_mut().vars[vi as usize], val);
+                        let old_var = std::mem::replace(&mut env.borrow_mut().vars[vi.idx()], val);
                         eval(update, acc_val, env, &mut |new_acc| { acc = new_acc; Ok(true) })?;
-                        env.borrow_mut().vars[vi as usize] = old_var;
+                        env.borrow_mut().vars[vi.idx()] = old_var;
                         Ok(true)
                     })?;
                     cb(acc)
@@ -3045,15 +3045,15 @@ pub fn eval(
                     let acc_val = std::mem::replace(&mut acc, Value::Null);
                     let (old_var, old_acc) = {
                         let mut e = env.borrow_mut();
-                        let ov = std::mem::replace(&mut e.vars[vi as usize], val);
-                        let oa = std::mem::replace(&mut e.vars[ai as usize], acc_val.clone());
+                        let ov = std::mem::replace(&mut e.vars[vi.idx()], val);
+                        let oa = std::mem::replace(&mut e.vars[ai.idx()], acc_val.clone());
                         (ov, oa)
                     };
                     eval(update, acc_val, env, &mut |new_acc| { acc = new_acc; Ok(true) })?;
                     {
                         let mut e = env.borrow_mut();
-                        e.vars[ai as usize] = old_acc;
-                        e.vars[vi as usize] = old_var;
+                        e.vars[ai.idx()] = old_acc;
+                        e.vars[vi.idx()] = old_var;
                     }
                     Ok(true)
                 })?;
@@ -3088,7 +3088,7 @@ pub fn eval(
                                         if cond_needs_var {
                                             // Slow path: cond_body references $item
                                             let old_var = std::mem::replace(
-                                                &mut env.borrow_mut().vars[vi as usize], val.clone());
+                                                &mut env.borrow_mut().vars[vi.idx()], val.clone());
                                             let is_true = match eval_one(cond_body, &val, env) {
                                                 Ok(v) => v.is_truthy(),
                                                 Err(()) => {
@@ -3102,12 +3102,12 @@ pub fn eval(
                                             let cont = if is_true {
                                                 cb(val)?
                                             } else if else_is_break {
-                                                env.borrow_mut().vars[vi as usize] = old_var;
+                                                env.borrow_mut().vars[vi.idx()] = old_var;
                                                 return eval(else_branch, Value::Null, env, cb);
                                             } else {
                                                 true
                                             };
-                                            env.borrow_mut().vars[vi as usize] = old_var;
+                                            env.borrow_mut().vars[vi.idx()] = old_var;
                                             Ok(cont)
                                         } else {
                                             // Fast path: evaluate cond before touching env
@@ -3131,9 +3131,9 @@ pub fn eval(
                                             } else if else_is_break {
                                                 // Store val in env only for break path
                                                 let old_var = std::mem::replace(
-                                                    &mut env.borrow_mut().vars[vi as usize], val);
+                                                    &mut env.borrow_mut().vars[vi.idx()], val);
                                                 let r = eval(else_branch, Value::Null, env, cb);
-                                                env.borrow_mut().vars[vi as usize] = old_var;
+                                                env.borrow_mut().vars[vi.idx()] = old_var;
                                                 r
                                             } else {
                                                 Ok(true)
@@ -3145,13 +3145,13 @@ pub fn eval(
                         }
                     }
                     return eval(source, input, env, &mut |val| {
-                        let old_var = std::mem::replace(&mut env.borrow_mut().vars[vi as usize], val);
+                        let old_var = std::mem::replace(&mut env.borrow_mut().vars[vi.idx()], val);
                         let cont = match eval_one_filter(extract_expr, &Value::Null, env) {
                             Ok(Some(v)) => cb(v)?,
                             Ok(None) => true,
                             Err(()) => eval(extract_expr, Value::Null, env, cb)?,
                         };
-                        env.borrow_mut().vars[vi as usize] = old_var;
+                        env.borrow_mut().vars[vi.idx()] = old_var;
                         Ok(cont)
                     });
                 }
@@ -3164,9 +3164,9 @@ pub fn eval(
                     let acc_val = std::mem::replace(&mut acc, Value::Null);
                     let (old_var, old_acc) = {
                         let mut e = env.borrow_mut();
-                        let ov = std::mem::replace(&mut e.vars[vi as usize], val);
+                        let ov = std::mem::replace(&mut e.vars[vi.idx()], val);
                         let oa = if acc_used {
-                            std::mem::replace(&mut e.vars[ai as usize], acc_val.clone())
+                            std::mem::replace(&mut e.vars[ai.idx()], acc_val.clone())
                         } else {
                             Value::Null
                         };
@@ -3178,7 +3178,7 @@ pub fn eval(
                     let update_result = eval(update, acc_val, env, &mut |new_acc| {
                         acc = new_acc.clone();
                         if acc_used {
-                            env.borrow_mut().vars[ai as usize] = new_acc.clone();
+                            env.borrow_mut().vars[ai.idx()] = new_acc.clone();
                         }
                         let cont = if let Some(extract_expr) = extract {
                             match eval_one_filter(extract_expr, &new_acc, env) {
@@ -3195,9 +3195,9 @@ pub fn eval(
                     {
                         let mut e = env.borrow_mut();
                         if acc_used {
-                            e.vars[ai as usize] = old_acc;
+                            e.vars[ai.idx()] = old_acc;
                         }
-                        e.vars[vi as usize] = old_var;
+                        e.vars[vi.idx()] = old_var;
                     }
                     update_result?;
                     Ok(!stopped)
@@ -3443,7 +3443,7 @@ pub fn eval(
                             }
                         } else {
                             // Multi-arg: check all LoadVar
-                            let all_loadvar: Option<Vec<u16>> = args.iter().map(|a| {
+                            let all_loadvar: Option<Vec<VarIdx>> = args.iter().map(|a| {
                                 if let Expr::LoadVar { var_index } = a { Some(*var_index) } else { None }
                             }).collect();
                             if let Some(ref vis) = all_loadvar {
@@ -3545,7 +3545,7 @@ pub fn eval(
                                 return eval(&body_rc, input, env, cb);
                             }
                         }
-                        let all_loadvar: Option<Vec<u16>> = args.iter().map(|a| {
+                        let all_loadvar: Option<Vec<VarIdx>> = args.iter().map(|a| {
                             if let Expr::LoadVar { var_index } = a { Some(*var_index) } else { None }
                         }).collect();
                         if let Some(var_indices) = all_loadvar {
@@ -3677,7 +3677,7 @@ pub fn eval(
                         }
                         drop(e);
                     }
-                    let old = std::mem::replace(&mut env.borrow_mut().vars[vi as usize], elem);
+                    let old = std::mem::replace(&mut env.borrow_mut().vars[vi.idx()], elem);
                     // jq's `all` returns true vacuously when the predicate
                     // emits no values for an element, and false on the first
                     // falsy value (other values are short-circuited away).
@@ -3692,7 +3692,7 @@ pub fn eval(
                             !found_falsy
                         }
                     };
-                    env.borrow_mut().vars[vi as usize] = old;
+                    env.borrow_mut().vars[vi.idx()] = old;
                     if is_true { Ok(true) } else { all_true = false; Ok(false) }
                 } else {
                     let pred_result = eval_one(predicate, &elem, env);
@@ -3733,7 +3733,7 @@ pub fn eval(
                         }
                         drop(e);
                     }
-                    let old = std::mem::replace(&mut env.borrow_mut().vars[vi as usize], elem);
+                    let old = std::mem::replace(&mut env.borrow_mut().vars[vi.idx()], elem);
                     // jq's `any` returns false vacuously when the predicate
                     // emits no values, and true on the first truthy value
                     // (other values are short-circuited away).
@@ -3748,7 +3748,7 @@ pub fn eval(
                             found_truthy
                         }
                     };
-                    env.borrow_mut().vars[vi as usize] = old;
+                    env.borrow_mut().vars[vi.idx()] = old;
                     if is_true { any_true = true; Ok(false) } else { Ok(true) }
                 } else {
                     let pred_result = eval_one(predicate, &elem, env);
@@ -5434,7 +5434,7 @@ thread_local! {
     // forwards the element's source path instead of being rejected as a value.
     // Outside a path-mode `foreach`, the stack is empty and variables behave
     // as ordinary (non-path) values. See #711.
-    static FOREACH_PATH_BIND: RefCell<Vec<(u16, Value)>> = const { RefCell::new(Vec::new()) };
+    static FOREACH_PATH_BIND: RefCell<Vec<(VarIdx, Value)>> = const { RefCell::new(Vec::new()) };
 }
 
 thread_local! {
@@ -5500,7 +5500,7 @@ thread_local! {
     // globally unique var index (the parser never reuses one), so a non-identity
     // rebind of the same name gets a fresh index absent from this set and
     // correctly shadows. See #837.
-    static IDENTITY_PATH_VARS: RefCell<Vec<u16>> = const { RefCell::new(Vec::new()) };
+    static IDENTITY_PATH_VARS: RefCell<Vec<VarIdx>> = const { RefCell::new(Vec::new()) };
 }
 
 /// RAII guard registering `var_index` as identity-path-bound for its lifetime.
@@ -5510,11 +5510,11 @@ impl Drop for IdentityVarGuard {
         IDENTITY_PATH_VARS.with(|s| { s.borrow_mut().pop(); });
     }
 }
-fn push_identity_path_var(var_index: u16) -> IdentityVarGuard {
+fn push_identity_path_var(var_index: VarIdx) -> IdentityVarGuard {
     IDENTITY_PATH_VARS.with(|s| s.borrow_mut().push(var_index));
     IdentityVarGuard
 }
-fn is_identity_path_var(var_index: u16) -> bool {
+fn is_identity_path_var(var_index: VarIdx) -> bool {
     IDENTITY_PATH_VARS.with(|s| s.borrow().contains(&var_index))
 }
 
@@ -5526,7 +5526,7 @@ thread_local! {
     // tracks a single path register through destructuring, so two or more
     // sibling navigations off the same source corrupt it — we mirror that by
     // refusing to register a source that is referenced more than once. See #880.
-    static NAV_PATH_SOURCES: RefCell<Vec<u16>> = const { RefCell::new(Vec::new()) };
+    static NAV_PATH_SOURCES: RefCell<Vec<VarIdx>> = const { RefCell::new(Vec::new()) };
 }
 
 /// RAII guard registering `var_index` as a single-spine navigation source.
@@ -5536,11 +5536,11 @@ impl Drop for NavSourceGuard {
         NAV_PATH_SOURCES.with(|s| { s.borrow_mut().pop(); });
     }
 }
-fn push_nav_path_source(var_index: u16) -> NavSourceGuard {
+fn push_nav_path_source(var_index: VarIdx) -> NavSourceGuard {
     NAV_PATH_SOURCES.with(|s| s.borrow_mut().push(var_index));
     NavSourceGuard
 }
-fn is_nav_path_source(var_index: u16) -> bool {
+fn is_nav_path_source(var_index: VarIdx) -> bool {
     NAV_PATH_SOURCES.with(|s| s.borrow().contains(&var_index))
 }
 
@@ -6313,14 +6313,14 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
                     let acc_val = std::mem::replace(&mut acc, Value::Null);
                     let (old_var, old_acc) = {
                         let mut e = env.borrow_mut();
-                        let ov = std::mem::replace(&mut e.vars[vi as usize], elem_val);
-                        let oa = std::mem::replace(&mut e.vars[ai as usize], acc_val.clone());
+                        let ov = std::mem::replace(&mut e.vars[vi.idx()], elem_val);
+                        let oa = std::mem::replace(&mut e.vars[ai.idx()], acc_val.clone());
                         (ov, oa)
                     };
                     let mut stopped = false;
                     let update_result = eval(update, acc_val, env, &mut |new_acc| {
                         acc = new_acc.clone();
-                        env.borrow_mut().vars[ai as usize] = new_acc.clone();
+                        env.borrow_mut().vars[ai.idx()] = new_acc.clone();
                         let extract_expr = extract.as_ref().unwrap();
                         FOREACH_PATH_BIND.with(|s| s.borrow_mut().push((vi, src_path.clone())));
                         // The navigating source owns the path register, so the
@@ -6338,8 +6338,8 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
                     });
                     {
                         let mut e = env.borrow_mut();
-                        e.vars[ai as usize] = old_acc;
-                        e.vars[vi as usize] = old_var;
+                        e.vars[ai.idx()] = old_acc;
+                        e.vars[vi.idx()] = old_var;
                     }
                     update_result?;
                     Ok(!stopped)
@@ -6415,13 +6415,13 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
             for sv in source_vals {
                 let (old_var, old_acc) = {
                     let mut e = env.borrow_mut();
-                    let ov = std::mem::replace(&mut e.vars[vi as usize], sv);
-                    (ov, e.vars[ai as usize].clone())
+                    let ov = std::mem::replace(&mut e.vars[vi.idx()], sv);
+                    (ov, e.vars[ai.idx()].clone())
                 };
                 let mut next: Vec<Value> = Vec::new();
                 for ap in &acc_paths {
                     let base_val = crate::runtime::rt_getpath(&input, ap).unwrap_or(Value::Null);
-                    env.borrow_mut().vars[ai as usize] = base_val.clone();
+                    env.borrow_mut().vars[ai.idx()] = base_val.clone();
                     let ap_vec: Vec<Value> = match ap { Value::Arr(a) => a.as_ref().clone(), _ => vec![] };
                     eval_path(update, base_val.clone(), env, &mut |rp| {
                         // jq only path-tracks a reduce whose UPDATE preserves the
@@ -6447,8 +6447,8 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
                 }
                 {
                     let mut e = env.borrow_mut();
-                    e.vars[ai as usize] = old_acc;
-                    e.vars[vi as usize] = old_var;
+                    e.vars[ai.idx()] = old_acc;
+                    e.vars[vi.idx()] = old_var;
                 }
                 acc_paths = next;
             }
@@ -6705,7 +6705,7 @@ fn eval_path_catch(
 /// `$v | .[k]` desugar of a computed object-pattern key). Returns `None` for any
 /// expression that does not bottom out in a single `LoadVar`. Used to decide
 /// whether a destructuring sub-binding navigates a path-tracked source. #880
-fn nav_source_var(expr: &Expr) -> Option<u16> {
+fn nav_source_var(expr: &Expr) -> Option<VarIdx> {
     match expr {
         Expr::LoadVar { var_index } => Some(*var_index),
         Expr::Index { expr, .. } | Expr::IndexOpt { expr, .. } | Expr::Slice { expr, .. } => {
@@ -6721,8 +6721,8 @@ fn nav_source_var(expr: &Expr) -> Option<u16> {
 /// (in its sole navigated child); two or more references mean sibling
 /// navigations, which jq cannot path-track. Mirrors `expr_uses_var`'s shape but
 /// counts. #880
-fn var_referenced_twice(expr: &Expr, target: u16) -> bool {
-    fn go(expr: &Expr, target: u16, count: &mut u8) {
+fn var_referenced_twice(expr: &Expr, target: VarIdx) -> bool {
+    fn go(expr: &Expr, target: VarIdx, count: &mut u8) {
         if *count >= 2 { return; }
         match expr {
             Expr::LoadVar { var_index } => { if *var_index == target { *count += 1; } }
@@ -6816,7 +6816,7 @@ fn var_referenced_twice(expr: &Expr, target: u16) -> bool {
 /// can inherit a path (#880). Out-of-line so eval_path's hot arms stay compact.
 #[inline(never)]
 fn eval_path_letbinding_identity(
-    var_index: u16,
+    var_index: VarIdx,
     body: &Expr,
     input: Value,
     env: &EnvRef,
@@ -6842,7 +6842,7 @@ fn eval_path_letbinding_identity(
 /// to keep eval_path's hot arms compact (see #839 perf note on #880). #880
 #[inline(never)]
 fn eval_path_navbind(
-    var_index: u16,
+    var_index: VarIdx,
     value: &Expr,
     body: &Expr,
     input: &Value,
@@ -6892,8 +6892,8 @@ fn eval_path_navbind(
 fn eval_foreach_nav_noextract_path(
     source: &Expr,
     init: &Expr,
-    vi: u16,
-    ai: u16,
+    vi: VarIdx,
+    ai: VarIdx,
     update: &Expr,
     input: &Value,
     env: &EnvRef,
@@ -6906,8 +6906,8 @@ fn eval_foreach_nav_noextract_path(
             let acc_val = std::mem::replace(&mut acc, Value::Null);
             let (old_var, old_acc) = {
                 let mut e = env.borrow_mut();
-                let ov = std::mem::replace(&mut e.vars[vi as usize], elem_val);
-                let oa = std::mem::replace(&mut e.vars[ai as usize], acc_val.clone());
+                let ov = std::mem::replace(&mut e.vars[vi.idx()], elem_val);
+                let oa = std::mem::replace(&mut e.vars[ai.idx()], acc_val.clone());
                 (ov, oa)
             };
             FOREACH_PATH_BIND.with(|s| s.borrow_mut().push((vi, src_path.clone())));
@@ -6920,15 +6920,15 @@ fn eval_foreach_nav_noextract_path(
                 eval_path(update, acc_val, env, &mut |upd_path| {
                     // The update result threads as the next accumulator value.
                     acc = crate::runtime::rt_getpath(input, &upd_path).unwrap_or(Value::Null);
-                    env.borrow_mut().vars[ai as usize] = acc.clone();
+                    env.borrow_mut().vars[ai.idx()] = acc.clone();
                     cb(upd_path)
                 })
             };
             FOREACH_PATH_BIND.with(|s| { s.borrow_mut().pop(); });
             {
                 let mut e = env.borrow_mut();
-                e.vars[ai as usize] = old_acc;
-                e.vars[vi as usize] = old_var;
+                e.vars[ai.idx()] = old_acc;
+                e.vars[vi.idx()] = old_var;
             }
             r
         })
@@ -6943,8 +6943,8 @@ fn eval_foreach_nav_noextract_path(
 fn eval_foreach_valuegen_path(
     source: &Expr,
     init: &Expr,
-    vi: u16,
-    ai: u16,
+    vi: VarIdx,
+    ai: VarIdx,
     update: &Expr,
     extract: &Option<Box<Expr>>,
     input: &Value,
@@ -6969,13 +6969,13 @@ fn eval_foreach_valuegen_path(
             for seed in init_paths {
                 let mut acc_paths: Vec<Value> = vec![seed];
                 for sv in &source_vals {
-                    let old_var = { let mut e = env.borrow_mut(); std::mem::replace(&mut e.vars[vi as usize], sv.clone()) };
+                    let old_var = { let mut e = env.borrow_mut(); std::mem::replace(&mut e.vars[vi.idx()], sv.clone()) };
                     let mut next: Vec<Value> = Vec::new();
                     let mut stop = false;
                     for ap in &acc_paths {
                         let base = crate::runtime::rt_getpath(input, ap).unwrap_or(Value::Null);
                         let ap_vec: Vec<Value> = match ap { Value::Arr(a) => a.as_ref().clone(), _ => vec![] };
-                        let old_acc = { let mut e = env.borrow_mut(); std::mem::replace(&mut e.vars[ai as usize], base.clone()) };
+                        let old_acc = { let mut e = env.borrow_mut(); std::mem::replace(&mut e.vars[ai.idx()], base.clone()) };
                         // UPDATE in path mode: each output is relative to the
                         // accumulator value and extends its path.
                         let r = eval_path(update, base.clone(), env, &mut |rp| {
@@ -6986,7 +6986,7 @@ fn eval_foreach_valuegen_path(
                             // EXTRACT emits per updated accumulator, with the
                             // accumulator value bound for navigation.
                             let nbase = crate::runtime::rt_getpath(input, &np).unwrap_or(Value::Null);
-                            let old_acc2 = { let mut e = env.borrow_mut(); std::mem::replace(&mut e.vars[ai as usize], nbase.clone()) };
+                            let old_acc2 = { let mut e = env.borrow_mut(); std::mem::replace(&mut e.vars[ai.idx()], nbase.clone()) };
                             let ec = if let Some(ex) = extract {
                                 eval_path(ex, nbase, env, &mut |ep| {
                                     let mut comb = np_vec.clone();
@@ -7005,23 +7005,23 @@ fn eval_foreach_valuegen_path(
                                 // #915
                                 cb(np.clone())
                             };
-                            env.borrow_mut().vars[ai as usize] = old_acc2;
+                            env.borrow_mut().vars[ai.idx()] = old_acc2;
                             let c = ec?;
                             if !c { stop = true; }
                             Ok(c)
                         });
-                        env.borrow_mut().vars[ai as usize] = old_acc;
+                        env.borrow_mut().vars[ai.idx()] = old_acc;
                         // Keep $i bound across all accumulator branches of this
                         // source element; restore it only after the loop (or on
                         // error) so a multi-valued UPDATE doesn't reset it
                         // mid-iteration.
                         if let Err(e) = r {
-                            env.borrow_mut().vars[vi as usize] = old_var;
+                            env.borrow_mut().vars[vi.idx()] = old_var;
                             return Err(e);
                         }
                         if stop { break; }
                     }
-                    env.borrow_mut().vars[vi as usize] = old_var;
+                    env.borrow_mut().vars[vi.idx()] = old_var;
                     if stop { return Ok(false); }
                     acc_paths = next;
                 }
@@ -7044,15 +7044,15 @@ fn eval_foreach_valuegen_path(
                 for sv in &source_vals {
                     let (old_var, old_acc) = {
                         let mut e = env.borrow_mut();
-                        let ov = std::mem::replace(&mut e.vars[vi as usize], sv.clone());
-                        let oa = std::mem::replace(&mut e.vars[ai as usize], acc.clone());
+                        let ov = std::mem::replace(&mut e.vars[vi.idx()], sv.clone());
+                        let oa = std::mem::replace(&mut e.vars[ai.idx()], acc.clone());
                         (ov, oa)
                     };
                     let acc_in = acc.clone();
                     let mut stop = false;
                     let r = eval(update, acc_in, env, &mut |new_acc| {
                         acc = new_acc.clone();
-                        env.borrow_mut().vars[ai as usize] = new_acc.clone();
+                        env.borrow_mut().vars[ai.idx()] = new_acc.clone();
                         let c = if let Some(ex) = extract {
                             eval_path(ex, new_acc.clone(), env, cb)?
                         } else {
@@ -7063,8 +7063,8 @@ fn eval_foreach_valuegen_path(
                     });
                     {
                         let mut e = env.borrow_mut();
-                        e.vars[ai as usize] = old_acc;
-                        e.vars[vi as usize] = old_var;
+                        e.vars[ai.idx()] = old_acc;
+                        e.vars[vi.idx()] = old_var;
                     }
                     r?;
                     if stop { return Ok(false); }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -494,7 +494,7 @@ fn expr_is_pure_scalar(e: &crate::ir::Expr) -> bool {
 /// True if `expr` contains a `LoadVar` reference to `var_index`. Used by the
 /// LetBinding inliner to decide whether substitution would actually use the
 /// bound value or only need to keep it for its side effect.
-fn expr_references_var(expr: &crate::ir::Expr, var_index: u16) -> bool {
+fn expr_references_var(expr: &crate::ir::Expr, var_index: crate::ir::VarIdx) -> bool {
     use crate::ir::Expr;
     match expr {
         Expr::LoadVar { var_index: idx } => *idx == var_index,
@@ -573,9 +573,9 @@ fn expr_references_var(expr: &crate::ir::Expr, var_index: u16) -> bool {
 /// `dot_same`; every other (or unenumerated) construct is treated as rebinding
 /// `.`, so a reference found there is reported (the inliner just declines the
 /// optimization and keeps the binding).
-fn var_in_rebound_dot_scope(expr: &crate::ir::Expr, var_index: u16) -> bool {
+fn var_in_rebound_dot_scope(expr: &crate::ir::Expr, var_index: crate::ir::VarIdx) -> bool {
     use crate::ir::{Expr, StringPart};
-    fn walk(e: &Expr, var: u16, dot_same: bool) -> bool {
+    fn walk(e: &Expr, var: crate::ir::VarIdx, dot_same: bool) -> bool {
         match e {
             Expr::LoadVar { var_index: v } => *v == var && !dot_same,
             // Dot-preserving: every sub-expression sees the same `.`.

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -3,6 +3,31 @@
 //! Every IR node is a generator: it takes an input Value and produces zero or more
 //! output Values. This unified model eliminates the generator-in-scalar-context problem.
 
+/// Index of a variable slot in the evaluation environment.
+///
+/// Variable slots, function ids, and label ids are all small integers; this
+/// newtype keeps the variable-slot domain from being mixed with the others
+/// (#1033). The raw slot number stays public so counter arithmetic at
+/// allocation sites stays local (`VarIdx(v.0 + 1)`); cross-layer plumbing
+/// must carry `VarIdx`, dropping to the raw `u16` only at the JIT/FFI
+/// boundary where indices become machine-code immediates.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct VarIdx(pub u16);
+
+impl VarIdx {
+    /// Slot position for direct slice/`Vec` indexing.
+    #[inline(always)]
+    pub const fn idx(self) -> usize {
+        self.0 as usize
+    }
+}
+
+impl std::fmt::Display for VarIdx {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
 /// A filter expression in the IR.
 #[derive(Debug, Clone)]
 pub enum Expr {
@@ -88,22 +113,22 @@ pub enum Expr {
 
     /// Variable binding: `expr as $var | body`
     LetBinding {
-        var_index: u16,
+        var_index: VarIdx,
         value: Box<Expr>,
         body: Box<Expr>,
     },
 
     /// Variable reference: `$var`
     LoadVar {
-        var_index: u16,
+        var_index: VarIdx,
     },
 
     /// Reduce: `reduce source as $var (init; update)`
     Reduce {
         source: Box<Expr>,
         init: Box<Expr>,
-        var_index: u16,
-        acc_index: u16,
+        var_index: VarIdx,
+        acc_index: VarIdx,
         update: Box<Expr>,
     },
 
@@ -111,8 +136,8 @@ pub enum Expr {
     Foreach {
         source: Box<Expr>,
         init: Box<Expr>,
-        var_index: u16,
-        acc_index: u16,
+        var_index: VarIdx,
+        acc_index: VarIdx,
         update: Box<Expr>,
         extract: Option<Box<Expr>>,
     },
@@ -152,13 +177,13 @@ pub enum Expr {
 
     /// Label-break: `label $name | body`
     Label {
-        var_index: u16,
+        var_index: VarIdx,
         body: Box<Expr>,
     },
 
     /// Break out of label
     Break {
-        var_index: u16,
+        var_index: VarIdx,
         value: Box<Expr>,
     },
 
@@ -549,7 +574,7 @@ pub struct CompiledFunc {
     pub name: Option<String>,
     pub nargs: usize,
     pub body: Expr,
-    pub param_vars: Vec<u16>,
+    pub param_vars: Vec<VarIdx>,
 }
 
 // ============================================================================
@@ -907,7 +932,7 @@ impl Expr {
     }
 
     /// Substitute all LoadVar references with the given var_index with the replacement expression.
-    pub fn substitute_var(&self, var_index: u16, replacement: &Expr) -> Expr {
+    pub fn substitute_var(&self, var_index: VarIdx, replacement: &Expr) -> Expr {
         match self {
             Expr::LoadVar { var_index: idx } if *idx == var_index => replacement.clone(),
             Expr::LoadVar { .. } | Expr::Literal(_) | Expr::Input | Expr::Empty

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -402,12 +402,12 @@ enum JitOp {
     InitVar { var: u32 },
 
     // jq variables
-    GetVar { dst: SlotId, var_index: u16 },
-    SetVar { var_index: u16, src: SlotId },
+    GetVar { dst: SlotId, var_index: VarIdx },
+    SetVar { var_index: VarIdx, src: SlotId },
     /// Take var value (move out, leave Null) — avoids clone, gives refcount = 1.
-    TakeVar { dst: SlotId, var_index: u16 },
+    TakeVar { dst: SlotId, var_index: VarIdx },
     /// Move src into var (drop old, leave src as Null) — avoids clone for accumulator stores.
-    MoveToVar { var_index: u16, src: SlotId },
+    MoveToVar { var_index: VarIdx, src: SlotId },
 
     /// In-place path extract: swap container[key] with Null, return old element.
     /// Container is modified in-place via Rc::make_mut (no clone if refcount == 1).
@@ -531,7 +531,7 @@ struct Flattener {
     /// After each fallible op, CheckError is emitted to branch to catch_label on error.
     try_catch_target: Option<(LabelId, SlotId)>,
     /// Label targets for break: var_index → done_label
-    label_targets: HashMap<u16, LabelId>,
+    label_targets: HashMap<VarIdx, LabelId>,
     /// Available compiled functions for FuncCall
     funcs: Vec<CompiledFunc>,
     /// Limit state: when inside a `limit(n; gen)`, emit_yield increments counter and breaks.
@@ -1456,7 +1456,7 @@ impl Flattener {
                     // Pre-load external variables as f64 vars
                     let acc = self.alloc_var();
                     self.emit(JitOp::ToF64Var { dst_var: acc, src: input_slot });
-                    let mut var_map: Vec<(u16, u32)> = Vec::new();
+                    let mut var_map: Vec<(VarIdx, u32)> = Vec::new();
                     for &vi in &ext_vars {
                         let slot = self.alloc_slot();
                         self.emit(JitOp::GetVar { dst: slot, var_index: vi });
@@ -2883,8 +2883,8 @@ impl Flattener {
                     // Both generators: rewrite as nested LetBinding
                     // jq evaluates rhs as outer, lhs as inner:
                     // (rhs_gen) as $__r | (lhs_gen) as $__l | $__l op $__r
-                    let lhs_var: u16 = 10100;
-                    let rhs_var: u16 = 10101;
+                    let lhs_var = VarIdx(10100);
+                    let rhs_var = VarIdx(10101);
                     let rewritten = Expr::LetBinding {
                         var_index: rhs_var,
                         value: Box::new((**rhs).clone()),
@@ -2934,7 +2934,7 @@ impl Flattener {
                     let t_in = test.alloc_slot();
                     if !test.flatten_gen(ext, t_in) { return false; }
                 }
-                let init_var: u16 = 10500;
+                let init_var = VarIdx(10500);
                 let rewritten = Expr::LetBinding {
                     var_index: init_var,
                     value: Box::new((**init).clone()),
@@ -3292,7 +3292,7 @@ impl Flattener {
 
             Expr::Limit { count, generator } if !is_scalar(count) => {
                 // Generator count: rewrite as count as $n | limit($n; body)
-                let count_var: u16 = 10300;
+                let count_var = VarIdx(10300);
                 let rewritten = Expr::LetBinding {
                     var_index: count_var,
                     value: Box::new((**count).clone()),
@@ -3546,7 +3546,7 @@ impl Flattener {
             // e.g., join(",","/") → (",","/") as $__arg | join($__arg)
             Expr::CallBuiltin { name, args } if !args.is_empty() && args.iter().any(|a| !is_scalar(a)) => {
                 // Each generator arg gets bound to a temp var
-                let base_var: u16 = 10200;
+                let base_var = VarIdx(10200);
                 let mut var_args = Vec::new();
                 let mut all_compilable = true;
                 for (i, arg) in args.iter().enumerate() {
@@ -3559,7 +3559,7 @@ impl Flattener {
                             break;
                         }
                     }
-                    var_args.push((base_var + i as u16, arg));
+                    var_args.push((VarIdx(base_var.0 + i as u16), arg));
                 }
                 if !all_compilable { return false; }
 
@@ -4164,12 +4164,12 @@ impl Flattener {
         // evaluation past any subsequent generator's bind, swallowing the error if
         // that generator yields zero outputs.
         // Use high var indices to avoid conflicts (starting at 10000).
-        let base_var: u16 = 10000;
+        let base_var = VarIdx(10000);
         let mut scalar_pairs = Vec::with_capacity(pairs.len());
         let mut bindings = Vec::with_capacity(pairs.len());
 
         for (i, (k, v)) in pairs.iter().enumerate() {
-            let var_idx = base_var + i as u16;
+            let var_idx = VarIdx(base_var.0 + i as u16);
             bindings.push((var_idx, v.clone()));
             scalar_pairs.push((k.clone(), Expr::LoadVar { var_index: var_idx }));
         }
@@ -4500,7 +4500,7 @@ impl Flattener {
     }
 
     /// Emit reduce loop inline. Returns false if the source generator can't be compiled.
-    fn flatten_gen_with_reduce(&mut self, source: &Expr, var_index: u16, acc_index: u16, update: &Expr, input_slot: SlotId) -> bool {
+    fn flatten_gen_with_reduce(&mut self, source: &Expr, var_index: VarIdx, acc_index: VarIdx, update: &Expr, input_slot: SlotId) -> bool {
         // Detect in-place update pattern: path |= f or path += f (wrapped in LetBinding)
         let inplace_info = detect_inplace_update(update);
 
@@ -4645,12 +4645,12 @@ impl Flattener {
 
     /// Check if an expression is a pure f64 function of acc (Input) and vars.
     /// Single-var convenience wrapper.
-    fn is_pure_f64_expr(expr: &Expr, var_index: u16) -> bool {
+    fn is_pure_f64_expr(expr: &Expr, var_index: VarIdx) -> bool {
         Self::is_pure_f64_expr_multi(expr, &[var_index])
     }
 
     /// Check with multiple allowed variable indices (for LetBinding support).
-    fn is_pure_f64_expr_multi(expr: &Expr, allowed: &[u16]) -> bool {
+    fn is_pure_f64_expr_multi(expr: &Expr, allowed: &[VarIdx]) -> bool {
         match expr {
             Expr::Input => true,
             Expr::LoadVar { var_index } if allowed.contains(var_index) => true,
@@ -4696,11 +4696,11 @@ impl Flattener {
     /// Compile a pure f64 expression into Cranelift f64 variables.
     /// acc_var = accumulator (Input). var_map maps IR var indices to f64 vars.
     /// Returns the f64 variable holding the result.
-    fn compile_f64_expr(&mut self, expr: &Expr, _unused: u16, acc_var: u32, x_var: u32) -> u32 {
+    fn compile_f64_expr(&mut self, expr: &Expr, _unused: VarIdx, acc_var: u32, x_var: u32) -> u32 {
         self.compile_f64_expr_multi(expr, acc_var, &[(_unused, x_var)])
     }
 
-    fn compile_f64_expr_multi(&mut self, expr: &Expr, acc_var: u32, var_map: &[(u16, u32)]) -> u32 {
+    fn compile_f64_expr_multi(&mut self, expr: &Expr, acc_var: u32, var_map: &[(VarIdx, u32)]) -> u32 {
         match expr {
             Expr::Input => acc_var,
             Expr::LoadVar { var_index } => {
@@ -4860,7 +4860,7 @@ impl Flattener {
     /// from the JIT env (see `new_delegated_env` / `reset_delegated_env`). A missing
     /// variant here silently loses any `$var` buried inside and degrades the
     /// delegated call to `null`.
-    fn collect_loadvar_indices(expr: &Expr, out: &mut Vec<u16>) {
+    fn collect_loadvar_indices(expr: &Expr, out: &mut Vec<VarIdx>) {
         use crate::ir::StringPart;
         match expr {
             Expr::LoadVar { var_index } => {
@@ -5047,7 +5047,7 @@ impl Flattener {
     }
 
     /// Iterate source for foreach: update acc and yield extract for each element.
-    fn flatten_gen_with_foreach(&mut self, source: &Expr, var_index: u16, acc_index: u16,
+    fn flatten_gen_with_foreach(&mut self, source: &Expr, var_index: VarIdx, acc_index: VarIdx,
                                 update: &Expr, extract: Option<&Expr>, input_slot: SlotId) -> bool {
         // The update+extract step for each source element
         let emit_step = |s: &mut Flattener, elem: SlotId| {
@@ -5217,7 +5217,7 @@ impl Flattener {
 
     /// Handle LetBinding with generator value.
     /// For each output of value, set $var and run body with original input.
-    fn flatten_gen_let_binding(&mut self, var_index: u16, value: &Expr, body: &Expr, input_slot: SlotId) -> bool {
+    fn flatten_gen_let_binding(&mut self, var_index: VarIdx, value: &Expr, body: &Expr, input_slot: SlotId) -> bool {
         // Pre-check: can we compile the body?
         {
             let mut test = self.test_flattener();
@@ -5484,7 +5484,7 @@ impl Flattener {
 
     /// Emit optimized in-place reduce update with LetBinding wrapping.
     /// Handles `path |= f` and `path += f` (which is LetBinding { body: Update }).
-    fn emit_reduce_update_with_lets(&mut self, acc_index: u16, info: &InplaceUpdateInfo) {
+    fn emit_reduce_update_with_lets(&mut self, acc_index: VarIdx, info: &InplaceUpdateInfo) {
         // TakeVar: move acc out (refcount = 1)
         let acc = self.alloc_slot();
         self.emit(JitOp::TakeVar { dst: acc, var_index: acc_index });
@@ -5601,7 +5601,7 @@ impl Flattener {
     }
 
     /// Emit in-place assign for reduce: .[path] = val with TakeVar for zero-copy.
-    fn emit_reduce_assign(&mut self, acc_index: u16, info: &InplaceAssignInfo) {
+    fn emit_reduce_assign(&mut self, acc_index: VarIdx, info: &InplaceAssignInfo) {
         // TakeVar: move acc out (refcount = 1)
         let acc = self.alloc_slot();
         self.emit(JitOp::TakeVar { dst: acc, var_index: acc_index });
@@ -5839,7 +5839,7 @@ fn extract_simple_path(expr: &Expr) -> Option<Vec<PathComponent>> {
 struct InplaceUpdateInfo<'a> {
     /// LetBindings wrapping the Update (from += desugaring).
     /// Each entry is (var_index, value_expr).
-    let_bindings: Vec<(u16, &'a Expr)>,
+    let_bindings: Vec<(VarIdx, &'a Expr)>,
     /// Path components for the update target.
     path_components: Vec<PathComponent>,
     /// The update expression (applied to the old value at the path).
@@ -5861,7 +5861,7 @@ struct InplaceUpdateInfo<'a> {
 /// Info for in-place reduce assign optimization (.[path] = val).
 struct InplaceAssignInfo<'a> {
     /// LetBindings wrapping the Assign.
-    let_bindings: Vec<(u16, &'a Expr)>,
+    let_bindings: Vec<(VarIdx, &'a Expr)>,
     /// Path components for the assign target.
     path_components: Vec<PathComponent>,
     /// The value expression to assign.
@@ -6168,7 +6168,7 @@ enum NestedInplaceAction<'a> {
         /// restore on the way out. Comes from `(value) as $x | inner_reduce`
         /// sequences that surround the inner reduce at this layer.
         /// Each value_expr must be `is_scalar`.
-        let_bindings: Vec<(u16, &'a Expr)>,
+        let_bindings: Vec<(VarIdx, &'a Expr)>,
         /// Skip the entire layer (loop body + everything below) when cond
         /// fires. `(cond, skip_on_truthy)` matches the leaf semantics:
         /// skip_on_truthy=true skips on truthy cond (e.g.
@@ -6178,7 +6178,7 @@ enum NestedInplaceAction<'a> {
         /// Generator for this inner reduce.
         source: &'a Expr,
         /// Iteration variable of this inner reduce.
-        var_index: u16,
+        var_index: VarIdx,
         /// What the inner reduce body does on each iteration. Recursive so
         /// the fusion can span any nesting depth.
         action: Box<NestedInplaceAction<'a>>,
@@ -6195,7 +6195,7 @@ enum NestedInplaceAction<'a> {
     /// fusion it was ~1.9× slower than the unmarked `{s: .., m: ..}`
     /// object-construct shape on the same input.
     Sequence {
-        let_bindings: Vec<(u16, &'a Expr)>,
+        let_bindings: Vec<(VarIdx, &'a Expr)>,
         actions: Vec<NestedInplaceAction<'a>>,
     },
 }
@@ -6237,7 +6237,7 @@ fn detect_inplace_action(expr: &Expr) -> Option<NestedInplaceAction<'_>> {
 /// `Sequence([a_action, b_action, c_action])`.
 fn detect_inplace_sequence<'a>(
     expr: &'a Expr,
-    mut let_bindings: Vec<(u16, &'a Expr)>,
+    mut let_bindings: Vec<(VarIdx, &'a Expr)>,
 ) -> Option<NestedInplaceAction<'a>> {
     if let Expr::LetBinding { var_index, value, body } = expr {
         if !is_scalar(value) { return None; }
@@ -6276,7 +6276,7 @@ fn detect_inplace_sequence<'a>(
 /// once on this layer.
 fn detect_inner_reduce_chain<'a>(
     expr: &'a Expr,
-    mut let_bindings: Vec<(u16, &'a Expr)>,
+    mut let_bindings: Vec<(VarIdx, &'a Expr)>,
 ) -> Option<NestedInplaceAction<'a>> {
     // Peel one LetBinding (value must be scalar to be safely evaluated
     // against acc; non-scalar values would yield multiple bindings, a
@@ -9984,22 +9984,22 @@ impl JitCompiler {
                     }
                     JitOp::GetVar { dst, var_index } => {
                         let d = slot_addr(&mut b, *dst);
-                        let vi = b.ins().iconst(types::I32, *var_index as i64);
+                        let vi = b.ins().iconst(types::I32, var_index.0 as i64);
                         b.ins().call(rt["get_var"], &[d, env_ptr, vi]);
                     }
                     JitOp::SetVar { var_index, src } => {
                         let s = slot_addr(&mut b, *src);
-                        let vi = b.ins().iconst(types::I32, *var_index as i64);
+                        let vi = b.ins().iconst(types::I32, var_index.0 as i64);
                         b.ins().call(rt["set_var"], &[env_ptr, vi, s]);
                     }
                     JitOp::TakeVar { dst, var_index } => {
                         let d = slot_addr(&mut b, *dst);
-                        let vi = b.ins().iconst(types::I32, *var_index as i64);
+                        let vi = b.ins().iconst(types::I32, var_index.0 as i64);
                         b.ins().call(rt["take_var"], &[d, env_ptr, vi]);
                     }
                     JitOp::MoveToVar { var_index, src } => {
                         let s = slot_addr(&mut b, *src);
-                        let vi = b.ins().iconst(types::I32, *var_index as i64);
+                        let vi = b.ins().iconst(types::I32, var_index.0 as i64);
                         b.ins().call(rt["move_to_var"], &[env_ptr, vi, s]);
                     }
                     JitOp::PathExtract { element, container, key } => {
@@ -10629,7 +10629,7 @@ thread_local! {
 /// `Env::new` directly — they guarantee the JIT-set let-bindings are seeded so
 /// new closure ops can't silently regress.
 fn seed_eval_env_from_jit(env: &Rc<RefCell<crate::eval::Env>>, exprs: &[&Expr]) {
-    let mut indices: Vec<u16> = Vec::new();
+    let mut indices: Vec<VarIdx> = Vec::new();
     for e in exprs {
         Flattener::collect_loadvar_indices(e, &mut indices);
     }
@@ -10639,7 +10639,7 @@ fn seed_eval_env_from_jit(env: &Rc<RefCell<crate::eval::Env>>, exprs: &[&Expr]) 
         let jit_env = match jit_env_opt.as_ref() { Some(e) => e, None => return };
         let mut env_mut = env.borrow_mut();
         for idx in indices {
-            let i = idx as usize;
+            let i = idx.idx();
             if i < jit_env.vars.len() {
                 env_mut.seed_var(idx, jit_env.vars[i].clone());
             }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -12,7 +12,7 @@ use crate::ir::*;
 /// Variable scope for tracking user-defined variables and functions.
 struct Scope {
     /// Variable name → var_index mapping.
-    vars: Vec<(String, u16)>,
+    vars: Vec<(String, VarIdx)>,
     /// Function name → (func_id, nargs) mapping.
     funcs: Vec<(String, usize, usize)>,
     /// Next available var_index.
@@ -24,7 +24,7 @@ struct Scope {
     /// captured slot becomes a hidden trailing parameter, and every call site
     /// forwards `LoadVar{captured_slot}`. Parse-time only — `eval` just sees
     /// the extra args/param_vars. See #714.
-    func_captures: std::collections::HashMap<usize, Vec<u16>>,
+    func_captures: std::collections::HashMap<usize, Vec<VarIdx>>,
     /// Next available memoize slot id. Each lexical occurrence of `memoize(...)`
     /// gets a unique slot; the Env allocates one cache map per slot.
     next_memo_slot: u32,
@@ -33,7 +33,7 @@ struct Scope {
     /// could resolve to either (#766). Higher = bound later = more local.
     next_bind_seq: u32,
     /// `var_index` → binding sequence, for filter-parameter vars.
-    var_bind_seq: std::collections::HashMap<u16, u32>,
+    var_bind_seq: std::collections::HashMap<VarIdx, u32>,
     /// `func_id` → binding sequence, for user-defined functions.
     func_bind_seq: std::collections::HashMap<usize, u32>,
 }
@@ -62,7 +62,7 @@ impl Scope {
 
     /// Whether the def `func_id` is lexically more local (bound later) than the
     /// filter-parameter var `var_idx` of the same name. Innermost wins (#766).
-    fn func_shadows_param(&self, func_id: usize, var_idx: u16) -> bool {
+    fn func_shadows_param(&self, func_id: usize, var_idx: VarIdx) -> bool {
         let fs = self.func_bind_seq.get(&func_id).copied().unwrap_or(0);
         let vs = self.var_bind_seq.get(&var_idx).copied().unwrap_or(0);
         fs > vs
@@ -74,8 +74,8 @@ impl Scope {
         id
     }
 
-    fn alloc_var(&mut self, name: &str) -> u16 {
-        let idx = self.next_var;
+    fn alloc_var(&mut self, name: &str) -> VarIdx {
+        let idx = VarIdx(self.next_var);
         self.next_var += 1;
         self.vars.push((name.to_string(), idx));
         let seq = self.next_bind_seq();
@@ -83,13 +83,13 @@ impl Scope {
         idx
     }
 
-    fn lookup_var(&self, name: &str) -> Option<u16> {
+    fn lookup_var(&self, name: &str) -> Option<VarIdx> {
         self.vars.iter().rev()
             .find(|(n, _)| n == name)
             .map(|(_, idx)| *idx)
     }
 
-    fn define_func(&mut self, name: &str, nargs: usize, body: Expr, param_vars: Vec<u16>) -> usize {
+    fn define_func(&mut self, name: &str, nargs: usize, body: Expr, param_vars: Vec<VarIdx>) -> usize {
         let func_id = self.compiled_funcs.len();
         self.funcs.push((name.to_string(), func_id, nargs));
         let seq = self.next_bind_seq();
@@ -107,7 +107,7 @@ impl Scope {
     /// in the name-lookup table. Used by module loading for nested defs that
     /// must keep a slot for runtime FuncCall dispatch but should not be
     /// callable by name from outside their parent.
-    fn define_anon_func(&mut self, nargs: usize, body: Expr, param_vars: Vec<u16>) -> usize {
+    fn define_anon_func(&mut self, nargs: usize, body: Expr, param_vars: Vec<VarIdx>) -> usize {
         let func_id = self.compiled_funcs.len();
         self.compiled_funcs.push(CompiledFunc {
             name: None,
@@ -118,7 +118,7 @@ impl Scope {
         func_id
     }
 
-    fn update_func_body(&mut self, func_id: usize, body: Expr, param_vars: Vec<u16>) {
+    fn update_func_body(&mut self, func_id: usize, body: Expr, param_vars: Vec<VarIdx>) {
         if let Some(f) = self.compiled_funcs.get_mut(func_id) {
             f.body = body;
             f.param_vars = param_vars;
@@ -132,7 +132,7 @@ impl Scope {
     }
 
     /// Record the captured outer filter-param slots for a lambda-lifted func.
-    fn set_func_captures(&mut self, func_id: usize, captures: Vec<u16>) {
+    fn set_func_captures(&mut self, func_id: usize, captures: Vec<VarIdx>) {
         if !captures.is_empty() {
             self.func_captures.insert(func_id, captures);
         }
@@ -826,7 +826,7 @@ pub struct Parser {
     /// resolves to the built-in environment (`Expr::Env`) only while this is the
     /// innermost binding of the name; a user `. as $ENV` (or `{$ENV}` pattern)
     /// allocates a deeper binding that shadows it, matching jq. See #886.
-    env_var_idx: u16,
+    env_var_idx: VarIdx,
     lib_dirs: Vec<String>,
     /// Source file these tokens came from, reported by `$__loc__.file`. The
     /// top-level program parser uses `"<top-level>"`; a module parser uses the
@@ -873,7 +873,7 @@ impl Parser {
             token_lines,
             pos: 0,
             scope: Scope::new(),
-            env_var_idx: 0,
+            env_var_idx: VarIdx(0),
             lib_dirs: lib_dirs.to_vec(),
             source_file: "<top-level>".to_string(),
             current_func: None,
@@ -1043,7 +1043,7 @@ impl Parser {
         }
 
         // Collect all top-level imports/includes and defs
-        let mut import_bindings: Vec<(u16, Expr)> = Vec::new();
+        let mut import_bindings: Vec<(VarIdx, Expr)> = Vec::new();
         loop {
             if self.at(&Token::Def) {
                 self.parse_funcdef()?;
@@ -1124,7 +1124,7 @@ impl Parser {
         // Allocate variables for parameters
         // Filter params use a special prefix to avoid collision with $vars of the same name
         let mut param_vars = Vec::new();
-        let mut value_param_bindings: Vec<(u16, u16)> = Vec::new(); // (filter_var, value_var)
+        let mut value_param_bindings: Vec<(VarIdx, VarIdx)> = Vec::new(); // (filter_var, value_var)
         for (p, is_value) in &params {
             let fparam_name = format!("\x00fparam:{}", p);
             let filter_idx = self.scope.alloc_var(&fparam_name);
@@ -1174,7 +1174,7 @@ impl Parser {
         // Value params and let-bindings already work via the env, so only
         // `\x00fparam:`-prefixed (filter) params from the enclosing scope need
         // this.
-        let mut captured: Vec<u16> = Vec::new();
+        let mut captured: Vec<VarIdx> = Vec::new();
         for (vname, vidx) in self.scope.vars[..saved_vars].iter() {
             if vname.starts_with('\x00')
                 && vname.starts_with("\x00fparam:")
@@ -1187,7 +1187,7 @@ impl Parser {
         }
         let mut param_vars = param_vars;
         if !captured.is_empty() {
-            let hidden: Vec<u16> = captured.iter()
+            let hidden: Vec<VarIdx> = captured.iter()
                 .map(|c| self.scope.alloc_var(&format!("\x00fparam:cap:{}", c)))
                 .collect();
             let hidden_loadvars: Vec<Expr> = hidden.iter()
@@ -1209,7 +1209,7 @@ impl Parser {
 
     /// Parse `import "path" as alias;` or `import "path" as $var;`
     /// Returns Some((var_index, value_expr)) for data imports, None for code imports.
-    fn parse_import(&mut self) -> Result<Option<(u16, Expr)>> {
+    fn parse_import(&mut self) -> Result<Option<(VarIdx, Expr)>> {
         self.advance(); // import
 
         // Get module path
@@ -1469,7 +1469,7 @@ impl Parser {
         }
 
         // Parse imports and defs in the module, collecting data import bindings
-        let mut data_bindings: Vec<(u16, Expr)> = Vec::new();
+        let mut data_bindings: Vec<(VarIdx, Expr)> = Vec::new();
         loop {
             if mod_parser.at(&Token::Def) {
                 mod_parser.parse_funcdef()?;
@@ -1612,7 +1612,7 @@ impl Parser {
         // they don't leak into outer lookups (#499).
         let saved_vars = self.scope.vars.len();
         // Allocate once for shared variables
-        let mut var_map: std::collections::HashMap<String, u16> = std::collections::HashMap::new();
+        let mut var_map: std::collections::HashMap<String, VarIdx> = std::collections::HashMap::new();
         for name in &unique_vars {
             let idx = self.scope.alloc_var(name);
             var_map.insert(name.clone(), idx);
@@ -1637,7 +1637,7 @@ impl Parser {
     /// chain. All alternatives bind the same set of names, so each unique name
     /// gets one slot (jq requires the alternatives to agree on variables). The
     /// caller is responsible for snapshotting/truncating `scope.vars`.
-    fn alloc_alt_destructure_vars(&mut self, alt_patterns: &[Pattern]) -> std::collections::HashMap<String, u16> {
+    fn alloc_alt_destructure_vars(&mut self, alt_patterns: &[Pattern]) -> std::collections::HashMap<String, VarIdx> {
         let mut var_names: Vec<String> = Vec::new();
         for pat in alt_patterns {
             self.collect_pattern_var_names(pat, &mut var_names);
@@ -1661,7 +1661,7 @@ impl Parser {
         &mut self,
         value_expr: &Expr,
         alt_patterns: &[Pattern],
-        var_map: &std::collections::HashMap<String, u16>,
+        var_map: &std::collections::HashMap<String, VarIdx>,
         body: &Expr,
     ) -> Result<Expr> {
         // jq applies `?//` *per source value*: for each value of `value_expr`
@@ -1735,7 +1735,7 @@ impl Parser {
         }
     }
 
-    fn build_binding_with_varmap(&mut self, value_expr: Expr, pattern: &Pattern, var_map: &std::collections::HashMap<String, u16>, body: Expr) -> Result<Expr> {
+    fn build_binding_with_varmap(&mut self, value_expr: Expr, pattern: &Pattern, var_map: &std::collections::HashMap<String, VarIdx>, body: Expr) -> Result<Expr> {
         match pattern {
             Pattern::Var(name) => {
                 let var_idx = var_map[name];
@@ -1777,7 +1777,7 @@ impl Parser {
         }
     }
 
-    fn build_array_destructure_varmap(&mut self, value: Expr, pats: &[Pattern], var_map: &std::collections::HashMap<String, u16>, body: Expr) -> Result<Expr> {
+    fn build_array_destructure_varmap(&mut self, value: Expr, pats: &[Pattern], var_map: &std::collections::HashMap<String, VarIdx>, body: Expr) -> Result<Expr> {
         let mut result = body;
         for (i, pat) in pats.iter().enumerate().rev() {
             let elem_expr = Expr::Index {
@@ -1789,7 +1789,7 @@ impl Parser {
         Ok(result)
     }
 
-    fn build_object_destructure_varmap(&mut self, value: Expr, pats: &[(Expr, Pattern)], var_map: &std::collections::HashMap<String, u16>, body: Expr) -> Result<Expr> {
+    fn build_object_destructure_varmap(&mut self, value: Expr, pats: &[(Expr, Pattern)], var_map: &std::collections::HashMap<String, VarIdx>, body: Expr) -> Result<Expr> {
         let mut result = body;
         for (key, pat) in pats.iter().rev() {
             let field_expr = obj_pat_field_expr(value.clone(), key.clone());
@@ -1798,7 +1798,7 @@ impl Parser {
         Ok(result)
     }
 
-    fn build_pattern_binding_varmap(&mut self, pat: &Pattern, value: Expr, var_map: &std::collections::HashMap<String, u16>, body: Expr) -> Result<Expr> {
+    fn build_pattern_binding_varmap(&mut self, pat: &Pattern, value: Expr, var_map: &std::collections::HashMap<String, VarIdx>, body: Expr) -> Result<Expr> {
         match pat {
             Pattern::Var(name) => {
                 let var_idx = var_map[name];
@@ -1840,7 +1840,7 @@ impl Parser {
         }
     }
 
-    fn build_binding(&mut self, value_expr: Expr, pattern: Pattern, allocs: Vec<u16>, body: Expr) -> Result<Expr> {
+    fn build_binding(&mut self, value_expr: Expr, pattern: Pattern, allocs: Vec<VarIdx>, body: Expr) -> Result<Expr> {
         match pattern {
             Pattern::Var(_name) => {
                 let var_idx = allocs[0];
@@ -1882,16 +1882,16 @@ impl Parser {
     }
 
     /// Pre-allocate all variables from a pattern before parsing the body.
-    fn alloc_pattern_vars(&mut self, pattern: &Pattern) -> Vec<u16> {
+    fn alloc_pattern_vars(&mut self, pattern: &Pattern) -> Vec<VarIdx> {
         // For repeated names within a single pattern, share the same slot —
         // necessary so object-pattern first-wins (#206) and array-pattern
         // last-wins land on the right binding without false aliasing across
         // separate names.
-        let mut seen: std::collections::HashMap<String, u16> = std::collections::HashMap::new();
+        let mut seen: std::collections::HashMap<String, VarIdx> = std::collections::HashMap::new();
         self.alloc_pattern_vars_inner(pattern, &mut seen)
     }
 
-    fn alloc_pattern_vars_inner(&mut self, pattern: &Pattern, seen: &mut std::collections::HashMap<String, u16>) -> Vec<u16> {
+    fn alloc_pattern_vars_inner(&mut self, pattern: &Pattern, seen: &mut std::collections::HashMap<String, VarIdx>) -> Vec<VarIdx> {
         match pattern {
             Pattern::Var(name) => {
                 let idx = if let Some(&existing) = seen.get(name) {
@@ -2045,7 +2045,7 @@ impl Parser {
         }
     }
 
-    fn build_array_destructure(&mut self, value: Expr, pats: &[Pattern], allocs: &[u16], body: Expr) -> Result<Expr> {
+    fn build_array_destructure(&mut self, value: Expr, pats: &[Pattern], allocs: &[VarIdx], body: Expr) -> Result<Expr> {
         let mut result = body;
         let mut alloc_idx = allocs.len();
         for (i, pat) in pats.iter().enumerate().rev() {
@@ -2060,7 +2060,7 @@ impl Parser {
         Ok(result)
     }
 
-    fn build_object_destructure(&mut self, value: Expr, pats: &[(Expr, Pattern)], allocs: &[u16], body: Expr) -> Result<Expr> {
+    fn build_object_destructure(&mut self, value: Expr, pats: &[(Expr, Pattern)], allocs: &[VarIdx], body: Expr) -> Result<Expr> {
         // jq's object-pattern destructure is first-wins for repeated variable
         // names in the same pattern (#206). With slot dedup in
         // `alloc_pattern_vars`, all references to `$a` map to one idx — so a
@@ -2074,7 +2074,7 @@ impl Parser {
             acc += self.count_pattern_vars(pat);
         }
         let mut keep: Vec<bool> = vec![false; pats.len()];
-        let mut bound: std::collections::HashSet<u16> = std::collections::HashSet::new();
+        let mut bound: std::collections::HashSet<VarIdx> = std::collections::HashSet::new();
         for (i, (_, pat)) in pats.iter().enumerate() {
             let count = self.count_pattern_vars(pat);
             let pair_allocs = &allocs[pair_offsets[i]..pair_offsets[i]+count];
@@ -2101,7 +2101,7 @@ impl Parser {
     }
 
     /// Recursively build bindings for a pattern. Handles nested arrays and objects.
-    fn build_pattern_binding(&mut self, pat: &Pattern, value: Expr, allocs: &[u16], body: Expr) -> Result<Expr> {
+    fn build_pattern_binding(&mut self, pat: &Pattern, value: Expr, allocs: &[VarIdx], body: Expr) -> Result<Expr> {
         match pat {
             Pattern::Var(_) => {
                 Ok(Expr::LetBinding {
@@ -3660,7 +3660,7 @@ impl Parser {
     /// produced key is then set to `$x` (last-write-wins across the fan-out).
     /// The earlier `. + {($x|f|tostring): $x}` object-merge collapsed a
     /// multi-output index expression to only its last key. See #883.
-    fn index_reduce(stream: Expr, f: Expr, x_var: u16, acc_var: u16) -> Expr {
+    fn index_reduce(stream: Expr, f: Expr, x_var: VarIdx, acc_var: VarIdx) -> Expr {
         let key = Expr::Pipe {
             left: Box::new(Expr::LoadVar { var_index: x_var }),
             right: Box::new(Expr::Pipe {


### PR DESCRIPTION
## Summary

First half of #1033. Variable slot indices were bare `u16` everywhere, so a variable index could silently be mixed with function ids, label ids, or any other small integer between the parser, eval `Env`, substitution caches, and JIT codegen — such a mix-up compiles fine and corrupts behavior at runtime.

This PR introduces `VarIdx(pub u16)` in ir.rs and threads it through all layers. The raw `u16` is extracted only at the Cranelift immediate boundary (`iconst`), per the doc contract on the type. `FuncId` is intentionally left for a follow-up PR to keep this one reviewable.

## Changes

- `Expr` variants (`LetBinding`/`LoadVar`/`Reduce`/`Foreach`/`Label`/`Break`) and `CompiledFunc::param_vars` carry `VarIdx`
- Parser scope tables (`vars`, `var_bind_seq`, `func_captures`, pattern var maps); `alloc_var` mints `VarIdx` from the raw counter
- eval `Env` API (`get/set/seed/ensure_var`), closures, subst caches, path-tracking thread-locals, `substitute_params`/rename maps
- JIT op IR (`GetVar`/`SetVar`/`TakeVar`/`MoveToVar`, `let_bindings`, f64 fast-path var maps)
- Allocation counters stay raw `u16`, preserving the documented wrap-around behavior (eval.rs Sudoku overflow case)

All changes are mechanical type threading; no behavior change.

## Verification

- `cargo build --release`: zero warnings
- `cargo test --release`: 614 passed, 0 failed (official 509, regression, differential, fuzz, selfdiff, contracts)
- `./bench/comprehensive.sh`: 8/220 entries showed >5% vs the v1.8.2 history column, but same-machine A/B interleave (best-of-7, main vs branch) on the worst offenders shows no real regression — the history deltas are cross-day noise:

| benchmark | main | varidx | ratio |
|---|---|---|---|
| reduce (sum) | 0.010s | 0.010s | 0.98 |
| reduce (product) | 0.036s | 0.036s | 1.00 |
| split\|rev\|join | 0.131s | 0.129s | 0.99 |
| if>.y .name\|empty | 0.136s | 0.137s | 1.01 |

The wrapper is repr-identical to `u16` with `#[inline(always)]` accessors, so identical codegen is expected.

Refs #1033 (FuncId follow-up still pending; the issue stays open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)