### PR TITLE
refactor(ir): introduce FuncId newtype for compiled-function ids

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -274,13 +274,13 @@ pub struct Env {
     /// Used to avoid deep-cloning function bodies via substitute_params.
     closures: Vec<(VarIdx, Expr)>,
     /// Cache for is_recursive check per func_id.
-    recursive_cache: Vec<(usize, bool)>,
+    recursive_cache: Vec<(FuncId, bool)>,
     /// Cache for substituted function bodies: (func_id, arg_var_indices) → substituted body.
     /// Only used when all args are LoadVar (the common case).
-    subst_cache: Vec<((usize, Vec<VarIdx>), Rc<Expr>)>,
+    subst_cache: Vec<((FuncId, Vec<VarIdx>), Rc<Expr>)>,
     /// Pointer-based substitution cache: func_id → (args_ptr, substituted_body).
     /// For non-LoadVar args from stable (cached) call sites.
-    subst_ptr_cache: Vec<(usize, usize, Rc<Expr>)>,
+    subst_ptr_cache: Vec<(FuncId, usize, Rc<Expr>)>,
     /// One cache map per lexical `memoize(...)` occurrence in the program,
     /// plus the per-slot entry cap. `None` for programs that don't use
     /// `memoize(...)` so the Env stays small. Lifetime is the whole program
@@ -511,7 +511,7 @@ fn subst_inner(
 /// def's hidden capture parameters through the def's own recursive self-calls,
 /// which were emitted (as zero-arg calls) before the captures were known.
 /// Exhaustive (no catch-all) so a new `Expr` variant forces review. See #714.
-pub(crate) fn append_call_args(expr: &Expr, target: usize, extra: &[Expr]) -> Expr {
+pub(crate) fn append_call_args(expr: &Expr, target: FuncId, extra: &[Expr]) -> Expr {
     macro_rules! r { ($e:expr) => { append_call_args($e, target, extra) } }
     macro_rules! rb { ($e:expr) => { Box::new(r!($e)) } }
     match expr {
@@ -961,7 +961,7 @@ fn subst_cow(expr: &Expr, pv: &[VarIdx], args: &[Expr]) -> Option<Expr> {
 }
 
 /// Check if an expression contains a FuncCall to the given func_id (direct recursion check).
-fn contains_func_call(expr: &Expr, target: usize) -> bool {
+fn contains_func_call(expr: &Expr, target: FuncId) -> bool {
     macro_rules! c { ($e:expr) => { contains_func_call($e, target) } }
     match expr {
         Expr::FuncCall { func_id, args } => *func_id == target || args.iter().any(|a| c!(a)),
@@ -1179,7 +1179,7 @@ pub(crate) fn expr_uses_var(expr: &Expr, target: VarIdx) -> bool {
 /// `out` (one level deep — the caller follows callees transitively). Exhaustive
 /// over `Expr` so a call buried in any sub-expression is found, which is what
 /// makes the #765 reachability check sound. Mirrors `expr_uses_var`'s structure.
-pub(crate) fn collect_func_calls(expr: &Expr, out: &mut Vec<usize>) {
+pub(crate) fn collect_func_calls(expr: &Expr, out: &mut Vec<FuncId>) {
     match expr {
         Expr::Input | Expr::Empty | Expr::Not | Expr::Env | Expr::Builtins
         | Expr::ReadInput | Expr::ReadInputs | Expr::ModuleMeta | Expr::GenLabel
@@ -1592,7 +1592,7 @@ fn eval_one(expr: &Expr, input: &Value, env: &EnvRef) -> std::result::Result<Val
         }
         Expr::FuncCall { func_id, args } => {
             if !args.is_empty() { return Err(()); }
-            let func = env.borrow().funcs.get(*func_id).cloned();
+            let func = env.borrow().funcs.get(func_id.idx()).cloned();
             if let Some(f) = func {
                 eval_one(&f.body, input, env)
             } else {
@@ -1654,7 +1654,7 @@ struct LinearRecursiveGen<'a> {
 /// Pattern: `if cond then pre, (transform | self), post else else_branch end`
 /// where cond, pre, transform, post, else_branch are all scalar (no generators).
 /// Handles both left-associated and right-associated Comma nesting.
-fn detect_linear_recursive_gen(body: &Expr, func_id: usize) -> Option<LinearRecursiveGen<'_>> {
+fn detect_linear_recursive_gen(body: &Expr, func_id: FuncId) -> Option<LinearRecursiveGen<'_>> {
     let (cond, then_branch, else_branch) = match body {
         Expr::IfThenElse { cond, then_branch, else_branch } => (cond.as_ref(), then_branch.as_ref(), else_branch.as_ref()),
         _ => return None,
@@ -1687,7 +1687,7 @@ fn detect_linear_recursive_gen(body: &Expr, func_id: usize) -> Option<LinearRecu
 }
 
 /// Extract the transform expression from Pipe { transform, FuncCall(func_id, []) }.
-fn extract_recursive_pipe(expr: &Expr, func_id: usize) -> Option<&Expr> {
+fn extract_recursive_pipe(expr: &Expr, func_id: FuncId) -> Option<&Expr> {
     if let Expr::Pipe { left, right } = expr {
         if let Expr::FuncCall { func_id: fid, args } = right.as_ref() {
             if *fid == func_id && args.is_empty() {
@@ -3399,7 +3399,7 @@ pub fn eval(
         Expr::FuncCall { func_id, args } => {
             // Consolidated function call: single env borrow for func lookup + recursive check + cache hit
             enum FuncAction {
-                Direct(Rc<CompiledFunc>, usize),
+                Direct(Rc<CompiledFunc>, FuncId),
                 Recursive(Rc<CompiledFunc>),
                 CacheHit(Rc<Expr>),
                 CacheMiss(Rc<CompiledFunc>),
@@ -3415,7 +3415,7 @@ pub fn eval(
             let arg_recursive = args.iter().any(|a| contains_func_call(a, *func_id));
             let action = {
                 let e = env.borrow();
-                let func = match e.funcs.get(*func_id) {
+                let func = match e.funcs.get(func_id.idx()) {
                     Some(f) => f.clone(),
                     None => bail!("undefined function id {}", func_id),
                 };
@@ -6006,7 +6006,7 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
             })
         }
         Expr::FuncCall { func_id, args } => {
-            let func = env.borrow().funcs.get(*func_id).cloned();
+            let func = env.borrow().funcs.get(func_id.idx()).cloned();
             let f = match func {
                 Some(f) => f,
                 None => bail!("undefined function id {}", func_id),

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -2692,7 +2692,7 @@ impl Filter {
         // hides the stream read behind the call, and without descending we'd
         // report no-inputs and skip seeding the queue (#853). `visited` guards
         // against recursive/mutually-recursive defs.
-        fn walk(e: &Expr, funcs: &[crate::ir::CompiledFunc], visited: &mut Vec<usize>) -> bool {
+        fn walk(e: &Expr, funcs: &[crate::ir::CompiledFunc], visited: &mut Vec<crate::ir::FuncId>) -> bool {
             macro_rules! walk { ($x:expr) => { walk($x, funcs, visited) }; }
             match e {
                 Expr::ReadInput | Expr::ReadInputs => true,
@@ -2760,7 +2760,7 @@ impl Filter {
                     if args.iter().any(|a| walk!(a)) { return true; }
                     if visited.contains(func_id) { return false; }
                     visited.push(*func_id);
-                    funcs.get(*func_id).map_or(false, |f| walk(&f.body, funcs, visited))
+                    funcs.get(func_id.idx()).map_or(false, |f| walk(&f.body, funcs, visited))
                 }
                 _ => false,
             }

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -28,6 +28,28 @@ impl std::fmt::Display for VarIdx {
     }
 }
 
+/// Id of a compiled function (slot in the `CompiledFunc` table).
+///
+/// Companion of [`VarIdx`] (#1033): keeps the function-id domain from being
+/// mixed with variable slots or other integer domains. The raw id stays
+/// public so table-slot minting stays local (`FuncId(table.len())`).
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct FuncId(pub usize);
+
+impl FuncId {
+    /// Table position for direct slice/`Vec` indexing.
+    #[inline(always)]
+    pub const fn idx(self) -> usize {
+        self.0
+    }
+}
+
+impl std::fmt::Display for FuncId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
 /// A filter expression in the IR.
 #[derive(Debug, Clone)]
 pub enum Expr {
@@ -238,7 +260,7 @@ pub enum Expr {
 
     /// User-defined function call
     FuncCall {
-        func_id: usize,
+        func_id: FuncId,
         args: Vec<Expr>,
     },
 

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -541,7 +541,7 @@ struct Flattener {
     /// Closure ops: key expressions for sort_by/group_by/etc.
     closure_ops: Vec<Expr>,
     /// Track which functions are currently being expanded (cycle detection)
-    expanding_funcs: HashSet<usize>,
+    expanding_funcs: HashSet<crate::ir::FuncId>,
     /// Pre-allocated Value constants for fused ops (hoisted out of per-call code).
     #[allow(clippy::vec_box)]
     value_constants: Vec<Box<Value>>,
@@ -620,12 +620,12 @@ impl Flattener {
     fn inline_func_calls(&mut self, expr: &Expr) -> Expr {
         match expr {
             Expr::FuncCall { func_id, args } => {
-                if *func_id >= self.funcs.len() { return expr.clone(); }
+                if func_id.idx() >= self.funcs.len() { return expr.clone(); }
                 if self.expanding_funcs.contains(func_id) {
                     self.has_unresolved_recursion = true;
                     return expr.clone();
                 }
-                let func = self.funcs[*func_id].clone();
+                let func = self.funcs[func_id.idx()].clone();
                 let body = if !func.param_vars.is_empty() && !args.is_empty() {
                     crate::eval::substitute_params(&func.body, &func.param_vars, args)
                 } else {
@@ -2211,9 +2211,9 @@ impl Flattener {
                 self.emit(JitOp::Label { id: end_lbl });
                 out
             }
-            Expr::FuncCall { func_id, args } if *func_id < self.funcs.len() && !self.expanding_funcs.contains(func_id) => {
+            Expr::FuncCall { func_id, args } if func_id.idx() < self.funcs.len() && !self.expanding_funcs.contains(func_id) => {
                 self.expanding_funcs.insert(*func_id);
-                let func = &self.funcs[*func_id].clone();
+                let func = &self.funcs[func_id.idx()].clone();
                 let body = if !func.param_vars.is_empty() && !args.is_empty() {
                     crate::eval::substitute_params(&func.body, &func.param_vars, args)
                 } else {
@@ -3386,11 +3386,11 @@ impl Flattener {
             }
 
             Expr::FuncCall { func_id, args } => {
-                if *func_id >= self.funcs.len() { return false; }
+                if func_id.idx() >= self.funcs.len() { return false; }
                 // Detect recursive function calls — not JIT-compilable
                 if self.expanding_funcs.contains(func_id) { return false; }
                 self.expanding_funcs.insert(*func_id);
-                let func = &self.funcs[*func_id].clone();
+                let func = &self.funcs[func_id.idx()].clone();
                 let body = if !func.param_vars.is_empty() && !args.is_empty() {
                     crate::eval::substitute_params(&func.body, &func.param_vars, args)
                 } else {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -14,7 +14,7 @@ struct Scope {
     /// Variable name → var_index mapping.
     vars: Vec<(String, VarIdx)>,
     /// Function name → (func_id, nargs) mapping.
-    funcs: Vec<(String, usize, usize)>,
+    funcs: Vec<(String, FuncId, usize)>,
     /// Next available var_index.
     next_var: u16,
     /// Compiled function bodies.
@@ -24,7 +24,7 @@ struct Scope {
     /// captured slot becomes a hidden trailing parameter, and every call site
     /// forwards `LoadVar{captured_slot}`. Parse-time only — `eval` just sees
     /// the extra args/param_vars. See #714.
-    func_captures: std::collections::HashMap<usize, Vec<VarIdx>>,
+    func_captures: std::collections::HashMap<FuncId, Vec<VarIdx>>,
     /// Next available memoize slot id. Each lexical occurrence of `memoize(...)`
     /// gets a unique slot; the Env allocates one cache map per slot.
     next_memo_slot: u32,
@@ -35,7 +35,7 @@ struct Scope {
     /// `var_index` → binding sequence, for filter-parameter vars.
     var_bind_seq: std::collections::HashMap<VarIdx, u32>,
     /// `func_id` → binding sequence, for user-defined functions.
-    func_bind_seq: std::collections::HashMap<usize, u32>,
+    func_bind_seq: std::collections::HashMap<FuncId, u32>,
 }
 
 impl Scope {
@@ -62,7 +62,7 @@ impl Scope {
 
     /// Whether the def `func_id` is lexically more local (bound later) than the
     /// filter-parameter var `var_idx` of the same name. Innermost wins (#766).
-    fn func_shadows_param(&self, func_id: usize, var_idx: VarIdx) -> bool {
+    fn func_shadows_param(&self, func_id: FuncId, var_idx: VarIdx) -> bool {
         let fs = self.func_bind_seq.get(&func_id).copied().unwrap_or(0);
         let vs = self.var_bind_seq.get(&var_idx).copied().unwrap_or(0);
         fs > vs
@@ -89,8 +89,8 @@ impl Scope {
             .map(|(_, idx)| *idx)
     }
 
-    fn define_func(&mut self, name: &str, nargs: usize, body: Expr, param_vars: Vec<VarIdx>) -> usize {
-        let func_id = self.compiled_funcs.len();
+    fn define_func(&mut self, name: &str, nargs: usize, body: Expr, param_vars: Vec<VarIdx>) -> FuncId {
+        let func_id = FuncId(self.compiled_funcs.len());
         self.funcs.push((name.to_string(), func_id, nargs));
         let seq = self.next_bind_seq();
         self.func_bind_seq.insert(func_id, seq);
@@ -107,8 +107,8 @@ impl Scope {
     /// in the name-lookup table. Used by module loading for nested defs that
     /// must keep a slot for runtime FuncCall dispatch but should not be
     /// callable by name from outside their parent.
-    fn define_anon_func(&mut self, nargs: usize, body: Expr, param_vars: Vec<VarIdx>) -> usize {
-        let func_id = self.compiled_funcs.len();
+    fn define_anon_func(&mut self, nargs: usize, body: Expr, param_vars: Vec<VarIdx>) -> FuncId {
+        let func_id = FuncId(self.compiled_funcs.len());
         self.compiled_funcs.push(CompiledFunc {
             name: None,
             nargs,
@@ -118,21 +118,21 @@ impl Scope {
         func_id
     }
 
-    fn update_func_body(&mut self, func_id: usize, body: Expr, param_vars: Vec<VarIdx>) {
-        if let Some(f) = self.compiled_funcs.get_mut(func_id) {
+    fn update_func_body(&mut self, func_id: FuncId, body: Expr, param_vars: Vec<VarIdx>) {
+        if let Some(f) = self.compiled_funcs.get_mut(func_id.idx()) {
             f.body = body;
             f.param_vars = param_vars;
         }
     }
 
-    fn lookup_func(&self, name: &str, nargs: usize) -> Option<usize> {
+    fn lookup_func(&self, name: &str, nargs: usize) -> Option<FuncId> {
         self.funcs.iter().rev()
             .find(|(n, _, na)| n == name && *na == nargs)
             .map(|(_, id, _)| *id)
     }
 
     /// Record the captured outer filter-param slots for a lambda-lifted func.
-    fn set_func_captures(&mut self, func_id: usize, captures: Vec<VarIdx>) {
+    fn set_func_captures(&mut self, func_id: FuncId, captures: Vec<VarIdx>) {
         if !captures.is_empty() {
             self.func_captures.insert(func_id, captures);
         }
@@ -140,7 +140,7 @@ impl Scope {
 
     /// Trailing capture args (`LoadVar{slot}` per captured slot) a call to
     /// `func_id` must forward, in declared order. Empty for ordinary funcs.
-    fn func_capture_args(&self, func_id: usize) -> Vec<Expr> {
+    fn func_capture_args(&self, func_id: FuncId) -> Vec<Expr> {
         self.func_captures.get(&func_id)
             .map(|caps| caps.iter().map(|&v| Expr::LoadVar { var_index: v }).collect())
             .unwrap_or_default()
@@ -149,7 +149,7 @@ impl Scope {
     /// Build a `FuncCall`, appending any lambda-lifted capture args after the
     /// caller-supplied `args` (#714). Use at every call-emission site so
     /// captures are forwarded uniformly.
-    fn make_funccall(&self, func_id: usize, mut args: Vec<Expr>) -> Expr {
+    fn make_funccall(&self, func_id: FuncId, mut args: Vec<Expr>) -> Expr {
         args.extend(self.func_capture_args(func_id));
         Expr::FuncCall { func_id, args }
     }
@@ -836,18 +836,18 @@ pub struct Parser {
     /// The `compiled_funcs` id of the function body currently being parsed, or
     /// `None` at the top level. Used to attribute a deferred unbound-variable
     /// reference to its enclosing def. #765
-    current_func: Option<usize>,
+    current_func: Option<FuncId>,
     /// Unbound `$var` references parked instead of erroring eagerly, as
     /// `(enclosing_func_id, name)`. After the whole program is parsed, only
     /// those reachable from the top-level expression (top-level refs, plus refs
     /// inside transitively-called defs) are errors — jq never compiles the body
     /// of an uncalled def. #765
-    deferred_unbound: Vec<(Option<usize>, String)>,
+    deferred_unbound: Vec<(Option<FuncId>, String)>,
     /// Unknown function/builtin references parked instead of erroring eagerly,
     /// as `(enclosing_func_id, name, nargs)`. Same reachability rule as
     /// `deferred_unbound`: jq resolves function names lazily, so an undefined
     /// name in the body of an uncalled def is not an error. #807
-    deferred_unknown_func: Vec<(Option<usize>, String, usize)>,
+    deferred_unknown_func: Vec<(Option<FuncId>, String, usize)>,
 }
 
 /// Result of parsing: expression + compiled functions.
@@ -955,17 +955,17 @@ impl Parser {
         if self.deferred_unbound.is_empty() && self.deferred_unknown_func.is_empty() {
             return Ok(());
         }
-        let mut reachable: std::collections::HashSet<usize> = std::collections::HashSet::new();
-        let mut stack: Vec<usize> = Vec::new();
+        let mut reachable: std::collections::HashSet<FuncId> = std::collections::HashSet::new();
+        let mut stack: Vec<FuncId> = Vec::new();
         crate::eval::collect_func_calls(program, &mut stack);
         while let Some(fid) = stack.pop() {
             if reachable.insert(fid) {
-                if let Some(f) = self.scope.compiled_funcs.get(fid) {
+                if let Some(f) = self.scope.compiled_funcs.get(fid.idx()) {
                     crate::eval::collect_func_calls(&f.body, &mut stack);
                 }
             }
         }
-        let is_reachable = |fid: &Option<usize>| match fid {
+        let is_reachable = |fid: &Option<FuncId>| match fid {
             None => true, // top-level reference
             Some(id) => reachable.contains(id),
         };
@@ -1498,8 +1498,9 @@ impl Parser {
         // (#638). Without this, a nested recursive `def g` inside a module's
         // exported `def f` triggered "undefined function id" at the recursive
         // self-call site.
-        let mut func_id_map: Vec<(usize, usize)> = Vec::new(); // (old, new)
+        let mut func_id_map: Vec<(FuncId, FuncId)> = Vec::new(); // (old, new)
         for (mod_func_id, mod_func) in mod_parser.scope.compiled_funcs.iter().enumerate() {
+            let mod_func_id = FuncId(mod_func_id);
             let top_level_name = mod_parser.scope.funcs.iter()
                 .find(|(_, fid, _)| *fid == mod_func_id)
                 .map(|(name, _, _)| name.clone());
@@ -1514,7 +1515,7 @@ impl Parser {
 
         // Second pass: remap func_ids in bodies and install them
         for (mod_func_id, new_func_id) in &func_id_map {
-            let func = mod_parser.scope.compiled_funcs[*mod_func_id].clone();
+            let func = mod_parser.scope.compiled_funcs[mod_func_id.idx()].clone();
             let mut body = remap_func_ids(func.body, &func_id_map);
             // Wrap function body with data import bindings (in reverse order)
             for (var_idx, value_expr) in data_bindings.iter().rev() {
@@ -4648,7 +4649,7 @@ fn wrap_mutate(body: Expr) -> Result<Expr> {
 }
 
 /// Remap FuncCall func_ids in an expression tree using a mapping table.
-fn remap_func_ids(expr: Expr, map: &[(usize, usize)]) -> Expr {
+fn remap_func_ids(expr: Expr, map: &[(FuncId, FuncId)]) -> Expr {
     match expr {
         Expr::FuncCall { func_id, args } => {
             let new_id = map.iter().find(|(old, _)| *old == func_id).map(|(_, new)| *new).unwrap_or(func_id);


### PR DESCRIPTION
## Summary

Second half of #1033, companion to #1039 (VarIdx). Compiled-function ids were bare `usize` through `Expr::FuncCall`, parser scope tables, eval's recursion/substitution caches, and the JIT inline-expansion guard. With `VarIdx` and `FuncId` both nominal, the two index domains that previously coexisted as raw integers in the same structures (e.g. `subst_cache: Vec<((usize, Vec<u16>), …)>`) can no longer be swapped silently.

## Changes

- `FuncId(pub usize)` in ir.rs with `idx()` accessor and `Display`, same pattern as `VarIdx`
- `Expr::FuncCall { func_id: FuncId, … }`; parser scope tables (`funcs`, `func_bind_seq`, `func_captures`, `current_func`, deferred unbound/unknown tracking, module func-id remapping) carry `FuncId`
- eval: `recursive_cache` / `subst_cache` / `subst_ptr_cache` keys, `FuncAction::Direct`, `contains_func_call` / `collect_func_calls` / `append_call_args`
- JIT inline-expansion guard is `HashSet<crate::ir::FuncId>` — written fully qualified because jit.rs imports `cranelift_module::FuncId` under the same name
- Ids are minted only at `define_func`/`define_anon_func`; raw extraction only via `FuncId::idx()` for table indexing

Mechanical type threading; no behavior change.

## Verification

- `cargo build --release`: zero warnings
- `cargo test --release`: 614 passed, 0 failed
- Same-machine A/B interleave (best-of-7) on FuncCall-dispatch-heavy workloads — no regression:

| workload | main | funcid | ratio |
|---|---|---|---|
| recursive fib (24) | 0.007s | 0.007s | 0.98 |
| def call chain ×200k | 0.015s | 0.015s | 1.00 |
| memoized collatz 10k | 0.019s | 0.020s | 1.01 |

Refs #1033 (remaining: ArrayIndex checked constructor for f64-to-index casts — final part of the issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
