### PR TITLE
refactor(value): centralize array read-index resolution, fix JIT getpath NaN gap

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -4336,10 +4336,9 @@ pub fn eval_index(base: &Value, key: &Value, optional: bool) -> std::result::Res
     match (base, key) {
         (Value::Obj(ObjInner(o)), Value::Str(k)) => Ok(o.get(k.as_str()).cloned().unwrap_or(Value::Null)),
         (Value::Arr(a), Value::Num(n, _)) => {
-            if n.is_nan() { return Ok(Value::Null); }
-            let idx = *n as i64;
-            let i = if idx < 0 { (a.len() as i64 + idx) as usize } else { idx as usize };
-            Ok(a.get(i).cloned().unwrap_or(Value::Null))
+            Ok(crate::value::resolve_array_index(*n, a.len())
+                .map(|i| a[i].clone())
+                .unwrap_or(Value::Null))
         }
         (Value::Str(_), Value::Num(_, _)) => {
             // jq's "Cannot index string with number" omits the value (#440).

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1214,7 +1214,6 @@ fn simplify_expr(expr: &crate::ir::Expr) -> crate::ir::Expr {
                         if let Expr::Literal(Literal::Num(n, _)) = key.as_ref() {
                             if n.is_nan() || !n.is_finite() { /* skip NaN/Inf indices */ }
                             else {
-                            let idx = *n as i64;
                             fn collect_comma_for_idx(e: &Expr, out: &mut Vec<Expr>) {
                                 match e {
                                     Expr::Comma { left, right } => {
@@ -1275,12 +1274,8 @@ fn simplify_expr(expr: &crate::ir::Expr) -> crate::ir::Expr {
                             // negative index (issue #42). Falling through for
                             // the out-of-range cases lets the runtime emit the
                             // correct null result.
-                            let effective: Option<usize> = if idx >= 0 {
-                                if (idx as usize) < elems.len() { Some(idx as usize) } else { None }
-                            } else {
-                                let v = elems.len() as i64 + idx;
-                                if v >= 0 && (v as usize) < elems.len() { Some(v as usize) } else { None }
-                            };
+                            let effective: Option<usize> =
+                                crate::value::resolve_array_index(*n, elems.len());
                             if all_single {
                                 if let Some(i) = effective {
                                     // jq evaluates every element when building

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -6707,13 +6707,10 @@ extern "C" fn jit_rt_index(dst: *mut Value, base: *const Value, key: *const Valu
     unsafe {
         // Fast path: Array[Num] — most common in loops
         if let (Value::Arr(a), Value::Num(n, _)) = (&*base, &*key) {
-            if n.is_nan() {
-                std::ptr::write(dst, Value::Null);
-                return 0;
-            }
-            let idx = *n as i64;
-            let i = if idx < 0 { (a.len() as i64 + idx) as usize } else { idx as usize };
-            std::ptr::write(dst, a.get(i).cloned().unwrap_or(Value::Null));
+            let v = crate::value::resolve_array_index(*n, a.len())
+                .map(|i| a[i].clone())
+                .unwrap_or(Value::Null);
+            std::ptr::write(dst, v);
             return 0;
         }
         // Fast path: Object[String]
@@ -8297,9 +8294,12 @@ extern "C" fn jit_rt_call_builtin(dst: *mut Value, name_ptr: *const u8, name_len
                             current = o.get(k.as_str()).cloned().unwrap_or(Value::Null);
                         }
                         (Value::Arr(a), Value::Num(n, _)) => {
-                            let idx = *n as i64;
-                            let actual = if idx < 0 { (a.len() as i64 + idx) as usize } else { idx as usize };
-                            current = a.get(actual).cloned().unwrap_or(Value::Null);
+                            // resolve_array_index also closes the NaN gap this
+                            // inline path had vs the runtime getpath (#813):
+                            // `nan as i64` truncated to 0 and read element 0.
+                            current = crate::value::resolve_array_index(*n, a.len())
+                                .map(|i| a[i].clone())
+                                .unwrap_or(Value::Null);
                         }
                         (Value::Null, Value::Str(_)) | (Value::Null, Value::Num(_, _)) | (Value::Null, Value::Obj(_)) => {
                             current = Value::Null;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2464,17 +2464,9 @@ pub fn rt_getpath(v: &Value, path: &Value) -> Result<Value> {
                         current = o.get(k.as_str()).cloned().unwrap_or(Value::Null);
                     }
                     (Value::Arr(a), Value::Num(n, _)) => {
-                        // A NaN index is out of range → null, matching jq and
-                        // `.[nan]`. `nan as i64` would otherwise truncate to 0
-                        // and return the first element (#813). (An infinite
-                        // index saturates to i64::MAX/MIN and already misses.)
-                        if n.is_nan() {
-                            current = Value::Null;
-                        } else {
-                            let idx = *n as i64;
-                            let actual = if idx < 0 { (a.len() as i64 + idx) as usize } else { idx as usize };
-                            current = a.get(actual).cloned().unwrap_or(Value::Null);
-                        }
+                        current = crate::value::resolve_array_index(*n, a.len())
+                            .map(|i| a[i].clone())
+                            .unwrap_or(Value::Null);
                     }
                     // Slice path element `{start, end}`. Originally added in
                     // #536 for `.[N:M] |= f` (eval's Update branch fetches the

--- a/src/value.rs
+++ b/src/value.rs
@@ -6876,6 +6876,26 @@ fn push_pretty_value_impl<const COLOR: bool>(buf: &mut Vec<u8>, v: &Value, depth
     }
 }
 
+/// Resolve a jq numeric array index for read access against `len`.
+///
+/// Encodes the shared `.[$n]` / `getpath` read rule in one place (#1033): a
+/// NaN index never resolves (`.[nan]` is null, #813), an infinite index
+/// saturates out of range, a fractional index truncates toward zero *before*
+/// the negative-wrap decision, and a negative index counts from the end.
+/// Returns the in-bounds slot, or `None` for any miss; the caller picks the
+/// miss policy (null / false / error). Write paths (setpath/delpaths) have
+/// different rules — out-of-range negatives error, missing slots extend the
+/// array — and must not use this resolver.
+#[inline]
+pub fn resolve_array_index(n: f64, len: usize) -> Option<usize> {
+    if n.is_nan() {
+        return None;
+    }
+    let idx = n as i64;
+    let actual = if idx < 0 { len as i64 + idx } else { idx };
+    usize::try_from(actual).ok().filter(|&i| i < len)
+}
+
 #[inline]
 fn push_pretty_value(buf: &mut Vec<u8>, v: &Value, depth: usize, step: usize, use_tab: bool, color: bool) {
     if color {

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -13332,3 +13332,18 @@ strftime("%-d %0d %_d")
 strftime("%N %")
 0
 "N %"
+
+# #1033: JIT inline getpath misses on NaN index like the runtime path (#813 gap)
+[10,20] | getpath([nan])
+null
+null
+
+# #1033: NaN index read stays null through the shared resolver
+.[nan]
+[10,20]
+null
+
+# #1033: fractional negative index truncates toward zero before the wrap decision
+.[-0.9]
+[10,20]
+10


### PR DESCRIPTION
## Summary

Final part of #1033 (after #1039 VarIdx, #1040 FuncId). Instead of an `ArrayIndex` newtype, this lands `value::resolve_array_index(n: f64, len: usize) -> Option<usize>` — a checked resolver that subsumes the newtype idea: a resolved `Option<usize>` is strictly stronger than a wrapped raw index, and it puts the NaN/Inf/fractional/negative-wrap rule in exactly one place. Callers keep their own miss policy (null / false / error), which genuinely differs per operation in jq.

## Bug found and fixed during migration

The JIT **inline getpath fast path had no NaN guard** — the #813 fix landed only on the runtime getpath:

```
$ jq-jit -n '[10,20] | getpath([nan])'   # before: 10 (element 0 via `nan as i64` → 0)
$ jq -n '[10,20] | getpath([nan])'       # null
```

Migrating the site to the shared resolver closes the divergence. Regression tests pin `getpath([nan])`, `.[nan]`, and `.[-0.9]` (all verified against jq 1.8.1).

## Migrated sites (read rule only)

- runtime.rs getpath array step
- eval.rs `eval_index` array arm
- jit.rs `jit_rt_index` Array[Num] fast path
- jit.rs inline getpath fast path (the bug fix)
- interpreter.rs `[…]|.[N]` const-fold effective-index computation

Write paths (setpath/delpaths) intentionally keep their own rules (out-of-range negatives error, missing slots extend the array), documented on the resolver. Noted for later: the two delete-path implementations (runtime.rs `delete_path` vs eval.rs #904 site) appear to wrap fractional negative indices differently — left untouched here, candidate for the Phase 3 canonicalization pass (#1036).

## Verification

- `cargo build --release`: zero warnings
- `cargo test --release`: 614 suites green (incl. new regression groups; selfdiff exercises all layers on them)
- Same-machine A/B interleave (best-of-7) on index-heavy workloads: `.a[2]+.a[-1]` ratio 1.01, `getpath(["a",1])` 1.01, `$a[$i]` reduce 0.93 — no regression

Closes #1033

🤖 Generated with [Claude Code](https://claude.com/claude-code)