### PR TITLE
refactor(eval): type the halt signal, start the signal module

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -3614,12 +3614,16 @@ fn real_main() {
         }
         if let Err(e) = result {
             let msg = format!("{}", e);
-            if let Some(code_str) = msg.strip_prefix("__halt__:") {
-                // halt / halt_error: drain any buffered output, release
-                // our hold on stdout, then terminate with the requested
-                // exit status. Stderr (halt_error's message) was already
-                // written directly in eval.rs before the sentinel bailed.
-                let code: i32 = code_str.parse().unwrap_or(0);
+            // halt / halt_error: drain any buffered output, release our
+            // hold on stdout, then terminate with the requested exit
+            // status. Stderr (halt_error's message) was already written
+            // directly in eval.rs at raise time. The string form is the
+            // fallback for halts that crossed the JIT FFI boundary, where
+            // only the Display text survives (see src/signal.rs).
+            let halt_code = e.downcast_ref::<jq_jit::signal::HaltSignal>()
+                .map(|h| h.code)
+                .or_else(|| msg.strip_prefix("__halt__:").map(|c| c.parse().unwrap_or(0)));
+            if let Some(code) = halt_code {
                 if !cbuf.is_empty() {
                     let _ = out.write_all(cbuf);
                     cbuf.clear();

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -2612,7 +2612,7 @@ pub fn eval(
                     // halt / halt_error are non-recoverable: jq lets them
                     // propagate past `try ... catch` so the process exits with
                     // the requested code (#182).
-                    if msg.starts_with("__halt__:") { return Err(e); }
+                    if e.downcast_ref::<crate::signal::HaltSignal>().is_some() { return Err(e); }
                     let catch_val = if let Some(json) = msg.strip_prefix("__jqerror__:") {
                         crate::value::json_to_value(json).unwrap_or(Value::from_str(&msg))
                     } else {
@@ -6044,7 +6044,7 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
                     // halt / halt_error are non-recoverable: jq lets them
                     // propagate past `try ... catch` so the process exits with
                     // the requested code (#182).
-                    if msg.starts_with("__halt__:") { return Err(e); }
+                    if e.downcast_ref::<crate::signal::HaltSignal>().is_some() { return Err(e); }
                     // The `?//` desugar (`restore_dot`) keeps `.` set to the
                     // original input across fallbacks rather than binding the
                     // caught destructuring error: jq never exposes that error to
@@ -7222,14 +7222,14 @@ fn eval_call_builtin(name: &str, args: &[Expr], input: Value, env: &EnvRef, cb: 
         }
         ("halt", 0) => {
             // halt: terminate with status 0 after emitting any values the
-            // preceding generator already yielded. Raising a sentinel
-            // error lets the CLI flush its buffered stdout before exiting
-            // (see `__halt__:` handling in bin/jq-jit.rs).
-            bail!("__halt__:0");
+            // preceding generator already yielded. Raising a signal error
+            // lets the CLI flush its buffered stdout before exiting (see
+            // the HaltSignal handling in bin/jq-jit.rs).
+            return Err(crate::signal::HaltSignal::raise(0));
         }
         ("halt_error", 0) => {
             halt_error_write(&input);
-            bail!("__halt__:5");
+            return Err(crate::signal::HaltSignal::raise(5));
         }
         ("halt_error", 1) => {
             return eval(&args[0], input.clone(), env, &mut |code_val| {
@@ -7246,7 +7246,7 @@ fn eval_call_builtin(name: &str, args: &[Expr], input: Value, env: &EnvRef, cb: 
                     ),
                 };
                 halt_error_write(&input);
-                bail!("__halt__:{}", code);
+                Err(crate::signal::HaltSignal::raise(code))
             });
         }
         ("add", 1) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod ir;
 pub mod runtime;
 pub mod parser;
 pub mod eval;
+pub mod signal;
 pub mod module;
 pub mod jit;
 pub mod fast_path;

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -1,0 +1,41 @@
+//! Typed control-flow signals threaded through the anyhow error channel.
+//!
+//! eval propagates non-error control flow (halt, label/break, `error(value)`
+//! payloads, path-expression results) as `anyhow::Error` so it rides the
+//! ordinary `?`/`Result` plumbing. Historically each signal was encoded in
+//! the Display string and recovered by prefix parsing — fragile, and lossy
+//! for non-finite numbers (#844). The types in this module make recovery a
+//! typed downcast instead (#1034).
+//!
+//! The Display strings keep the legacy sentinel forms byte-for-byte: they
+//! are still the wire format across the JIT FFI boundary (jit.rs serializes
+//! errors with `format!("{}", e)` into its thread-local string channel), so
+//! a signal that crosses JIT-compiled code arrives at the consumer as plain
+//! text. Consumers therefore downcast first and keep a string fallback only
+//! where JIT-crossed signals can land. Once the JIT channel itself carries a
+//! typed payload, those fallbacks and the sentinel Display forms can go.
+
+use std::fmt;
+
+/// `halt` / `halt_error`: non-recoverable, propagates past `try`/`catch`
+/// (#182); the CLI flushes buffered output and exits with `code`.
+/// `halt_error`'s stderr payload is written at raise time, not carried here.
+#[derive(Debug)]
+pub struct HaltSignal {
+    pub code: i32,
+}
+
+impl HaltSignal {
+    pub fn raise(code: i32) -> anyhow::Error {
+        HaltSignal { code }.into()
+    }
+}
+
+impl fmt::Display for HaltSignal {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Legacy sentinel form — still the JIT-boundary wire format.
+        write!(f, "__halt__:{}", self.code)
+    }
+}
+
+impl std::error::Error for HaltSignal {}


### PR DESCRIPTION
## Summary

First step of #1034 (Phase 1 of the type-safety series). halt / halt_error rode the anyhow channel as the sentinel string `__halt__:<code>`, recovered by prefix parsing at two try/catch pass-through guards (eval.rs) and the CLI exit handler (bin).

This PR adds `src/signal.rs` — the home for typed control-flow signals — with `HaltSignal { code: i32 }` as the first resident. Raise sites construct it, consumers `downcast_ref` it.

## JIT boundary constraint (why Display keeps the sentinel form)

jit.rs serializes errors crossing its FFI boundary with `format!("{}", e)` into a thread-local string channel, so a halt raised under JIT-compiled code reaches the CLI as plain text. `HaltSignal`'s `Display` therefore keeps the legacy `__halt__:<code>` form as the wire format, and bin keeps a string fallback *only* for that path (documented inline). Typing the JIT channel itself is the last step of #1034; then the fallback and sentinel Display go.

## Pre-existing bug found while verifying (not fixed here)

`jq-jit -n 'halt'` fails with `unknown builtin: halt (nargs=1)` and exit 5 (expected: clean exit 0); `halt_error(7)` exits 5 instead of 7. Reproduced on pre-series main (4557d89), so unrelated to recent changes: the JIT/interpreter engines dispatch `CallBuiltin("halt")` to `runtime::call_builtin`, which has no halt arms — only eval's dispatch does. Invisible to the test suite because the harness compares stdout only and tolerates exit 5. Fix follows as a separate PR on top of this one (the runtime arms will raise `HaltSignal`).

## Verification

- `cargo build --release`: zero warnings; `cargo test --release`: 614 suites green
- Manual matrix vs jq 1.8.1: `halt`, `1,halt,2`, `try halt catch .`, `halt_error/0` (stderr + exit 5), `halt_error(7)`, `halt_error(-3)` (#979 clamp), and a JIT-path halt — behavior byte-identical to current main on every case

Refs #1034

🤖 Generated with [Claude Code](https://claude.com/claude-code)