### PR TITLE
refactor(signal): move BreakError and ErrorValue into the signal module

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -151,71 +151,7 @@ pub fn read_next_input() -> Option<Value> {
     }
 }
 
-/// Typed error for label/break to avoid string formatting/parsing overhead.
-#[derive(Debug)]
-struct BreakError(u64);
-impl std::fmt::Display for BreakError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "__break__:{}:", self.0)
-    }
-}
-impl std::error::Error for BreakError {}
-
-thread_local! {
-    /// Lossless payload slot for the most recently raised `error(value)`
-    /// (#844). `Value` holds `Rc`s, so it cannot live inside an
-    /// `anyhow::Error` (which requires `Send + Sync`); instead `error`
-    /// stashes the value here and bails with the `Send + Sync` [`ErrorValue`]
-    /// marker. The matching `catch` takes the value straight back. This
-    /// mirrors jit.rs's `JIT_ERROR_VALUE` channel. The slot is safe as a
-    /// single cell because error propagation is synchronous LIFO unwinding:
-    /// only one `error(value)` is ever in flight, and the catching `try`
-    /// takes it immediately. A stale value left by an uncaught error is
-    /// overwritten by the next `error` and is never read by the string path
-    /// (which only fires when the `ErrorValue` downcast fails).
-    static ERROR_PAYLOAD: std::cell::RefCell<Option<Value>> = const { std::cell::RefCell::new(None) };
-}
-
-/// Typed marker error carrying an `error(value)` payload losslessly (#844).
-///
-/// The string channel (`__jqerror__:<JSON>`) serializes the payload with
-/// `value_to_json_precise`, which is lossy for non-finite numbers anywhere
-/// in the value: `nan` becomes `null` and `±infinite` saturates to the
-/// nearest finite f64. Round-tripping that JSON back in a `catch` branch
-/// therefore corrupts the caught value. The exact `Value` rides in
-/// [`ERROR_PAYLOAD`] instead; `Display` still emits the `__jqerror__:<JSON>`
-/// form so uncaught errors print exactly as before.
-#[derive(Debug)]
-struct ErrorValue {
-    display: String,
-}
-impl ErrorValue {
-    /// Stash `value` in the thread-local payload slot and build the marker
-    /// error whose `Display` reproduces the legacy `__jqerror__:<JSON>` text.
-    fn raise(value: Value) -> anyhow::Error {
-        let display = format!("__jqerror__:{}", crate::value::value_to_json_precise(&value));
-        ERROR_PAYLOAD.with(|slot| *slot.borrow_mut() = Some(value));
-        ErrorValue { display }.into()
-    }
-}
-impl std::fmt::Display for ErrorValue {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.display)
-    }
-}
-impl std::error::Error for ErrorValue {}
-
-/// Take the payload stashed by the most recent `error(value)`. Falls back to
-/// re-parsing the marker's `display` JSON if the slot is somehow empty.
-fn take_error_payload(ev: &ErrorValue) -> Value {
-    if let Some(v) = ERROR_PAYLOAD.with(|slot| slot.borrow_mut().take()) {
-        return v;
-    }
-    match ev.display.strip_prefix("__jqerror__:") {
-        Some(json) => crate::value::json_to_value(json).unwrap_or_else(|_| Value::from_str(&ev.display)),
-        None => Value::from_str(&ev.display),
-    }
-}
+use crate::signal::{BreakError, ErrorValue, take_error_payload};
 
 /// The value a `try ... catch` / `?` receives when it catches a `break`
 /// signal. jq surfaces the break as `{"__jq": <label id>}`; matching the

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -40,6 +40,77 @@ impl fmt::Display for HaltSignal {
 
 impl std::error::Error for HaltSignal {}
 
+/// Typed error for label/break to avoid string formatting/parsing overhead.
+#[derive(Debug)]
+pub(crate) struct BreakError(pub(crate) u64);
+impl fmt::Display for BreakError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "__break__:{}:", self.0)
+    }
+}
+impl std::error::Error for BreakError {}
+
+thread_local! {
+    /// Lossless payload slot for the most recently raised `error(value)`
+    /// (#844). `Value` holds `Rc`s, so it cannot live inside an
+    /// `anyhow::Error` (which requires `Send + Sync`); instead `error`
+    /// stashes the value here and bails with the `Send + Sync` [`ErrorValue`]
+    /// marker. The matching `catch` takes the value straight back. This
+    /// mirrors jit.rs's `JIT_ERROR_VALUE` channel. The slot is safe as a
+    /// single cell because error propagation is synchronous LIFO unwinding:
+    /// only one `error(value)` is ever in flight, and the catching `try`
+    /// takes it immediately. A stale value left by an uncaught error is
+    /// overwritten by the next `error` and is never read by the string path
+    /// (which only fires when the `ErrorValue` downcast fails).
+    static ERROR_PAYLOAD: std::cell::RefCell<Option<crate::value::Value>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+/// Typed marker error carrying an `error(value)` payload losslessly (#844).
+///
+/// The string channel (`__jqerror__:<JSON>`) serializes the payload with
+/// `value_to_json_precise`, which is lossy for non-finite numbers anywhere
+/// in the value: `nan` becomes `null` and `±infinite` saturates to the
+/// nearest finite f64. Round-tripping that JSON back in a `catch` branch
+/// therefore corrupts the caught value. The exact `Value` rides in
+/// [`ERROR_PAYLOAD`] instead; `Display` still emits the `__jqerror__:<JSON>`
+/// form so uncaught errors print exactly as before.
+#[derive(Debug)]
+pub(crate) struct ErrorValue {
+    display: String,
+}
+impl ErrorValue {
+    /// Stash `value` in the thread-local payload slot and build the marker
+    /// error whose `Display` reproduces the legacy `__jqerror__:<JSON>` text.
+    pub(crate) fn raise(value: crate::value::Value) -> anyhow::Error {
+        let display = format!(
+            "__jqerror__:{}",
+            crate::value::value_to_json_precise(&value)
+        );
+        ERROR_PAYLOAD.with(|slot| *slot.borrow_mut() = Some(value));
+        ErrorValue { display }.into()
+    }
+}
+impl fmt::Display for ErrorValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.display)
+    }
+}
+impl std::error::Error for ErrorValue {}
+
+/// Take the payload stashed by the most recent `error(value)`. Falls back to
+/// re-parsing the marker's `display` JSON if the slot is somehow empty.
+pub(crate) fn take_error_payload(ev: &ErrorValue) -> crate::value::Value {
+    if let Some(v) = ERROR_PAYLOAD.with(|slot| slot.borrow_mut().take()) {
+        return v;
+    }
+    match ev.display.strip_prefix("__jqerror__:") {
+        Some(json) => crate::value::json_to_value(json)
+            .unwrap_or_else(|_| crate::value::Value::from_str(&ev.display)),
+        None => crate::value::Value::from_str(&ev.display),
+    }
+}
+
 thread_local! {
     /// Payload slot for the most recent [`PathResultSignal`]. `Value` holds
     /// `Rc`s, so it cannot live inside an `anyhow::Error` (`Send + Sync`);


### PR DESCRIPTION
## Summary

Third step of #1034, pure code motion: `BreakError`, `ErrorValue` (+ its `ERROR_PAYLOAD` thread-local and `take_error_payload`) move verbatim from eval.rs into `src/signal.rs`, joining `HaltSignal` and `PathResultSignal` so every control-flow signal type lives in one module. eval.rs imports them; zero call-site or behavior changes.

## Why now

The next step types the JIT error channel (`error_msg: Option<String>` → typed payload, 78 touchpoints). jit.rs needs these types visible to convert between anyhow errors and the channel payload without stringifying — that conversion is where `error(value)` payloads, halt codes, and break ids currently collapse into display text.

## Verification

- `cargo build --release`: zero warnings
- `cargo test --release`: 614 suites green

Refs #1034

🤖 Generated with [Claude Code](https://claude.com/claude-code)