### PR TITLE
refactor(ir): resolve format directives to a FormatKind enum at parse time

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -410,7 +410,7 @@ fn subst_inner(
             Expr::Break { var_index: idx, value: sb!(value) }
         }
         Expr::Error { msg } => Expr::Error { msg: msg.as_ref().map(|m| sb!(m)) },
-        Expr::Format { name, expr: e } => Expr::Format { name: name.clone(), expr: sb!(e) },
+        Expr::Format { kind, expr: e } => Expr::Format { kind: kind.clone(), expr: sb!(e) },
         Expr::ClosureOp { op, input_expr, key_expr } => Expr::ClosureOp {
             op: *op, input_expr: sb!(input_expr), key_expr: sb!(key_expr),
         },
@@ -514,7 +514,7 @@ pub(crate) fn append_call_args(expr: &Expr, target: FuncId, extra: &[Expr]) -> E
         Expr::Label { var_index, body } => Expr::Label { var_index: *var_index, body: rb!(body) },
         Expr::Break { var_index, value } => Expr::Break { var_index: *var_index, value: rb!(value) },
         Expr::Error { msg } => Expr::Error { msg: msg.as_ref().map(|m| rb!(m)) },
-        Expr::Format { name, expr: e } => Expr::Format { name: name.clone(), expr: rb!(e) },
+        Expr::Format { kind, expr: e } => Expr::Format { kind: kind.clone(), expr: rb!(e) },
         Expr::ClosureOp { op, input_expr, key_expr } => Expr::ClosureOp {
             op: *op, input_expr: rb!(input_expr), key_expr: rb!(key_expr),
         },
@@ -785,7 +785,7 @@ fn subst_cow(expr: &Expr, pv: &[VarIdx], args: &[Expr]) -> Option<Expr> {
             let m = msg.as_ref().and_then(|m2| s!(m2));
             m.map(|v| Expr::Error { msg: Some(Box::new(v)) })
         }
-        Expr::Format { name, expr: e } => s!(e).map(|v| Expr::Format { name: name.clone(), expr: Box::new(v) }),
+        Expr::Format { kind, expr: e } => s!(e).map(|v| Expr::Format { kind: kind.clone(), expr: Box::new(v) }),
         Expr::ClosureOp { op, input_expr, key_expr } => {
             let i = s!(input_expr); let k = s!(key_expr);
             if i.is_none() && k.is_none() { return None; }
@@ -3689,9 +3689,9 @@ pub fn eval(
             }
         }
 
-        Expr::Format { name, expr: fmt_expr } => {
+        Expr::Format { kind, expr: fmt_expr } => {
             eval(fmt_expr, input, env, &mut |val| {
-                cb(Value::from_str(&eval_format(name, &val)?))
+                cb(Value::from_str(&eval_format(kind, &val)?))
             })
         }
 
@@ -4468,10 +4468,10 @@ fn format_sh(val: &Value) -> Result<String> {
     }
 }
 
-pub fn eval_format(name: &str, val: &Value) -> Result<String> {
+pub fn eval_format(kind: &FormatKind, val: &Value) -> Result<String> {
     // For csv/tsv, the input must be an array
-    match name {
-        "csv" => {
+    match kind {
+        FormatKind::Csv => {
             let arr = match val { Value::Arr(a) => a, _ => bail!("{} cannot be csv-formatted, only array", crate::runtime::errdesc_pub(val)) };
             let mut buf = String::with_capacity(arr.len() * 16);
             for (i, v) in arr.iter().enumerate() {
@@ -4512,7 +4512,7 @@ pub fn eval_format(name: &str, val: &Value) -> Result<String> {
             }
             return Ok(buf);
         }
-        "tsv" => {
+        FormatKind::Tsv => {
             let arr = match val { Value::Arr(a) => a, _ => bail!("{} cannot be tsv-formatted, only array", crate::runtime::errdesc_pub(val)) };
             let mut buf = String::with_capacity(arr.len() * 16);
             for (i, v) in arr.iter().enumerate() {
@@ -4558,15 +4558,17 @@ pub fn eval_format(name: &str, val: &Value) -> Result<String> {
     // `MC4w`). `value_to_json_tojson` keeps the literal form when f64 can
     // round-trip it, matching `rt_tostring`. See #564.
     let s = match val { Value::Str(s) => s.to_string(), _ => crate::value::value_to_json_tojson(val) };
-    match name {
-        "text" => Ok(s),
+    match kind {
+        // Returned from the array-format match above.
+        FormatKind::Csv | FormatKind::Tsv => unreachable!(),
+        FormatKind::Text => Ok(s),
         // `@json` mirrors the `tojson` builtin, so it must preserve the
         // carried number repr exactly the way `rt_tojson` does — otherwise
         // `0.0 | @json | length` returned 1 (the value was the string
         // `"0"`, even though the raw-byte CLI fast path printed `"0.0"` for
         // the standalone `@json` form). See #562.
-        "json" => Ok(crate::value::value_to_json_tojson(val)),
-        "html" => {
+        FormatKind::Json => Ok(crate::value::value_to_json_tojson(val)),
+        FormatKind::Html => {
             let mut r = String::with_capacity(s.len());
             for c in s.chars() {
                 match c {
@@ -4584,7 +4586,7 @@ pub fn eval_format(name: &str, val: &Value) -> Result<String> {
             }
             Ok(r)
         }
-        "uri" => {
+        FormatKind::Uri => {
             const HEX: &[u8; 16] = b"0123456789ABCDEF";
             let mut r = String::with_capacity(s.len());
             for b in s.bytes() {
@@ -4595,7 +4597,7 @@ pub fn eval_format(name: &str, val: &Value) -> Result<String> {
             }
             Ok(r)
         }
-        "urid" => {
+        FormatKind::Urid => {
             // jq validates `@urid` input (#961): a `%` must be followed by two
             // hex digits, and a maximal run of consecutive `%XX` escapes must
             // decode to valid UTF-8 — a malformed escape (`%`, `%4`, `%GG`) or
@@ -4639,8 +4641,8 @@ pub fn eval_format(name: &str, val: &Value) -> Result<String> {
             flush(&mut esc, &mut out)?;
             Ok(out)
         }
-        "sh" => format_sh(val),
-        "base64" => {
+        FormatKind::Sh => format_sh(val),
+        FormatKind::Base64 => {
             const C: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
             let d = s.as_bytes(); let mut r = String::new();
             for ch in d.chunks(3) { let (b0,b1,b2) = (ch[0] as u32, ch.get(1).copied().unwrap_or(0) as u32, ch.get(2).copied().unwrap_or(0) as u32); let n = (b0<<16)|(b1<<8)|b2;
@@ -4648,7 +4650,7 @@ pub fn eval_format(name: &str, val: &Value) -> Result<String> {
                 r.push(if ch.len()>1 { C[((n>>6)&0x3f) as usize] as char } else { '=' }); r.push(if ch.len()>2 { C[(n&0x3f) as usize] as char } else { '=' }); }
             Ok(r)
         }
-        "base64d" => {
+        FormatKind::Base64d => {
             const D: [i8;128] = { let mut t = [-1i8;128]; let c = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"; let mut i=0; while i<c.len() { t[c[i] as usize]=i as i8; i+=1; } t };
             // jq's `@base64d` validates the data in this order (#557, #605):
             //
@@ -4697,7 +4699,7 @@ pub fn eval_format(name: &str, val: &Value) -> Result<String> {
             }
             Ok(jq_utf8_lossy(&r))
         }
-        _ => bail!("{} is not a valid format", name),
+        FormatKind::Invalid(name) => bail!("{} is not a valid format", name),
     }
 }
 
@@ -7219,11 +7221,11 @@ fn eval_call_builtin(name: &str, args: &[Expr], input: Value, env: &EnvRef, cb: 
             // format(f): evaluate f to get the format directive name, then
             // apply it to the current input (same result as `@<fmt>`).
             return eval(&args[0], input.clone(), env, &mut |fmt_val| {
-                let fmt_name = match &fmt_val {
-                    Value::Str(s) => s.as_str().to_string(),
+                let kind = match &fmt_val {
+                    Value::Str(s) => FormatKind::from_name(s.as_str()),
                     _ => bail!("{} is not a valid format", crate::value::value_to_json(&fmt_val)),
                 };
-                cb(Value::from_str(&eval_format(&fmt_name, &input)?))
+                cb(Value::from_str(&eval_format(&kind, &input)?))
             });
         }
         ("combinations", 0) => {

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -5487,15 +5487,19 @@ impl Filter {
     pub fn detect_field_format(&self) -> Option<(String, String)> {
         use crate::ir::{Expr, Literal};
         let expr = self.detect_expr()?;
-        let is_supported = |name: &str| matches!(name, "base64" | "uri" | "html" | "json" | "text");
+        use crate::ir::FormatKind;
+        let is_supported = |kind: &FormatKind| matches!(
+            kind,
+            FormatKind::Base64 | FormatKind::Uri | FormatKind::Html | FormatKind::Json | FormatKind::Text
+        );
         // Pipe form: .field | @format
         if let Expr::Pipe { left, right } = expr {
             if let Expr::Index { expr: base, key } = left.as_ref() {
                 if matches!(base.as_ref(), Expr::Input) {
                     if let Expr::Literal(Literal::Str(field)) = key.as_ref() {
-                        if let Expr::Format { name, expr: fmt_expr } = right.as_ref() {
-                            if matches!(fmt_expr.as_ref(), Expr::Input) && is_supported(name) {
-                                return Some((field.clone(), name.clone()));
+                        if let Expr::Format { kind, expr: fmt_expr } = right.as_ref() {
+                            if matches!(fmt_expr.as_ref(), Expr::Input) && is_supported(kind) {
+                                return Some((field.clone(), kind.name().to_string()));
                             }
                         }
                     }
@@ -5503,12 +5507,12 @@ impl Filter {
             }
         }
         // Beta-reduced form: @format(.field)
-        if let Expr::Format { name, expr: fmt_expr } = expr {
-            if is_supported(name) {
+        if let Expr::Format { kind, expr: fmt_expr } = expr {
+            if is_supported(kind) {
                 if let Expr::Index { expr: base, key } = fmt_expr.as_ref() {
                     if matches!(base.as_ref(), Expr::Input) {
                         if let Expr::Literal(Literal::Str(field)) = key.as_ref() {
-                            return Some((field.clone(), name.clone()));
+                            return Some((field.clone(), kind.name().to_string()));
                         }
                     }
                 }
@@ -7683,7 +7687,7 @@ impl Filter {
         use crate::ir::{Expr, UnaryOp};
         let expr = match self.detect_expr() { Some(e) => e, None => return false };
         matches!(expr, Expr::UnaryOp { op: UnaryOp::ToJson, operand } if matches!(operand.as_ref(), Expr::Input))
-            || matches!(expr, Expr::Format { name, expr: inner } if name == "json" && matches!(inner.as_ref(), Expr::Input))
+            || matches!(expr, Expr::Format { kind: crate::ir::FormatKind::Json, expr: inner } if matches!(inner.as_ref(), Expr::Input))
     }
 
     /// Detect `tojson | fromjson` — identity for valid JSON input (from files).
@@ -7717,7 +7721,7 @@ impl Filter {
         let is_tojson = matches!(tojson_check,
             Expr::UnaryOp { op: UnaryOp::ToJson, operand } if matches!(operand.as_ref(), Expr::Input))
             || matches!(tojson_check,
-            Expr::Format { name, expr: inner } if name == "json" && matches!(inner.as_ref(), Expr::Input));
+            Expr::Format { kind: crate::ir::FormatKind::Json, expr: inner } if matches!(inner.as_ref(), Expr::Input));
         if !is_tojson { return None; }
         // Check left is {key: .field, ...}
         if let Expr::ObjectConstruct { pairs } = remap_expr {
@@ -7978,12 +7982,12 @@ impl Filter {
         use crate::ir::Expr;
         let expr = self.detect_expr()?;
         if let Expr::Pipe { left, right } = expr {
-            if let Expr::Format { name, .. } = right.as_ref() {
-                if matches!(name.as_str(), "csv" | "tsv") {
+            if let Expr::Format { kind, .. } = right.as_ref() {
+                if matches!(kind, crate::ir::FormatKind::Csv | crate::ir::FormatKind::Tsv) {
                     if let Expr::Collect { generator } = left.as_ref() {
                         let mut fields = Vec::new();
                         if collect_comma_fields(generator, &mut fields) && fields.len() >= 2 {
-                            return Some((fields, name.clone()));
+                            return Some((fields, kind.name().to_string()));
                         }
                     }
                 }

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -50,6 +50,61 @@ impl std::fmt::Display for FuncId {
     }
 }
 
+/// A format directive: `@base64`, `@uri`, etc. (#1035).
+///
+/// Known directives resolve to a variant at parse time; an unknown `@name`
+/// is kept as `Invalid(name)` rather than rejected, because jq reports it
+/// only when the format is actually applied (`if false then @nope else 1
+/// end` is fine), via "<name> is not a valid format" at runtime.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FormatKind {
+    Text,
+    Json,
+    Html,
+    Uri,
+    Urid,
+    Csv,
+    Tsv,
+    Sh,
+    Base64,
+    Base64d,
+    Invalid(std::rc::Rc<str>),
+}
+
+impl FormatKind {
+    pub fn from_name(name: &str) -> FormatKind {
+        match name {
+            "text" => FormatKind::Text,
+            "json" => FormatKind::Json,
+            "html" => FormatKind::Html,
+            "uri" => FormatKind::Uri,
+            "urid" => FormatKind::Urid,
+            "csv" => FormatKind::Csv,
+            "tsv" => FormatKind::Tsv,
+            "sh" => FormatKind::Sh,
+            "base64" => FormatKind::Base64,
+            "base64d" => FormatKind::Base64d,
+            other => FormatKind::Invalid(other.into()),
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        match self {
+            FormatKind::Text => "text",
+            FormatKind::Json => "json",
+            FormatKind::Html => "html",
+            FormatKind::Uri => "uri",
+            FormatKind::Urid => "urid",
+            FormatKind::Csv => "csv",
+            FormatKind::Tsv => "tsv",
+            FormatKind::Sh => "sh",
+            FormatKind::Base64 => "base64",
+            FormatKind::Base64d => "base64d",
+            FormatKind::Invalid(n) => n,
+        }
+    }
+}
+
 /// A filter expression in the IR.
 #[derive(Debug, Clone)]
 pub enum Expr {
@@ -311,7 +366,7 @@ pub enum Expr {
 
     /// Format string: `@base64`, `@uri`, etc.
     Format {
-        name: String,
+        kind: FormatKind,
         expr: Box<Expr>,
     },
 
@@ -920,8 +975,8 @@ impl Expr {
                 primary: Box::new(primary.substitute_input(replacement)),
                 fallback: Box::new(fallback.substitute_input(replacement)),
             },
-            Expr::Format { name, expr } => Expr::Format {
-                name: name.clone(),
+            Expr::Format { kind, expr } => Expr::Format {
+                kind: kind.clone(),
                 expr: Box::new(expr.substitute_input(replacement)),
             },
             Expr::Debug { expr } => Expr::Debug {
@@ -1083,8 +1138,8 @@ impl Expr {
             // `@fmt EXPR` formats its operand: a `$x` in the operand must be
             // substituted, otherwise inlining `E as $x | $x | @json` leaves a
             // dangling LoadVar that the input-free fast path reads as null (#808).
-            Expr::Format { name, expr } => Expr::Format {
-                name: name.clone(),
+            Expr::Format { kind, expr } => Expr::Format {
+                kind: kind.clone(),
                 expr: Box::new(expr.substitute_var(var_index, replacement)),
             },
             _ => self.clone(),

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -929,8 +929,8 @@ impl Flattener {
                     StringPart::Expr(e) => StringPart::Expr(self.inline_func_calls(e)),
                 }).collect(),
             },
-            Expr::Format { name, expr } => Expr::Format {
-                name: name.clone(),
+            Expr::Format { kind, expr } => Expr::Format {
+                kind: kind.clone(),
                 expr: Box::new(self.inline_func_calls(expr)),
             },
             Expr::SetPath { path, value } => Expr::SetPath {
@@ -1697,10 +1697,10 @@ impl Flattener {
                 self.emit(JitOp::Drop { slot: to_slot });
                 out
             }
-            Expr::Format { name, expr: format_expr } => {
+            Expr::Format { kind, expr: format_expr } => {
                 let val = self.flatten_scalar(format_expr, input_slot);
                 let out = self.alloc_slot();
-                self.emit(JitOp::CallBuiltin { dst: out, name: format!("@{}", name), args: vec![val] });
+                self.emit(JitOp::CallBuiltin { dst: out, name: format!("@{}", kind.name()), args: vec![val] });
                 self.emit(JitOp::Drop { slot: val });
                 out
             }
@@ -8478,7 +8478,7 @@ extern "C" fn jit_rt_call_builtin(dst: *mut Value, name_ptr: *const u8, name_len
                     return GEN_ERROR;
                 }
             }
-            match crate::eval::eval_format(format_name, &args[0]) {
+            match crate::eval::eval_format(&crate::ir::FormatKind::from_name(format_name), &args[0]) {
                 Ok(s) => { std::ptr::write(dst, Value::from_str(&s)); return 0; }
                 Err(e) => { set_jit_error_from(&e); std::ptr::write(dst, Value::Null); return GEN_ERROR; }
             }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2851,7 +2851,9 @@ impl Parser {
 
             Token::Format(name) => {
                 self.advance();
-                // @base64, @uri, etc.
+                // @base64, @uri, etc. — resolved to FormatKind here; unknown
+                // names stay as FormatKind::Invalid and error when applied.
+                let kind = FormatKind::from_name(&name);
                 // May be followed by a string for @base64 "str" or interpolated string
                 if matches!(self.current(), Token::Str(_)) {
                     let s = match self.advance() {
@@ -2859,7 +2861,7 @@ impl Parser {
                         _ => unreachable!(),
                     };
                     Ok(Expr::Format {
-                        name,
+                        kind,
                         expr: Box::new(Expr::Literal(Literal::Str(s))),
                     })
                 } else if matches!(self.current(), Token::Ident(n) if n == "__string_interp__") {
@@ -2871,7 +2873,7 @@ impl Parser {
                         let new_parts = parts.into_iter().map(|p| match p {
                             StringPart::Literal(s) => StringPart::Literal(s),
                             StringPart::Expr(e) => StringPart::Expr(Expr::Format {
-                                name: name.clone(),
+                                kind: kind.clone(),
                                 expr: Box::new(e),
                             }),
                         }).collect();
@@ -2879,13 +2881,13 @@ impl Parser {
                     } else {
                         // Shouldn't happen but fallback
                         Ok(Expr::Format {
-                            name,
+                            kind,
                             expr: Box::new(interp),
                         })
                     }
                 } else {
                     Ok(Expr::Format {
-                        name,
+                        kind,
                         expr: Box::new(Expr::Input),
                     })
                 }
@@ -3004,10 +3006,10 @@ impl Parser {
                 Ok((key_expr, val))
             }
             Token::Format(ref name) => {
-                let name = name.clone();
+                let kind = FormatKind::from_name(name);
                 self.advance();
                 let key_expr = Expr::Format {
-                    name,
+                    kind,
                     expr: Box::new(Expr::Input),
                 };
                 if self.eat(&Token::Colon) {
@@ -4765,7 +4767,7 @@ fn remap_func_ids(expr: Expr, map: &[(FuncId, FuncId)]) -> Expr {
             predicate: Box::new(remap_func_ids(*predicate, map)),
         },
         Expr::Error { msg } => Expr::Error { msg: msg.map(|m| Box::new(remap_func_ids(*m, map))) },
-        Expr::Format { name, expr } => Expr::Format { name, expr: Box::new(remap_func_ids(*expr, map)) },
+        Expr::Format { kind, expr } => Expr::Format { kind, expr: Box::new(remap_func_ids(*expr, map)) },
         Expr::ClosureOp { op, input_expr, key_expr } => Expr::ClosureOp {
             op, input_expr: Box::new(remap_func_ids(*input_expr, map)),
             key_expr: Box::new(remap_func_ids(*key_expr, map)),


### PR DESCRIPTION
## Summary

First stage of #1035 (Phase 2 of the type-safety series). `@format` names rode the IR as raw strings and were re-matched at every application site. `Expr::Format` now carries a `FormatKind` enum, resolved once in the parser.

## Design: why unknown formats are data, not parse errors

jq does **not** reject unknown formats at parse time — `@invalid` inside a never-taken branch must succeed, and the error (`invalid is not a valid format`) fires only when the format is applied. `FormatKind::Invalid(Rc<str>)` keeps the unknown name as data and the eval arm reproduces the message byte-for-byte, so behavior is identical while every *known* directive gets exhaustive enum dispatch (the `_ => bail!` catch-all is gone from `eval_format`).

`format/1` (runtime string argument) resolves through the same `FormatKind::from_name`.

## Boundaries intentionally left for the next stage

- The JIT still lowers formats to its `CallBuiltin "@name"` string boundary, now minted from `kind.name()` — typing that boundary is the builtin-name half of #1035.

## Found while verifying (issues to follow)

- `format("csv")` fails with `unknown builtin: format (nargs=2)` under JIT/runtime dispatch (works via the eval engine) — same dispatch-gap class as #1043.
- `@invalid "literal"` (no interpolation): jq returns the literal unchanged (format never invoked); jq-jit errors. Pre-existing, preserved by this PR.

## Verification

- `cargo build --release`: zero warnings; `cargo test --release`: 614 suites green
- All ten directives byte-identical vs jq 1.8.1 on representative inputs, plus `@uri` interpolation, `@text` object keys, bare/interpolated `@invalid`, and `format/1` via eval
- Bench skipped: replaces per-application string matching with enum matching (neutral-to-positive); the JIT string boundary is unchanged

Refs #1035

🤖 Generated with [Claude Code](https://claude.com/claude-code)