### PR TITLE
refactor(ir): resolve CallBuiltin names to a BuiltinOp enum at parse time

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -414,8 +414,8 @@ fn subst_inner(
         Expr::ClosureOp { op, input_expr, key_expr } => Expr::ClosureOp {
             op: *op, input_expr: sb!(input_expr), key_expr: sb!(key_expr),
         },
-        Expr::CallBuiltin { name, args: bargs } => Expr::CallBuiltin {
-            name: name.clone(), args: bargs.iter().map(|a| s!(a)).collect(),
+        Expr::CallBuiltin { op, args: bargs } => Expr::CallBuiltin {
+            op: *op, args: bargs.iter().map(|a| s!(a)).collect(),
         },
         Expr::Slice { expr: e, from, to } => Expr::Slice {
             expr: sb!(e), from: from.as_ref().map(|f| sb!(f)), to: to.as_ref().map(|t| sb!(t)),
@@ -518,8 +518,8 @@ pub(crate) fn append_call_args(expr: &Expr, target: FuncId, extra: &[Expr]) -> E
         Expr::ClosureOp { op, input_expr, key_expr } => Expr::ClosureOp {
             op: *op, input_expr: rb!(input_expr), key_expr: rb!(key_expr),
         },
-        Expr::CallBuiltin { name, args } => Expr::CallBuiltin {
-            name: name.clone(), args: args.iter().map(|a| r!(a)).collect(),
+        Expr::CallBuiltin { op, args } => Expr::CallBuiltin {
+            op: *op, args: args.iter().map(|a| r!(a)).collect(),
         },
         Expr::Slice { expr: e, from, to } => Expr::Slice {
             expr: rb!(e), from: from.as_ref().map(|f| rb!(f)), to: to.as_ref().map(|t| rb!(t)),
@@ -795,11 +795,11 @@ fn subst_cow(expr: &Expr, pv: &[VarIdx], args: &[Expr]) -> Option<Expr> {
                 key_expr: Box::new(k.unwrap_or_else(|| key_expr.as_ref().clone())),
             })
         }
-        Expr::CallBuiltin { name, args: bargs } => {
+        Expr::CallBuiltin { op, args: bargs } => {
             let results: Vec<_> = bargs.iter().map(|a| s!(a)).collect();
             if results.iter().all(|r| r.is_none()) { return None; }
             Some(Expr::CallBuiltin {
-                name: name.clone(),
+                op: *op,
                 args: bargs.iter().zip(results).map(|(a, r)| r.unwrap_or_else(|| a.clone())).collect(),
             })
         }
@@ -4000,8 +4000,8 @@ pub fn eval(
             cb(Value::number(id as f64))
         }
 
-        Expr::CallBuiltin { name, args } => {
-            eval_call_builtin(name, args, input, env, cb)
+        Expr::CallBuiltin { op, args } => {
+            eval_call_builtin(op.name(), args, input, env, cb)
         }
 
         Expr::Memoize { slot_id, key, body } => {
@@ -5551,24 +5551,24 @@ fn source_nav_error(source: &Expr, input: &Value, env: &EnvRef) -> anyhow::Error
 /// argument. `$x` (`arg`) is evaluated against the same input as the builtin,
 /// matching `def`-bound semantics; it is referenced twice, so a generator
 /// argument (vanishingly rare in a path expression) is re-evaluated.
-fn lower_trimstr_path(name: &str, arg: &Expr) -> Expr {
+fn lower_trimstr_path(op: BuiltinOp, arg: &Expr) -> Expr {
     let len_of_arg = || Expr::UnaryOp { op: crate::ir::UnaryOp::Length, operand: Box::new(arg.clone()) };
-    match name {
-        "ltrimstr" => Expr::IfThenElse {
-            cond: Box::new(Expr::CallBuiltin { name: "startswith".to_string(), args: vec![arg.clone()] }),
+    match op {
+        BuiltinOp::LtrimStr => Expr::IfThenElse {
+            cond: Box::new(Expr::CallBuiltin { op: BuiltinOp::StartsWith, args: vec![arg.clone()] }),
             then_branch: Box::new(Expr::Slice { expr: Box::new(Expr::Input), from: Some(Box::new(len_of_arg())), to: None }),
             else_branch: Box::new(Expr::Input),
         },
-        "rtrimstr" => Expr::IfThenElse {
-            cond: Box::new(Expr::CallBuiltin { name: "endswith".to_string(), args: vec![arg.clone()] }),
+        BuiltinOp::RtrimStr => Expr::IfThenElse {
+            cond: Box::new(Expr::CallBuiltin { op: BuiltinOp::EndsWith, args: vec![arg.clone()] }),
             then_branch: Box::new(Expr::Slice { expr: Box::new(Expr::Input), from: None, to: Some(Box::new(Expr::Negate { operand: Box::new(len_of_arg()) })) }),
             else_branch: Box::new(Expr::Input),
         },
         // `trimstr` is `ltrimstr | rtrimstr`: a left match then a right match
         // compose into a two-component slice path, exactly as jq emits.
         _ => Expr::Pipe {
-            left: Box::new(lower_trimstr_path("ltrimstr", arg)),
-            right: Box::new(lower_trimstr_path("rtrimstr", arg)),
+            left: Box::new(lower_trimstr_path(BuiltinOp::LtrimStr, arg)),
+            right: Box::new(lower_trimstr_path(BuiltinOp::RtrimStr, arg)),
         },
     }
 }
@@ -5896,17 +5896,6 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
                 }
             }
             Ok(true)
-        }
-        Expr::CallBuiltin { name, args } if name == "getpath" && args.len() == 1 => {
-            // In path context, getpath(p) yields the path p — but jq still
-            // traverses the input along p and raises a type error if an
-            // intermediate value cannot be indexed. `rt_getpath` performs that
-            // exact check (lenient on missing keys, strict on type mismatch), so
-            // validate before emitting the path. #775
-            eval(&args[0], input.clone(), env, &mut |pv| {
-                crate::runtime::rt_getpath(&input, &pv)?;
-                cb(pv)
-            })
         }
         Expr::GetPath { path } => {
             // In path context, getpath(p) = the path p itself, validated against
@@ -6385,10 +6374,10 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
         // The `*str` trim builtins are jq-defined slice expressions, so they are
         // path-transparent: lower to that definition and reuse the slice-path
         // machinery (no-match → identity `[]`, match → slice path). #962
-        Expr::CallBuiltin { name, args }
-            if args.len() == 1 && matches!(name.as_str(), "ltrimstr" | "rtrimstr" | "trimstr") =>
+        Expr::CallBuiltin { op, args }
+            if args.len() == 1 && matches!(op, BuiltinOp::LtrimStr | BuiltinOp::RtrimStr | BuiltinOp::TrimStr) =>
         {
-            let lowered = lower_trimstr_path(name, &args[0]);
+            let lowered = lower_trimstr_path(*op, &args[0]);
             eval_path(&lowered, input, env, cb)
         }
         // The whitespace trim builtins (`trim`/`ltrim`/`rtrim`) are value-

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -6,7 +6,7 @@
 
 use anyhow::Result;
 
-use crate::ir::CompiledFunc;
+use crate::ir::{BuiltinOp, CompiledFunc};
 use crate::value::Value;
 
 /// Self-diff knob for issue #323: when set, [`Filter::execute`] and
@@ -348,13 +348,13 @@ fn extract_strfunc_cond(expr: &crate::ir::Expr) -> Option<StrFuncCond> {
                 return Some(StrFuncCond::Test(pattern.clone(), flags_str));
             }
         }
-        Expr::CallBuiltin { name, args } => {
+        Expr::CallBuiltin { op: name, args } => {
             if args.len() == 2 && matches!(args[0], Expr::Input) {
                 if let Expr::Literal(Literal::Str(s)) = &args[1] {
-                    match name.as_str() {
-                        "startswith" => return Some(StrFuncCond::Startswith(s.clone())),
-                        "endswith" => return Some(StrFuncCond::Endswith(s.clone())),
-                        "contains" => return Some(StrFuncCond::Contains(s.clone())),
+                    match name {
+                        BuiltinOp::StartsWith => return Some(StrFuncCond::Startswith(s.clone())),
+                        BuiltinOp::EndsWith => return Some(StrFuncCond::Endswith(s.clone())),
+                        BuiltinOp::Contains => return Some(StrFuncCond::Contains(s.clone())),
                         _ => {}
                     }
                 }
@@ -986,7 +986,7 @@ fn simplify_expr(expr: &crate::ir::Expr) -> crate::ir::Expr {
                     if matches!(el.as_ref(), Expr::UnaryOp { op: UnaryOp::Explode, operand } if matches!(operand.as_ref(), Expr::Input)) {
                         if let Some(shift) = is_map_shift(er) {
                             return Expr::CallBuiltin {
-                                name: "__shift_codepoints__".to_string(),
+                                op: BuiltinOp::ShiftCodepoints,
                                 args: vec![Expr::Literal(Literal::Num(shift, None))],
                             };
                         }
@@ -999,7 +999,7 @@ fn simplify_expr(expr: &crate::ir::Expr) -> crate::ir::Expr {
                     if matches!(ir.as_ref(), Expr::UnaryOp { op: UnaryOp::Implode, operand } if matches!(operand.as_ref(), Expr::Input)) {
                         if let Some(shift) = is_map_shift(mr) {
                             return Expr::CallBuiltin {
-                                name: "__shift_codepoints__".to_string(),
+                                op: BuiltinOp::ShiftCodepoints,
                                 args: vec![Expr::Literal(Literal::Num(shift, None))],
                             };
                         }
@@ -1582,8 +1582,8 @@ fn simplify_expr(expr: &crate::ir::Expr) -> crate::ir::Expr {
                 }
             }
             // split("s") | length > 1 → contains("s")  (more efficient, enables raw byte path)
-            if let Expr::CallBuiltin { name, args } = &sl {
-                if name == "split" && args.len() == 1 {
+            if let Expr::CallBuiltin { op: name, args } = &sl {
+                if *name == BuiltinOp::Split && args.len() == 1 {
                     if let Expr::Literal(crate::ir::Literal::Str(delim)) = &args[0] {
                         if let Expr::BinOp { op, lhs: cmp_lhs, rhs: cmp_rhs } = &sr {
                             if let Expr::UnaryOp { op: crate::ir::UnaryOp::Length, operand } = cmp_lhs.as_ref() {
@@ -1593,7 +1593,7 @@ fn simplify_expr(expr: &crate::ir::Expr) -> crate::ir::Expr {
                                         // split(S) | length > 0 is always true for any finite string
                                         if !delim.is_empty() && *n == 1.0 && matches!(op, crate::ir::BinOp::Gt) {
                                             return Expr::CallBuiltin {
-                                                name: "contains".to_string(),
+                                                op: BuiltinOp::Contains,
                                                 args: vec![Expr::Literal(crate::ir::Literal::Str(delim.clone()))],
                                             };
                                         }
@@ -1906,13 +1906,13 @@ fn simplify_expr(expr: &crate::ir::Expr) -> crate::ir::Expr {
             }
             Expr::IndexOpt { expr: Box::new(se), key: Box::new(sk) }
         }
-        Expr::CallBuiltin { name, args } => {
+        Expr::CallBuiltin { op: name, args } => {
             let sargs: Vec<_> = args.iter().map(|a| simplify_expr(a)).collect();
             // walk(.) → identity
-            if name == "walk" && sargs.len() == 1 && matches!(&sargs[0], Expr::Input) {
+            if *name == BuiltinOp::Walk && sargs.len() == 1 && matches!(&sargs[0], Expr::Input) {
                 return Expr::Input;
             }
-            Expr::CallBuiltin { name: name.clone(), args: sargs }
+            Expr::CallBuiltin { op: *name, args: sargs }
         }
         Expr::Alternative { primary, fallback } => {
             Expr::Alternative { primary: Box::new(simplify_expr(primary)), fallback: Box::new(simplify_expr(fallback)) }
@@ -1981,7 +1981,7 @@ fn simplify_expr(expr: &crate::ir::Expr) -> crate::ir::Expr {
             // `del` at compile time (issue #155).
             if matches!(&su, Expr::Empty) {
                 return Expr::CallBuiltin {
-                    name: "del".to_string(),
+                    op: BuiltinOp::Del,
                     args: vec![sp],
                 };
             }
@@ -2014,13 +2014,13 @@ fn simplify_expr(expr: &crate::ir::Expr) -> crate::ir::Expr {
                                 Expr::UnaryOp { op, operand } => {
                                     replace_field_with_input(operand, field).map(|o| Expr::UnaryOp { op: *op, operand: Box::new(o) })
                                 }
-                                Expr::CallBuiltin { name, args } => {
+                                Expr::CallBuiltin { op: name, args } => {
                                     let mut any_replaced = false;
                                     let new_args: Vec<_> = args.iter().map(|a| {
                                         if let Some(r) = replace_field_with_input(a, field) { any_replaced = true; r }
                                         else { a.clone() }
                                     }).collect();
-                                    if any_replaced { Some(Expr::CallBuiltin { name: name.clone(), args: new_args }) }
+                                    if any_replaced { Some(Expr::CallBuiltin { op: *name, args: new_args }) }
                                     else { None }
                                 }
                                 Expr::RegexTest { input_expr, re, flags } => {
@@ -2145,7 +2145,7 @@ fn simplify_expr(expr: &crate::ir::Expr) -> crate::ir::Expr {
                 if let Expr::Collect { generator: inner } = generator.as_ref() {
                     if let Expr::Literal(Literal::Str(field)) = inner.as_ref() {
                         return Expr::CallBuiltin {
-                            name: "del".into(),
+                            op: BuiltinOp::Del,
                             args: vec![Expr::Index {
                                 expr: Box::new(Expr::Input),
                                 key: Box::new(Expr::Literal(Literal::Str(field.clone()))),
@@ -3397,11 +3397,11 @@ impl Filter {
                             if !matches!(base.as_ref(), Expr::Input) { return None; }
                             if let Expr::Literal(Literal::Str(field)) = key.as_ref() {
                                 // CallBuiltin(startswith/endswith/contains, [Literal(Str)])
-                                if let Expr::CallBuiltin { name, args } = right.as_ref() {
+                                if let Expr::CallBuiltin { op: name, args } = right.as_ref() {
                                     if args.len() == 1 {
                                         if let Expr::Literal(Literal::Str(arg)) = &args[0] {
-                                            if matches!(name.as_str(), "startswith" | "endswith" | "contains") {
-                                                return Some((field.clone(), name.clone(), arg.clone()));
+                                            if matches!(name, BuiltinOp::StartsWith | BuiltinOp::EndsWith | BuiltinOp::Contains) {
+                                                return Some((field.clone(), name.name().to_string(), arg.clone()));
                                             }
                                         }
                                     }
@@ -3411,14 +3411,6 @@ impl Filter {
                                     if matches!(input_expr.as_ref(), Expr::Input) {
                                         if let Expr::Literal(Literal::Str(pat)) = re.as_ref() {
                                             return Some((field.clone(), "test".to_string(), pat.clone()));
-                                        }
-                                    }
-                                }
-                                // CallBuiltin("test", [Literal(Str)])
-                                if let Expr::CallBuiltin { name, args } = right.as_ref() {
-                                    if name == "test" && args.len() == 1 {
-                                        if let Expr::Literal(Literal::Str(arg)) = &args[0] {
-                                            return Some((field.clone(), "test".to_string(), arg.clone()));
                                         }
                                     }
                                 }
@@ -3923,11 +3915,11 @@ impl Filter {
                 if let Expr::Index { expr: base, key } = left.as_ref() {
                     if !matches!(base.as_ref(), Expr::Input) { return None; }
                     if let Expr::Literal(Literal::Str(field)) = key.as_ref() {
-                        if let Expr::CallBuiltin { name, args } = right.as_ref() {
+                        if let Expr::CallBuiltin { op: name, args } = right.as_ref() {
                             if args.len() == 1 {
                                 if let Expr::Literal(Literal::Str(arg)) = &args[0] {
-                                    if matches!(name.as_str(), "startswith" | "endswith" | "contains") {
-                                        return Some((field.clone(), name.clone(), arg.clone()));
+                                    if matches!(name, BuiltinOp::StartsWith | BuiltinOp::EndsWith | BuiltinOp::Contains) {
+                                        return Some((field.clone(), name.name().to_string(), arg.clone()));
                                     }
                                 }
                             }
@@ -3979,10 +3971,10 @@ impl Filter {
                     if let Expr::Index { expr: base, key } = left.as_ref() {
                         if !matches!(base.as_ref(), Expr::Input) { return None; }
                         if let Expr::Literal(Literal::Str(field)) = key.as_ref() {
-                            if let Expr::CallBuiltin { name, args } = right.as_ref() {
-                                if matches!(name.as_str(), "startswith" | "endswith" | "contains") && args.len() == 1 {
+                            if let Expr::CallBuiltin { op: name, args } = right.as_ref() {
+                                if matches!(name, BuiltinOp::StartsWith | BuiltinOp::EndsWith | BuiltinOp::Contains) && args.len() == 1 {
                                     if let Expr::Literal(Literal::Str(arg)) = &args[0] {
-                                        return Some((field.clone(), name.clone(), arg.clone()));
+                                        return Some((field.clone(), name.name().to_string(), arg.clone()));
                                     }
                                 }
                             }
@@ -3990,13 +3982,13 @@ impl Filter {
                     }
                 }
                 // Also handle beta-reduced form: CallBuiltin("startswith", [Index(Input, "field"), Literal("str")])
-                if let Expr::CallBuiltin { name, args } = e {
-                    if matches!(name.as_str(), "startswith" | "endswith" | "contains") && args.len() == 2 {
+                if let Expr::CallBuiltin { op: name, args } = e {
+                    if matches!(name, BuiltinOp::StartsWith | BuiltinOp::EndsWith | BuiltinOp::Contains) && args.len() == 2 {
                         if let Expr::Index { expr: base, key } = &args[0] {
                             if matches!(base.as_ref(), Expr::Input) {
                                 if let Expr::Literal(Literal::Str(field)) = key.as_ref() {
                                     if let Expr::Literal(Literal::Str(arg)) = &args[1] {
-                                        return Some((field.clone(), name.clone(), arg.clone()));
+                                        return Some((field.clone(), name.name().to_string(), arg.clone()));
                                     }
                                 }
                             }
@@ -4061,10 +4053,10 @@ impl Filter {
                     if let Expr::Index { expr: base, key } = left.as_ref() {
                         if matches!(base.as_ref(), Expr::Input) {
                             if let Expr::Literal(Literal::Str(field)) = key.as_ref() {
-                                if let Expr::CallBuiltin { name, args } = right.as_ref() {
-                                    if matches!(name.as_str(), "startswith" | "endswith" | "contains") && args.len() == 1 {
+                                if let Expr::CallBuiltin { op: name, args } = right.as_ref() {
+                                    if matches!(name, BuiltinOp::StartsWith | BuiltinOp::EndsWith | BuiltinOp::Contains) && args.len() == 1 {
                                         if let Expr::Literal(Literal::Str(arg)) = &args[0] {
-                                            return Some(MixedCond::StrTest(field.clone(), name.clone(), arg.clone()));
+                                            return Some(MixedCond::StrTest(field.clone(), name.name().to_string(), arg.clone()));
                                         }
                                     }
                                 }
@@ -4081,13 +4073,13 @@ impl Filter {
                     }
                 }
                 // Beta-reduced: CallBuiltin("startswith", [Index, Literal])
-                if let Expr::CallBuiltin { name, args } = e {
-                    if matches!(name.as_str(), "startswith" | "endswith" | "contains") && args.len() == 2 {
+                if let Expr::CallBuiltin { op: name, args } = e {
+                    if matches!(name, BuiltinOp::StartsWith | BuiltinOp::EndsWith | BuiltinOp::Contains) && args.len() == 2 {
                         if let Expr::Index { expr: base, key } = &args[0] {
                             if matches!(base.as_ref(), Expr::Input) {
                                 if let Expr::Literal(Literal::Str(field)) = key.as_ref() {
                                     if let Expr::Literal(Literal::Str(arg)) = &args[1] {
-                                        return Some(MixedCond::StrTest(field.clone(), name.clone(), arg.clone()));
+                                        return Some(MixedCond::StrTest(field.clone(), name.name().to_string(), arg.clone()));
                                     }
                                 }
                             }
@@ -4545,8 +4537,8 @@ impl Filter {
                     if let Expr::Literal(Literal::Str(field)) = key.as_ref() {
                         // .field | split(sep) | ...
                         if let Expr::Pipe { left: split_expr, right: tail_expr } = right.as_ref() {
-                            if let Expr::CallBuiltin { name: sn, args: sa } = split_expr.as_ref() {
-                                if sn == "split" && sa.len() == 1 {
+                            if let Expr::CallBuiltin { op: sn, args: sa } = split_expr.as_ref() {
+                                if *sn == BuiltinOp::Split && sa.len() == 1 {
                                     if let Expr::Literal(Literal::Str(sep)) = &sa[0] {
                                         // .field | split(sep) | length
                                         if matches!(tail_expr.as_ref(), Expr::UnaryOp { op: UnaryOp::Length, operand } if matches!(operand.as_ref(), Expr::Input)) {
@@ -4571,16 +4563,16 @@ impl Filter {
                             }
                         }
                         // .field | builtin("arg") — string builtins
-                        if let Expr::CallBuiltin { name: bn, args: ba } = right.as_ref() {
+                        if let Expr::CallBuiltin { op: bn, args: ba } = right.as_ref() {
                             if ba.len() == 1 {
                                 if let Expr::Literal(Literal::Str(arg)) = &ba[0] {
-                                    let op = match bn.as_str() {
-                                        "ltrimstr" => Some(StrBuiltin::Ltrimstr),
-                                        "rtrimstr" => Some(StrBuiltin::Rtrimstr),
-                                        "startswith" => Some(StrBuiltin::Startswith),
-                                        "endswith" => Some(StrBuiltin::Endswith),
-                                        "index" => Some(StrBuiltin::Index),
-                                        "contains" => Some(StrBuiltin::Contains),
+                                    let op = match bn {
+                                        BuiltinOp::LtrimStr => Some(StrBuiltin::Ltrimstr),
+                                        BuiltinOp::RtrimStr => Some(StrBuiltin::Rtrimstr),
+                                        BuiltinOp::StartsWith => Some(StrBuiltin::Startswith),
+                                        BuiltinOp::EndsWith => Some(StrBuiltin::Endswith),
+                                        BuiltinOp::Index => Some(StrBuiltin::Index),
+                                        BuiltinOp::Contains => Some(StrBuiltin::Contains),
                                         _ => None,
                                     };
                                     if let Some(op) = op {
@@ -4630,11 +4622,11 @@ impl Filter {
                 if matches!(base.as_ref(), Expr::Input) {
                     if let Expr::Literal(Literal::Str(field)) = key.as_ref() {
                         if let Expr::Pipe { left: split_expr, right: join_expr } = right.as_ref() {
-                            if let Expr::CallBuiltin { name: sn, args: sa } = split_expr.as_ref() {
-                                if sn == "split" && sa.len() == 1 {
+                            if let Expr::CallBuiltin { op: sn, args: sa } = split_expr.as_ref() {
+                                if *sn == BuiltinOp::Split && sa.len() == 1 {
                                     if let Expr::Literal(Literal::Str(sep)) = &sa[0] {
-                                        if let Expr::CallBuiltin { name: jn, args: ja } = join_expr.as_ref() {
-                                            if jn == "join" && ja.len() == 1 {
+                                        if let Expr::CallBuiltin { op: jn, args: ja } = join_expr.as_ref() {
+                                            if *jn == BuiltinOp::Join && ja.len() == 1 {
                                                 if let Expr::Literal(Literal::Str(rep)) = &ja[0] {
                                                     return Some(RemapExpr::FieldSplitJoin(field.clone(), sep.clone(), rep.clone()));
                                                 }
@@ -5159,11 +5151,11 @@ impl Filter {
             if let Expr::Index { expr: base, key } = left.as_ref() {
                 if !matches!(base.as_ref(), Expr::Input) { return None; }
                 if let Expr::Literal(Literal::Str(field)) = key.as_ref() {
-                    if let Expr::CallBuiltin { name, args } = right.as_ref() {
+                    if let Expr::CallBuiltin { op: name, args } = right.as_ref() {
                         if args.len() == 1 {
-                            if matches!(name.as_str(), "startswith" | "endswith" | "ltrimstr" | "rtrimstr" | "split" | "index" | "rindex" | "indices" | "contains") {
+                            if matches!(name, BuiltinOp::StartsWith | BuiltinOp::EndsWith | BuiltinOp::LtrimStr | BuiltinOp::RtrimStr | BuiltinOp::Split | BuiltinOp::Index | BuiltinOp::Rindex | BuiltinOp::Indices | BuiltinOp::Contains) {
                                 if let Expr::Literal(Literal::Str(arg)) = &args[0] {
-                                    return Some((field.clone(), name.clone(), arg.clone()));
+                                    return Some((field.clone(), name.name().to_string(), arg.clone()));
                                 }
                             }
                         }
@@ -5185,11 +5177,11 @@ impl Filter {
                 if let Expr::Literal(Literal::Str(field)) = key.as_ref() {
                     if let Expr::BinOp { op, lhs, rhs } = right.as_ref() {
                         if !matches!(op, BinOp::Add | BinOp::Sub | BinOp::Mul | BinOp::Div) { return None; }
-                        if let Expr::CallBuiltin { name, args } = lhs.as_ref() {
-                            if (name == "index" || name == "rindex") && args.len() == 1 {
+                        if let Expr::CallBuiltin { op: name, args } = lhs.as_ref() {
+                            if (*name == BuiltinOp::Index || *name == BuiltinOp::Rindex) && args.len() == 1 {
                                 if let Expr::Literal(Literal::Str(search)) = &args[0] {
                                     if let Expr::Literal(Literal::Num(n, _)) = rhs.as_ref() {
-                                        return Some((field.clone(), search.clone(), name == "rindex", *op, *n));
+                                        return Some((field.clone(), search.clone(), *name == BuiltinOp::Rindex, *op, *n));
                                     }
                                 }
                             }
@@ -5249,13 +5241,13 @@ impl Filter {
     fn try_extract_terminal(expr: &crate::ir::Expr) -> StringChainTerminal {
         use crate::ir::{Expr, Literal, UnaryOp};
         match expr {
-            Expr::CallBuiltin { name, args } if args.len() == 1 => {
+            Expr::CallBuiltin { op: name, args } if args.len() == 1 => {
                 if let Expr::Literal(Literal::Str(arg)) = &args[0] {
-                    match name.as_str() {
-                        "startswith" => return StringChainTerminal::Startswith(arg.clone()),
-                        "endswith" => return StringChainTerminal::Endswith(arg.clone()),
-                        "contains" => return StringChainTerminal::Contains(arg.clone()),
-                        "index" => return StringChainTerminal::Index(arg.clone()),
+                    match name {
+                        BuiltinOp::StartsWith => return StringChainTerminal::Startswith(arg.clone()),
+                        BuiltinOp::EndsWith => return StringChainTerminal::Endswith(arg.clone()),
+                        BuiltinOp::Contains => return StringChainTerminal::Contains(arg.clone()),
+                        BuiltinOp::Index => return StringChainTerminal::Index(arg.clone()),
                         _ => {}
                     }
                 }
@@ -5277,23 +5269,23 @@ impl Filter {
             Expr::UnaryOp { op: UnaryOp::AsciiUpcase, operand } if matches!(operand.as_ref(), Expr::Input) => {
                 ops.push(StringChainOp::AsciiUpcase); true
             }
-            Expr::CallBuiltin { name, args } if args.len() == 1 => {
+            Expr::CallBuiltin { op: name, args } if args.len() == 1 => {
                 if let Expr::Literal(Literal::Str(arg)) = &args[0] {
-                    match name.as_str() {
-                        "ltrimstr" => { ops.push(StringChainOp::Ltrimstr(arg.clone())); true }
-                        "rtrimstr" => { ops.push(StringChainOp::Rtrimstr(arg.clone())); true }
+                    match name {
+                        BuiltinOp::LtrimStr => { ops.push(StringChainOp::Ltrimstr(arg.clone())); true }
+                        BuiltinOp::RtrimStr => { ops.push(StringChainOp::Rtrimstr(arg.clone())); true }
                         _ => false,
                     }
                 } else { false }
             }
             // split(sep) | join(rep) — fused as SplitJoin
             Expr::Pipe { left, right } => {
-                if let Expr::CallBuiltin { name: sn, args: sa } = left.as_ref() {
-                    if sn == "split" && sa.len() == 1 {
+                if let Expr::CallBuiltin { op: sn, args: sa } = left.as_ref() {
+                    if *sn == BuiltinOp::Split && sa.len() == 1 {
                         if let Expr::Literal(Literal::Str(sep)) = &sa[0] {
                             // Check for split | join
-                            if let Expr::CallBuiltin { name: jn, args: ja } = right.as_ref() {
-                                if jn == "join" && ja.len() == 1 {
+                            if let Expr::CallBuiltin { op: jn, args: ja } = right.as_ref() {
+                                if *jn == BuiltinOp::Join && ja.len() == 1 {
                                     if let Expr::Literal(Literal::Str(rep)) = &ja[0] {
                                         ops.push(StringChainOp::SplitJoin(sep.clone(), rep.clone()));
                                         return true;
@@ -5303,8 +5295,8 @@ impl Filter {
                             // Check for split | reverse | join
                             if let Expr::Pipe { left: rev, right: join_expr } = right.as_ref() {
                                 if matches!(rev.as_ref(), Expr::UnaryOp { op: UnaryOp::Reverse, operand } if matches!(operand.as_ref(), Expr::Input)) {
-                                    if let Expr::CallBuiltin { name: jn, args: ja } = join_expr.as_ref() {
-                                        if jn == "join" && ja.len() == 1 {
+                                    if let Expr::CallBuiltin { op: jn, args: ja } = join_expr.as_ref() {
+                                        if *jn == BuiltinOp::Join && ja.len() == 1 {
                                             if let Expr::Literal(Literal::Str(rep)) = &ja[0] {
                                                 ops.push(StringChainOp::SplitReverseJoin(sep.clone(), rep.clone()));
                                                 return true;
@@ -5364,10 +5356,10 @@ impl Filter {
                     if let Expr::Index { expr: base, key } = pl.as_ref() {
                         if matches!(base.as_ref(), Expr::Input) {
                             if let Expr::Literal(Literal::Str(field)) = key.as_ref() {
-                                if let Expr::CallBuiltin { name, args } = pr.as_ref() {
-                                    if matches!(name.as_str(), "startswith" | "endswith" | "contains") && args.len() == 1 {
+                                if let Expr::CallBuiltin { op: name, args } = pr.as_ref() {
+                                    if matches!(name, BuiltinOp::StartsWith | BuiltinOp::EndsWith | BuiltinOp::Contains) && args.len() == 1 {
                                         if let Expr::Literal(Literal::Str(arg)) = &args[0] {
-                                            return Some((field.clone(), name.clone(), arg.clone(), remap));
+                                            return Some((field.clone(), name.name().to_string(), arg.clone(), remap));
                                         }
                                     }
                                 }
@@ -5615,11 +5607,6 @@ impl Filter {
                                     }
                                 }
                             }
-                            Expr::CallBuiltin { name, args } if name == "test" && args.len() == 1 => {
-                                if let Expr::Literal(Literal::Str(pattern)) = &args[0] {
-                                    return Some((field.clone(), is_upper, pattern.clone()));
-                                }
-                            }
                             _ => {}
                         }
                     }
@@ -5641,8 +5628,8 @@ impl Filter {
                 if !matches!(base.as_ref(), Expr::Input) { return None; }
                 if let Expr::Literal(Literal::Str(field)) = key.as_ref() {
                     if let Expr::Pipe { left: mid, right: rr } = right.as_ref() {
-                        if let Expr::CallBuiltin { name, args } = mid.as_ref() {
-                            if name == "ltrimstr" && args.len() == 1 {
+                        if let Expr::CallBuiltin { op: name, args } = mid.as_ref() {
+                            if *name == BuiltinOp::LtrimStr && args.len() == 1 {
                                 if let Expr::Literal(Literal::Str(prefix)) = &args[0] {
                                     // tonumber with no further ops
                                     if let Expr::UnaryOp { op: UnaryOp::ToNumber, operand } = rr.as_ref() {
@@ -5714,8 +5701,8 @@ impl Filter {
         let expr = self.detect_expr()?;
         if let Expr::Pipe { left, right } = expr {
             // right must be join("sep")
-            if let Expr::CallBuiltin { name, args } = right.as_ref() {
-                if name != "join" || args.len() != 1 { return None; }
+            if let Expr::CallBuiltin { op: name, args } = right.as_ref() {
+                if *name != BuiltinOp::Join || args.len() != 1 { return None; }
                 if let Expr::Literal(Literal::Str(sep)) = &args[0] {
                     // left must be [expr1, expr2, ...]
                     if let Expr::Collect { generator } = left.as_ref() {
@@ -5771,8 +5758,8 @@ impl Filter {
             if let Expr::Collect { generator } = left.as_ref() {
                 if let Expr::Pipe { left: map_expr, right: join_expr } = right.as_ref() {
                     // Check join(sep)
-                    let sep = if let Expr::CallBuiltin { name, args } = join_expr.as_ref() {
-                        if name != "join" || args.len() != 1 { return None; }
+                    let sep = if let Expr::CallBuiltin { op: name, args } = join_expr.as_ref() {
+                        if *name != BuiltinOp::Join || args.len() != 1 { return None; }
                         if let Expr::Literal(Literal::Str(s)) = &args[0] { s.clone() } else { return None; }
                     } else { return None; };
                     // Check map(tostring) = [.[] | tostring]
@@ -6028,14 +6015,14 @@ impl Filter {
                 if !matches!(base.as_ref(), Expr::Input) { return None; }
                 if let Expr::Literal(Literal::Str(field)) = key.as_ref() {
                     if let Expr::Pipe { left: split_expr, right: rest } = right.as_ref() {
-                        if let Expr::CallBuiltin { name, args } = split_expr.as_ref() {
-                            if name == "split" && args.len() == 1 {
+                        if let Expr::CallBuiltin { op: name, args } = split_expr.as_ref() {
+                            if *name == BuiltinOp::Split && args.len() == 1 {
                                 if let Expr::Literal(Literal::Str(sep)) = &args[0] {
                                     if sep.is_empty() {
                                         if let Expr::Pipe { left: rev_expr, right: join_expr } = rest.as_ref() {
                                             if matches!(rev_expr.as_ref(), Expr::UnaryOp { op: UnaryOp::Reverse, operand } if matches!(operand.as_ref(), Expr::Input)) {
-                                                if let Expr::CallBuiltin { name: jn, args: ja } = join_expr.as_ref() {
-                                                    if jn == "join" && ja.len() == 1 {
+                                                if let Expr::CallBuiltin { op: jn, args: ja } = join_expr.as_ref() {
+                                                    if *jn == BuiltinOp::Join && ja.len() == 1 {
                                                         if let Expr::Literal(Literal::Str(js)) = &ja[0] {
                                                             if js.is_empty() {
                                                                 return Some(field.clone());
@@ -6066,13 +6053,13 @@ impl Filter {
                 if !matches!(base.as_ref(), Expr::Input) { return None; }
                 if let Expr::Literal(Literal::Str(field)) = key.as_ref() {
                     if let Expr::Pipe { left: split_expr, right: rest } = right.as_ref() {
-                        if let Expr::CallBuiltin { name, args } = split_expr.as_ref() {
-                            if name == "split" && args.len() == 1 {
+                        if let Expr::CallBuiltin { op: name, args } = split_expr.as_ref() {
+                            if *name == BuiltinOp::Split && args.len() == 1 {
                                 if let Expr::Literal(Literal::Str(sep)) = &args[0] {
                                     if let Expr::Pipe { left: rev_expr, right: join_expr } = rest.as_ref() {
                                         if matches!(rev_expr.as_ref(), Expr::UnaryOp { op: UnaryOp::Reverse, operand } if matches!(operand.as_ref(), Expr::Input)) {
-                                            if let Expr::CallBuiltin { name: jn, args: ja } = join_expr.as_ref() {
-                                                if jn == "join" && ja.len() == 1 {
+                                            if let Expr::CallBuiltin { op: jn, args: ja } = join_expr.as_ref() {
+                                                if *jn == BuiltinOp::Join && ja.len() == 1 {
                                                     if let Expr::Literal(Literal::Str(js)) = &ja[0] {
                                                         if !sep.is_empty() {
                                                             return Some((field.clone(), sep.clone(), js.clone()));
@@ -6108,11 +6095,11 @@ impl Filter {
                             _ => return None,
                         };
                         if let Expr::Pipe { left: split_expr, right: join_expr } = rest.as_ref() {
-                            if let Expr::CallBuiltin { name, args } = split_expr.as_ref() {
-                                if name == "split" && args.len() == 1 {
+                            if let Expr::CallBuiltin { op: name, args } = split_expr.as_ref() {
+                                if *name == BuiltinOp::Split && args.len() == 1 {
                                     if let Expr::Literal(Literal::Str(sep)) = &args[0] {
-                                        if let Expr::CallBuiltin { name: jn, args: ja } = join_expr.as_ref() {
-                                            if jn == "join" && ja.len() == 1 {
+                                        if let Expr::CallBuiltin { op: jn, args: ja } = join_expr.as_ref() {
+                                            if *jn == BuiltinOp::Join && ja.len() == 1 {
                                                 if let Expr::Literal(Literal::Str(js)) = &ja[0] {
                                                     if !sep.is_empty() {
                                                         return Some((field.clone(), is_upper, sep.clone(), js.clone()));
@@ -6146,8 +6133,8 @@ impl Filter {
                             Expr::UnaryOp { op: UnaryOp::AsciiDowncase, operand } if matches!(operand.as_ref(), Expr::Input) => false,
                             _ => return None,
                         };
-                        if let Expr::CallBuiltin { name, args } = split_expr.as_ref() {
-                            if name == "split" && args.len() == 1 {
+                        if let Expr::CallBuiltin { op: name, args } = split_expr.as_ref() {
+                            if *name == BuiltinOp::Split && args.len() == 1 {
                                 if let Expr::Literal(Literal::Str(sep)) = &args[0] {
                                     if !sep.is_empty() {
                                         return Some((field.clone(), is_upper, sep.clone()));
@@ -6157,8 +6144,8 @@ impl Filter {
                         }
                     }
                     // Also handle beta-reduced form: CallBuiltin(split, [UnaryOp(case, .field)])
-                    if let Expr::CallBuiltin { name, args } = right.as_ref() {
-                        if name == "split" && args.len() == 1 {
+                    if let Expr::CallBuiltin { op: name, args } = right.as_ref() {
+                        if *name == BuiltinOp::Split && args.len() == 1 {
                             if let Expr::Literal(Literal::Str(_sep)) = &args[0] {
                                 // This form doesn't include the case op, skip
                             }
@@ -6168,8 +6155,8 @@ impl Filter {
             }
         }
         // Beta-reduced: CallBuiltin(split, [UnaryOp(case, Index(.field))])
-        if let Expr::CallBuiltin { name, args } = expr {
-            if name == "split" && args.len() == 1 {
+        if let Expr::CallBuiltin { op: name, args } = expr {
+            if *name == BuiltinOp::Split && args.len() == 1 {
                 if let Expr::Literal(Literal::Str(sep)) = &args[0] {
                     if !sep.is_empty() {
                         // The input to split would be the case-converted field — check operand
@@ -6199,8 +6186,8 @@ impl Filter {
                             _ => return None,
                         };
                         if let Expr::Pipe { left: split_expr, right: idx_expr } = rest.as_ref() {
-                            if let Expr::CallBuiltin { name, args } = split_expr.as_ref() {
-                                if name == "split" && args.len() == 1 {
+                            if let Expr::CallBuiltin { op: name, args } = split_expr.as_ref() {
+                                if *name == BuiltinOp::Split && args.len() == 1 {
                                     if let Expr::Literal(Literal::Str(sep)) = &args[0] {
                                         if !sep.is_empty() {
                                             if let Expr::Index { expr: ibase, key: ikey } = idx_expr.as_ref() {
@@ -6208,16 +6195,6 @@ impl Filter {
                                                     if let Expr::Literal(Literal::Num(n, _)) = ikey.as_ref() {
                                                         let idx = *n as i64;
                                                         return Some((field.clone(), is_upper, sep.clone(), idx));
-                                                    }
-                                                }
-                                            }
-                                            // Check for first/last
-                                            if let Expr::CallBuiltin { name: fn_name, args: fn_args } = idx_expr.as_ref() {
-                                                if fn_args.is_empty() || (fn_args.len() == 1 && matches!(fn_args[0], Expr::Input)) {
-                                                    if fn_name == "first" {
-                                                        return Some((field.clone(), is_upper, sep.clone(), 0));
-                                                    } else if fn_name == "last" {
-                                                        return Some((field.clone(), is_upper, sep.clone(), -1));
                                                     }
                                                 }
                                             }
@@ -6654,8 +6631,8 @@ impl Filter {
     pub fn detect_del_field(&self) -> Option<String> {
         use crate::ir::{Expr, Literal};
         let expr = self.detect_expr()?;
-        if let Expr::CallBuiltin { name, args } = expr {
-            if name == "del" && args.len() == 1 {
+        if let Expr::CallBuiltin { op: name, args } = expr {
+            if *name == BuiltinOp::Del && args.len() == 1 {
                 if let Expr::Index { expr: base, key } = &args[0] {
                     if matches!(base.as_ref(), Expr::Input) {
                         if let Expr::Literal(Literal::Str(field)) = key.as_ref() {
@@ -6699,8 +6676,8 @@ impl Filter {
             } else { return None; }
         } else { return None; };
         // Parse del expression
-        if let Expr::CallBuiltin { name, args } = del_expr {
-            if name != "del" || args.len() != 1 { return None; }
+        if let Expr::CallBuiltin { op: name, args } = del_expr {
+            if *name != BuiltinOp::Del || args.len() != 1 { return None; }
             let mut del_fields = Vec::new();
             fn collect_del_fields(expr: &Expr, fields: &mut Vec<String>) -> bool {
                 match expr {
@@ -6747,12 +6724,12 @@ impl Filter {
             if let Expr::Index { expr: base, key } = left.as_ref() {
                 if !matches!(base.as_ref(), Expr::Input) { return None; }
                 if let Expr::Literal(Literal::Str(f)) = key.as_ref() {
-                    if let Expr::CallBuiltin { name, args } = right.as_ref() {
+                    if let Expr::CallBuiltin { op: name, args } = right.as_ref() {
                         if args.len() == 1 {
                             if let Expr::Literal(Literal::Str(s)) = &args[0] {
-                                match name.as_str() {
-                                    "startswith" | "endswith" | "test" | "contains" => {
-                                        (f.clone(), name.clone(), s.clone())
+                                match name {
+                                    BuiltinOp::StartsWith | BuiltinOp::EndsWith | BuiltinOp::Contains => {
+                                        (f.clone(), name.name().to_string(), s.clone())
                                     }
                                     _ => return None,
                                 }
@@ -6774,8 +6751,8 @@ impl Filter {
             } else { return None; }
         } else { return None; };
         // Parse del expression
-        if let Expr::CallBuiltin { name, args } = del_expr {
-            if name != "del" || args.len() != 1 { return None; }
+        if let Expr::CallBuiltin { op: name, args } = del_expr {
+            if *name != BuiltinOp::Del || args.len() != 1 { return None; }
             let mut del_fields = Vec::new();
             fn collect_del(expr: &Expr, fields: &mut Vec<String>) -> bool {
                 match expr {
@@ -6883,12 +6860,12 @@ impl Filter {
             if let Expr::Index { expr: base, key } = left.as_ref() {
                 if !matches!(base.as_ref(), Expr::Input) { return None; }
                 if let Expr::Literal(Literal::Str(f)) = key.as_ref() {
-                    if let Expr::CallBuiltin { name, args } = right.as_ref() {
+                    if let Expr::CallBuiltin { op: name, args } = right.as_ref() {
                         if args.len() == 1 {
                             if let Expr::Literal(Literal::Str(s)) = &args[0] {
-                                match name.as_str() {
-                                    "startswith" | "endswith" | "test" | "contains" => {
-                                        (f.clone(), name.clone(), s.clone())
+                                match name {
+                                    BuiltinOp::StartsWith | BuiltinOp::EndsWith | BuiltinOp::Contains => {
+                                        (f.clone(), name.name().to_string(), s.clone())
                                     }
                                     _ => return None,
                                 }
@@ -6934,8 +6911,8 @@ impl Filter {
     pub fn detect_del_fields(&self) -> Option<Vec<String>> {
         use crate::ir::{Expr, Literal};
         let expr = self.detect_expr()?;
-        if let Expr::CallBuiltin { name, args } = expr {
-            if name == "del" && args.len() == 1 {
+        if let Expr::CallBuiltin { op: name, args } = expr {
+            if *name == BuiltinOp::Del && args.len() == 1 {
                 let mut fields = Vec::new();
                 fn collect_fields(expr: &Expr, fields: &mut Vec<String>) -> bool {
                     match expr {
@@ -6973,8 +6950,8 @@ impl Filter {
     pub fn detect_has_field(&self) -> Option<String> {
         use crate::ir::{Expr, Literal};
         let expr = self.detect_expr()?;
-        if let Expr::CallBuiltin { name, args } = expr {
-            if name == "has" && args.len() == 1 {
+        if let Expr::CallBuiltin { op: name, args } = expr {
+            if *name == BuiltinOp::Has && args.len() == 1 {
                 if let Expr::Literal(Literal::Str(field)) = &args[0] {
                     return Some(field.clone());
                 }
@@ -6999,8 +6976,8 @@ impl Filter {
                             return collect(lhs, fields, is_and) && collect(rhs, fields, is_and);
                         }
                     }
-                    if let Expr::CallBuiltin { name, args } = e {
-                        if name == "has" && args.len() == 1 {
+                    if let Expr::CallBuiltin { op: name, args } = e {
+                        if *name == BuiltinOp::Has && args.len() == 1 {
                             if let Expr::Literal(Literal::Str(f)) = &args[0] {
                                 fields.push(f.clone());
                                 return true;
@@ -7027,8 +7004,8 @@ impl Filter {
             if !matches!(then_branch.as_ref(), Expr::Input) { return None; }
             if !matches!(else_branch.as_ref(), Expr::Empty) { return None; }
             // Also handle single has: select(has("a"))
-            if let Expr::CallBuiltin { name, args } = cond.as_ref() {
-                if name == "has" && args.len() == 1 {
+            if let Expr::CallBuiltin { op: name, args } = cond.as_ref() {
+                if *name == BuiltinOp::Has && args.len() == 1 {
                     if let crate::ir::Literal::Str(f) = match &args[0] {
                         Expr::Literal(l) => l,
                         _ => return None,
@@ -7046,8 +7023,8 @@ impl Filter {
                         return collect_has(lhs, fields, is_and) && collect_has(rhs, fields, is_and);
                     }
                 }
-                if let Expr::CallBuiltin { name, args } = e {
-                    if name == "has" && args.len() == 1 {
+                if let Expr::CallBuiltin { op: name, args } = e {
+                    if *name == BuiltinOp::Has && args.len() == 1 {
                         if let Expr::Literal(Literal::Str(f)) = &args[0] {
                             fields.push(f.clone());
                             return true;
@@ -7362,14 +7339,14 @@ impl Filter {
                             if !matches!(then_branch.as_ref(), Expr::Input) { return None; }
                             if !matches!(else_branch.as_ref(), Expr::Empty) { return None; }
                             // .key | startswith("str") — beta-reduced form
-                            if let Expr::CallBuiltin { name, args } = cond.as_ref() {
-                                if matches!(name.as_str(), "startswith" | "endswith" | "contains") && args.len() == 2 {
+                            if let Expr::CallBuiltin { op: name, args } = cond.as_ref() {
+                                if matches!(name, BuiltinOp::StartsWith | BuiltinOp::EndsWith | BuiltinOp::Contains) && args.len() == 2 {
                                     if let Expr::Index { expr: base, key } = &args[0] {
                                         if matches!(base.as_ref(), Expr::Input) {
                                             if let Expr::Literal(Literal::Str(f)) = key.as_ref() {
                                                 if f == "key" {
                                                     if let Expr::Literal(Literal::Str(s)) = &args[1] {
-                                                        return Some((name.clone(), s.clone()));
+                                                        return Some((name.name().to_string(), s.clone()));
                                                     }
                                                 }
                                             }
@@ -7384,18 +7361,18 @@ impl Filter {
                                     if matches!(base.as_ref(), Expr::Input) {
                                         if let Expr::Literal(Literal::Str(f)) = key.as_ref() {
                                             if f == "key" {
-                                                if let Expr::CallBuiltin { name, args } = pr.as_ref() {
-                                                    if matches!(name.as_str(), "startswith" | "endswith" | "contains") {
+                                                if let Expr::CallBuiltin { op: name, args } = pr.as_ref() {
+                                                    if matches!(name, BuiltinOp::StartsWith | BuiltinOp::EndsWith | BuiltinOp::Contains) {
                                                         // 1-arg form: CallBuiltin("startswith", [Literal("str")])
                                                         if args.len() == 1 {
                                                             if let Expr::Literal(Literal::Str(s)) = &args[0] {
-                                                                return Some((name.clone(), s.clone()));
+                                                                return Some((name.name().to_string(), s.clone()));
                                                             }
                                                         }
                                                         // 2-arg form: CallBuiltin("startswith", [Input, Literal("str")])
                                                         if args.len() == 2 && matches!(args[0], Expr::Input) {
                                                             if let Expr::Literal(Literal::Str(s)) = &args[1] {
-                                                                return Some((name.clone(), s.clone()));
+                                                                return Some((name.name().to_string(), s.clone()));
                                                             }
                                                         }
                                                     }
@@ -8008,11 +7985,11 @@ impl Filter {
                 if !matches!(base.as_ref(), Expr::Input) { return None; }
                 if let Expr::Literal(Literal::Str(field)) = key.as_ref() {
                     if let Expr::Pipe { left: split_expr, right: join_expr } = right.as_ref() {
-                        if let Expr::CallBuiltin { name: split_name, args: split_args } = split_expr.as_ref() {
-                            if split_name != "split" || split_args.len() != 1 { return None; }
+                        if let Expr::CallBuiltin { op: split_name, args: split_args } = split_expr.as_ref() {
+                            if *split_name != BuiltinOp::Split || split_args.len() != 1 { return None; }
                             if let Expr::Literal(Literal::Str(split_str)) = &split_args[0] {
-                                if let Expr::CallBuiltin { name: join_name, args: join_args } = join_expr.as_ref() {
-                                    if join_name != "join" || join_args.len() != 1 { return None; }
+                                if let Expr::CallBuiltin { op: join_name, args: join_args } = join_expr.as_ref() {
+                                    if *join_name != BuiltinOp::Join || join_args.len() != 1 { return None; }
                                     if let Expr::Literal(Literal::Str(join_str)) = &join_args[0] {
                                         return Some((field.clone(), split_str.clone(), join_str.clone()));
                                     }
@@ -8040,8 +8017,8 @@ impl Filter {
                 else { return None; }
             } else { return None; };
             if let Expr::Pipe { left: l2, right: r2 } = right.as_ref() {
-                let split_sep = if let Expr::CallBuiltin { name, args } = l2.as_ref() {
-                    if name != "split" || args.len() != 1 { return None; }
+                let split_sep = if let Expr::CallBuiltin { op: name, args } = l2.as_ref() {
+                    if *name != BuiltinOp::Split || args.len() != 1 { return None; }
                     if let Expr::Literal(Literal::Str(s)) = &args[0] { s.clone() }
                     else { return None; }
                 } else { return None; };
@@ -8069,8 +8046,8 @@ impl Filter {
                         };
                         (from_val, to_val)
                     } else { return None; };
-                    let join_sep = if let Expr::CallBuiltin { name, args } = r3.as_ref() {
-                        if name != "join" || args.len() != 1 { return None; }
+                    let join_sep = if let Expr::CallBuiltin { op: name, args } = r3.as_ref() {
+                        if *name != BuiltinOp::Join || args.len() != 1 { return None; }
                         if let Expr::Literal(Literal::Str(s)) = &args[0] { s.clone() }
                         else { return None; }
                     } else { return None; };
@@ -8093,8 +8070,8 @@ impl Filter {
                 _ => return None,
             };
             if !matches!(operand.as_ref(), Expr::Input) { return None; }
-            if let Expr::CallBuiltin { name, args } = right.as_ref() {
-                if name == "join" && args.len() == 1 {
+            if let Expr::CallBuiltin { op: name, args } = right.as_ref() {
+                if *name == BuiltinOp::Join && args.len() == 1 {
                     if let Expr::Literal(crate::ir::Literal::Str(sep)) = &args[0] {
                         return Some((sep.clone(), is_sorted));
                     }
@@ -8260,8 +8237,8 @@ impl Filter {
                         None
                     }
                     fn extract_split(e: &Expr) -> Option<String> {
-                        if let Expr::CallBuiltin { name, args } = e {
-                            if name == "split" && args.len() == 1 {
+                        if let Expr::CallBuiltin { op: name, args } = e {
+                            if *name == BuiltinOp::Split && args.len() == 1 {
                                 if let Expr::Literal(Literal::Str(sep)) = &args[0] {
                                     return Some(sep.clone());
                                 }
@@ -8314,17 +8291,11 @@ impl Filter {
                                 if let Some(sep) = extract_split(inner) { return Some(sep); }
                             }
                         }
-                        // Form 3: CallBuiltin("last", [split])
-                        if let Expr::CallBuiltin { name, args } = e {
-                            if name == "last" && args.len() == 1 {
-                                if let Some(sep) = extract_split(&args[0]) { return Some(sep); }
-                            }
-                        }
                         None
                     }
                     fn extract_split(e: &Expr) -> Option<String> {
-                        if let Expr::CallBuiltin { name, args } = e {
-                            if name == "split" && args.len() == 1 {
+                        if let Expr::CallBuiltin { op: name, args } = e {
+                            if *name == BuiltinOp::Split && args.len() == 1 {
                                 if let Expr::Literal(Literal::Str(sep)) = &args[0] {
                                     return Some(sep.clone());
                                 }
@@ -8344,11 +8315,6 @@ impl Filter {
                         // last is .[-1] or CallBuiltin("last", [Input])
                         if let Expr::Index { expr: inner, key } = e {
                             if matches!(inner.as_ref(), Expr::Input) && matches!(key.as_ref(), Expr::Literal(Literal::Num(n, _)) if *n == -1.0) {
-                                return true;
-                            }
-                        }
-                        if let Expr::CallBuiltin { name, args } = e {
-                            if name == "last" && args.len() == 1 && matches!(args[0], Expr::Input) {
                                 return true;
                             }
                         }
@@ -8426,12 +8392,12 @@ impl Filter {
             if let Expr::Index { expr: base, key } = path_expr.as_ref() {
                 if !matches!(base.as_ref(), Expr::Input) { return None; }
                 if let Expr::Literal(Literal::Str(field)) = key.as_ref() {
-                    if let Expr::CallBuiltin { name, args } = upd.as_ref() {
+                    if let Expr::CallBuiltin { op: name, args } = upd.as_ref() {
                         if args.len() == 1 {
                             if let Expr::Literal(Literal::Str(arg)) = &args[0] {
-                                match name.as_str() {
-                                    "ltrimstr" => return Some((field.clone(), arg.clone(), false)),
-                                    "rtrimstr" => return Some((field.clone(), arg.clone(), true)),
+                                match name {
+                                    BuiltinOp::LtrimStr => return Some((field.clone(), arg.clone(), false)),
+                                    BuiltinOp::RtrimStr => return Some((field.clone(), arg.clone(), true)),
                                     _ => {}
                                 }
                             }
@@ -8657,8 +8623,8 @@ impl Filter {
                 if !matches!(base.as_ref(), Expr::Input) { return None; }
                 if let Expr::Literal(Literal::Str(field)) = key.as_ref() {
                     if let Expr::Pipe { left: split_expr, right: index_expr } = right.as_ref() {
-                        if let Expr::CallBuiltin { name, args } = split_expr.as_ref() {
-                            if name != "split" || args.len() != 1 { return None; }
+                        if let Expr::CallBuiltin { op: name, args } = split_expr.as_ref() {
+                            if *name != BuiltinOp::Split || args.len() != 1 { return None; }
                             if let Expr::Literal(Literal::Str(delim)) = &args[0] {
                                 // Check for .[0]
                                 let is_first = match index_expr.as_ref() {
@@ -8690,8 +8656,8 @@ impl Filter {
                 if !matches!(base.as_ref(), Expr::Input) { return None; }
                 if let Expr::Literal(Literal::Str(field)) = key.as_ref() {
                     if let Expr::Pipe { left: split_expr, right: index_expr } = right.as_ref() {
-                        if let Expr::CallBuiltin { name, args } = split_expr.as_ref() {
-                            if name != "split" || args.len() != 1 { return None; }
+                        if let Expr::CallBuiltin { op: name, args } = split_expr.as_ref() {
+                            if *name != BuiltinOp::Split || args.len() != 1 { return None; }
                             if let Expr::Literal(Literal::Str(delim)) = &args[0] {
                                 if let Expr::Index { expr: ibase, key: ikey } = index_expr.as_ref() {
                                     if matches!(ibase.as_ref(), Expr::Input) {
@@ -8723,8 +8689,8 @@ impl Filter {
                 if !matches!(base.as_ref(), Expr::Input) { return None; }
                 if let Expr::Literal(Literal::Str(field)) = key.as_ref() {
                     if let Expr::Pipe { left: split_expr, right: last_expr } = right.as_ref() {
-                        if let Expr::CallBuiltin { name, args } = split_expr.as_ref() {
-                            if name != "split" || args.len() != 1 { return None; }
+                        if let Expr::CallBuiltin { op: name, args } = split_expr.as_ref() {
+                            if *name != BuiltinOp::Split || args.len() != 1 { return None; }
                             if let Expr::Literal(Literal::Str(delim)) = &args[0] {
                                 // Check for .[-1] (last is parsed as .[-1])
                                 let is_last = matches!(last_expr.as_ref(),
@@ -8754,8 +8720,8 @@ impl Filter {
                 if let Expr::Literal(Literal::Str(field)) = key.as_ref() {
                     // Pipe(split("s"), Pipe(last, tonumber)) or Pipe(split("s"), tonumber(last))
                     if let Expr::Pipe { left: split_expr, right: rest } = right.as_ref() {
-                        if let Expr::CallBuiltin { name, args } = split_expr.as_ref() {
-                            if name != "split" || args.len() != 1 { return None; }
+                        if let Expr::CallBuiltin { op: name, args } = split_expr.as_ref() {
+                            if *name != BuiltinOp::Split || args.len() != 1 { return None; }
                             if let Expr::Literal(Literal::Str(delim)) = &args[0] {
                                 // rest should be Pipe(last, tonumber) or UnaryOp(Tonumber, last)
                                 if let Expr::Pipe { left: last_expr, right: tonum_expr } = rest.as_ref() {
@@ -8802,8 +8768,8 @@ impl Filter {
                 if !matches!(base.as_ref(), Expr::Input) { return None; }
                 if let Expr::Literal(Literal::Str(field)) = key.as_ref() {
                     if let Expr::Pipe { left: split_expr, right: rest } = right.as_ref() {
-                        if let Expr::CallBuiltin { name, args } = split_expr.as_ref() {
-                            if name != "split" || args.len() != 1 { return None; }
+                        if let Expr::CallBuiltin { op: name, args } = split_expr.as_ref() {
+                            if *name != BuiltinOp::Split || args.len() != 1 { return None; }
                             if let Expr::Literal(Literal::Str(delim)) = &args[0] {
                                 // rest: Pipe(.[N], tonumber) or UnaryOp(ToNumber, .[N])
                                 if let Expr::Pipe { left: idx_expr, right: tonum_expr } = rest.as_ref() {
@@ -8856,8 +8822,8 @@ impl Filter {
                 if !matches!(base.as_ref(), Expr::Input) { return None; }
                 if let Expr::Literal(Literal::Str(field)) = key.as_ref() {
                     if let Expr::Pipe { left: split_expr, right: len_expr } = right.as_ref() {
-                        if let Expr::CallBuiltin { name, args } = split_expr.as_ref() {
-                            if name != "split" || args.len() != 1 { return None; }
+                        if let Expr::CallBuiltin { op: name, args } = split_expr.as_ref() {
+                            if *name != BuiltinOp::Split || args.len() != 1 { return None; }
                             if let Expr::Literal(Literal::Str(delim)) = &args[0] {
                                 // Plain length
                                 if matches!(len_expr.as_ref(), Expr::UnaryOp { op: UnaryOp::Length, operand } if matches!(operand.as_ref(), Expr::Input)) {
@@ -8904,8 +8870,8 @@ impl Filter {
                             if matches!(base.as_ref(), Expr::Input) {
                                 if let Expr::Literal(Literal::Str(field)) = key.as_ref() {
                                     if let Expr::Pipe { left: split_expr, right: len_expr } = right.as_ref() {
-                                        if let Expr::CallBuiltin { name, args } = split_expr.as_ref() {
-                                            if name == "split" && args.len() == 1 {
+                                        if let Expr::CallBuiltin { op: name, args } = split_expr.as_ref() {
+                                            if *name == BuiltinOp::Split && args.len() == 1 {
                                                 if let Expr::Literal(Literal::Str(delim)) = &args[0] {
                                                     if matches!(len_expr.as_ref(), Expr::UnaryOp { op: UnaryOp::Length, operand } if matches!(operand.as_ref(), Expr::Input)) {
                                                         return Some((field.clone(), delim.clone(), *op, *n));
@@ -8920,8 +8886,8 @@ impl Filter {
                     }
                     // Beta-reduced: lhs might be Length(Split(.field, "sep"))
                     if let Expr::UnaryOp { op: UnaryOp::Length, operand: inner } = lhs.as_ref() {
-                        if let Expr::CallBuiltin { name, args } = inner.as_ref() {
-                            if name == "split" && args.len() == 2 {
+                        if let Expr::CallBuiltin { op: name, args } = inner.as_ref() {
+                            if *name == BuiltinOp::Split && args.len() == 2 {
                                 if let Expr::Index { expr: base, key } = &args[0] {
                                     if matches!(base.as_ref(), Expr::Input) {
                                         if let Expr::Literal(Literal::Str(field)) = key.as_ref() {
@@ -8943,8 +8909,8 @@ impl Filter {
                 if matches!(base.as_ref(), Expr::Input) {
                     if let Expr::Literal(Literal::Str(field)) = key.as_ref() {
                         if let Expr::Pipe { left: split_expr, right: cmp_expr } = right.as_ref() {
-                            if let Expr::CallBuiltin { name, args } = split_expr.as_ref() {
-                                if name == "split" && args.len() == 1 {
+                            if let Expr::CallBuiltin { op: name, args } = split_expr.as_ref() {
+                                if *name == BuiltinOp::Split && args.len() == 1 {
                                     if let Expr::Literal(Literal::Str(delim)) = &args[0] {
                                         if let Expr::BinOp { op, lhs: cmp_lhs, rhs: cmp_rhs } = cmp_expr.as_ref() {
                                             if matches!(op, BinOp::Gt | BinOp::Lt | BinOp::Ge | BinOp::Le | BinOp::Eq | BinOp::Ne) {
@@ -8976,8 +8942,8 @@ impl Filter {
                 if !matches!(base.as_ref(), Expr::Input) { return None; }
                 if let Expr::Literal(Literal::Str(field)) = key.as_ref() {
                     if let Expr::Pipe { left: split_expr, right: concat_expr } = right.as_ref() {
-                        if let Expr::CallBuiltin { name, args } = split_expr.as_ref() {
-                            if name != "split" || args.len() != 1 { return None; }
+                        if let Expr::CallBuiltin { op: name, args } = split_expr.as_ref() {
+                            if *name != BuiltinOp::Split || args.len() != 1 { return None; }
                             if let Expr::Literal(Literal::Str(delim)) = &args[0] {
                                 let mut parts = Vec::new();
                                 if Self::collect_split_concat_parts(concat_expr, &mut parts) && parts.len() >= 2 {
@@ -9055,10 +9021,10 @@ impl Filter {
             if let Expr::Pipe { left: op_expr, right: len_expr } = right.as_ref() {
                 if matches!(len_expr.as_ref(), Expr::UnaryOp { op: UnaryOp::Length, operand } if matches!(operand.as_ref(), Expr::Input)) {
                     match op_expr.as_ref() {
-                        Expr::CallBuiltin { name, args } if args.len() == 1 => {
+                        Expr::CallBuiltin { op: name, args } if args.len() == 1 => {
                             if let Expr::Literal(Literal::Str(arg)) = &args[0] {
-                                match name.as_str() {
-                                    "ltrimstr" | "rtrimstr" => return Some((field, name.clone(), Some(arg.clone()))),
+                                match name {
+                                    BuiltinOp::LtrimStr | BuiltinOp::RtrimStr => return Some((field, name.name().to_string(), Some(arg.clone()))),
                                     _ => {}
                                 }
                             }
@@ -9240,10 +9206,6 @@ impl Filter {
                         else { return None; }
                     } else { return None; };
                     match right.as_ref() {
-                        Expr::CallBuiltin { name, args } if args.is_empty() => {
-                            if name == "max" { return Some((field1, field2, true)); }
-                            if name == "min" { return Some((field1, field2, false)); }
-                        }
                         Expr::UnaryOp { op: UnaryOp::Max, operand } if matches!(operand.as_ref(), Expr::Input) => {
                             return Some((field1, field2, true));
                         }
@@ -9994,14 +9956,13 @@ impl Filter {
                 if let Expr::Index { expr: base, key } = left.as_ref() {
                     if matches!(base.as_ref(), Expr::Input) {
                         if let Expr::Literal(Literal::Str(field)) = key.as_ref() {
-                            if let Expr::CallBuiltin { name, args } = right.as_ref() {
+                            if let Expr::CallBuiltin { op: name, args } = right.as_ref() {
                                 if args.len() == 1 {
                                     if let Expr::Literal(Literal::Str(s)) = &args[0] {
-                                        let rhs = match name.as_str() {
-                                            "startswith" => Some(CondRhs::Startswith(s.clone())),
-                                            "endswith" => Some(CondRhs::Endswith(s.clone())),
-                                            "contains" => Some(CondRhs::Contains(s.clone())),
-                                            "test" => Some(CondRhs::Test(s.clone())),
+                                        let rhs = match name {
+                                            BuiltinOp::StartsWith => Some(CondRhs::Startswith(s.clone())),
+                                            BuiltinOp::EndsWith => Some(CondRhs::Endswith(s.clone())),
+                                            BuiltinOp::Contains => Some(CondRhs::Contains(s.clone())),
                                             _ => None,
                                         };
                                         if let Some(r) = rhs {
@@ -10973,10 +10934,10 @@ impl Filter {
                     if let Expr::Index { expr: base, key } = pl.as_ref() {
                         if matches!(base.as_ref(), Expr::Input) {
                             if let Expr::Literal(Literal::Str(field)) = key.as_ref() {
-                                if let Expr::CallBuiltin { name, args } = pr.as_ref() {
-                                    if matches!(name.as_str(), "startswith" | "endswith" | "contains") && args.len() == 1 {
+                                if let Expr::CallBuiltin { op: name, args } = pr.as_ref() {
+                                    if matches!(name, BuiltinOp::StartsWith | BuiltinOp::EndsWith | BuiltinOp::Contains) && args.len() == 1 {
                                         if let Expr::Literal(Literal::Str(arg)) = &args[0] {
-                                            return Some((field.clone(), name.clone(), arg.clone(), rexprs));
+                                            return Some((field.clone(), name.name().to_string(), arg.clone(), rexprs));
                                         }
                                     }
                                 }
@@ -11039,10 +11000,10 @@ impl Filter {
                     if let Expr::Index { expr: base, key } = pipe_left.as_ref() {
                         if matches!(base.as_ref(), Expr::Input) {
                             if let Expr::Literal(Literal::Str(field)) = key.as_ref() {
-                                if let Expr::CallBuiltin { name, args } = pipe_right.as_ref() {
-                                    if matches!(name.as_str(), "startswith" | "endswith" | "contains") && args.len() == 1 {
+                                if let Expr::CallBuiltin { op: name, args } = pipe_right.as_ref() {
+                                    if matches!(name, BuiltinOp::StartsWith | BuiltinOp::EndsWith | BuiltinOp::Contains) && args.len() == 1 {
                                         if let Expr::Literal(Literal::Str(arg)) = &args[0] {
-                                            return Some((field.clone(), name.clone(), arg.clone(), output_field));
+                                            return Some((field.clone(), name.name().to_string(), arg.clone(), output_field));
                                         }
                                     }
                                 }
@@ -11104,10 +11065,10 @@ impl Filter {
                     if let Expr::Index { expr: base, key } = pipe_left.as_ref() {
                         if matches!(base.as_ref(), Expr::Input) {
                             if let Expr::Literal(Literal::Str(field)) = key.as_ref() {
-                                if let Expr::CallBuiltin { name, args } = pipe_right.as_ref() {
-                                    if matches!(name.as_str(), "startswith" | "endswith" | "contains") && args.len() == 1 {
+                                if let Expr::CallBuiltin { op: name, args } = pipe_right.as_ref() {
+                                    if matches!(name, BuiltinOp::StartsWith | BuiltinOp::EndsWith | BuiltinOp::Contains) && args.len() == 1 {
                                         if let Expr::Literal(Literal::Str(arg)) = &args[0] {
-                                            return Some((field.clone(), name.clone(), arg.clone(), upd_field, arith_op, arith_val));
+                                            return Some((field.clone(), name.name().to_string(), arg.clone(), upd_field, arith_op, arith_val));
                                         }
                                     }
                                 }
@@ -11201,10 +11162,10 @@ impl Filter {
                 if let Expr::Index { expr: base, key } = left.as_ref() {
                     if matches!(base.as_ref(), Expr::Input) {
                         if let Expr::Literal(Literal::Str(field)) = key.as_ref() {
-                            if let Expr::CallBuiltin { name, args } = right.as_ref() {
-                                if matches!(name.as_str(), "startswith" | "endswith" | "contains") && args.len() == 1 {
+                            if let Expr::CallBuiltin { op: name, args } = right.as_ref() {
+                                if matches!(name, BuiltinOp::StartsWith | BuiltinOp::EndsWith | BuiltinOp::Contains) && args.len() == 1 {
                                     if let Expr::Literal(Literal::Str(arg)) = &args[0] {
-                                        return Some((field.clone(), name.clone(), arg.clone()));
+                                        return Some((field.clone(), name.name().to_string(), arg.clone()));
                                     }
                                 }
                             }
@@ -11505,8 +11466,8 @@ impl Filter {
     pub fn detect_walk_num_op(&self) -> Option<(crate::ir::BinOp, f64)> {
         use crate::ir::{Expr, BinOp, Literal, UnaryOp};
         let expr = self.detect_expr()?;
-        if let Expr::CallBuiltin { name, args } = expr {
-            if name != "walk" || args.len() != 1 { return None; }
+        if let Expr::CallBuiltin { op: name, args } = expr {
+            if *name != BuiltinOp::Walk || args.len() != 1 { return None; }
             // The body should be: if type == "number" then . op N else . end
             if let Expr::IfThenElse { cond, then_branch, else_branch } = &args[0] {
                 // else_branch must be identity (.)

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -105,6 +105,168 @@ impl FormatKind {
     }
 }
 
+/// Defines [`BuiltinOp`] together with its bijective name mapping so the
+/// variant list, `name()`, and `from_name()` can never drift apart.
+macro_rules! builtin_ops {
+    ($($(#[$attr:meta])* $variant:ident => $name:literal),+ $(,)?) => {
+        /// Identity of a runtime-dispatched builtin (`Expr::CallBuiltin`),
+        /// resolved from its source name once, in the parser (#1035).
+        ///
+        /// This covers only builtins that flow through `CallBuiltin`; most
+        /// builtins lower to dedicated `Expr` nodes (`UnaryOp`, `RegexTest`,
+        /// `Limit`, ...) and never appear here. The JIT keeps a *wider*
+        /// string keyspace at its own `JitOp::CallBuiltin` boundary (it
+        /// synthesizes names like `_slice` and `@text` that have no `Expr`
+        /// form), so `name()` remains the bridge into that layer.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        pub enum BuiltinOp {
+            $($(#[$attr])* $variant),+
+        }
+
+        impl BuiltinOp {
+            /// The jq-source-level builtin name (also the runtime/JIT dispatch key).
+            pub fn name(self) -> &'static str {
+                match self {
+                    $(BuiltinOp::$variant => $name),+
+                }
+            }
+
+            /// Resolve a builtin name; `None` for names not routed through
+            /// `CallBuiltin` (parse sites match on a closed name set first).
+            pub fn from_name(name: &str) -> Option<BuiltinOp> {
+                match name {
+                    $($name => Some(BuiltinOp::$variant)),+,
+                    _ => None,
+                }
+            }
+        }
+    };
+}
+
+builtin_ops! {
+    // Strings
+    StartsWith => "startswith",
+    EndsWith => "endswith",
+    LtrimStr => "ltrimstr",
+    RtrimStr => "rtrimstr",
+    /// jqx extension (jq has no `trimstr/1`).
+    TrimStr => "trimstr",
+    Split => "split",
+    Join => "join",
+    Index => "index",
+    Rindex => "rindex",
+    Indices => "indices",
+    /// `explode | map(. + N) | implode` fused by the interpreter (internal).
+    ShiftCodepoints => "__shift_codepoints__",
+
+    // Containers
+    Has => "has",
+    In => "in",
+    Contains => "contains",
+    Inside => "inside",
+    Add => "add",
+    Flatten => "flatten",
+    Del => "del",
+    Pick => "pick",
+    Walk => "walk",
+    Bsearch => "bsearch",
+    Combinations => "combinations",
+    Skip => "skip",
+
+    // Streaming
+    ToStream => "tostream",
+    FromStream => "fromstream",
+    TruncateStream => "truncate_stream",
+
+    // Conversion
+    FromJson => "fromjson",
+    ToBoolean => "toboolean",
+    Format => "format",
+    /// jqx extensions (jq has no CSV/TSV *parsers*).
+    FromCsv => "fromcsv",
+    FromCsvh => "fromcsvh",
+    FromTsv => "fromtsv",
+    FromTsvh => "fromtsvh",
+
+    // Date/time
+    ToDate => "todate",
+    FromDate => "fromdate",
+    Date => "date",
+    ToDateIso8601 => "todateiso8601",
+    FromDateIso8601 => "fromdateiso8601",
+    ToIsoDate => "toisodate",
+    FromIsoDate => "fromisodate",
+    Strftime => "strftime",
+    Strptime => "strptime",
+    Strflocaltime => "strflocaltime",
+
+    // libm, no explicit args (input-driven; not in `UnaryOp` because the
+    // runtime owns their edge-case semantics)
+    Gamma => "gamma",
+    Tgamma => "tgamma",
+    Lgamma => "lgamma",
+    LgammaR => "lgamma_r",
+    Frexp => "frexp",
+    Modf => "modf",
+    Expm1 => "expm1",
+    Log1p => "log1p",
+    Erf => "erf",
+    Erfc => "erfc",
+    Y0 => "y0",
+    Y1 => "y1",
+
+    // libm, 2-3 explicit args
+    Pow => "pow",
+    Atan2 => "atan2",
+    Fma => "fma",
+    Remainder => "remainder",
+    Drem => "drem",
+    Hypot => "hypot",
+    Ldexp => "ldexp",
+    Scalb => "scalb",
+    Scalbln => "scalbln",
+    Copysign => "copysign",
+    Fdim => "fdim",
+    Fmax => "fmax",
+    Fmin => "fmin",
+    Fmod => "fmod",
+    Nextafter => "nextafter",
+    Nexttoward => "nexttoward",
+    Jn => "jn",
+    Yn => "yn",
+
+    // Process / environment
+    Halt => "halt",
+    HaltError => "halt_error",
+    InputFilename => "input_filename",
+    InputLineNumber => "input_line_number",
+    GetJqOrigin => "get_jq_origin",
+    GetProgOrigin => "get_prog_origin",
+    GetSearchList => "get_search_list",
+    HaveLiteralNumbers => "have_literal_numbers",
+    /// jqx extensions (process execution).
+    Exec => "exec",
+    Execv => "execv",
+}
+
+impl BuiltinOp {
+    /// Resolve a name the caller already matched against the builtin set
+    /// (parse sites whose `match` arm patterns pin the name). Panicking on
+    /// a miss is deliberate: it would mean the arm pattern and the
+    /// `builtin_ops!` table drifted, which is a parser bug, not user input.
+    #[track_caller]
+    pub fn resolve(name: &str) -> BuiltinOp {
+        BuiltinOp::from_name(name)
+            .unwrap_or_else(|| panic!("builtin name {name:?} not in BuiltinOp"))
+    }
+}
+
+impl std::fmt::Display for BuiltinOp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.name())
+    }
+}
+
 /// A filter expression in the IR.
 #[derive(Debug, Clone)]
 pub enum Expr {
@@ -462,7 +624,7 @@ pub enum Expr {
 
     /// Runtime builtin call with evaluated args: contains, startswith, etc.
     CallBuiltin {
-        name: String,
+        op: BuiltinOp,
         args: Vec<Expr>,
     },
 
@@ -996,8 +1158,8 @@ impl Expr {
                     StringPart::Expr(e) => StringPart::Expr(e.substitute_input(replacement)),
                 }).collect(),
             },
-            Expr::CallBuiltin { name, args } => Expr::CallBuiltin {
-                name: name.clone(),
+            Expr::CallBuiltin { op, args } => Expr::CallBuiltin {
+                op: *op,
                 args: args.iter().map(|a| a.substitute_input(replacement)).collect(),
             },
             Expr::Error { msg } => Expr::Error {
@@ -1077,8 +1239,8 @@ impl Expr {
                     Expr::LetBinding { var_index: *vi, value: new_value, body: Box::new(body.substitute_var(var_index, replacement)) }
                 }
             },
-            Expr::CallBuiltin { name, args } => Expr::CallBuiltin {
-                name: name.clone(),
+            Expr::CallBuiltin { op, args } => Expr::CallBuiltin {
+                op: *op,
                 args: args.iter().map(|a| a.substitute_var(var_index, replacement)).collect(),
             },
             Expr::Update { path_expr, update_expr } => Expr::Update {

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -325,13 +325,16 @@ fn is_scalar(expr: &Expr) -> bool {
         Expr::LetBinding { value, body, .. } => is_scalar(value) && is_scalar(body),
         Expr::Alternative { primary, fallback } => is_scalar(primary) && is_scalar(fallback),
         Expr::Until { cond, update } => is_scalar(cond) && is_scalar(update),
-        Expr::CallBuiltin { name, args } => {
+        Expr::CallBuiltin { op, args } => {
             // Filter-argument builtins can't be treated as scalar
-            match (name.as_str(), args.len()) {
-                ("walk", _) | ("pick", _) | ("skip", _) | ("del", _) | ("exec", 2)
-                | ("fromcsv", _) | ("fromtsv", _) | ("fromcsvh", _) | ("fromtsvh", _)
-                | ("tostream", _) | ("fromstream", _) | ("truncate_stream", _) => false,
-                ("add", 1) => false,
+            match (op, args.len()) {
+                (BuiltinOp::Walk, _) | (BuiltinOp::Pick, _) | (BuiltinOp::Skip, _)
+                | (BuiltinOp::Del, _) | (BuiltinOp::Exec, 2)
+                | (BuiltinOp::FromCsv, _) | (BuiltinOp::FromTsv, _)
+                | (BuiltinOp::FromCsvh, _) | (BuiltinOp::FromTsvh, _)
+                | (BuiltinOp::ToStream, _) | (BuiltinOp::FromStream, _)
+                | (BuiltinOp::TruncateStream, _) => false,
+                (BuiltinOp::Add, 1) => false,
                 _ => args.iter().all(is_scalar),
             }
         }
@@ -401,9 +404,6 @@ fn is_scalar(expr: &Expr) -> bool {
 
 type SlotId = u32;
 type LabelId = u32;
-
-#[derive(Debug, Clone, Copy)]
-enum MutateFn { Reverse, Sort }
 
 #[derive(Debug, Clone)]
 enum JitOp {
@@ -565,7 +565,6 @@ enum JitOp {
 
     /// In-place unary mutate: call runtime fn(v: *mut Value) -> i64
     /// Consumes input_slot and mutates the clone in-place.
-    MutateInplace { slot: SlotId, func: MutateFn },
 
     /// Fused [range(n)]: pre-allocate and fill array in one call.
     CollectRange { dst: SlotId, n: SlotId },
@@ -911,8 +910,8 @@ impl Flattener {
                 var_index: *var_index,
                 value: Box::new(self.inline_func_calls(value)),
             },
-            Expr::CallBuiltin { name, args } => Expr::CallBuiltin {
-                name: name.clone(),
+            Expr::CallBuiltin { op, args } => Expr::CallBuiltin {
+                op: *op,
                 args: args.iter().map(|a| self.inline_func_calls(a)).collect(),
             },
             Expr::ObjectConstruct { pairs } => Expr::ObjectConstruct {
@@ -1026,7 +1025,7 @@ impl Flattener {
             JitOp::Index { .. } | JitOp::IndexField { .. } |
             JitOp::BinOp { .. } | JitOp::AddMove { .. } | JitOp::UnaryOp { .. } |
             JitOp::Negate { .. } | JitOp::CallBuiltin { .. } |
-            JitOp::MutateInplace { .. } | JitOp::ThrowError { .. } |
+            JitOp::ThrowError { .. } |
             // The fused field-op runtimes index `.field` on the base and return
             // GEN_ERROR for a non-object base ("Cannot index <type> with string").
             // Without a CheckError that error is set but never propagated, so the
@@ -1635,29 +1634,7 @@ impl Flattener {
                 }
                 out
             }
-            Expr::CallBuiltin { name, args } => {
-                // In-place mutation for unary builtins: reverse, sort
-                // Clone input → out, drop input_slot (so Rc refcount → 1), mutate in-place
-                let mutate_fn = if args.is_empty() {
-                    match name.as_str() {
-                        "reverse" => Some(MutateFn::Reverse),
-                        "sort" => Some(MutateFn::Sort),
-                        _ => None,
-                    }
-                } else {
-                    None
-                };
-                if let Some(func) = mutate_fn {
-                    let out = self.alloc_slot();
-                    self.emit(JitOp::Clone { dst: out, src: input_slot });
-                    // Drop input_slot so the clone becomes sole owner (refcount 1)
-                    // → Rc::make_mut can mutate in-place without cloning inner data
-                    self.emit(JitOp::Drop { slot: input_slot });
-                    self.emit(JitOp::Null { dst: input_slot });
-                    self.emit_propagating(JitOp::MutateInplace { slot: out, func });
-                    return out;
-                }
-
+            Expr::CallBuiltin { op, args } => {
                 let mut arg_slots = Vec::new();
                 // First arg is always the input (.)
                 let inp = self.alloc_slot();
@@ -1667,7 +1644,7 @@ impl Flattener {
                     arg_slots.push(self.flatten_scalar(arg, input_slot));
                 }
                 let out = self.alloc_slot();
-                self.emit(JitOp::CallBuiltin { dst: out, name: name.clone(), args: arg_slots.clone() });
+                self.emit(JitOp::CallBuiltin { dst: out, name: op.name().to_string(), args: arg_slots.clone() });
                 for s in &arg_slots {
                     self.emit(JitOp::Drop { slot: *s });
                 }
@@ -3602,16 +3579,17 @@ impl Flattener {
             }
 
             // Filter-argument builtins: delegate to eval (not JIT-compilable)
-            Expr::CallBuiltin { name, args } if matches!(
-                (name.as_str(), args.len()),
-                ("walk", _) | ("pick", _) | ("skip", _) | ("add", 1) | ("del", _)
+            Expr::CallBuiltin { op, args } if matches!(
+                (op, args.len()),
+                (BuiltinOp::Walk, _) | (BuiltinOp::Pick, _) | (BuiltinOp::Skip, _)
+                | (BuiltinOp::Add, 1) | (BuiltinOp::Del, _)
             ) => {
                 false
             }
 
             // CallBuiltin with generator args: rewrite as nested LetBinding
             // e.g., join(",","/") → (",","/") as $__arg | join($__arg)
-            Expr::CallBuiltin { name, args } if !args.is_empty() && args.iter().any(|a| !is_scalar(a)) => {
+            Expr::CallBuiltin { op, args } if !args.is_empty() && args.iter().any(|a| !is_scalar(a)) => {
                 // Each generator arg gets bound to a temp var
                 let base_var = VarIdx(10200);
                 let mut var_args = Vec::new();
@@ -3632,7 +3610,7 @@ impl Flattener {
 
                 // Build nested LetBinding: arg0 as $v0 | arg1 as $v1 | ... | CallBuiltin(name, [$v0, $v1, ...])
                 let inner = Expr::CallBuiltin {
-                    name: name.clone(),
+                    op: *op,
                     args: var_args.iter().map(|(vi, _)| Expr::LoadVar { var_index: *vi }).collect(),
                 };
                 let mut rewritten = inner;
@@ -8928,7 +8906,6 @@ fn optimize_clone_yield(mut ops: Vec<JitOp>) -> Vec<JitOp> {
             }
             JitOp::StrBufAppendVal { src } => { *use_count.entry(*src).or_insert(0) += 1; }
             JitOp::ThrowError { msg } => { *use_count.entry(*msg).or_insert(0) += 1; }
-            JitOp::MutateInplace { slot, .. } => { *use_count.entry(*slot).or_insert(0) += 1; }
             JitOp::CollectRange { n, .. } => { *use_count.entry(*n).or_insert(0) += 1; }
             JitOp::ArrPush { arr, val } => {
                 *use_count.entry(*arr).or_insert(0) += 1;
@@ -9015,7 +8992,6 @@ fn optimize_clone_yield(mut ops: Vec<JitOp>) -> Vec<JitOp> {
                 }
                 JitOp::StrBufAppendVal { src } => { *use_count.entry(*src).or_insert(0) += 1; }
                 JitOp::ThrowError { msg } => { *use_count.entry(*msg).or_insert(0) += 1; }
-                JitOp::MutateInplace { slot, .. } => { *use_count.entry(*slot).or_insert(0) += 1; }
                 JitOp::CollectRange { n, .. } => { *use_count.entry(*n).or_insert(0) += 1; }
                 JitOp::ArrPush { arr, val } => {
                     *use_count.entry(*arr).or_insert(0) += 1;
@@ -10472,14 +10448,6 @@ impl JitCompiler {
                         let msg_addr = slot_addr(&mut b, *msg);
                         b.ins().call(rt["throw_error"], &[msg_addr, env_ptr]);
                         // Don't return here — CheckError or ReturnError will handle it
-                    }
-                    JitOp::MutateInplace { slot, func } => {
-                        let s = slot_addr(&mut b, *slot);
-                        let rt_name = match func {
-                            MutateFn::Reverse => "reverse_inplace",
-                            MutateFn::Sort => "sort_inplace",
-                        };
-                        b.ins().call(rt[rt_name], &[s]);
                     }
                     JitOp::CollectRange { dst, n } => {
                         let d = slot_addr(&mut b, *dst);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1293,7 +1293,7 @@ impl Parser {
                 let value_expr = Expr::Literal(Literal::Str(array_json));
                 // Parse at runtime via fromjson
                 let fromjson_expr = Expr::CallBuiltin {
-                    name: "fromjson".to_string(),
+                    op: BuiltinOp::FromJson,
                     args: vec![],
                 };
                 let pipe_expr = Expr::Pipe {
@@ -2201,7 +2201,7 @@ impl Parser {
                 // the deletion form (issue #155).
                 if matches!(&update, Expr::Empty) {
                     return Ok(Expr::CallBuiltin {
-                        name: "del".to_string(),
+                        op: BuiltinOp::Del,
                         args: vec![expr],
                     });
                 }
@@ -3483,7 +3483,7 @@ impl Parser {
                 // Run through CallBuiltin so the runtime dispatches them.
                 // `have_literal_numbers` is a feature-flag builtin; jq 1.8.1
                 // returns true (decnum is enabled in mainline). See #473.
-                Ok(Expr::CallBuiltin { name: name.to_string(), args: vec![] })
+                Ok(Expr::CallBuiltin { op: BuiltinOp::resolve(name), args: vec![] })
             }
             "values" => {
                 // values = select(. != null) - type filter
@@ -3598,36 +3598,36 @@ impl Parser {
                 Ok(Expr::Literal(Literal::False))
             }
             "toboolean" => {
-                Ok(Expr::CallBuiltin { name: "toboolean".to_string(), args: vec![] })
+                Ok(Expr::CallBuiltin { op: BuiltinOp::ToBoolean, args: vec![] })
             }
             "halt" => {
-                Ok(Expr::CallBuiltin { name: "halt".to_string(), args: vec![] })
+                Ok(Expr::CallBuiltin { op: BuiltinOp::Halt, args: vec![] })
             }
             "halt_error" => {
-                Ok(Expr::CallBuiltin { name: "halt_error".to_string(), args: vec![] })
+                Ok(Expr::CallBuiltin { op: BuiltinOp::HaltError, args: vec![] })
             }
             "input_line_number" => {
                 // Resolved at eval/JIT time from the current input's line counter
                 // (set by the CLI before each input is processed).
-                Ok(Expr::CallBuiltin { name: "input_line_number".to_string(), args: vec![] })
+                Ok(Expr::CallBuiltin { op: BuiltinOp::InputLineNumber, args: vec![] })
             }
             "fromcsv" | "fromtsv" | "fromcsvh" | "fromtsvh" => {
-                Ok(Expr::CallBuiltin { name: name.to_string(), args: vec![] })
+                Ok(Expr::CallBuiltin { op: BuiltinOp::resolve(name), args: vec![] })
             }
             "fromdateiso8601" | "todateiso8601" | "fromisodate" | "toisodate" => {
-                Ok(Expr::CallBuiltin { name: name.to_string(), args: vec![] })
+                Ok(Expr::CallBuiltin { op: BuiltinOp::resolve(name), args: vec![] })
             }
             "todate" | "fromdate" | "date" => {
-                Ok(Expr::CallBuiltin { name: name.to_string(), args: vec![] })
+                Ok(Expr::CallBuiltin { op: BuiltinOp::resolve(name), args: vec![] })
             }
             "combinations" | "modf" => {
-                Ok(Expr::CallBuiltin { name: name.to_string(), args: vec![] })
+                Ok(Expr::CallBuiltin { op: BuiltinOp::resolve(name), args: vec![] })
             }
             "get_jq_origin" | "get_prog_origin" | "get_search_list" => {
-                Ok(Expr::CallBuiltin { name: name.to_string(), args: vec![] })
+                Ok(Expr::CallBuiltin { op: BuiltinOp::resolve(name), args: vec![] })
             }
             "tostream" => {
-                Ok(Expr::CallBuiltin { name: "tostream".to_string(), args: vec![] })
+                Ok(Expr::CallBuiltin { op: BuiltinOp::ToStream, args: vec![] })
             }
             "input_filename" => {
                 // Resolved at eval/JIT time from the current input's filename
@@ -3635,7 +3635,7 @@ impl Parser {
                 // file path for a named file argument, "<stdin>" for the stdin
                 // stream, and null before any input has been read (e.g. `-n`
                 // mode before the first `input`). See #926.
-                Ok(Expr::CallBuiltin { name: "input_filename".to_string(), args: vec![] })
+                Ok(Expr::CallBuiltin { op: BuiltinOp::InputFilename, args: vec![] })
             }
             _ => {
                 // User defs and filter parameters were already resolved at the
@@ -4007,19 +4007,19 @@ impl Parser {
             }
             ("has", 1) => {
                 let key = args.into_iter().next().unwrap();
-                Ok(Expr::CallBuiltin { name: "has".to_string(), args: vec![key] })
+                Ok(Expr::CallBuiltin { op: BuiltinOp::Has, args: vec![key] })
             }
             ("in", 1) => {
                 let container = args.into_iter().next().unwrap();
-                Ok(Expr::CallBuiltin { name: "in".to_string(), args: vec![container] })
+                Ok(Expr::CallBuiltin { op: BuiltinOp::In, args: vec![container] })
             }
             ("contains", 1) => {
                 let other = args.into_iter().next().unwrap();
-                Ok(Expr::CallBuiltin { name: "contains".to_string(), args: vec![other] })
+                Ok(Expr::CallBuiltin { op: BuiltinOp::Contains, args: vec![other] })
             }
             ("inside", 1) => {
                 let other = args.into_iter().next().unwrap();
-                Ok(Expr::CallBuiltin { name: "inside".to_string(), args: vec![other] })
+                Ok(Expr::CallBuiltin { op: BuiltinOp::Inside, args: vec![other] })
             }
             ("test", 1) | ("test", 2) => {
                 let mut args = args.into_iter();
@@ -4087,7 +4087,7 @@ impl Parser {
             }
             ("flatten", 1) => {
                 let depth = args.into_iter().next().unwrap();
-                Ok(Expr::CallBuiltin { name: "flatten".to_string(), args: vec![depth] })
+                Ok(Expr::CallBuiltin { op: BuiltinOp::Flatten, args: vec![depth] })
             }
             ("splits", 1) | ("splits", 2) => {
                 // splits(re) = split(re; null) | .[] — regex split streamed
@@ -4096,7 +4096,7 @@ impl Parser {
                 let re = args_iter.next().unwrap();
                 let flags = args_iter.next().unwrap_or(Expr::Literal(Literal::Null));
                 Ok(Expr::Pipe {
-                    left: Box::new(Expr::CallBuiltin { name: "split".to_string(), args: vec![re, flags] }),
+                    left: Box::new(Expr::CallBuiltin { op: BuiltinOp::Split, args: vec![re, flags] }),
                     right: Box::new(Expr::Each { input_expr: Box::new(Expr::Input) }),
                 })
             }
@@ -4106,36 +4106,36 @@ impl Parser {
                 let sep = args.next().unwrap();
                 if n == 2 {
                     let flags = args.next().unwrap();
-                    Ok(Expr::CallBuiltin { name: "split".to_string(), args: vec![sep, flags] })
+                    Ok(Expr::CallBuiltin { op: BuiltinOp::Split, args: vec![sep, flags] })
                 } else {
-                    Ok(Expr::CallBuiltin { name: "split".to_string(), args: vec![sep] })
+                    Ok(Expr::CallBuiltin { op: BuiltinOp::Split, args: vec![sep] })
                 }
             }
             ("join", 1) => {
                 let sep = args.into_iter().next().unwrap();
-                Ok(Expr::CallBuiltin { name: "join".to_string(), args: vec![sep] })
+                Ok(Expr::CallBuiltin { op: BuiltinOp::Join, args: vec![sep] })
             }
             ("ascii_downcase", 0) => Ok(Expr::UnaryOp { op: UnaryOp::AsciiDowncase, operand: Box::new(Expr::Input) }),
             ("ascii_upcase", 0) => Ok(Expr::UnaryOp { op: UnaryOp::AsciiUpcase, operand: Box::new(Expr::Input) }),
             ("ltrimstr", 1) => {
                 let s = args.into_iter().next().unwrap();
-                Ok(Expr::CallBuiltin { name: "ltrimstr".to_string(), args: vec![s] })
+                Ok(Expr::CallBuiltin { op: BuiltinOp::LtrimStr, args: vec![s] })
             }
             ("rtrimstr", 1) => {
                 let s = args.into_iter().next().unwrap();
-                Ok(Expr::CallBuiltin { name: "rtrimstr".to_string(), args: vec![s] })
+                Ok(Expr::CallBuiltin { op: BuiltinOp::RtrimStr, args: vec![s] })
             }
             ("startswith", 1) => {
                 let s = args.into_iter().next().unwrap();
-                Ok(Expr::CallBuiltin { name: "startswith".to_string(), args: vec![s] })
+                Ok(Expr::CallBuiltin { op: BuiltinOp::StartsWith, args: vec![s] })
             }
             ("endswith", 1) => {
                 let s = args.into_iter().next().unwrap();
-                Ok(Expr::CallBuiltin { name: "endswith".to_string(), args: vec![s] })
+                Ok(Expr::CallBuiltin { op: BuiltinOp::EndsWith, args: vec![s] })
             }
             ("indices", 1) | ("index", 1) | ("rindex", 1) => {
                 let s = args.into_iter().next().unwrap();
-                Ok(Expr::CallBuiltin { name: name.to_string(), args: vec![s] })
+                Ok(Expr::CallBuiltin { op: BuiltinOp::resolve(name), args: vec![s] })
             }
             ("error", 1) => {
                 let msg = args.into_iter().next().unwrap();
@@ -4151,7 +4151,7 @@ impl Parser {
                 // print the *input* to stderr, then terminate. Runtime
                 // handles message encoding — see eval_call_builtin.
                 let code = args.into_iter().next().unwrap();
-                Ok(Expr::CallBuiltin { name: "halt_error".to_string(), args: vec![code] })
+                Ok(Expr::CallBuiltin { op: BuiltinOp::HaltError, args: vec![code] })
             }
             ("pow", 2) | ("atan2", 2) | ("fma", 3)
             | ("remainder", 2) | ("drem", 2) | ("hypot", 2)
@@ -4159,7 +4159,7 @@ impl Parser {
             | ("copysign", 2) | ("fdim", 2) | ("fmax", 2) | ("fmin", 2)
             | ("fmod", 2) | ("nextafter", 2) | ("nexttoward", 2)
             | ("jn", 2) | ("yn", 2) => {
-                Ok(Expr::CallBuiltin { name: name.to_string(), args })
+                Ok(Expr::CallBuiltin { op: BuiltinOp::resolve(name), args })
             }
             ("nth", 1) => {
                 // jq 1.8.1: def nth($n): .[$n];
@@ -4255,10 +4255,10 @@ impl Parser {
             ("fromjson", 0) => Ok(Expr::UnaryOp { op: UnaryOp::FromJson, operand: Box::new(Expr::Input) }),
             ("strftime", 1) | ("strptime", 1)
             | ("todate", 0) | ("fromdate", 0) | ("date", 0) => {
-                Ok(Expr::CallBuiltin { name: name.to_string(), args })
+                Ok(Expr::CallBuiltin { op: BuiltinOp::resolve(name), args })
             }
             ("combinations", 1) => {
-                Ok(Expr::CallBuiltin { name: "combinations".to_string(), args })
+                Ok(Expr::CallBuiltin { op: BuiltinOp::Combinations, args })
             }
             ("input", 0) => Ok(Expr::ReadInput),
             ("inputs", 0) => Ok(Expr::ReadInputs),
@@ -4270,23 +4270,23 @@ impl Parser {
                 // format to the current input. Delegate to the runtime so
                 // the directive name can vary per input.
                 let fmt = args.into_iter().next().unwrap();
-                Ok(Expr::CallBuiltin { name: "format".to_string(), args: vec![fmt] })
+                Ok(Expr::CallBuiltin { op: BuiltinOp::Format, args: vec![fmt] })
             }
             ("length", 0) => Ok(Expr::UnaryOp { op: UnaryOp::Length, operand: Box::new(Expr::Input) }),
             ("type", 0) => Ok(Expr::UnaryOp { op: UnaryOp::Type, operand: Box::new(Expr::Input) }),
             ("trimstr", 1) => {
                 let s = args.into_iter().next().unwrap();
-                Ok(Expr::CallBuiltin { name: "trimstr".to_string(), args: vec![s] })
+                Ok(Expr::CallBuiltin { op: BuiltinOp::TrimStr, args: vec![s] })
             }
             // toboolean/0: convert to boolean
             ("toboolean", 0) => {
-                Ok(Expr::CallBuiltin { name: "toboolean".to_string(), args: vec![] })
+                Ok(Expr::CallBuiltin { op: BuiltinOp::ToBoolean, args: vec![] })
             }
             // add/1: add(f) = reduce .[] as $x (null; . + ($x | f))
             // But it's simpler to delegate to CallBuiltin
             ("add", 1) => {
                 let f = args.into_iter().next().unwrap();
-                Ok(Expr::CallBuiltin { name: "add".to_string(), args: vec![f] })
+                Ok(Expr::CallBuiltin { op: BuiltinOp::Add, args: vec![f] })
             }
             // skip/2: skip(n; gen) = limit(n; gen) | empty, limit(n; gen) outputs n items then the rest
             // Actually: skip(n; exp) = def _skip(n; exp): if n > 0 then (exp | _skip(n-1; exp)) else ., exp end;
@@ -4297,86 +4297,86 @@ impl Parser {
                 let mut args = args.into_iter();
                 let n = args.next().unwrap();
                 let generator = args.next().unwrap();
-                Ok(Expr::CallBuiltin { name: "skip".to_string(), args: vec![n, generator] })
+                Ok(Expr::CallBuiltin { op: BuiltinOp::Skip, args: vec![n, generator] })
             }
             // pick/1: pick(f) extracts paths from . that f generates
             ("pick", 1) => {
                 let f = args.into_iter().next().unwrap();
-                Ok(Expr::CallBuiltin { name: "pick".to_string(), args: vec![f] })
+                Ok(Expr::CallBuiltin { op: BuiltinOp::Pick, args: vec![f] })
             }
             // bsearch/1: binary search
             ("bsearch", 1) => {
                 let target = args.into_iter().next().unwrap();
-                Ok(Expr::CallBuiltin { name: "bsearch".to_string(), args: vec![target] })
+                Ok(Expr::CallBuiltin { op: BuiltinOp::Bsearch, args: vec![target] })
             }
             // strflocaltime/1
             ("strflocaltime", 1) => {
                 let fmt = args.into_iter().next().unwrap();
-                Ok(Expr::CallBuiltin { name: "strflocaltime".to_string(), args: vec![fmt] })
+                Ok(Expr::CallBuiltin { op: BuiltinOp::Strflocaltime, args: vec![fmt] })
             }
             // walk/1: walk(f) recursively applies f to all values
             ("walk", 1) => {
                 let f = args.into_iter().next().unwrap();
-                Ok(Expr::CallBuiltin { name: "walk".to_string(), args: vec![f] })
+                Ok(Expr::CallBuiltin { op: BuiltinOp::Walk, args: vec![f] })
             }
             // fromstream/1, truncate_stream/1: stream reassembly + slicing (#89)
             ("fromstream", 1) => {
                 let f = args.into_iter().next().unwrap();
-                Ok(Expr::CallBuiltin { name: "fromstream".to_string(), args: vec![f] })
+                Ok(Expr::CallBuiltin { op: BuiltinOp::FromStream, args: vec![f] })
             }
             ("truncate_stream", 1) => {
                 let f = args.into_iter().next().unwrap();
-                Ok(Expr::CallBuiltin { name: "truncate_stream".to_string(), args: vec![f] })
+                Ok(Expr::CallBuiltin { op: BuiltinOp::TruncateStream, args: vec![f] })
             }
             // exec/1: execute shell command and return stdout
             ("exec", 1) => {
                 let cmd = args.into_iter().next().unwrap();
-                Ok(Expr::CallBuiltin { name: "exec".to_string(), args: vec![cmd] })
+                Ok(Expr::CallBuiltin { op: BuiltinOp::Exec, args: vec![cmd] })
             }
             // execv/1: execute shell command, return {exitcode, stdout, stderr}
             ("execv", 1) => {
                 let cmd = args.into_iter().next().unwrap();
-                Ok(Expr::CallBuiltin { name: "execv".to_string(), args: vec![cmd] })
+                Ok(Expr::CallBuiltin { op: BuiltinOp::Execv, args: vec![cmd] })
             }
             // exec/2: pipe generator output to shell command, yield stdout lines
             ("exec", 2) => {
                 let mut args = args.into_iter();
                 let gen = args.next().unwrap();
                 let cmd = args.next().unwrap();
-                Ok(Expr::CallBuiltin { name: "exec".to_string(), args: vec![gen, cmd] })
+                Ok(Expr::CallBuiltin { op: BuiltinOp::Exec, args: vec![gen, cmd] })
             }
             // fromcsv/0, fromtsv/0: parse CSV/TSV string, yield arrays per row
             ("fromcsv", 0) => {
-                Ok(Expr::CallBuiltin { name: "fromcsv".to_string(), args: vec![] })
+                Ok(Expr::CallBuiltin { op: BuiltinOp::FromCsv, args: vec![] })
             }
             ("fromtsv", 0) => {
-                Ok(Expr::CallBuiltin { name: "fromtsv".to_string(), args: vec![] })
+                Ok(Expr::CallBuiltin { op: BuiltinOp::FromTsv, args: vec![] })
             }
             // fromcsvh/0, fromcsvh/1: parse CSV with headers, yield objects per row
             ("fromcsvh", 0) => {
-                Ok(Expr::CallBuiltin { name: "fromcsvh".to_string(), args: vec![] })
+                Ok(Expr::CallBuiltin { op: BuiltinOp::FromCsvh, args: vec![] })
             }
             ("fromcsvh", 1) => {
                 let headers = args.into_iter().next().unwrap();
-                Ok(Expr::CallBuiltin { name: "fromcsvh".to_string(), args: vec![headers] })
+                Ok(Expr::CallBuiltin { op: BuiltinOp::FromCsvh, args: vec![headers] })
             }
             // fromtsvh/0, fromtsvh/1: parse TSV with headers, yield objects per row
             ("fromtsvh", 0) => {
-                Ok(Expr::CallBuiltin { name: "fromtsvh".to_string(), args: vec![] })
+                Ok(Expr::CallBuiltin { op: BuiltinOp::FromTsvh, args: vec![] })
             }
             ("fromtsvh", 1) => {
                 let headers = args.into_iter().next().unwrap();
-                Ok(Expr::CallBuiltin { name: "fromtsvh".to_string(), args: vec![headers] })
+                Ok(Expr::CallBuiltin { op: BuiltinOp::FromTsvh, args: vec![headers] })
             }
             // fromdateiso8601/0, todateiso8601/0 (canonical jq names)
             // plus fromisodate/0, toisodate/0 aliases kept for
             // backward compatibility: all four route to the same
             // runtime impl.
             ("fromdateiso8601", 0) | ("fromisodate", 0) => {
-                Ok(Expr::CallBuiltin { name: "fromisodate".to_string(), args: vec![] })
+                Ok(Expr::CallBuiltin { op: BuiltinOp::FromIsoDate, args: vec![] })
             }
             ("todateiso8601", 0) | ("toisodate", 0) => {
-                Ok(Expr::CallBuiltin { name: "toisodate".to_string(), args: vec![] })
+                Ok(Expr::CallBuiltin { op: BuiltinOp::ToIsoDate, args: vec![] })
             }
             // IN/1: IN(s) = any(. == s; .)... actually IN(s) = . as $x | first(s | if . == $x then true else empty end) // false
             ("IN", 1) => {
@@ -4533,7 +4533,7 @@ impl Parser {
             // del/1: del(f) — delegate to eval for proper slice handling
             ("del", 1) => {
                 let f = args.into_iter().next().unwrap();
-                Ok(Expr::CallBuiltin { name: "del".to_string(), args: vec![f] })
+                Ok(Expr::CallBuiltin { op: BuiltinOp::Del, args: vec![f] })
             }
             _ => {
                 // Check user-defined functions
@@ -4820,8 +4820,8 @@ fn remap_func_ids(expr: Expr, map: &[(FuncId, FuncId)]) -> Expr {
         Expr::AlternativeDestructure { alternatives } => Expr::AlternativeDestructure {
             alternatives: alternatives.into_iter().map(|a| remap_func_ids(a, map)).collect(),
         },
-        Expr::CallBuiltin { name, args } => Expr::CallBuiltin {
-            name, args: args.into_iter().map(|a| remap_func_ids(a, map)).collect(),
+        Expr::CallBuiltin { op, args } => Expr::CallBuiltin {
+            op, args: args.into_iter().map(|a| remap_func_ids(a, map)).collect(),
         },
         Expr::Memoize { slot_id, key, body } => Expr::Memoize {
             slot_id,


### PR DESCRIPTION
Part of #1035 — **stage 2** of the builtin/format enum series (stage 1 was `FormatKind`, #1047).

## What

- `Expr::CallBuiltin { name: String }` → `{ op: BuiltinOp }`. The enum (83 variants) is defined via a `builtin_ops!` macro that keeps the variant list, `name()` and `from_name()` bijective by construction.
- Builtin identity is now resolved **once, in the parser**. Producer sites construct variants directly; match-arm sites whose patterns pin the name use `BuiltinOp::resolve` (panics only if the arm pattern and the table drift, i.e. a parser bug).
- Interpreter fast-path detectors compare/match on the enum instead of strings — a typo'd or stale name in a detector can no longer silently disable an optimization.
- `eval_call_builtin`, `runtime::call_builtin` and `JitOp::CallBuiltin` keep their string keyspace for now, fed via `op.name()`. Converting those dispatches to the enum (and the JIT name boundary) is stage 3 — the JIT synthesizes names with no `Expr` form (`_slice`, `@text`, `_plus`, ...), so its keyspace is wider and needs its own treatment.

## Dead code surfaced by the type change

Exhaustively enumerating consumers turned up arms that string matching had been hiding; all were unreachable on main as well, now provably so:

- Interpreter detectors for CallBuiltin forms of `test`, `first`, `last`, `max`, `min` — those names never parse to `CallBuiltin` (they lower to `RegexTest`, `.[-1]`, `UnaryOp::Max/Min`, ...), and every site already has a sibling arm handling the real form. Deleted.
- `eval_path`'s CallBuiltin `getpath` arm — `getpath/1` parses to `Expr::GetPath`, handled identically by the next arm. Deleted.
- The JIT in-place `sort`/`reverse` fast path (`JitOp::MutateInplace`) — its detector matched a CallBuiltin form the parser never emits, so the optimization **never fired**. Removed with its machinery; restoring it on the `UnaryOp` path is tracked in #1050.

## Verification

- `cargo build --release`: zero warnings
- `cargo test --release`: full suite passes (official, regression, differential, fuzz, selfdiff, metamorphic, contracts)
- Spot check vs system jq 1.8.1: 30 converted builtins byte-identical (`ltrimstr`/`rtrimstr`/`trimstr`, `startswith`/`endswith`, `split`/`join`, `index`/`rindex`/`indices`, `has`/`contains`/`with_entries`, `walk`/`pick`/`del`, `tostream`, libm 2-arg family, ...). The only diff (`modf` error wording) pre-exists on main.
- No bench run: dispatch still goes through the same string-keyed runtime entry points (`op.name()` returns a `&'static str`), so hot paths are unchanged; the enum-keyed dispatch lands in stage 3 with its own A/B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)