### PR TITLE
refactor(runtime): retire the string-keyed call_builtin wrapper

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -257,16 +257,6 @@ impl RtBuiltin {
     }
 }
 
-/// String-keyed entry point for JIT-compiled code, whose call sites still
-/// pass builtin names across the FFI boundary (stage-4b of #1035 will type
-/// that channel); everything else should call [`call_builtin_op`] directly.
-pub fn call_builtin(name: &str, args: &[Value]) -> Result<Value> {
-    match RtBuiltin::from_name(name) {
-        Some(op) => call_builtin_op(op, args),
-        None => bail!("unknown builtin: {} (nargs={})", name, args.len()),
-    }
-}
-
 pub fn call_builtin_op(op: RtBuiltin, args: &[Value]) -> Result<Value> {
     match op {
         // Binary arithmetic (nargs=3: input, lhs, rhs)
@@ -2714,7 +2704,7 @@ pub fn rt_getpath(v: &Value, path: &Value) -> Result<Value> {
                     // src/eval.rs and #467). getpath inherits the same
                     // semantics so `getpath([[]])` returns `[]`, etc.
                     (Value::Arr(_), Value::Arr(_)) => {
-                        current = call_builtin("indices", &[current.clone(), key.clone()])?;
+                        current = call_builtin_op(RtBuiltin::Indices, &[current.clone(), key.clone()])?;
                     }
                     // jq short-circuits getpath on null for string/number/object keys
                     // (matching `.[k]` on null), but still errors for null/bool/array keys.


### PR DESCRIPTION
Final stage of #1035 (**Closes #1035**). With the JIT FFI channel typed (#1060), nothing passes a builtin name string anymore: the last caller (getpath's array-key subsequence lookup) moves to `call_builtin_op(RtBuiltin::Indices)` and the `call_builtin(&str)` wrapper is deleted.

## Series summary

| Stage | PR | What got typed |
|---|---|---|
| 1 | #1047 | `@format` directives → `FormatKind` (parser-resolved, `Invalid` as data) |
| 2 | #1051 | `Expr::CallBuiltin` identity → `BuiltinOp` (83 variants, bijective-name macro) |
| 3 | #1052 | eval special-arm dispatch → `(BuiltinOp, arity)` |
| 4a | #1057 | generic runtime table → exhaustive `RtBuiltin` match (191 variants) |
| 4b | #1060 | JIT FFI channel → `JitBuiltin` descriptors (payload protocols included) |

Acceptance criteria from the issue: builtin/format names resolve exactly once, in the parser; no string `match name` dispatch remains in eval/runtime/jit; cross-layer drift ("added an arm in one layer, forgot the other") is now a compile error at the exhaustive matches. Eval-only builtins reaching the JIT path (`halt` family, `format/1`) keep their "unknown builtin" behavior bug-for-bug via `JitBuiltin::Unknown` — fixing those dispatch gaps is tracked separately in #1043/#1048, now expressible as types (`RtBuiltin::from_builtin(...) == None`).

Verification: zero warnings, full suite passes, `getpath([[1,2]])` spot-checked against jq 1.8.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)