### PR TITLE
fix: use jq's total order for NaN in every fast-path ordering comparison

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -1100,7 +1100,9 @@ fn emit_remap_value(
             let idx = field_idx[f.as_str()];
             let (vs, ve) = ranges[idx];
             if let Some(a) = parse_json_num(&raw[vs..ve]) {
-                let r = match op { BinOp::Gt => a > *n, BinOp::Lt => a < *n, BinOp::Ge => a >= *n, BinOp::Le => a <= *n, BinOp::Eq => a == *n, BinOp::Ne => a != *n, _ => unreachable!() };
+                // Ordering uses jq's total order — the threshold literal can
+                // be nan (`.x > nan`); equality stays IEEE (#1062).
+                let r = match op { BinOp::Gt => jq_jit::eval::jq_num_gt(a, *n), BinOp::Lt => jq_jit::eval::jq_num_lt(a, *n), BinOp::Ge => jq_jit::eval::jq_num_ge(a, *n), BinOp::Le => jq_jit::eval::jq_num_le(a, *n), BinOp::Eq => a == *n, BinOp::Ne => a != *n, _ => unreachable!() };
                 buf.extend_from_slice(if r { b"true" } else { b"false" });
             } else { buf.extend_from_slice(b"null"); }
         }
@@ -1629,7 +1631,8 @@ fn emit_resolved_value(
         ResolvedRemap::FieldCmpConst(idx, ref op, n) => {
             let (vs, ve) = ranges[idx];
             if let Some(a) = parse_json_num(&raw[vs..ve]) {
-                let r = match op { BinOp::Gt => a > n, BinOp::Lt => a < n, BinOp::Ge => a >= n, BinOp::Le => a <= n, BinOp::Eq => a == n, BinOp::Ne => a != n, _ => unreachable!() };
+                // jq total order for the (possibly nan) literal threshold (#1062).
+                let r = match op { BinOp::Gt => jq_jit::eval::jq_num_gt(a, n), BinOp::Lt => jq_jit::eval::jq_num_lt(a, n), BinOp::Ge => jq_jit::eval::jq_num_ge(a, n), BinOp::Le => jq_jit::eval::jq_num_le(a, n), BinOp::Eq => a == n, BinOp::Ne => a != n, _ => unreachable!() };
                 buf.extend_from_slice(if r { b"true" } else { b"false" });
             } else { buf.extend_from_slice(b"null"); }
         }
@@ -2074,11 +2077,13 @@ fn emit_resolved_value(
         }
         ResolvedRemap::ArithCmp(ref arith, cmp_op, rhs_const) => {
             if let Some(lhs_val) = eval_arith_raw(arith, raw, ranges) {
+                // Computed arithmetic can be NaN (nan consts, inf - inf):
+                // jq total order for ordering, IEEE equality (#1062).
                 let result = match cmp_op {
-                    jq_jit::ir::BinOp::Gt => lhs_val > rhs_const,
-                    jq_jit::ir::BinOp::Lt => lhs_val < rhs_const,
-                    jq_jit::ir::BinOp::Ge => lhs_val >= rhs_const,
-                    jq_jit::ir::BinOp::Le => lhs_val <= rhs_const,
+                    jq_jit::ir::BinOp::Gt => jq_jit::eval::jq_num_gt(lhs_val, rhs_const),
+                    jq_jit::ir::BinOp::Lt => jq_jit::eval::jq_num_lt(lhs_val, rhs_const),
+                    jq_jit::ir::BinOp::Ge => jq_jit::eval::jq_num_ge(lhs_val, rhs_const),
+                    jq_jit::ir::BinOp::Le => jq_jit::eval::jq_num_le(lhs_val, rhs_const),
                     jq_jit::ir::BinOp::Eq => lhs_val == rhs_const,
                     jq_jit::ir::BinOp::Ne => lhs_val != rhs_const,
                     _ => false,
@@ -2200,7 +2205,8 @@ fn eval_resolved_bool(resolved: &ResolvedRemap, raw: &[u8], ranges: &[(usize, us
         ResolvedRemap::FieldCmpConst(idx, ref op, n) => {
             let (vs, ve) = ranges[*idx];
             let a = parse_json_num(&raw[vs..ve])?;
-            Some(match op { BinOp::Gt => a > *n, BinOp::Lt => a < *n, BinOp::Ge => a >= *n, BinOp::Le => a <= *n, BinOp::Eq => a == *n, BinOp::Ne => a != *n, _ => return None })
+            // jq total order for the (possibly nan) literal threshold (#1062).
+            Some(match op { BinOp::Gt => jq_jit::eval::jq_num_gt(a, *n), BinOp::Lt => jq_jit::eval::jq_num_lt(a, *n), BinOp::Ge => jq_jit::eval::jq_num_ge(a, *n), BinOp::Le => jq_jit::eval::jq_num_le(a, *n), BinOp::Eq => a == *n, BinOp::Ne => a != *n, _ => return None })
         }
         ResolvedRemap::FieldCmpField(idx1, ref op, idx2) => {
             let r1 = ranges[*idx1];

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1267,13 +1267,15 @@ fn eval_bool_compound(expr: &Expr, input: &Value, vars: &[Value]) -> Option<bool
                 BinOp::Eq | BinOp::Ne | BinOp::Lt | BinOp::Gt | BinOp::Le | BinOp::Ge => {
                     let ln = get_num_leaf(lhs, input, vars)?;
                     let rn = get_num_leaf(rhs, input, vars)?;
+                    // Ordering follows jq's total order (NaN below every
+                    // number); equality stays IEEE, matching jq (#1062).
                     Some(match op {
                         BinOp::Eq => ln == rn,
                         BinOp::Ne => ln != rn,
-                        BinOp::Lt => ln < rn,
-                        BinOp::Gt => ln > rn,
-                        BinOp::Le => ln <= rn,
-                        BinOp::Ge => ln >= rn,
+                        BinOp::Lt => jq_num_lt(ln, rn),
+                        BinOp::Gt => jq_num_gt(ln, rn),
+                        BinOp::Le => jq_num_le(ln, rn),
+                        BinOp::Ge => jq_num_ge(ln, rn),
                         _ => unreachable!(),
                     })
                 }
@@ -1295,10 +1297,11 @@ fn eval_bool_numeric(expr: &Expr, vars: &[Value], override_vi: VarIdx, override_
             match op {
                 BinOp::Eq => Some(ln == rn),
                 BinOp::Ne => Some(ln != rn),
-                BinOp::Lt => Some(ln < rn),
-                BinOp::Gt => Some(ln > rn),
-                BinOp::Le => Some(ln <= rn),
-                BinOp::Ge => Some(ln >= rn),
+                // jq's total order for NaN, IEEE equality (#1062).
+                BinOp::Lt => Some(jq_num_lt(ln, rn)),
+                BinOp::Gt => Some(jq_num_gt(ln, rn)),
+                BinOp::Le => Some(jq_num_le(ln, rn)),
+                BinOp::Ge => Some(jq_num_ge(ln, rn)),
                 BinOp::And => {
                     if ln == 0.0 { return Some(false); }
                     Some(rn != 0.0)

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -882,10 +882,10 @@ where
         None => return RawApplyOutcome::Bail,
     };
     let result = match cmp_op {
-        BinOp::Gt => a > b,
-        BinOp::Lt => a < b,
-        BinOp::Ge => a >= b,
-        BinOp::Le => a <= b,
+        BinOp::Gt => crate::eval::jq_num_gt(a, b),
+        BinOp::Lt => crate::eval::jq_num_lt(a, b),
+        BinOp::Ge => crate::eval::jq_num_ge(a, b),
+        BinOp::Le => crate::eval::jq_num_le(a, b),
         BinOp::Eq => a == b,
         BinOp::Ne => a != b,
         _ => return RawApplyOutcome::Bail,
@@ -1299,10 +1299,10 @@ where
                 None => return RawApplyOutcome::Bail,
             };
             match cmp_op {
-                BinOp::Gt => n > *threshold,
-                BinOp::Lt => n < *threshold,
-                BinOp::Ge => n >= *threshold,
-                BinOp::Le => n <= *threshold,
+                BinOp::Gt => crate::eval::jq_num_gt(n, *threshold),
+                BinOp::Lt => crate::eval::jq_num_lt(n, *threshold),
+                BinOp::Ge => crate::eval::jq_num_ge(n, *threshold),
+                BinOp::Le => crate::eval::jq_num_le(n, *threshold),
                 BinOp::Eq => n == *threshold,
                 BinOp::Ne => n != *threshold,
                 _ => unreachable!(),
@@ -1865,10 +1865,10 @@ where
                     None => return RawApplyOutcome::Bail,
                 };
                 match op {
-                    BinOp::Gt => n > *threshold,
-                    BinOp::Lt => n < *threshold,
-                    BinOp::Ge => n >= *threshold,
-                    BinOp::Le => n <= *threshold,
+                    BinOp::Gt => crate::eval::jq_num_gt(n, *threshold),
+                    BinOp::Lt => crate::eval::jq_num_lt(n, *threshold),
+                    BinOp::Ge => crate::eval::jq_num_ge(n, *threshold),
+                    BinOp::Le => crate::eval::jq_num_le(n, *threshold),
                     BinOp::Eq => n == *threshold,
                     BinOp::Ne => n != *threshold,
                     _ => return RawApplyOutcome::Bail,
@@ -2201,10 +2201,10 @@ where
         None => return RawApplyOutcome::Bail,
     };
     let pass = match cmp_op {
-        BinOp::Gt => val > threshold,
-        BinOp::Lt => val < threshold,
-        BinOp::Ge => val >= threshold,
-        BinOp::Le => val <= threshold,
+        BinOp::Gt => crate::eval::jq_num_gt(val, threshold),
+        BinOp::Lt => crate::eval::jq_num_lt(val, threshold),
+        BinOp::Ge => crate::eval::jq_num_ge(val, threshold),
+        BinOp::Le => crate::eval::jq_num_le(val, threshold),
         BinOp::Eq => val == threshold,
         BinOp::Ne => val != threshold,
         _ => unreachable!(),
@@ -2277,10 +2277,10 @@ where
         None => return RawApplyOutcome::Bail,
     };
     let num_pass = match num_op {
-        BinOp::Gt => n > num_threshold,
-        BinOp::Lt => n < num_threshold,
-        BinOp::Ge => n >= num_threshold,
-        BinOp::Le => n <= num_threshold,
+        BinOp::Gt => crate::eval::jq_num_gt(n, num_threshold),
+        BinOp::Lt => crate::eval::jq_num_lt(n, num_threshold),
+        BinOp::Ge => crate::eval::jq_num_ge(n, num_threshold),
+        BinOp::Le => crate::eval::jq_num_le(n, num_threshold),
         BinOp::Eq => n == num_threshold,
         BinOp::Ne => n != num_threshold,
         _ => unreachable!(),
@@ -2389,10 +2389,10 @@ where
     for (idx, op, threshold) in cmp_spec {
         let v = vals_buf[*idx];
         let cmp_result = match op {
-            BinOp::Gt => v > *threshold,
-            BinOp::Lt => v < *threshold,
-            BinOp::Ge => v >= *threshold,
-            BinOp::Le => v <= *threshold,
+            BinOp::Gt => crate::eval::jq_num_gt(v, *threshold),
+            BinOp::Lt => crate::eval::jq_num_lt(v, *threshold),
+            BinOp::Ge => crate::eval::jq_num_ge(v, *threshold),
+            BinOp::Le => crate::eval::jq_num_le(v, *threshold),
             BinOp::Eq => v == *threshold,
             BinOp::Ne => v != *threshold,
             _ => return RawApplyOutcome::Bail,
@@ -2432,10 +2432,10 @@ where
         None => return RawApplyOutcome::Bail,
     };
     let result = match cmp_op {
-        BinOp::Gt => n > cval,
-        BinOp::Lt => n < cval,
-        BinOp::Ge => n >= cval,
-        BinOp::Le => n <= cval,
+        BinOp::Gt => crate::eval::jq_num_gt(n, cval),
+        BinOp::Lt => crate::eval::jq_num_lt(n, cval),
+        BinOp::Ge => crate::eval::jq_num_ge(n, cval),
+        BinOp::Le => crate::eval::jq_num_le(n, cval),
         BinOp::Eq => n == cval,
         BinOp::Ne => n != cval,
         _ => return RawApplyOutcome::Bail,
@@ -3128,10 +3128,10 @@ where
         None => return RawApplyOutcome::Bail,
     };
     let pass = match op {
-        BinOp::Gt => val > threshold,
-        BinOp::Lt => val < threshold,
-        BinOp::Ge => val >= threshold,
-        BinOp::Le => val <= threshold,
+        BinOp::Gt => crate::eval::jq_num_gt(val, threshold),
+        BinOp::Lt => crate::eval::jq_num_lt(val, threshold),
+        BinOp::Ge => crate::eval::jq_num_ge(val, threshold),
+        BinOp::Le => crate::eval::jq_num_le(val, threshold),
         BinOp::Eq => val == threshold,
         BinOp::Ne => val != threshold,
         _ => return RawApplyOutcome::Bail,
@@ -3671,10 +3671,10 @@ where
         };
     }
     let pass = match cmp_op {
-        BinOp::Gt => val > threshold,
-        BinOp::Lt => val < threshold,
-        BinOp::Ge => val >= threshold,
-        BinOp::Le => val <= threshold,
+        BinOp::Gt => crate::eval::jq_num_gt(val, threshold),
+        BinOp::Lt => crate::eval::jq_num_lt(val, threshold),
+        BinOp::Ge => crate::eval::jq_num_ge(val, threshold),
+        BinOp::Le => crate::eval::jq_num_le(val, threshold),
         BinOp::Eq => val == threshold,
         BinOp::Ne => val != threshold,
         _ => return RawApplyOutcome::Bail,
@@ -3729,10 +3729,10 @@ where
         };
     }
     let result = match cmp_op {
-        BinOp::Gt => n > threshold,
-        BinOp::Lt => n < threshold,
-        BinOp::Ge => n >= threshold,
-        BinOp::Le => n <= threshold,
+        BinOp::Gt => crate::eval::jq_num_gt(n, threshold),
+        BinOp::Lt => crate::eval::jq_num_lt(n, threshold),
+        BinOp::Ge => crate::eval::jq_num_ge(n, threshold),
+        BinOp::Le => crate::eval::jq_num_le(n, threshold),
         BinOp::Eq => n == threshold,
         BinOp::Ne => n != threshold,
         _ => return RawApplyOutcome::Bail,

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -6574,13 +6574,16 @@ extern "C" fn jit_rt_field_cmp_num(base: *const Value, key_ptr: *const u8, key_l
         };
         match field_val {
             Some(Value::Num(lhs, _)) => {
+                // Ordering uses jq's sort total order (NaN below every
+                // number, reachable via computed objects like {x: nan});
+                // equality stays IEEE, matching jq (#1062).
                 let result = match op {
                     5 => lhs == &rhs,
                     6 => lhs != &rhs,
-                    7 => lhs < &rhs,
-                    8 => lhs > &rhs,
-                    9 => lhs <= &rhs,
-                    10 => lhs >= &rhs,
+                    7 => crate::eval::jq_num_lt(*lhs, rhs),
+                    8 => crate::eval::jq_num_gt(*lhs, rhs),
+                    9 => crate::eval::jq_num_le(*lhs, rhs),
+                    10 => crate::eval::jq_num_ge(*lhs, rhs),
                     _ => return 0,
                 };
                 if result { 1 } else { 0 }
@@ -6649,12 +6652,14 @@ extern "C" fn jit_rt_field_binop_field(
                 0 => { std::ptr::write(dst, Value::number(na + nb)); return 0; }
                 1 => { std::ptr::write(dst, Value::number(na - nb)); return 0; }
                 2 => { std::ptr::write(dst, Value::number(na * nb)); return 0; }
+                // Ordering follows jq's sort total order (NaN below every
+                // number); equality stays IEEE, matching jq (#1062).
                 5 => { std::ptr::write(dst, Value::from_bool(na == nb)); return 0; }
                 6 => { std::ptr::write(dst, Value::from_bool(na != nb)); return 0; }
-                7 => { std::ptr::write(dst, Value::from_bool(na < nb)); return 0; }
-                8 => { std::ptr::write(dst, Value::from_bool(na > nb)); return 0; }
-                9 => { std::ptr::write(dst, Value::from_bool(na <= nb)); return 0; }
-                10 => { std::ptr::write(dst, Value::from_bool(na >= nb)); return 0; }
+                7 => { std::ptr::write(dst, Value::from_bool(crate::eval::jq_num_lt(*na, *nb))); return 0; }
+                8 => { std::ptr::write(dst, Value::from_bool(crate::eval::jq_num_gt(*na, *nb))); return 0; }
+                9 => { std::ptr::write(dst, Value::from_bool(crate::eval::jq_num_le(*na, *nb))); return 0; }
+                10 => { std::ptr::write(dst, Value::from_bool(crate::eval::jq_num_ge(*na, *nb))); return 0; }
                 _ => {} // div, mod: fall through to general path
             }
         }
@@ -6702,12 +6707,14 @@ extern "C" fn jit_rt_field_binop_const(
                 0 => { std::ptr::write(dst, Value::number(na + nb)); return 0; }
                 1 => { std::ptr::write(dst, Value::number(na - nb)); return 0; }
                 2 => { std::ptr::write(dst, Value::number(na * nb)); return 0; }
+                // Ordering follows jq's sort total order (NaN below every
+                // number); equality stays IEEE, matching jq (#1062).
                 5 => { std::ptr::write(dst, Value::from_bool(na == nb)); return 0; }
                 6 => { std::ptr::write(dst, Value::from_bool(na != nb)); return 0; }
-                7 => { std::ptr::write(dst, Value::from_bool(na < nb)); return 0; }
-                8 => { std::ptr::write(dst, Value::from_bool(na > nb)); return 0; }
-                9 => { std::ptr::write(dst, Value::from_bool(na <= nb)); return 0; }
-                10 => { std::ptr::write(dst, Value::from_bool(na >= nb)); return 0; }
+                7 => { std::ptr::write(dst, Value::from_bool(crate::eval::jq_num_lt(*na, *nb))); return 0; }
+                8 => { std::ptr::write(dst, Value::from_bool(crate::eval::jq_num_gt(*na, *nb))); return 0; }
+                9 => { std::ptr::write(dst, Value::from_bool(crate::eval::jq_num_le(*na, *nb))); return 0; }
+                10 => { std::ptr::write(dst, Value::from_bool(crate::eval::jq_num_ge(*na, *nb))); return 0; }
                 _ => {}
             }
         }
@@ -6848,12 +6855,15 @@ extern "C" fn jit_rt_binop(dst: *mut Value, op: i32, lhs: *const Value, rhs: *co
                         }
                     }
                 }
+                // Equality is IEEE (nan != nan), but the ordering operators
+                // follow jq's sort total order, where NaN ranks below every
+                // number — delegate to the canonical eval comparators (#1062).
                 5 => { std::ptr::write(dst, Value::from_bool(a == b)); return 0; }
                 6 => { std::ptr::write(dst, Value::from_bool(a != b)); return 0; }
-                7 => { std::ptr::write(dst, Value::from_bool(a < b)); return 0; }
-                8 => { std::ptr::write(dst, Value::from_bool(a > b)); return 0; }
-                9 => { std::ptr::write(dst, Value::from_bool(a <= b)); return 0; }
-                10 => { std::ptr::write(dst, Value::from_bool(a >= b)); return 0; }
+                7 => { std::ptr::write(dst, Value::from_bool(crate::eval::jq_num_lt(*a, *b))); return 0; }
+                8 => { std::ptr::write(dst, Value::from_bool(crate::eval::jq_num_gt(*a, *b))); return 0; }
+                9 => { std::ptr::write(dst, Value::from_bool(crate::eval::jq_num_le(*a, *b))); return 0; }
+                10 => { std::ptr::write(dst, Value::from_bool(crate::eval::jq_num_ge(*a, *b))); return 0; }
                 _ => {}
             }
         }
@@ -9678,6 +9688,20 @@ impl JitCompiler {
                             let lf = b.ins().load(types::F64, cranelift_codegen::ir::MemFlags::new(), l2, 8);
                             let rf = b.ins().load(types::F64, cranelift_codegen::ir::MemFlags::new(), r2, 8);
                             let d2 = slot_addr(&mut b, *dst);
+                            if kind >= 12 {
+                                // Ordering comparison: jq uses the sort total
+                                // order (NaN below every number), which raw
+                                // fcmp cannot express — send unordered operand
+                                // pairs to jit_rt_binop's canonical path
+                                // (#1062). Eq/Ne (10/11) are IEEE in jq too.
+                                let lhs_is_nan = b.ins().fcmp(cranelift_codegen::ir::condcodes::FloatCC::Unordered, lf, lf);
+                                let rhs_is_nan = b.ins().fcmp(cranelift_codegen::ir::condcodes::FloatCC::Unordered, rf, rf);
+                                let any_nan = b.ins().bor(lhs_is_nan, rhs_is_nan);
+                                let cmp_ok_blk = b.create_block();
+                                b.ins().brif(any_nan, slow_blk, &[], cmp_ok_blk, &[]);
+                                b.switch_to_block(cmp_ok_blk);
+                                b.seal_block(cmp_ok_blk);
+                            }
                             if kind == 3 {
                                 // Div: need to check for zero/NaN divisor
                                 let fzero = b.ins().f64const(0.0);
@@ -10337,15 +10361,33 @@ impl JitCompiler {
                         let b_bits = b.use_var(vars[*bv as usize]);
                         let a_f = b.ins().bitcast(types::F64, cranelift_codegen::ir::MemFlags::new(), a_bits);
                         let b_f = b.ins().bitcast(types::F64, cranelift_codegen::ir::MemFlags::new(), b_bits);
-                        let fcc = match cc {
-                            0 => FloatCC::GreaterThanOrEqual,
-                            1 => FloatCC::GreaterThan,
-                            2 => FloatCC::LessThanOrEqual,
-                            3 => FloatCC::LessThan,
-                            4 => FloatCC::Equal,
-                            _ => FloatCC::NotEqual,
+                        // Ordering (cc 0-3) follows jq's sort total order —
+                        // NaN ranks below every number (eval's jq_num_lt/gt
+                        // family, #1062): lt = a_nan | (a < b);
+                        // gt = !a_nan & (b_nan | (a > b)); ge/le negate them.
+                        // Equality (cc 4-5) stays IEEE, matching jq.
+                        let cmp = match cc {
+                            4 => b.ins().fcmp(FloatCC::Equal, a_f, b_f),
+                            5 => b.ins().fcmp(FloatCC::NotEqual, a_f, b_f),
+                            _ => {
+                                let a_nan = b.ins().fcmp(FloatCC::Unordered, a_f, a_f);
+                                let b_nan = b.ins().fcmp(FloatCC::Unordered, b_f, b_f);
+                                match cc {
+                                    3 | 0 => {
+                                        let raw_lt = b.ins().fcmp(FloatCC::LessThan, a_f, b_f);
+                                        let lt = b.ins().bor(a_nan, raw_lt);
+                                        if *cc == 3 { lt } else { b.ins().bxor_imm(lt, 1) }
+                                    }
+                                    _ => {
+                                        let raw_gt = b.ins().fcmp(FloatCC::GreaterThan, a_f, b_f);
+                                        let gt_rhs = b.ins().bor(b_nan, raw_gt);
+                                        let not_a_nan = b.ins().bxor_imm(a_nan, 1);
+                                        let gt = b.ins().band(not_a_nan, gt_rhs);
+                                        if *cc == 1 { gt } else { b.ins().bxor_imm(gt, 1) }
+                                    }
+                                }
+                            }
                         };
-                        let cmp = b.ins().fcmp(fcc, a_f, b_f);
                         let result = b.ins().uextend(ptr_ty, cmp);
                         b.def_var(vars[*dst_var as usize], result);
                     }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -13347,3 +13347,28 @@ null
 .[-0.9]
 [10,20]
 10
+
+# Issue #1062: ordering comparisons follow jq's total order for NaN (NaN below every number) on every layer
+[((.x*nan) < 1), ((.x*nan) <= 1), ((.x*nan) > 1), ((.x*nan) >= 1)]
+{"x":1}
+[true,true,false,false]
+
+# Issue #1062: NaN as the comparison threshold (literal in the filter)
+[(.x > nan), (.x >= nan), (.x < nan), (.x <= nan), (.x == nan), (.x != nan)]
+{"x":1}
+[true,true,false,false,false,true]
+
+# Issue #1062: NaN ordering through the collect/map fast paths
+[.x, .x] | map((.*nan) < 1)
+{"x":1}
+[true,true]
+
+# Issue #1062: select on a computed-object NaN field (field-compare fast paths)
+{y: nan} | [(select(.y < 1) | "lt") // "not-lt", (select(.y > 1) | "gt") // "not-gt"]
+null
+["lt","not-gt"]
+
+# Issue #1062: NaN/-0.0 pinned through sort and arithmetic (Phase 3 #1036 path-equivalence gate)
+(.x*nan) as $n | [[1, $n, 2, -0.0, 0.0] | sort | map(tostring), (-0.0 + 0.0 | tostring), $n != $n]
+{"x":1}
+[["null","0.0","0.0","1","2"],"0",true]


### PR DESCRIPTION
**Closes #1062.** Found while working Phase 3 (#1036) — exactly the path-dependent comparison-semantics class that phase exists to pin down.

## Semantics

jq's ordering operators follow the **sort total order** (NaN below every number: `nan < 1` → `true`, `1 > nan` → `true`, `nan <= nan` → `true`), while equality is **IEEE** (`nan == nan` → `false`). eval has implemented the split via `jq_num_lt/gt/le/ge` since #115 — but raw IEEE comparisons survived in every fast layer, so the answer depended on which engine ran:

```
$ echo '{"x":1}' | jq -c '[.x > nan, (.x*nan) < 1]'       # [true,true]
$ echo '{"x":1}' | jq-jit -c '[.x > nan, (.x*nan) < 1]'   # was: [false,false]
```

JSON can't carry NaN, which kept this invisible to the differential corpus: NaN reaches comparisons only via a nan literal threshold, a nan-producing arithmetic chain, or a computed object (`{y: nan}`).

## Sites converted (ordering only; `Eq`/`Ne` stay IEEE, matching jq)

| Layer | Sites |
|---|---|
| fast_path.rs | all numeric threshold/arith comparison families (44 arms); byte-slice string compares and raw-two-JSON-fields compare untouched (operands provably non-NaN) |
| jit.rs | `jit_rt_binop` slow-path arms; inline Cranelift fcmp branches unordered pairs to that slow path (mirrors the Div guard); `F64Cmp` lowers the total order branchlessly; `jit_rt_field_cmp_num`, both `jit_rt_field_binop_*` |
| eval.rs | `eval_bool_compound` / `eval_bool_numeric` (compound-select helpers missed by #115) |
| bin | resolved-remap engine `FieldCmpConst`/`ArithCmp` arms (emit, bool-eval, and unresolved forms) |

## Verification

- **4-way** equivalence (system jq 1.8.1, default engine, `JQJIT_FORCE_INTERPRETER`, `JQJIT_DISABLE_RAW_BYTE`) across literal-threshold, computed-chain, field, map/collect, and select shapes.
- New regression groups pin the full operator table, the collect/map shapes, computed-object fields, and NaN/-0.0 through `sort` (#1036's path-equivalence acceptance case).
- Full suite passes; zero warnings.

## Benchmark

geomean **1.003** vs main (208 cases). The only >50ms outlier (`sel(and)|[arr]` +7.6%) measures **1.000** on same-machine A/B interleave — noise. Bonus confirmation of the #1060 analysis: the stage-4b layout-lottery victims (`flatten` −12%, `path()` −9.5%, `computed remap` −8%) re-rolled back to baseline with this unrelated change, as predicted.

## Related

#1063 (filed during this investigation): the ArithCmp fast path also *masks division-by-zero errors* (`select(.x / 0 > 1)` silently selects) — distinct mechanism (error channel, not comparator semantics), separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)