### PR TITLE
fix: stop fast-path arithmetic from masking division-by-zero errors

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -1296,8 +1296,10 @@ fn eval_arith_raw_unresolved(
                 BinOp::Add => l + r,
                 BinOp::Sub => l - r,
                 BinOp::Mul => l * r,
-                BinOp::Div => l / r,
-                BinOp::Mod => jq_jit::runtime::jq_mod_f64(l, r).unwrap_or(f64::NAN),
+                // jq raises on a zero divisor — None routes the row to
+                // generic eval via the would-error probes (#1063).
+                BinOp::Div => { if r == 0.0 { return None; } l / r }
+                BinOp::Mod => jq_jit::runtime::jq_mod_f64(l, r)?,
                 _ => return None,
             })
         }
@@ -1423,7 +1425,13 @@ fn resolved_would_error(
     let arith_fastpath_ok = |a: &[u8], b: &[u8], op: &BinOp| -> bool {
         match op {
             BinOp::Add => (is_num(a) && is_num(b)) || (is_str(a) && is_str(b)),
-            BinOp::Sub | BinOp::Mul | BinOp::Div | BinOp::Mod => is_num(a) && is_num(b),
+            BinOp::Sub | BinOp::Mul => is_num(a) && is_num(b),
+            // jq raises on a zero divisor; the inline emitters compute
+            // IEEE inf/NaN instead, so route those rows to generic eval
+            // (#1063).
+            BinOp::Div | BinOp::Mod => {
+                is_num(a) && matches!(parse_json_num(b), Some(d) if d != 0.0)
+            }
             _ => true,
         }
     };
@@ -1446,8 +1454,18 @@ fn resolved_would_error(
     let str_domain = |idx: usize| -> bool { !is_str(bytes_of(idx)) };
     match resolved {
         ResolvedRemap::FieldOpField(i1, op, i2) => !arith_fastpath_ok(bytes_of(*i1), bytes_of(*i2), op),
-        ResolvedRemap::FieldOpConst(i, op, _) => !arith_op_with_const_ok(bytes_of(*i), op),
-        ResolvedRemap::ConstOpField(_, op, i) => !arith_op_with_const_ok(bytes_of(*i), op),
+        // Zero divisors raise in jq: a Div/Mod *constant* divisor of 0
+        // (`.x / 0`), or a zero *field* divisor when the field is on the
+        // right (`5 / .y`) — bail those rows to generic eval (#1063).
+        ResolvedRemap::FieldOpConst(i, op, n) => {
+            !arith_op_with_const_ok(bytes_of(*i), op)
+                || (matches!(op, BinOp::Div | BinOp::Mod) && *n == 0.0)
+        }
+        ResolvedRemap::ConstOpField(_, op, i) => {
+            !arith_op_with_const_ok(bytes_of(*i), op)
+                || (matches!(op, BinOp::Div | BinOp::Mod)
+                    && parse_json_num(bytes_of(*i)) == Some(0.0))
+        }
         ResolvedRemap::FieldArray(items) => items.iter().any(|r| resolved_would_error(r, raw, ranges)),
         // FieldSlice's inline emitter handles only ASCII-quoted strings;
         // every other shape lands in its `else` branch and emits null
@@ -1489,10 +1507,13 @@ fn resolved_would_error(
         ResolvedRemap::ArithToString(arith) => eval_arith_raw(arith, raw, ranges).is_none(),
         ResolvedRemap::ArithUnary(_, arith) => eval_arith_raw(arith, raw, ranges).is_none(),
         ResolvedRemap::ArithCmp(arith, _, _) => eval_arith_raw(arith, raw, ranges).is_none(),
-        ResolvedRemap::FieldOpFieldToString(i1, _, i2) => {
-            parse_json_num(bytes_of(*i1)).is_none() || parse_json_num(bytes_of(*i2)).is_none()
+        ResolvedRemap::FieldOpFieldToString(i1, op, i2) => {
+            !arith_fastpath_ok(bytes_of(*i1), bytes_of(*i2), op) || is_str(bytes_of(*i1))
         }
-        ResolvedRemap::FieldOpConstToString(i, _, _) => parse_json_num(bytes_of(*i)).is_none(),
+        ResolvedRemap::FieldOpConstToString(i, op, n) => {
+            parse_json_num(bytes_of(*i)).is_none()
+                || (matches!(op, BinOp::Div | BinOp::Mod) && *n == 0.0)
+        }
         // `field cmp const` — the inline emitter handles only numeric
         // fields. For non-numeric, jq still produces a verdict via its
         // total ordering (`null < false < true < number < string <
@@ -1566,7 +1587,10 @@ fn resolved_would_error(
             ResolvedStringChainPart::Literal(_) => false,
             ResolvedStringChainPart::Field(idx) => !is_str(bytes_of(*idx)),
             ResolvedStringChainPart::FieldToString(_) => false,
-            ResolvedStringChainPart::FieldArithToString(idx, _) => parse_json_num(bytes_of(*idx)).is_none(),
+            ResolvedStringChainPart::FieldArithToString(idx, ops) => {
+                parse_json_num(bytes_of(*idx)).is_none()
+                    || ops.iter().any(|(op, n)| matches!(op, BinOp::Div | BinOp::Mod) && *n == 0.0)
+            }
         }),
         _ => false,
     }
@@ -2264,8 +2288,10 @@ fn eval_arith_raw(
                 BinOp::Add => l + r,
                 BinOp::Sub => l - r,
                 BinOp::Mul => l * r,
-                BinOp::Div => l / r,
-                BinOp::Mod => jq_jit::runtime::jq_mod_f64(l, r).unwrap_or(f64::NAN),
+                // jq raises on a zero divisor — None routes the row to
+                // generic eval via the would-error probes (#1063).
+                BinOp::Div => { if r == 0.0 { return None; } l / r }
+                BinOp::Mod => jq_jit::runtime::jq_mod_f64(l, r)?,
                 _ => return None,
             })
         }

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -697,6 +697,8 @@ where
         Err(_) => return RawApplyOutcome::Bail,
     };
     for (op, c) in arith_ops {
+        // jq raises on a zero divisor; bail to generic eval (#1063)
+        if matches!(op, BinOp::Div | BinOp::Mod) && *c == 0.0 { return RawApplyOutcome::Bail; }
         n = match op {
             BinOp::Add => n + c,
             BinOp::Sub => n - c,
@@ -835,6 +837,8 @@ where
         Some(p) => p,
         None => return RawApplyOutcome::Bail,
     };
+    // jq raises on a zero divisor; bail to generic eval (#1063)
+    if matches!(op, BinOp::Div | BinOp::Mod) && b == 0.0 { return RawApplyOutcome::Bail; }
     let result = match op {
         BinOp::Add => a + b,
         BinOp::Sub => a - b,
@@ -2502,6 +2506,8 @@ where
         };
         if let Some(p) = pos {
             let cp_pos = inner[..p].iter().filter(|&&b| (b & 0xC0) != 0x80).count() as f64;
+            // jq raises on a zero divisor; bail to generic eval (#1063)
+            if matches!(op, BinOp::Div | BinOp::Mod) && n == 0.0 { return RawApplyOutcome::Bail; }
             let result = match op {
                 BinOp::Add => cp_pos + n,
                 BinOp::Sub => cp_pos - n,
@@ -2812,6 +2818,8 @@ where
     };
     let mut v = base;
     for (op, c) in arith_steps {
+        // jq raises on a zero divisor; bail to generic eval (#1063)
+        if matches!(op, BinOp::Div | BinOp::Mod) && *c == 0.0 { return RawApplyOutcome::Bail; }
         v = match op {
             BinOp::Add => v + c,
             BinOp::Sub => v - c,
@@ -2869,6 +2877,8 @@ where
         None => return RawApplyOutcome::Bail,
     };
     let (a, b) = if const_left { (cval, n) } else { (n, cval) };
+    // jq raises on a zero divisor; bail to generic eval (#1063)
+    if matches!(bop, BinOp::Div | BinOp::Mod) && b == 0.0 { return RawApplyOutcome::Bail; }
     let mid = match bop {
         BinOp::Add => a + b,
         BinOp::Sub => a - b,
@@ -2929,6 +2939,8 @@ where
         Some(p) => p,
         None => return RawApplyOutcome::Bail,
     };
+    // jq raises on a zero divisor; bail to generic eval (#1063)
+    if matches!(op1, BinOp::Div | BinOp::Mod) && b == 0.0 { return RawApplyOutcome::Bail; }
     let inner = match op1 {
         BinOp::Add => a + b,
         BinOp::Sub => a - b,
@@ -2937,6 +2949,8 @@ where
         BinOp::Mod => jq_mod_f64(a, b).unwrap_or(f64::NAN),
         _ => return RawApplyOutcome::Bail,
     };
+    // jq raises on a zero divisor; bail to generic eval (#1063)
+    if matches!(op2, BinOp::Div | BinOp::Mod) && cval == 0.0 { return RawApplyOutcome::Bail; }
     let result = match op2 {
         BinOp::Add => inner + cval,
         BinOp::Sub => inner - cval,
@@ -2987,6 +3001,8 @@ where
     };
     let mut result = n;
     for (op, c) in ops {
+        // jq raises on a zero divisor; bail to generic eval (#1063)
+        if matches!(op, BinOp::Div | BinOp::Mod) && *c == 0.0 { return RawApplyOutcome::Bail; }
         result = match op {
             BinOp::Add => result + c,
             BinOp::Sub => result - c,
@@ -3661,6 +3677,8 @@ where
         None => return RawApplyOutcome::Bail,
     };
     for (op, n) in arith_ops {
+        // jq raises on a zero divisor; bail to generic eval (#1063)
+        if matches!(op, BinOp::Div | BinOp::Mod) && *n == 0.0 { return RawApplyOutcome::Bail; }
         val = match op {
             BinOp::Add => val + n,
             BinOp::Sub => val - n,
@@ -3719,6 +3737,8 @@ where
         None => return RawApplyOutcome::Bail,
     };
     for (op, c) in arith_ops {
+        // jq raises on a zero divisor; bail to generic eval (#1063)
+        if matches!(op, BinOp::Div | BinOp::Mod) && *c == 0.0 { return RawApplyOutcome::Bail; }
         n = match op {
             BinOp::Add => n + c,
             BinOp::Sub => n - c,

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -3056,6 +3056,8 @@ impl Filter {
                         if let Expr::BinOp { op: aop, lhs: al, rhs: ar } = cur {
                             if matches!(aop, BinOp::Add | BinOp::Sub | BinOp::Mul | BinOp::Div | BinOp::Mod) {
                                 if let Expr::Literal(Literal::Num(n, _)) = ar.as_ref() {
+                                    // jq raises on a zero divisor; keep the chain on generic eval (#1063)
+                                    if matches!(aop, BinOp::Div | BinOp::Mod) && *n == 0.0 { break; }
                                     arith_ops.push((*aop, *n));
                                     cur = al.as_ref();
                                     continue;
@@ -3769,6 +3771,8 @@ impl Filter {
                 if let Expr::BinOp { op: aop, lhs, rhs } = cur {
                     if matches!(aop, BinOp::Add | BinOp::Sub | BinOp::Mul | BinOp::Div | BinOp::Mod) {
                         if let Expr::Literal(Literal::Num(n, _)) = rhs.as_ref() {
+                            // jq raises on a zero divisor; keep the chain on generic eval (#1063)
+                            if matches!(aop, BinOp::Div | BinOp::Mod) && *n == 0.0 { break; }
                             arith_ops.push((*aop, *n));
                             cur = lhs.as_ref();
                             continue;
@@ -4739,6 +4743,8 @@ impl Filter {
                     if let Expr::BinOp { op: aop, lhs, rhs } = cur {
                         if matches!(aop, BinOp::Add | BinOp::Sub | BinOp::Mul | BinOp::Div | BinOp::Mod) {
                             if let Expr::Literal(Literal::Num(n, _)) = rhs.as_ref() {
+                                // jq raises on a zero divisor; keep the chain on generic eval (#1063)
+                                if matches!(aop, BinOp::Div | BinOp::Mod) && *n == 0.0 { break; }
                                 arith_ops.push((*aop, *n));
                                 cur = lhs.as_ref();
                                 continue;
@@ -4847,6 +4853,8 @@ impl Filter {
                     if let Expr::BinOp { op: aop, lhs: al, rhs: ar } = cur {
                         if matches!(aop, BinOp::Add | BinOp::Sub | BinOp::Mul | BinOp::Div | BinOp::Mod) {
                             if let Expr::Literal(Literal::Num(n, _)) = ar.as_ref() {
+                                // jq raises on a zero divisor; keep the chain on generic eval (#1063)
+                                if matches!(aop, BinOp::Div | BinOp::Mod) && *n == 0.0 { break; }
                                 arith_ops.push((*aop, *n));
                                 cur = al.as_ref();
                                 continue;
@@ -5651,6 +5659,8 @@ impl Filter {
                                                 if matches!(op, BinOp::Add | BinOp::Sub | BinOp::Mul | BinOp::Div | BinOp::Mod) {
                                                     if matches!(lhs.as_ref(), Expr::Input) {
                                                         if let Expr::Literal(Literal::Num(n, _)) = rhs.as_ref() {
+                                                            // jq raises on a zero divisor; keep the row on generic eval (#1063)
+                                                            if matches!(op, BinOp::Div | BinOp::Mod) && *n == 0.0 { break; }
                                                             arith_ops.push((*op, *n));
                                                             continue;
                                                         }
@@ -6553,6 +6563,8 @@ impl Filter {
                 if let Expr::BinOp { op: aop, lhs, rhs } = cur {
                     if matches!(aop, BinOp::Add | BinOp::Sub | BinOp::Mul | BinOp::Div | BinOp::Mod) {
                         if let Expr::Literal(Literal::Num(n, _)) = rhs.as_ref() {
+                            // jq raises on a zero divisor; keep the chain on generic eval (#1063)
+                            if matches!(aop, BinOp::Div | BinOp::Mod) && *n == 0.0 { break; }
                             arith_ops.push((*aop, *n));
                             cur = lhs.as_ref();
                             continue;
@@ -9904,6 +9916,8 @@ impl Filter {
                     if let Expr::BinOp { op: aop, lhs: al, rhs: ar } = cur {
                         if matches!(aop, BinOp::Add | BinOp::Sub | BinOp::Mul | BinOp::Div | BinOp::Mod) {
                             if let Expr::Literal(Literal::Num(n, _)) = ar.as_ref() {
+                                // jq raises on a zero divisor; keep the chain on generic eval (#1063)
+                                if matches!(aop, BinOp::Div | BinOp::Mod) && *n == 0.0 { break; }
                                 arith_ops.push((*aop, *n));
                                 cur = al.as_ref();
                                 continue;
@@ -10075,6 +10089,8 @@ impl Filter {
                             if let Expr::BinOp { op: aop, lhs: al, rhs: ar } = cur {
                                 if matches!(aop, BinOp::Add | BinOp::Sub | BinOp::Mul | BinOp::Div | BinOp::Mod) {
                                     if let Expr::Literal(Literal::Num(n, _)) = ar.as_ref() {
+                                        // jq raises on a zero divisor; keep the chain on generic eval (#1063)
+                                        if matches!(aop, BinOp::Div | BinOp::Mod) && *n == 0.0 { break; }
                                         arith_ops.push((*aop, *n));
                                         cur = al.as_ref();
                                         continue;
@@ -10746,6 +10762,8 @@ impl Filter {
                             if let Expr::BinOp { op: aop, lhs: al, rhs: ar } = cur {
                                 if matches!(aop, BinOp::Add | BinOp::Sub | BinOp::Mul | BinOp::Div | BinOp::Mod) {
                                     if let Expr::Literal(Literal::Num(n, _)) = ar.as_ref() {
+                                        // jq raises on a zero divisor; keep the chain on generic eval (#1063)
+                                        if matches!(aop, BinOp::Div | BinOp::Mod) && *n == 0.0 { break; }
                                         arith_ops.push((*aop, *n));
                                         cur = al.as_ref();
                                         continue;
@@ -11101,6 +11119,8 @@ impl Filter {
                 if let Expr::BinOp { op: aop, lhs, rhs } = cur {
                     if matches!(aop, BinOp::Add | BinOp::Sub | BinOp::Mul | BinOp::Div | BinOp::Mod) {
                         if let Expr::Literal(Literal::Num(n, _)) = rhs.as_ref() {
+                            // jq raises on a zero divisor; keep the chain on generic eval (#1063)
+                            if matches!(aop, BinOp::Div | BinOp::Mod) && *n == 0.0 { break; }
                             arith_ops.push((*aop, *n));
                             cur = lhs.as_ref();
                             continue;
@@ -11219,6 +11239,8 @@ impl Filter {
                 if let Expr::BinOp { op: aop, lhs, rhs } = cur {
                     if matches!(aop, BinOp::Add | BinOp::Sub | BinOp::Mul | BinOp::Div | BinOp::Mod) {
                         if let Expr::Literal(Literal::Num(n, _)) = rhs.as_ref() {
+                            // jq raises on a zero divisor; keep the chain on generic eval (#1063)
+                            if matches!(aop, BinOp::Div | BinOp::Mod) && *n == 0.0 { break; }
                             arith_ops.push((*aop, *n));
                             cur = lhs.as_ref();
                             continue;

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -13372,3 +13372,28 @@ null
 (.x*nan) as $n | [[1, $n, 2, -0.0, 0.0] | sort | map(tostring), (-0.0 + 0.0 | tostring), $n != $n]
 {"x":1}
 [["null","0.0","0.0","1","2"],"0",true]
+
+# Issue #1063: select with an arithmetic condition must raise on a zero constant divisor, not mask it
+try (select(.x / 0 > 1)) catch "div0"
+{"x":1}
+"div0"
+
+# Issue #1063: modulo by zero in a select condition raises (was: NaN compare, silently empty)
+try (select(.x % 0 >= 0)) catch "mod0"
+{"x":1}
+"mod0"
+
+# Issue #1063: zero field divisor in a remap raises (was: emitted clamped inf)
+try ({r: (.x / .y)}) catch "fdiv0"
+{"x":1,"y":0}
+"fdiv0"
+
+# Issue #1063: zero field divisor in modulo remap raises (was: emitted null)
+try ({r: (.x % .y)}) catch "fmod0"
+{"x":1,"y":0}
+"fmod0"
+
+# Issue #1063: nonzero divisors keep taking the fast path with jq's values
+[{r: (.x / 2)}, {m: (.x % 3)}, (select(.x / 2 > 0.4) | .x)]
+{"x":7}
+[{"r":3.5},{"m":1},7]


### PR DESCRIPTION
**Closes #1063** (found while probing #1036/#1062 — the error-masking sibling of the NaN-ordering bug).

## Symptom

jq raises on a zero divisor; the raw fast paths computed IEEE `inf`/`NaN` instead:

```
$ echo '{"x":1}' | jq 'select(.x / 0 > 1)'          # error: divisor is zero
$ echo '{"x":1}' | jq-jit 'select(.x / 0 > 1)'      # was: {"x":1} (selected!)
$ echo '{"x":1,"y":0}' | jq-jit -c '{r: (.x / .y)}' # was: {"r":1.797…e+308}
$ echo '{"x":1}' | jq-jit 'select(.x % 0 >= 0)'     # was: empty output
```

Same family as the metamorphic gate's `resolved_would_error` choke point: a fast-path evaluator with no error channel admitted expressions whose generic-eval semantics raise.

## Fix

Route affected rows back to generic eval (which raises with jq's exact message); nonzero divisors stay on the fast path:

- **interpreter.rs** — the eleven `field OP const` chain detectors bail at detection on `Div`/`Mod` by a zero constant (cold code, zero hot-path cost).
- **fast_path.rs** — every arith applier returns `Bail` on a zero divisor, covering *data-dependent* divisors (`.x / .y` with `y = 0`) that detectors cannot see. The `ArithExpr::eval` callers were already safe behind their `is_finite` bails.
- **bin** — `eval_arith_raw`/`_unresolved` return `None` on zero divisors (Mod now propagates `jq_mod_f64`'s error instead of NaN-ing it away), which the existing `resolved_would_error` probes convert into per-row bails; the `FieldOpConst`/`ConstOpField`/`*ToString`/`FieldArithToString` would-error arms gained the missing zero-divisor checks.

## Verification

- 21 shapes × 3 engines (jq 1.8.1, default, `JQJIT_FORCE_INTERPRETER`): error/value behavior identical (modulo the known error-location formatting class).
- Regression groups pin select/remap shapes for const and field divisors, Div and Mod, plus a nonzero-divisor group asserting the fast path still produces jq's values.
- Full suite passes; zero warnings. Bench geomean **0.976** vs the previous same-machine run; the worst positive outlier is +3.5% on a ~57ms case — noise envelope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)