### PR TITLE
fix(runtime): dispatch format/1 through the runtime builtin table

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -7242,7 +7242,9 @@ fn eval_call_builtin(op: BuiltinOp, args: &[Expr], input: Value, env: &EnvRef, c
             return eval(&args[0], input.clone(), env, &mut |fmt_val| {
                 let kind = match &fmt_val {
                     Value::Str(s) => FormatKind::from_name(s.as_str()),
-                    _ => bail!("{} is not a valid format", crate::value::value_to_json(&fmt_val)),
+                    // jq's wording uses the errdesc shape: `number (123) is
+                    // not a valid format`, not the bare JSON value (#1048).
+                    _ => bail!("{} is not a valid format", crate::runtime::errdesc_pub(&fmt_val)),
                 };
                 cb(Value::from_str(&eval_format(&kind, &input)?))
             });

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -242,6 +242,7 @@ crate::ir::named_op_enum! {
         Toboolean => "toboolean",
         Bsearch => "bsearch",
         Strflocaltime => "strflocaltime",
+        Format => "format",
         ShiftCodepoints => "__shift_codepoints__",
     }
 }
@@ -880,6 +881,18 @@ pub fn call_builtin_op(op: RtBuiltin, args: &[Value]) -> Result<Value> {
             // strflocaltime(fmt): args[0] = input, args[1] = format string
             if args.len() < 2 { bail!("strflocaltime requires 2 arguments"); }
             rt_strflocaltime_impl(&args[0], &args[1])
+        }
+        RtBuiltin::Format => {
+            // format(f): apply the @<fmt> directive named by f to the input.
+            // Mirrors eval's special arm so engines that dispatch
+            // CallBuiltin through this table don't bail with "unknown
+            // builtin: format" (#1048, the #1043 dispatch-gap class).
+            if args.len() < 2 { bail!("format requires 2 arguments"); }
+            let kind = match &args[1] {
+                Value::Str(s) => crate::ir::FormatKind::from_name(s.as_str()),
+                other => bail!("{} is not a valid format", errdesc(other)),
+            };
+            Ok(Value::from_str(&crate::eval::eval_format(&kind, &args[0])?))
         }
         // Fused: explode | map(. + N) | implode
         RtBuiltin::ShiftCodepoints => {

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -13417,3 +13417,18 @@ null
 [try path(null, .a, 1) catch .]
 null
 [[],["a"],"Invalid path expression with result 1"]
+
+# Issue #1048: format/1 dispatches through the runtime table instead of "unknown builtin"
+[format("text"), format("json")]
+"t"
+["t","\"t\""]
+
+# Issue #1048: array formats through the runtime dispatch
+[format("csv"), format("tsv")]
+[1,"a b"]
+["1,\"a b\"","1\ta b"]
+
+# Issue #1048: invalid format name and non-string argument use jq's error wording
+[try format("zzz") catch ., try format(123) catch .]
+"t"
+["zzz is not a valid format","number (123) is not a valid format"]


### PR DESCRIPTION
## Summary

`format/1` was implemented only in eval's special arm (`(BuiltinOp::Format, 1)`), so engines that route `CallBuiltin` through `runtime::call_builtin_op` — the JIT path, e.g. `jq-jit -n '"t" | format("text")'` — bailed with `unknown builtin: format (nargs=2)` while the stdin-driven eval path worked.

## Changes

- Add `RtBuiltin::Format` (`format` name mapping) and a `call_builtin_op` arm that resolves the directive via `FormatKind::from_name` and applies `eval_format` to the input, mirroring eval's special arm.
- Align the non-string-argument error with jq's errdesc wording in both dispatches: `number (123) is not a valid format` (was the bare JSON value `123 is not a valid format`).

## Verification

- Differential battery: 14 `format(...)` cases (every valid directive plus `zzz`/number/null/array arguments) × both `-n` (JIT) and stdin (eval) paths against system jq 1.8.1 — all outputs, error messages, and exit codes match (remaining diffs are the pre-existing `(at <unknown>)` vs `(at <stdin>:0)` location prefix in -n mode).
- `cargo build --release`: zero warnings. `cargo test --release`: full suite green, including 3 new regression groups (text/json, csv/tsv, error wording) which the selfdiff harness also drives through the JIT layer.

Closes #1048

🤖 Generated with [Claude Code](https://claude.com/claude-code)