### PR TITLE
fix(runtime,jit): dispatch halt/halt_error through the runtime table and propagate halt past JIT try/catch

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -7608,7 +7608,7 @@ fn eval_truncate_stream(
 /// string inputs are written raw (no quotes, no newline); null inputs
 /// produce no output at all; everything else is JSON-encoded (no
 /// trailing newline).
-fn halt_error_write(input: &Value) {
+pub(crate) fn halt_error_write(input: &Value) {
     use std::io::Write;
     let stderr = std::io::stderr();
     let mut stderr = stderr.lock();

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -94,9 +94,10 @@ impl JitError {
         }
     }
 
-    /// The value a JIT-compiled `try ... catch` binds. Halt/break keep their
-    /// legacy sentinel-string shape: a JIT catch currently treats them as
-    /// catchable text (#1043 tracks making halt propagate instead).
+    /// The value a JIT-compiled `try ... catch` binds. Break keeps its
+    /// legacy sentinel-string shape (catchable text); a pending Halt never
+    /// reaches this — `jit_rt_get_error` refuses to consume it so it
+    /// propagates past the catch (#182, #1043).
     fn into_catch_value(self) -> Value {
         match self {
             JitError::Raise(v) => v,
@@ -8750,14 +8751,26 @@ extern "C" fn jit_rt_has_error() -> i64 {
     if pending { 1 } else { 0 }
 }
 
-/// Get the last error as a Value and write it to dst. Clears the error.
-extern "C" fn jit_rt_get_error(dst: *mut Value, env: *mut JitEnv) {
+/// Consume the pending error into a catch value, write it to dst, and
+/// return 1 (caught). halt / halt_error are non-recoverable: jq lets them
+/// propagate past `try ... catch` so the process exits with the requested
+/// code (#182). For a pending halt the error is left in the channel and 0
+/// is returned, so the CheckError lowering propagates it out of the JIT
+/// function instead of entering the catch handler (#1043).
+extern "C" fn jit_rt_get_error(dst: *mut Value, env: *mut JitEnv) -> i64 {
+    let halt = JIT_LAST_ERROR.with(|cell| unsafe {
+        matches!(&*cell.get(), Some(JitError::Halt(_)))
+    });
+    if halt {
+        return 0;
+    }
     unsafe { (*env).error_flag = 0; }
     let v = match take_jit_error() {
         Some(err) => err.into_catch_value(),
         None => Value::Null,
     };
     unsafe { std::ptr::write(dst, v); }
+    1
 }
 
 fn binop_to_i32(op: BinOp) -> i32 {
@@ -10442,12 +10455,24 @@ impl JitCompiler {
                         let err_blk = b.create_block();
                         let ok_blk = b.create_block();
                         b.ins().brif(is_err, err_blk, &[], ok_blk, &[]);
-                        // Error path: get the error value and jump to catch
+                        // Error path: consume the error into the catch slot.
+                        // get_error returns 0 for a non-catchable halt (#182,
+                        // #1043) — propagate it out of the JIT function like
+                        // ReturnError instead of entering the catch handler.
                         b.switch_to_block(err_blk);
                         b.seal_block(err_blk);
                         let d = slot_addr(&mut b, *error_dst);
-                        b.ins().call(rt["get_error"], &[d, env_ptr]);
-                        b.ins().jump(label_blocks[*catch_label as usize], &[]);
+                        let call = b.ins().call(rt["get_error"], &[d, env_ptr]);
+                        let caught = b.inst_results(call)[0];
+                        let zero2 = b.ins().iconst(ptr_ty, 0);
+                        let is_caught = b.ins().icmp(cranelift_codegen::ir::condcodes::IntCC::NotEqual, caught, zero2);
+                        let prop_blk = b.create_block();
+                        b.ins().brif(is_caught, label_blocks[*catch_label as usize], &[], prop_blk, &[]);
+                        b.switch_to_block(prop_blk);
+                        b.seal_block(prop_blk);
+                        b.ins().call(rt["propagate_error"], &[env_ptr]);
+                        let gen_err = b.ins().iconst(ptr_ty, GEN_ERROR);
+                        b.ins().return_(&[gen_err]);
                         // OK path: continue
                         b.switch_to_block(ok_blk);
                         b.seal_block(ok_blk);
@@ -10629,7 +10654,7 @@ fn declare_rt_funcs(module: &mut JITModule, map: &mut HashMap<&'static str, Func
     decl!("try_end", [p], []);
     decl!("propagate_error", [p], []);
     decl!("has_error", [], [p]);  // -> 0/1
-    decl!("get_error", [p, p], []);  // dst, env
+    decl!("get_error", [p, p], [p]);  // dst, env -> 1=caught / 0=non-catchable (halt)
     decl!("throw_error", [p, p], [p]);
     decl!("call_builtin", [p, p, p, p], [p]);  // dst, builtin_desc, args_ptr, nargs -> status
     decl!("collect_range", [p, f], []);  // dst, n (f64)

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -243,6 +243,8 @@ crate::ir::named_op_enum! {
         Bsearch => "bsearch",
         Strflocaltime => "strflocaltime",
         Format => "format",
+        Halt => "halt",
+        HaltError => "halt_error",
         ShiftCodepoints => "__shift_codepoints__",
     }
 }
@@ -250,7 +252,7 @@ crate::ir::named_op_enum! {
 impl RtBuiltin {
     /// Total mapping from the parser-level builtin identity to the runtime
     /// dispatch key. `None` marks builtins implemented only in eval's
-    /// special arms (filter arguments, halt family, CSV/TSV parsers, ...);
+    /// special arms (filter arguments, CSV/TSV parsers, ...);
     /// routing one of those here is the #1043 bug class, and the generic
     /// path reports it as "unknown builtin" exactly as before.
     pub fn from_builtin(op: crate::ir::BuiltinOp) -> Option<RtBuiltin> {
@@ -893,6 +895,28 @@ pub fn call_builtin_op(op: RtBuiltin, args: &[Value]) -> Result<Value> {
                 other => bail!("{} is not a valid format", errdesc(other)),
             };
             Ok(Value::from_str(&crate::eval::eval_format(&kind, &args[0])?))
+        }
+        RtBuiltin::Halt => {
+            // halt: exit 0. Raised as a typed signal so the CLI flushes
+            // buffered stdout before exiting; a JIT catch refuses to
+            // consume it (see jit_rt_get_error), matching jq's
+            // propagate-past-try semantics (#182, #1043).
+            Err(crate::signal::HaltSignal::raise(0))
+        }
+        RtBuiltin::HaltError => {
+            // halt_error/0 (args=[input]) exits 5; halt_error/1
+            // (args=[input, code]) exits with the code, clamping negatives
+            // to 0 (#979). Both write the input payload to stderr first.
+            // Mirrors eval's special arms (#1043).
+            let input = &args[0];
+            let code = match args.get(1) {
+                None => 5,
+                Some(Value::Num(n, _)) if *n < 0.0 => 0,
+                Some(Value::Num(n, _)) => *n as i32,
+                Some(_) => bail!("{} halt_error/1: number required", errdesc(input)),
+            };
+            crate::eval::halt_error_write(input);
+            Err(crate::signal::HaltSignal::raise(code))
         }
         // Fused: explode | map(. + N) | implode
         RtBuiltin::ShiftCodepoints => {

--- a/tests/halt_exit_codes.rs
+++ b/tests/halt_exit_codes.rs
@@ -1,0 +1,147 @@
+//! Issue #1043: `halt` / `halt_error` must work on every dispatch engine and
+//! produce jq's exit codes, and halt must propagate past `try ... catch`
+//! (#182) instead of being bound as a catch value.
+//!
+//! `regression.test` / `corpus.test` can't cover this: both harnesses compare
+//! stdout only and tolerate nonzero exits, so wrong exit codes and the
+//! try/catch propagation are invisible. Shell out and assert the full
+//! (stdout, stderr, exit code) triple instead, driving both the stdin path
+//! (eval dispatch) and the `-n` path (JIT dispatch via runtime::call_builtin).
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+struct Run {
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
+    code: i32,
+}
+
+fn run_stdin(input: &str, filter: &str) -> Run {
+    let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
+    let mut child = Command::new(jq_jit)
+        .arg(filter)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn jq-jit");
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(input.as_bytes())
+        .unwrap();
+    let out = child.wait_with_output().expect("wait failed");
+    Run {
+        stdout: out.stdout,
+        stderr: out.stderr,
+        code: out.status.code().expect("no exit code"),
+    }
+}
+
+fn run_null_input(filter: &str) -> Run {
+    let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
+    let out = Command::new(jq_jit)
+        .arg("-n")
+        .arg(filter)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("failed to spawn jq-jit");
+    Run {
+        stdout: out.stdout,
+        stderr: out.stderr,
+        code: out.status.code().expect("no exit code"),
+    }
+}
+
+/// Both dispatch paths for the same program: stdin-driven (eval) and `-n`
+/// (JIT). The stdin path feeds `null` so the two see the same input.
+fn both_paths(filter: &str) -> [(&'static str, Run); 2] {
+    [
+        ("stdin", run_stdin("null", filter)),
+        ("-n", run_null_input(filter)),
+    ]
+}
+
+fn assert_run(label: &str, filter: &str, r: &Run, stdout: &[u8], stderr: &[u8], code: i32) {
+    assert_eq!(
+        (r.stdout.as_slice(), r.stderr.as_slice(), r.code),
+        (stdout, stderr, code),
+        "[{}] {}",
+        label,
+        filter
+    );
+}
+
+#[test]
+fn halt_exits_zero_silently() {
+    for (label, r) in both_paths("halt") {
+        assert_run(label, "halt", &r, b"", b"", 0);
+    }
+}
+
+#[test]
+fn halt_after_yield_keeps_prior_output() {
+    for (label, r) in both_paths("1,halt,2") {
+        assert_run(label, "1,halt,2", &r, b"1\n", b"", 0);
+    }
+}
+
+#[test]
+fn halt_propagates_past_try_catch() {
+    for f in ["try halt catch .", "[try halt catch .]", "(try halt catch .) // 9"] {
+        for (label, r) in both_paths(f) {
+            assert_run(label, f, &r, b"", b"", 0);
+        }
+    }
+}
+
+#[test]
+fn halt_error_zero_arity_exits_five_with_payload() {
+    for (label, r) in both_paths("\"x\" | halt_error") {
+        assert_run(label, "halt_error/0", &r, b"", b"x", 5);
+    }
+}
+
+#[test]
+fn halt_error_code_seven() {
+    for (label, r) in both_paths("\"x\" | halt_error(7)") {
+        assert_run(label, "halt_error(7)", &r, b"", b"x", 7);
+    }
+}
+
+#[test]
+fn halt_error_negative_code_clamps_to_zero() {
+    // jq clamps negative halt_error codes to 0 (#979) while still emitting
+    // the stderr payload.
+    for (label, r) in both_paths("\"x\" | halt_error(-3)") {
+        assert_run(label, "halt_error(-3)", &r, b"", b"x", 0);
+    }
+}
+
+#[test]
+fn halt_error_propagates_past_try_catch() {
+    for (label, r) in both_paths("try (\"x\" | halt_error(7)) catch .") {
+        assert_run(label, "try halt_error(7) catch .", &r, b"", b"x", 7);
+    }
+}
+
+#[test]
+fn halt_error_non_number_code_is_catchable_error() {
+    // A non-number code is an ordinary (catchable) error, not a halt: jq
+    // reports `string ("x") halt_error/1: number required` and exits 5.
+    for (label, r) in both_paths("\"x\" | halt_error(\"s\")") {
+        assert_eq!(r.stdout, b"", "[{}] stdout", label);
+        assert_eq!(r.code, 5, "[{}] exit code", label);
+        let stderr = String::from_utf8_lossy(&r.stderr);
+        assert!(
+            stderr.contains("string (\"x\") halt_error/1: number required"),
+            "[{}] stderr: {}",
+            label,
+            stderr
+        );
+    }
+}


### PR DESCRIPTION
## Summary

`halt` / `halt_error` were implemented only in eval's special arms, so engines that route `CallBuiltin` through `runtime::call_builtin_op` (the JIT path, e.g. under `-n`) failed with `unknown builtin: halt (nargs=1)` and exited 5 instead of the requested code. Additionally, jq requires halt to **propagate past `try ... catch`** (#182), but the JIT's catch path consumed whatever error was pending, so `try halt catch .` under JIT bound the halt as a catch value.

## Changes

- **runtime**: add `RtBuiltin::Halt` / `RtBuiltin::HaltError` arms mirroring eval's — raise `HaltSignal(0)` / `HaltSignal(5 | clamped code)` after writing the `halt_error` payload to stderr (negative codes clamp to 0, #979; non-number codes raise jq's `halt_error/1: number required` as an ordinary catchable error). The typed JIT error channel (#1034) already carries `JitError::Halt` across the FFI boundary.
- **jit**: `jit_rt_get_error` now returns a catchability flag. For a pending Halt it leaves the error in the channel and returns 0; the `CheckError` lowering then propagates it out of the JIT function (`propagate_error` + `GEN_ERROR`) instead of entering the catch handler. The success path of `CheckError` (no pending error) is unchanged, so hot-path cost is untouched.
- **tests**: new shell-out integration suite `tests/halt_exit_codes.rs` asserting the full (stdout, stderr, exit code) triple — the stdout-only regression harness cannot see exit codes — for `halt`, `1,halt,2`, try/catch propagation (3 shapes), `halt_error/0`, `halt_error(7)`, `halt_error(-3)`, and the non-number-code error, each through both the stdin (eval) and `-n` (JIT) paths.

## Verification

- Differential battery: 15 halt-family programs × both `-n` and stdin paths vs system jq 1.8.1 — all (stdout, stderr, exit code) triples match.
- `cargo build --release`: zero warnings. `cargo test --release`: full suite green including the 8 new integration tests.

Closes #1043

🤖 Generated with [Claude Code](https://claude.com/claude-code)