### PR TITLE
fix(parser): never invoke @fmt on a literal-only string

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2860,10 +2860,12 @@ impl Parser {
                         Token::Str(s) => s,
                         _ => unreachable!(),
                     };
-                    Ok(Expr::Format {
-                        kind,
-                        expr: Box::new(Expr::Literal(Literal::Str(s))),
-                    })
+                    // jq formats only the *interpolated segments* of a
+                    // `@fmt "..."` string (see the interpolation branch
+                    // below). A literal-only string never invokes the
+                    // format: `@base64 "x"` is `"x"` and `@invalid ""`
+                    // passes through without erroring (#1049).
+                    Ok(Expr::Literal(Literal::Str(s)))
                 } else if matches!(self.current(), Token::Ident(n) if n == "__string_interp__") {
                     // Interpolated string after format: @html "<b>\(.)</b>"
                     // Apply format to each interpolated expr, not literals

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -4243,3 +4243,11 @@ try @urid catch .
 # #953: $x-anchored navigation in a navigating-source foreach is document-rooted
 [path(foreach .[] as $x (0; .; $x.b))]
 {"a":{"b":2},"c":{"b":9}}
+
+# #1049: literal-only @fmt strings never invoke the format
+[@invalid "", @base64 "x", @uri "a b", @csv "x", @html "<>"]
+null
+
+# #1049: only interpolated segments are formatted; unknown names error on interpolation
+[@base64 "a\(1)b", try (@invalid "a\(1)b") catch .]
+null

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -13432,3 +13432,13 @@ null
 [try format("zzz") catch ., try format(123) catch .]
 "t"
 ["zzz is not a valid format","number (123) is not a valid format"]
+
+# Issue #1049: literal-only @fmt strings pass through without invoking the format
+[@invalid "", @base64 "x", @uri "a b", @csv "x", @html "<>"]
+null
+["","x","a b","x","<>"]
+
+# Issue #1049: interpolated segments still apply the format; unknown names error there
+[@base64 "a\(1)b", try (@invalid "a\(1)b") catch .]
+null
+["aMQ==b","invalid is not a valid format"]


### PR DESCRIPTION
## Summary

jq applies a format directive only to the *interpolated segments* of `@fmt "..."`: a literal-only string passes through unchanged, so `@base64 "x"` is `"x"` and an unknown directive like `@invalid ""` never errors. jq-jit's parser wrapped the literal in `Expr::Format`, applying the format — `@base64 "x"` → `"eA=="`, `@uri "a b"` → `"a%20b"`, `@csv "x"` → type error, `@invalid ""` → "invalid is not a valid format" (exit 5).

## Changes

Emit the bare literal in the parser's `Token::Format` + `Token::Str` branch, matching the interpolation branch that already formats only `StringPart::Expr` parts. The bare-`@fmt` form (`"x" | @base64`) and object-key form are untouched.

## Verification

- Differential battery: 15 `@fmt` literal/interpolation shapes vs system jq 1.8.1 — all outputs and errors match, including `@invalid "a\(1)b"` still erroring on the interpolated segment.
- `cargo build --release`: zero warnings. `cargo test --release`: full suite green.
- New regression groups (literal passthrough, interpolation-only application) plus differential-corpus cases that CI checks against system jq on all 3 OSes.

Closes #1049

🤖 Generated with [Claude Code](https://claude.com/claude-code)