### PR TITLE
fix(serialization): re-encode \uXXXX escapes and literal DEL in raw passthrough output

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -304,7 +304,7 @@ fn print_jq_error(msg: &str) {
     }
 }
 
-use jq_jit::value::{Value, json_to_value, json_stream, json_stream_offsets, json_stream_raw, json_stream_project, json_value_has_duplicate_keys, json_stream_has_duplicate_keys, json_object_get_num, json_object_get_two_nums, json_object_get_field_raw, json_object_get_fields_raw_buf, parse_json_num, json_value_length, json_object_keys_unsorted_to_buf,json_object_keys_join_to_buf, json_object_has_key, json_object_has_all_keys, json_object_has_any_key, json_object_del_field, json_object_del_fields, json_object_merge_literal, json_object_sort_keys, json_each_value_raw, json_each_value_cb, json_to_entries_raw, json_object_set_field_raw, json_object_update_field_num, json_object_update_field_num_chain,json_object_select_then_update_num, json_object_select_then_update_str_concat, json_object_select_compound_then_update_num, json_object_select_str_then_update_num, is_json_compact, push_json_compact_raw, push_tojson_raw, push_json_pretty_raw, push_json_pretty_raw_at, value_to_json_precise, value_to_json_pretty_ext, push_compact_line, push_compact_line_color, push_pretty_line, push_pretty_line_color, push_jq_number_bytes, write_value_compact_ext, write_value_compact_line, write_value_pretty_line_color, value_to_json_pretty_color, walk_json_transform_nums, pool_value, skip_json_value, raw_contains_non_canonical_number, append_canonical_value, raw_contains_escaped_solidus, push_raw_canon_solidus};
+use jq_jit::value::{Value, json_to_value, json_stream, json_stream_offsets, json_stream_raw, json_stream_project, json_value_has_duplicate_keys, json_stream_has_duplicate_keys, json_object_get_num, json_object_get_two_nums, json_object_get_field_raw, json_object_get_fields_raw_buf, parse_json_num, json_value_length, json_object_keys_unsorted_to_buf,json_object_keys_join_to_buf, json_object_has_key, json_object_has_all_keys, json_object_has_any_key, json_object_del_field, json_object_del_fields, json_object_merge_literal, json_object_sort_keys, json_each_value_raw, json_each_value_cb, json_to_entries_raw, json_object_set_field_raw, json_object_update_field_num, json_object_update_field_num_chain,json_object_select_then_update_num, json_object_select_then_update_str_concat, json_object_select_compound_then_update_num, json_object_select_str_then_update_num, is_json_compact, push_json_compact_raw, push_tojson_raw, push_json_pretty_raw, push_json_pretty_raw_at, value_to_json_precise, value_to_json_pretty_ext, push_compact_line, push_compact_line_color, push_pretty_line, push_pretty_line_color, push_jq_number_bytes, write_value_compact_ext, write_value_compact_line, write_value_pretty_line_color, value_to_json_pretty_color, walk_json_transform_nums, pool_value, skip_json_value, raw_contains_non_canonical_number, append_canonical_value, raw_contains_noncanon_escape, push_raw_canon_escapes};
 use jq_jit::interpreter::Filter;
 use jq_jit::fast_path::{
     apply_arith_chain_cmp_raw, apply_field_access_raw, apply_field_alternative_raw,
@@ -1618,9 +1618,9 @@ fn emit_resolved_value(
                     Ok(v) => buf.extend_from_slice(value_to_json_precise(&v).as_bytes()),
                     Err(_) => buf.extend_from_slice(val),
                 }
-            } else if raw_contains_escaped_solidus(val) {
+            } else if raw_contains_noncanon_escape(val) {
                 // `\/` → `/` (jq never escapes the solidus, #780).
-                push_raw_canon_solidus(buf, val);
+                push_raw_canon_escapes(buf, val);
             } else {
                 buf.extend_from_slice(val);
             }
@@ -2863,8 +2863,8 @@ fn real_main() {
                     push_json_pretty_raw($buf, $raw, 2, false);
                     $buf.push(b'\n');
                 } else if is_json_compact($raw) {
-                    if raw_contains_escaped_solidus($raw) {
-                        push_raw_canon_solidus($buf, $raw);
+                    if raw_contains_noncanon_escape($raw) {
+                        push_raw_canon_escapes($buf, $raw);
                     } else {
                         $buf.extend_from_slice($raw);
                     }
@@ -2877,8 +2877,8 @@ fn real_main() {
                 push_json_pretty_raw($buf, $raw, 2, false);
                 $buf.push(b'\n');
             } else if is_json_compact($raw) {
-                if raw_contains_escaped_solidus($raw) {
-                    push_raw_canon_solidus($buf, $raw);
+                if raw_contains_noncanon_escape($raw) {
+                    push_raw_canon_escapes($buf, $raw);
                 } else {
                     $buf.extend_from_slice($raw);
                 }
@@ -3567,8 +3567,8 @@ fn real_main() {
                             // `\/` in input strings must be canonicalised to `/`
                             // (jq never escapes the solidus, #780). The verbatim
                             // copy would leak it, so normalise only when present.
-                            if raw_contains_escaped_solidus(raw) {
-                                push_raw_canon_solidus(cbuf, raw);
+                            if raw_contains_noncanon_escape(raw) {
+                                push_raw_canon_escapes(cbuf, raw);
                             } else {
                                 cbuf.extend_from_slice(raw);
                             }
@@ -3890,7 +3890,7 @@ fn real_main() {
                                         // null → empty
                                     } else {
                                         // number, boolean — output as-is
-                                        if raw_contains_escaped_solidus(val) { push_raw_canon_solidus(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
+                                        if raw_contains_noncanon_escape(val) { push_raw_canon_escapes(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
                                     }
                                 }
                                 compact_buf.push(b'"');
@@ -3966,7 +3966,7 @@ fn real_main() {
                                     compact_buf.extend_from_slice(b"false");
                                 } else {
                                     // number
-                                    if raw_contains_escaped_solidus(val) { push_raw_canon_solidus(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
+                                    if raw_contains_noncanon_escape(val) { push_raw_canon_escapes(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
                                 }
                             }
                             compact_buf.push(b'\n');
@@ -6208,7 +6208,7 @@ fn real_main() {
                     let stream_clean = whole_file_compact
                         && !raw_contains_non_canonical_number(content)
                         && !raw_contains_del_byte(content)
-                        && !raw_contains_escaped_solidus(content)
+                        && !raw_contains_noncanon_escape(content)
                         && !json_stream_has_duplicate_keys(content);
                     if stream_clean {
                         let _ = out.write_all(content);
@@ -6220,8 +6220,8 @@ fn real_main() {
                                 let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                                 push_compact_line(&mut compact_buf, &v);
                             } else if is_json_compact(raw) && !raw_contains_non_canonical_number(raw) && !raw_contains_del_byte(raw) {
-                                if raw_contains_escaped_solidus(raw) {
-                                    push_raw_canon_solidus(&mut compact_buf, raw);
+                                if raw_contains_noncanon_escape(raw) {
+                                    push_raw_canon_escapes(&mut compact_buf, raw);
                                 } else {
                                     compact_buf.extend_from_slice(raw);
                                 }
@@ -6362,7 +6362,7 @@ fn real_main() {
                                         if val[0] == b'{' || val[0] == b'[' {
                                             push_json_pretty_raw_at(&mut compact_buf, val, 2, false, 1);
                                         } else {
-                                            if raw_contains_escaped_solidus(val) { push_raw_canon_solidus(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
+                                            if raw_contains_noncanon_escape(val) { push_raw_canon_escapes(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
                                         }
                                     }
                                     compact_buf.extend_from_slice(b"\n]\n");
@@ -6370,7 +6370,7 @@ fn real_main() {
                                     compact_buf.push(b'[');
                                     for (i, (vs, ve)) in ranges.iter().enumerate() {
                                         if i > 0 { compact_buf.push(b','); }
-                                        { let _vv = &raw[*vs..*ve]; if raw_contains_escaped_solidus(_vv) { push_raw_canon_solidus(&mut compact_buf, _vv); } else { compact_buf.extend_from_slice(_vv); } }
+                                        { let _vv = &raw[*vs..*ve]; if raw_contains_noncanon_escape(_vv) { push_raw_canon_escapes(&mut compact_buf, _vv); } else { compact_buf.extend_from_slice(_vv); } }
                                     }
                                     compact_buf.extend_from_slice(b"]\n");
                                 }
@@ -6432,7 +6432,7 @@ fn real_main() {
                                         if val[0] == b'{' || val[0] == b'[' {
                                             push_json_pretty_raw_at(&mut compact_buf, val, 2, false, 1);
                                         } else {
-                                            if raw_contains_escaped_solidus(val) { push_raw_canon_solidus(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
+                                            if raw_contains_noncanon_escape(val) { push_raw_canon_escapes(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
                                         }
                                     }
                                     compact_buf.extend_from_slice(b"\n}\n");
@@ -6467,7 +6467,7 @@ fn real_main() {
                                 |ranges, raw| {
                                     for (i, (vs, ve)) in ranges.iter().enumerate() {
                                         compact_buf.extend_from_slice(&key_prefixes[i]);
-                                        { let _vv = &raw[*vs..*ve]; if raw_contains_escaped_solidus(_vv) { push_raw_canon_solidus(&mut compact_buf, _vv); } else { compact_buf.extend_from_slice(_vv); } }
+                                        { let _vv = &raw[*vs..*ve]; if raw_contains_noncanon_escape(_vv) { push_raw_canon_escapes(&mut compact_buf, _vv); } else { compact_buf.extend_from_slice(_vv); } }
                                     }
                                     compact_buf.extend_from_slice(b"}\n");
                                 },
@@ -7426,7 +7426,7 @@ fn real_main() {
                             match (ff_format.as_str(), content) {
                                 ("text", Some(_)) => {
                                     // @text on string: identity — output the JSON string as-is
-                                    if raw_contains_escaped_solidus(val) { push_raw_canon_solidus(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
+                                    if raw_contains_noncanon_escape(val) { push_raw_canon_escapes(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
                                     compact_buf.push(b'\n');
                                     RawApplyOutcome::Emit
                                 }
@@ -7450,7 +7450,7 @@ fn real_main() {
                                 ("json" | "text", None) => {
                                     // @json/@text on non-string scalars: wrap raw bytes in quotes
                                     compact_buf.push(b'"');
-                                    if raw_contains_escaped_solidus(val) { push_raw_canon_solidus(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
+                                    if raw_contains_noncanon_escape(val) { push_raw_canon_escapes(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
                                     compact_buf.extend_from_slice(b"\"\n");
                                     RawApplyOutcome::Emit
                                 }
@@ -7561,7 +7561,7 @@ fn real_main() {
                                     if val[0] == b'"' && val.len() >= 2 {
                                         compact_buf.extend_from_slice(&val[1..val.len()-1]);
                                     } else {
-                                        if raw_contains_escaped_solidus(val) { push_raw_canon_solidus(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
+                                        if raw_contains_noncanon_escape(val) { push_raw_canon_escapes(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
                                     }
                                 }
                             }
@@ -7696,7 +7696,7 @@ fn real_main() {
                                         }
                                     } else {
                                         // Number/bool/null: copy as-is (jq tostring behavior)
-                                        if raw_contains_escaped_solidus(val) { push_raw_canon_solidus(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
+                                        if raw_contains_noncanon_escape(val) { push_raw_canon_escapes(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
                                     }
                                 }
                             }
@@ -8121,7 +8121,7 @@ fn real_main() {
                             raw,
                             alt_field,
                             fallback_bytes,
-                            |bytes| if raw_contains_escaped_solidus(bytes) { push_raw_canon_solidus(&mut compact_buf, bytes); } else { compact_buf.extend_from_slice(bytes); },
+                            |bytes| if raw_contains_noncanon_escape(bytes) { push_raw_canon_escapes(&mut compact_buf, bytes); } else { compact_buf.extend_from_slice(bytes); },
                         );
                         match outcome {
                             RawApplyOutcome::Emit => compact_buf.push(b'\n'),
@@ -8144,7 +8144,7 @@ fn real_main() {
                             raw,
                             prim_field,
                             fallback_field,
-                            |bytes| if raw_contains_escaped_solidus(bytes) { push_raw_canon_solidus(&mut compact_buf, bytes); } else { compact_buf.extend_from_slice(bytes); },
+                            |bytes| if raw_contains_noncanon_escape(bytes) { push_raw_canon_escapes(&mut compact_buf, bytes); } else { compact_buf.extend_from_slice(bytes); },
                         );
                         match outcome {
                             RawApplyOutcome::Emit => compact_buf.push(b'\n'),
@@ -8268,7 +8268,7 @@ fn real_main() {
                                             if use_pretty_buf && (val[0] == b'{' || val[0] == b'[') {
                                                 push_json_pretty_raw(&mut compact_buf, val, 2, false);
                                             } else {
-                                                if raw_contains_escaped_solidus(val) { push_raw_canon_solidus(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
+                                                if raw_contains_noncanon_escape(val) { push_raw_canon_escapes(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
                                             }
                                             compact_buf.push(b'\n');
                                         } else {
@@ -8332,7 +8332,7 @@ fn real_main() {
                                                 if use_pretty_buf && (val[0] == b'{' || val[0] == b'[') {
                                                     push_json_pretty_raw(&mut compact_buf, val, 2, false);
                                                 } else {
-                                                    if raw_contains_escaped_solidus(val) { push_raw_canon_solidus(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
+                                                    if raw_contains_noncanon_escape(val) { push_raw_canon_escapes(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
                                                 }
                                                 compact_buf.push(b'\n');
                                             } else {
@@ -8390,7 +8390,7 @@ fn real_main() {
                                             if use_pretty_buf && (val[0] == b'{' || val[0] == b'[') {
                                                 push_json_pretty_raw(&mut compact_buf, val, 2, false);
                                             } else {
-                                                if raw_contains_escaped_solidus(val) { push_raw_canon_solidus(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
+                                                if raw_contains_noncanon_escape(val) { push_raw_canon_escapes(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
                                             }
                                             compact_buf.push(b'\n');
                                         } else {
@@ -8671,7 +8671,7 @@ fn real_main() {
                                     if use_pretty_buf && (val[0] == b'{' || val[0] == b'[') {
                                         push_json_pretty_raw(&mut compact_buf, val, 2, false);
                                     } else {
-                                        if raw_contains_escaped_solidus(val) { push_raw_canon_solidus(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
+                                        if raw_contains_noncanon_escape(val) { push_raw_canon_escapes(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
                                     }
                                     compact_buf.push(b'\n');
                                 }
@@ -9439,7 +9439,7 @@ fn real_main() {
                                 if use_pretty_buf && (val[0] == b'{' || val[0] == b'[') {
                                     push_json_pretty_raw(&mut compact_buf, val, 2, false);
                                 } else {
-                                    if raw_contains_escaped_solidus(val) { push_raw_canon_solidus(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
+                                    if raw_contains_noncanon_escape(val) { push_raw_canon_escapes(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
                                 }
                                 compact_buf.push(b'\n');
                             } else {
@@ -11082,7 +11082,7 @@ fn real_main() {
                                 if use_pretty_buf && (val[0] == b'{' || val[0] == b'[') {
                                     push_json_pretty_raw(&mut compact_buf, val, 2, false);
                                 } else {
-                                    if raw_contains_escaped_solidus(val) { push_raw_canon_solidus(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
+                                    if raw_contains_noncanon_escape(val) { push_raw_canon_escapes(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
                                 }
                                 compact_buf.push(b'\n');
                             } else {
@@ -12181,7 +12181,7 @@ fn real_main() {
                             if pass {
                                 if !first_elem { compact_buf.push(b','); }
                                 first_elem = false;
-                                if raw_contains_escaped_solidus(val) { push_raw_canon_solidus(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
+                                if raw_contains_noncanon_escape(val) { push_raw_canon_escapes(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
                             }
                         });
                         if ok {
@@ -12962,7 +12962,7 @@ fn real_main() {
                                 } else if val == b"null" {
                                     // null → empty
                                 } else {
-                                    if raw_contains_escaped_solidus(val) { push_raw_canon_solidus(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
+                                    if raw_contains_noncanon_escape(val) { push_raw_canon_escapes(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
                                 }
                             }
                             compact_buf.push(b'"');
@@ -13034,7 +13034,7 @@ fn real_main() {
                             } else if val == b"false" {
                                 compact_buf.extend_from_slice(b"false");
                             } else {
-                                if raw_contains_escaped_solidus(val) { push_raw_canon_solidus(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
+                                if raw_contains_noncanon_escape(val) { push_raw_canon_escapes(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
                             }
                         }
                         compact_buf.push(b'\n');
@@ -15276,7 +15276,7 @@ fn real_main() {
                                     if val[0] == b'{' || val[0] == b'[' {
                                         push_json_pretty_raw_at(&mut compact_buf, val, 2, false, 1);
                                     } else {
-                                        if raw_contains_escaped_solidus(val) { push_raw_canon_solidus(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
+                                        if raw_contains_noncanon_escape(val) { push_raw_canon_escapes(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
                                     }
                                 }
                                 compact_buf.extend_from_slice(b"\n]\n");
@@ -15284,7 +15284,7 @@ fn real_main() {
                                 compact_buf.push(b'[');
                                 for (i, (vs, ve)) in ranges.iter().enumerate() {
                                     if i > 0 { compact_buf.push(b','); }
-                                    { let _vv = &raw[*vs..*ve]; if raw_contains_escaped_solidus(_vv) { push_raw_canon_solidus(&mut compact_buf, _vv); } else { compact_buf.extend_from_slice(_vv); } }
+                                    { let _vv = &raw[*vs..*ve]; if raw_contains_noncanon_escape(_vv) { push_raw_canon_escapes(&mut compact_buf, _vv); } else { compact_buf.extend_from_slice(_vv); } }
                                 }
                                 compact_buf.extend_from_slice(b"]\n");
                             }
@@ -15622,7 +15622,7 @@ fn real_main() {
                         raw,
                         alt_field,
                         fallback_bytes,
-                        |bytes| if raw_contains_escaped_solidus(bytes) { push_raw_canon_solidus(&mut compact_buf, bytes); } else { compact_buf.extend_from_slice(bytes); },
+                        |bytes| if raw_contains_noncanon_escape(bytes) { push_raw_canon_escapes(&mut compact_buf, bytes); } else { compact_buf.extend_from_slice(bytes); },
                     );
                     match outcome {
                         RawApplyOutcome::Emit => compact_buf.push(b'\n'),
@@ -15645,7 +15645,7 @@ fn real_main() {
                         raw,
                         prim_field,
                         fallback_field,
-                        |bytes| if raw_contains_escaped_solidus(bytes) { push_raw_canon_solidus(&mut compact_buf, bytes); } else { compact_buf.extend_from_slice(bytes); },
+                        |bytes| if raw_contains_noncanon_escape(bytes) { push_raw_canon_escapes(&mut compact_buf, bytes); } else { compact_buf.extend_from_slice(bytes); },
                     );
                     match outcome {
                         RawApplyOutcome::Emit => compact_buf.push(b'\n'),
@@ -15757,7 +15757,7 @@ fn real_main() {
                                         if use_pretty_buf && (val[0] == b'{' || val[0] == b'[') {
                                             push_json_pretty_raw(&mut compact_buf, val, 2, false);
                                         } else {
-                                            if raw_contains_escaped_solidus(val) { push_raw_canon_solidus(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
+                                            if raw_contains_noncanon_escape(val) { push_raw_canon_escapes(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
                                         }
                                         compact_buf.push(b'\n');
                                     } else {
@@ -15819,7 +15819,7 @@ fn real_main() {
                                             if use_pretty_buf && (val[0] == b'{' || val[0] == b'[') {
                                                 push_json_pretty_raw(&mut compact_buf, val, 2, false);
                                             } else {
-                                                if raw_contains_escaped_solidus(val) { push_raw_canon_solidus(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
+                                                if raw_contains_noncanon_escape(val) { push_raw_canon_escapes(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
                                             }
                                             compact_buf.push(b'\n');
                                         } else {
@@ -15872,7 +15872,7 @@ fn real_main() {
                                         if use_pretty_buf && (val[0] == b'{' || val[0] == b'[') {
                                             push_json_pretty_raw(&mut compact_buf, val, 2, false);
                                         } else {
-                                            if raw_contains_escaped_solidus(val) { push_raw_canon_solidus(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
+                                            if raw_contains_noncanon_escape(val) { push_raw_canon_escapes(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
                                         }
                                         compact_buf.push(b'\n');
                                     } else {
@@ -16144,7 +16144,7 @@ fn real_main() {
                                 if use_pretty_buf && (val[0] == b'{' || val[0] == b'[') {
                                     push_json_pretty_raw(&mut compact_buf, val, 2, false);
                                 } else {
-                                    if raw_contains_escaped_solidus(val) { push_raw_canon_solidus(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
+                                    if raw_contains_noncanon_escape(val) { push_raw_canon_escapes(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
                                 }
                                 compact_buf.push(b'\n');
                             }
@@ -16898,7 +16898,7 @@ fn real_main() {
                             if use_pretty_buf && (val[0] == b'{' || val[0] == b'[') {
                                 push_json_pretty_raw(&mut compact_buf, val, 2, false);
                             } else {
-                                if raw_contains_escaped_solidus(val) { push_raw_canon_solidus(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
+                                if raw_contains_noncanon_escape(val) { push_raw_canon_escapes(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
                             }
                             compact_buf.push(b'\n');
                         } else {
@@ -18442,7 +18442,7 @@ fn real_main() {
                             if use_pretty_buf && (val[0] == b'{' || val[0] == b'[') {
                                 push_json_pretty_raw(&mut compact_buf, val, 2, false);
                             } else {
-                                if raw_contains_escaped_solidus(val) { push_raw_canon_solidus(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
+                                if raw_contains_noncanon_escape(val) { push_raw_canon_escapes(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
                             }
                             compact_buf.push(b'\n');
                         } else {
@@ -18930,7 +18930,7 @@ fn real_main() {
                                     if val[0] == b'{' || val[0] == b'[' {
                                         push_json_pretty_raw_at(&mut compact_buf, val, 2, false, 1);
                                     } else {
-                                        if raw_contains_escaped_solidus(val) { push_raw_canon_solidus(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
+                                        if raw_contains_noncanon_escape(val) { push_raw_canon_escapes(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
                                     }
                                 }
                                 compact_buf.extend_from_slice(b"\n}\n");
@@ -18965,7 +18965,7 @@ fn real_main() {
                             |ranges, raw| {
                                 for (i, (vs, ve)) in ranges.iter().enumerate() {
                                     compact_buf.extend_from_slice(&key_prefixes[i]);
-                                    { let _vv = &raw[*vs..*ve]; if raw_contains_escaped_solidus(_vv) { push_raw_canon_solidus(&mut compact_buf, _vv); } else { compact_buf.extend_from_slice(_vv); } }
+                                    { let _vv = &raw[*vs..*ve]; if raw_contains_noncanon_escape(_vv) { push_raw_canon_escapes(&mut compact_buf, _vv); } else { compact_buf.extend_from_slice(_vv); } }
                                 }
                                 compact_buf.extend_from_slice(b"}\n");
                             },
@@ -19949,7 +19949,7 @@ fn real_main() {
                     let outcome = apply_field_format_raw(raw, ff_field, |val, content_no_quotes| {
                         match (ff_format.as_str(), content_no_quotes) {
                             ("text", Some(_)) => {
-                                if raw_contains_escaped_solidus(val) { push_raw_canon_solidus(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
+                                if raw_contains_noncanon_escape(val) { push_raw_canon_escapes(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
                                 compact_buf.push(b'\n');
                                 RawApplyOutcome::Emit
                             }
@@ -19971,7 +19971,7 @@ fn real_main() {
                             }
                             ("json" | "text", None) => {
                                 compact_buf.push(b'"');
-                                if raw_contains_escaped_solidus(val) { push_raw_canon_solidus(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
+                                if raw_contains_noncanon_escape(val) { push_raw_canon_escapes(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
                                 compact_buf.extend_from_slice(b"\"\n");
                                 RawApplyOutcome::Emit
                             }
@@ -20086,7 +20086,7 @@ fn real_main() {
                                 if val[0] == b'"' && val.len() >= 2 {
                                     compact_buf.extend_from_slice(&val[1..val.len()-1]);
                                 } else {
-                                    if raw_contains_escaped_solidus(val) { push_raw_canon_solidus(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
+                                    if raw_contains_noncanon_escape(val) { push_raw_canon_escapes(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
                                 }
                             }
                         }
@@ -20209,7 +20209,7 @@ fn real_main() {
                                         }
                                     }
                                 } else {
-                                    if raw_contains_escaped_solidus(val) { push_raw_canon_solidus(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
+                                    if raw_contains_noncanon_escape(val) { push_raw_canon_escapes(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
                                 }
                             }
                         }
@@ -20941,7 +20941,7 @@ fn real_main() {
                         if pass {
                             if !first_elem { compact_buf.push(b','); }
                             first_elem = false;
-                            if raw_contains_escaped_solidus(val) { push_raw_canon_solidus(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
+                            if raw_contains_noncanon_escape(val) { push_raw_canon_escapes(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
                         }
                     });
                     if ok {
@@ -21591,7 +21591,7 @@ fn real_main() {
                 let bulk_safe = whole_compact2
                     && (!body_has_escapes
                         || (!raw_contains_surrogate_escape(cbody)
-                            && !raw_contains_escaped_solidus(cbody)));
+                            && !raw_contains_noncanon_escape(cbody)));
                 if bulk_safe {
                     let _ = out.write_all(cbody);
                     Ok(())
@@ -21602,8 +21602,8 @@ fn real_main() {
                             let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                             process_input(&v, Some(raw), &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         } else if is_json_compact(raw) {
-                            if body_has_escapes && raw_contains_escaped_solidus(raw) {
-                                push_raw_canon_solidus(&mut compact_buf, raw);
+                            if body_has_escapes && raw_contains_noncanon_escape(raw) {
+                                push_raw_canon_escapes(&mut compact_buf, raw);
                             } else {
                                 compact_buf.extend_from_slice(raw);
                             }

--- a/src/value.rs
+++ b/src/value.rs
@@ -1419,7 +1419,7 @@ pub fn json_object_keys_to_buf_reuse(b: &[u8], pos: usize, buf: &mut Vec<u8>, ke
     buf.push(b'[');
     for (idx, (ks, ke)) in keys.iter().enumerate() {
         if idx > 0 { buf.push(b','); }
-        push_key_canon_solidus(buf, &b[*ks..*ke]);
+        push_key_canon_escapes(buf, &b[*ks..*ke]);
     }
     buf.extend_from_slice(b"]\n");
     true
@@ -1527,19 +1527,11 @@ pub fn json_object_keys_join_to_buf(b: &[u8], pos: usize, sep: &[u8], sorted: bo
             }
         }
         // Key content is between quotes: b[ks+1..ke-1]
-        // Escapes preserved, except `\/` is decoded to `/` (#780).
+        // Canonical escapes copy verbatim; `\/` and `\uXXXX` are re-encoded
+        // to jq's output form (#780, #1027).
         let content = &b[ks+1..ke-1];
-        if raw_contains_escaped_solidus(content) {
-            let mut j = 0;
-            while j < content.len() {
-                let run = j;
-                while j < content.len() && content[j] != b'\\' { j += 1; }
-                if j > run { buf.extend_from_slice(&content[run..j]); }
-                if j >= content.len() { break; }
-                if j + 1 < content.len() && content[j+1] == b'/' { buf.push(b'/'); j += 2; }
-                else if j + 1 < content.len() { buf.push(b'\\'); buf.push(content[j+1]); j += 2; }
-                else { buf.push(b'\\'); j += 1; }
-            }
+        if raw_contains_noncanon_escape(content) {
+            push_string_content_canon(buf, content);
         } else {
             buf.extend_from_slice(content);
         }
@@ -1588,7 +1580,7 @@ pub fn json_object_keys_unsorted_to_buf(b: &[u8], pos: usize, buf: &mut Vec<u8>)
             buf.push(b'[');
             for (idx, (ks, ke, _, _)) in pairs.iter().enumerate() {
                 if idx > 0 { buf.push(b','); }
-                push_key_canon_solidus(buf, &b[*ks..*ke]);
+                push_key_canon_escapes(buf, &b[*ks..*ke]);
             }
             buf.extend_from_slice(b"]\n");
             return true;
@@ -1598,7 +1590,7 @@ pub fn json_object_keys_unsorted_to_buf(b: &[u8], pos: usize, buf: &mut Vec<u8>)
 
         if !first { buf.push(b','); }
         first = false;
-        push_key_canon_solidus(buf, &b[key_start..key_end]);
+        push_key_canon_escapes(buf, &b[key_start..key_end]);
         i = key_end;
         while i < b.len() && matches!(b[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
         if i >= b.len() || b[i] != b':' { return false; }
@@ -3323,7 +3315,7 @@ pub fn json_to_entries_raw(b: &[u8], pos: usize, buf: &mut Vec<u8>) -> bool {
             for (idx, (ks, ke, vs, ve)) in pairs.iter().enumerate() {
                 if idx > 0 { buf.push(b','); }
                 buf.extend_from_slice(b"{\"key\":");
-                push_key_canon_solidus(buf, &b[*ks..*ke]);
+                push_key_canon_escapes(buf, &b[*ks..*ke]);
                 buf.extend_from_slice(b",\"value\":");
                 if !append_canonical_value(buf, &b[*vs..*ve]) { buf.truncate(buf_start); return false; }
                 buf.push(b'}');
@@ -3344,7 +3336,7 @@ pub fn json_to_entries_raw(b: &[u8], pos: usize, buf: &mut Vec<u8>) -> bool {
         if !first { buf.push(b','); }
         first = false;
         buf.extend_from_slice(b"{\"key\":");
-        push_key_canon_solidus(buf, &b[key_start..key_end]);
+        push_key_canon_escapes(buf, &b[key_start..key_end]);
         buf.extend_from_slice(b",\"value\":");
         if !append_canonical_value(buf, &b[vs..i]) { buf.truncate(buf_start); return false; }
         buf.push(b'}');
@@ -3977,34 +3969,43 @@ fn walk_json_nums_inner(buf: &mut Vec<u8>, b: &[u8], pos: &mut usize, op: u8, op
     }
 }
 
-/// Returns true if `b` contains an escaped solidus (`\/`) inside a string —
-/// the only escape jq canonicalises that the raw-byte passthrough paths would
-/// otherwise leak verbatim (#780). Escape-aware so `\\/` (escaped backslash
-/// followed by a literal `/`) is not a false positive. Callers gate the
-/// (slightly slower) normalising copy on this so backslash-free input — the
-/// overwhelmingly common case — keeps its single `extend_from_slice`.
+/// Returns true if `b` contains string bytes that jq's output encoder would
+/// not emit verbatim: an escaped solidus (`\/`, #780), a `\uXXXX` escape
+/// (printable ones decode to their literal character on output, #1027), or a
+/// literal DEL byte (0x7F — valid unescaped in JSON input, but jq escapes it
+/// to `\u007f` on output, #446). The raw-byte passthrough paths would
+/// otherwise leak these verbatim. Escape-aware so `\\/` / `\\u` (escaped
+/// backslash followed by a literal `/` / `u`) are not false positives.
+/// Callers gate the (slightly slower) normalising copy on this so
+/// backslash-free input — the overwhelmingly common case — keeps its single
+/// `extend_from_slice`.
 #[inline]
-pub fn raw_contains_escaped_solidus(b: &[u8]) -> bool {
-    // Cheapest pre-filter first: no backslash at all means no escape of any
-    // kind, so no escaped solidus. A single-byte `memchr` has lower per-call
-    // setup than memmem's two-byte searcher, which matters because this gates
-    // every raw string output — one call per record on the NDJSON
-    // field-access hot paths, where the value almost never contains `\`.
-    let Some(first) = memchr::memchr(b'\\', b) else {
+pub fn raw_contains_noncanon_escape(b: &[u8]) -> bool {
+    // Cheapest pre-filter first: no backslash or DEL means nothing to
+    // canonicalise. A two-byte `memchr2` still has low per-call setup, which
+    // matters because this gates every raw string output — one call per
+    // record on the NDJSON field-access hot paths, where the value almost
+    // never contains `\` or 0x7F.
+    let Some(first) = memchr::memchr2(b'\\', 0x7F, b) else {
         return false;
     };
-    // A backslash exists; it may be the `\/` we canonicalise, or a literal `/`
-    // following an escaped backslash (`\\/`). Walk escape-aware from the first
-    // backslash so that case is not a false positive.
+    if b[first] == 0x7F {
+        return true;
+    }
+    // A backslash exists; it may start an escape we canonicalise, or be an
+    // escaped backslash (`\\`) followed by a literal `/`/`u`. Walk
+    // escape-aware from the first backslash so that case is not a false
+    // positive.
     let mut i = first;
     while i + 1 < b.len() {
-        match memchr::memchr(b'\\', &b[i..]) {
+        match memchr::memchr2(b'\\', 0x7F, &b[i..]) {
             Some(off) => {
                 let p = i + off;
+                if b[p] == 0x7F { return true; }
                 if p + 1 >= b.len() { return false; }
-                if b[p + 1] == b'/' { return true; }
+                if b[p + 1] == b'/' || b[p + 1] == b'u' { return true; }
                 // Skip the whole escape pair so `\\` does not let the second
-                // backslash pair with a following `/`.
+                // backslash pair with a following `/`/`u`.
                 i = p + 2;
             }
             None => return false,
@@ -4013,35 +4014,92 @@ pub fn raw_contains_escaped_solidus(b: &[u8]) -> bool {
     false
 }
 
-/// Append the raw JSON value bytes `b` to `buf` verbatim, except that `\/`
-/// inside any string is decoded to `/` (jq canonical form, #780). Object keys
-/// are strings too, so this also fixes keys. Used by identity-passthrough
-/// echo sites; gate with [`raw_contains_escaped_solidus`] so the fast path
-/// (plain `extend_from_slice`) is preserved when no escaped solidus is present.
-pub fn push_raw_canon_solidus(buf: &mut Vec<u8>, b: &[u8]) {
+/// Append the canonical jq re-encoding of a JSON string token's *content*
+/// (the bytes between the quotes, escapes intact) to `buf`, without the
+/// surrounding quotes. Decodes the content through the same parser the typed
+/// path uses (so `\uXXXX` printables, surrogate pairs, and `\/` all
+/// normalise identically, #780 / #1027) and re-escapes with the canonical
+/// output encoder. A malformed escape falls back to the verbatim copy with
+/// only `\/` rewritten — the pre-existing behavior — so these emit sites
+/// never start erroring on input the raw path previously passed through.
+fn push_string_content_canon(buf: &mut Vec<u8>, content: &[u8]) {
+    let mut tok = Vec::with_capacity(content.len() + 2);
+    tok.push(b'"');
+    tok.extend_from_slice(content);
+    tok.push(b'"');
+    if let Ok((s, end)) = parse_json_string_raw(&tok, 0) {
+        if end == tok.len() {
+            let mut enc = Vec::with_capacity(s.len() + 2);
+            push_json_string_to_vec(&mut enc, &s);
+            buf.extend_from_slice(&enc[1..enc.len() - 1]);
+            return;
+        }
+    }
+    // Fallback: verbatim with `\/` → `/` (the #780 rewrite).
+    let mut j = 0;
+    while j < content.len() {
+        let run = j;
+        while j < content.len() && content[j] != b'\\' { j += 1; }
+        if j > run { buf.extend_from_slice(&content[run..j]); }
+        if j >= content.len() { break; }
+        if j + 1 < content.len() && content[j + 1] == b'/' {
+            buf.push(b'/');
+            j += 2;
+        } else if j + 1 < content.len() {
+            buf.push(b'\\');
+            buf.push(content[j + 1]);
+            j += 2;
+        } else {
+            buf.push(b'\\');
+            j += 1;
+        }
+    }
+}
+
+/// Append the raw JSON value bytes `b` to `buf` verbatim, except that every
+/// string token containing a non-canonical escape (`\/`, `\uXXXX`) is
+/// re-encoded to jq's canonical output form (#780, #1027). Object keys are
+/// strings too, so this also fixes keys. Used by identity-passthrough echo
+/// sites; gate with [`raw_contains_noncanon_escape`] so the fast path (plain
+/// `extend_from_slice`) is preserved when no such escape is present.
+pub fn push_raw_canon_escapes(buf: &mut Vec<u8>, b: &[u8]) {
     let mut i = 0;
     let len = b.len();
     while i < len {
         if b[i] == b'"' {
-            buf.push(b'"');
+            // Find the end of the string token, escape-aware.
+            let start = i;
             i += 1;
-            loop {
-                let run_start = i;
-                while i < len && b[i] != b'"' && b[i] != b'\\' { i += 1; }
-                if i > run_start { buf.extend_from_slice(&b[run_start..i]); }
-                if i >= len { return; }
-                if b[i] == b'"' { buf.push(b'"'); i += 1; break; }
-                if i + 1 < len && b[i + 1] == b'/' {
-                    buf.push(b'/');
-                    i += 2;
-                } else if i + 1 < len {
-                    buf.push(b'\\');
-                    buf.push(b[i + 1]);
-                    i += 2;
-                } else {
-                    buf.push(b'\\');
-                    i += 1;
+            let mut end = None;
+            while i < len {
+                match memchr::memchr2(b'"', b'\\', &b[i..]) {
+                    Some(off) => {
+                        i += off;
+                        if b[i] == b'"' {
+                            end = Some(i + 1);
+                            i += 1;
+                            break;
+                        }
+                        i += 2;
+                    }
+                    None => {
+                        i = len;
+                    }
                 }
+            }
+            match end {
+                Some(e) => {
+                    let content = &b[start + 1..e - 1];
+                    if raw_contains_noncanon_escape(content) {
+                        buf.push(b'"');
+                        push_string_content_canon(buf, content);
+                        buf.push(b'"');
+                    } else {
+                        buf.extend_from_slice(&b[start..e]);
+                    }
+                }
+                // Unterminated string (malformed input): copy verbatim.
+                None => buf.extend_from_slice(&b[start..]),
             }
         } else {
             let run_start = i;
@@ -4052,12 +4110,12 @@ pub fn push_raw_canon_solidus(buf: &mut Vec<u8>, b: &[u8]) {
 }
 
 /// Append a JSON string token `key` (including its surrounding quotes),
-/// decoding `\/` to `/` (#780). Fast-paths the common no-escaped-solidus key
-/// with a single `extend_from_slice`.
+/// re-encoding non-canonical escapes (`\/`, `\uXXXX`; #780 / #1027).
+/// Fast-paths the common escape-free key with a single `extend_from_slice`.
 #[inline]
-pub fn push_key_canon_solidus(buf: &mut Vec<u8>, key: &[u8]) {
-    if raw_contains_escaped_solidus(key) {
-        push_raw_canon_solidus(buf, key);
+pub fn push_key_canon_escapes(buf: &mut Vec<u8>, key: &[u8]) {
+    if raw_contains_noncanon_escape(key) {
+        push_raw_canon_escapes(buf, key);
     } else {
         buf.extend_from_slice(key);
     }
@@ -5853,9 +5911,10 @@ pub enum CompositeCanon {
     /// Carries a number whose lexeme differs from jq's output form (or a
     /// special-float / surrogate that must round-trip through the parser).
     NonCanonicalNumber,
-    /// No non-canonical number, but a nested string holds an escaped solidus
-    /// (`\/`) that must be decoded to `/`.
-    EscapedSolidus,
+    /// No non-canonical number, but a nested string holds an escape jq
+    /// re-encodes on output: `\/` -> `/` (#780) or a non-surrogate `\uXXXX`
+    /// (#1027).
+    NoncanonEscape,
     /// Copies verbatim.
     Clean,
 }
@@ -5879,7 +5938,7 @@ pub fn raw_composite_canon_class(bytes: &[u8]) -> CompositeCanon {
         while k < chars.len() { t[chars[k] as usize] = true; k += 1; }
         t
     };
-    let mut saw_solidus = false;
+    let mut saw_noncanon_escape = false;
     let mut i = 0;
     while i < bytes.len() {
         // Skip ahead to the next interesting byte. The hot loop is just
@@ -5890,13 +5949,17 @@ pub fn raw_composite_canon_class(bytes: &[u8]) -> CompositeCanon {
             b'"' => {
                 // Skip string contents — a stray `e` inside a string isn't
                 // a number's exponent marker. Use memchr to jump to the
-                // next `"` or `\` instead of byte-by-byte.
+                // next `"`, `\`, or DEL instead of byte-by-byte.
                 i += 1;
                 while i < bytes.len() {
-                    match memchr::memchr2(b'"', b'\\', &bytes[i..]) {
+                    match memchr::memchr3(b'"', b'\\', 0x7F, &bytes[i..]) {
                         Some(off) => {
                             i += off;
                             if bytes[i] == b'"' { i += 1; break; }
+                            // A literal DEL byte is valid unescaped JSON
+                            // input, but jq escapes it to `\u007f` on
+                            // output (#446) — normalise on copy (#1027).
+                            if bytes[i] == 0x7F { saw_noncanon_escape = true; i += 1; continue; }
                             // \uD[8-F]XX is a surrogate codepoint — jq either
                             // errors (lone high), replaces with U+FFFD (lone
                             // low), or decodes to UTF-8 (valid pair). Identity
@@ -5911,13 +5974,14 @@ pub fn raw_composite_canon_class(bytes: &[u8]) -> CompositeCanon {
                             {
                                 return CompositeCanon::NonCanonicalNumber;
                             }
-                            // `\/` is the one escape jq canonicalises (#780).
-                            // Note it but keep scanning — a later non-canonical
+                            // `\/` (#780) and non-surrogate `\uXXXX` (#1027)
+                            // are escapes jq canonicalises on output. Note
+                            // them but keep scanning — a later non-canonical
                             // number must still take priority. `\\/` is not a
                             // false positive: skipping the whole escape pair
                             // (`i += 2`) lands past the `\\`, so its trailing
                             // `/` is a fresh literal, not paired with a `\`.
-                            if bytes[i + 1] == b'/' { saw_solidus = true; }
+                            if bytes[i + 1] == b'/' || bytes[i + 1] == b'u' { saw_noncanon_escape = true; }
                             // backslash: skip the escape sequence
                             i = i.saturating_add(2);
                         }
@@ -5961,7 +6025,7 @@ pub fn raw_composite_canon_class(bytes: &[u8]) -> CompositeCanon {
             _ => i += 1,
         }
     }
-    if saw_solidus { CompositeCanon::EscapedSolidus } else { CompositeCanon::Clean }
+    if saw_noncanon_escape { CompositeCanon::NoncanonEscape } else { CompositeCanon::Clean }
 }
 
 /// Append a single JSON value's raw bytes `val` to `buf`, canonicalising number
@@ -5993,8 +6057,8 @@ pub fn append_canonical_value(buf: &mut Vec<u8>, val: &[u8]) -> bool {
         Some(b'"') => {
             // Decode `\/` to `/` (jq never escapes the solidus, #780); other
             // escapes copy verbatim. Fast-path the no-escaped-solidus string.
-            if raw_contains_escaped_solidus(val) {
-                push_raw_canon_solidus(buf, val);
+            if raw_contains_noncanon_escape(val) {
+                push_raw_canon_escapes(buf, val);
             } else {
                 buf.extend_from_slice(val);
             }
@@ -6008,7 +6072,7 @@ pub fn append_canonical_value(buf: &mut Vec<u8>, val: &[u8]) -> bool {
             // scan of the composite per record on the construction hot paths.
             match raw_composite_canon_class(val) {
                 CompositeCanon::NonCanonicalNumber => return false,
-                CompositeCanon::EscapedSolidus => push_raw_canon_solidus(buf, val),
+                CompositeCanon::NoncanonEscape => push_raw_canon_escapes(buf, val),
                 CompositeCanon::Clean => buf.extend_from_slice(val),
             }
             true

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -13442,3 +13442,23 @@ null
 [@base64 "a\(1)b", try (@invalid "a\(1)b") catch .]
 null
 ["aMQ==b","invalid is not a valid format"]
+
+# Issue #1027: raw passthrough re-encodes printable \uXXXX escapes (field access)
+.x
+{"x":"\u0041\u3042"}
+"Aあ"
+
+# Issue #1027: identity passthrough re-encodes \uXXXX in values and keys
+.
+{"\u0041k":"\u3042","y":["\uD83D\uDE00"]}
+{"Ak":"あ","y":["😀"]}
+
+# Issue #1027: control \uXXXX stays escaped, \u0009 becomes \t, lone low surrogate becomes U+FFFD
+.x
+{"x":"\u0007\u0009\uDE00"}
+"\u0007\t�"
+
+# Issue #1027: literal DEL byte (0x7F) is escaped on output like jq (#446)
+.x
+{"x":"ab"}
+"a\u007fb"


### PR DESCRIPTION
## Summary

Raw-byte passthrough paths copy string content verbatim from input to output, so escapes jq re-encodes leaked through: `.x` on `{"x":"\u0041\u3042"}` printed `"\u0041\u3042"` where jq prints `"Aあ"`. The same mechanism also leaked a **literal DEL byte** (0x7F — valid unescaped in JSON input, but jq escapes it to `\u007f` on output, #446). #780 fixed the `\/` instance; this closes the remaining classes **structurally at the shared gate** instead of per-site, as the issue proposed.

## Changes

- `raw_contains_escaped_solidus` -> `raw_contains_noncanon_escape`: the single detector all ~50 raw emit sites already gate on now also catches `\u` escapes and literal DEL. Escape-free strings (the overwhelmingly common case) keep the one-`memchr` fast path.
- `push_raw_canon_solidus` -> `push_raw_canon_escapes`: string tokens containing a flagged escape are decoded through `parse_json_string_raw` — the same parser the typed path uses, so `\uXXXX` printables, surrogate pairs, lone low surrogates (U+FFFD), and control escapes all normalize identically to the interpreter (#615) — then re-escaped with the canonical output encoder. Malformed escapes fall back to the old verbatim-with-`\/`-rewrite copy, so the raw path never starts erroring on input it previously passed through.
- The keys-join inline duplicate of the `\/` rewrite and the composite classifier (`raw_composite_canon_class`) route through the same helpers; the classifier now also flags non-surrogate `\u` escapes and DEL inside nested strings.

## Verification

- Differential battery: 11 escape-bearing string contents (\u printable ASCII / non-ASCII BMP / surrogate pair / lone low surrogate / control / tab / DEL escaped+raw / `\\u` false-positive guard) x 14 filter shapes (field access, identity, collect, tojson, tostring, to_entries, object construct, keys, keys-join, array iterate, ...) = 154 cases vs system jq 1.8.1 — all match.
- `cargo build --release`: zero warnings. `cargo test --release`: full suite green, including 4 new regression groups.
- Hot-path check: same-machine interleaved A/B vs main on 2M-record NDJSON passthrough workloads (`.a` / `.` / `.msg` / `select(.b > N) | .a`) x 3 rounds — no regression (new binary equal or marginally faster in every round).

Closes #1027

🤖 Generated with [Claude Code](https://claude.com/claude-code)
