### PR TITLE
fix(serialization): stop parsed NaN/Infinity and non-canonical number lexemes leaking through @json/@text/interpolation/tostring

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -874,40 +874,136 @@ fn resolve_remap_exprs_array(
 fn emit_tostring_raw(buf: &mut Vec<u8>, val: &[u8]) {
     if val.is_empty() { buf.extend_from_slice(b"null"); return; }
     match val[0] {
-        b'"' => buf.extend_from_slice(val), // string → as-is
+        // String: identity, but `\/` / `\uXXXX` re-encode like any raw
+        // string output (#1027).
+        b'"' => {
+            if raw_contains_noncanon_escape(val) {
+                push_raw_canon_escapes(buf, val);
+            } else {
+                buf.extend_from_slice(val);
+            }
+        }
         b't' => buf.extend_from_slice(b"\"true\""),
         b'f' => buf.extend_from_slice(b"\"false\""),
         b'n' => buf.extend_from_slice(b"\"null\""),
         _ => {
-            // number → wrap in quotes
+            // Number → wrap in quotes. A canonical lexeme copies verbatim —
+            // jq's tostring preserves the literal repr ("1.50" stays
+            // "1.50") — and a NaN/Infinity/non-canonical lexeme re-renders
+            // through the tojson number writer (#1021).
             buf.push(b'"');
-            // Re-format through push_jq_number_bytes for jq compat
-            if let Some(n) = parse_json_num(val) {
-                push_jq_number_bytes(buf, n);
-            } else {
-                buf.extend_from_slice(val);
-            }
+            push_interp_num_canon(buf, val);
             buf.push(b'"');
         }
     }
 }
 
+/// Append a raw JSON number lexeme in tostring form: canonical lexemes copy
+/// verbatim (preserving the literal repr, e.g. `1.50`), while a NaN/Infinity
+/// or non-canonical lexeme (`nan`, `1e3`) re-renders through the typed tojson
+/// number writer so it matches eval (`null`, `1E+3`; #1021).
+#[inline]
+fn push_interp_num_canon(buf: &mut Vec<u8>, val: &[u8]) {
+    // Plain integers — the overwhelmingly common case — are always canonical;
+    // a tight all-digits check skips the LUT classifier (mirrors
+    // append_canonical_value's hot path).
+    if val.iter().all(|&x| x.is_ascii_digit() || x == b'-') {
+        buf.extend_from_slice(val);
+        return;
+    }
+    if raw_contains_non_canonical_number(val) {
+        if let Ok(v @ jq_jit::value::Value::Num(..)) =
+            json_to_value(unsafe { std::str::from_utf8_unchecked(val) })
+        {
+            // value_to_json_tojson on a bare number is exactly the tojson
+            // number writer (push_num_tojson_str) — NaN -> null, Infinity ->
+            // clamped max double, literal reprs in canonical uppercase-E form.
+            buf.extend_from_slice(jq_jit::value::value_to_json_tojson(&v).as_bytes());
+            return;
+        }
+    }
+    buf.extend_from_slice(val);
+}
+
+/// Variant of [`emit_interp_field_raw`] for records pre-checked to contain
+/// no `\` / DEL byte anywhere (one per-record `memchr2` amortizes the
+/// per-field escape scans on the interpolation hot paths): string content
+/// copies verbatim, composites still escape their quotes for embedding and
+/// re-render on a non-canonical nested number, numbers go through the
+/// canonical lexeme gate (#1021).
+#[inline]
+fn emit_interp_field_raw_clean(buf: &mut Vec<u8>, val: &[u8]) {
+    if val.is_empty() { return; }
+    match val[0] {
+        b'"' if val.len() >= 2 => buf.extend_from_slice(&val[1..val.len()-1]),
+        b't' => buf.extend_from_slice(b"true"),
+        b'f' => buf.extend_from_slice(b"false"),
+        b'n' if val == b"null" => buf.extend_from_slice(b"null"),
+        b'[' | b'{' => {
+            if raw_contains_non_canonical_number(val) {
+                if let Ok(v) = json_to_value(unsafe { std::str::from_utf8_unchecked(val) }) {
+                    let s = jq_jit::value::value_to_json_tojson(&v);
+                    for &b in s.as_bytes() {
+                        match b {
+                            b'"' => buf.extend_from_slice(b"\\\""),
+                            b'\\' => buf.extend_from_slice(b"\\\\"),
+                            _ => buf.push(b),
+                        }
+                    }
+                    return;
+                }
+            }
+            for &b in val {
+                match b {
+                    b'"' => buf.extend_from_slice(b"\\\""),
+                    // No backslash in a clean record; only quotes need escaping.
+                    _ => buf.push(b),
+                }
+            }
+        }
+        _ => push_interp_num_canon(buf, val),
+    }
+}
+
 /// Emit a raw JSON field value into a string interpolation context (tostring, no outer quotes).
-/// Strings: copy inner content (already JSON-escaped). Numbers/bool/null: copy as-is.
-/// Arrays/objects: copy raw JSON but escape any " and \ for embedding in JSON string.
+/// Strings: copy inner content, re-encoding non-canonical escapes (#1027).
+/// Numbers: canonical lexemes as-is, NaN/Infinity/non-canonical re-rendered (#1021).
+/// Arrays/objects: copy raw JSON, escaping " and \ for embedding; nested
+/// non-canonical numbers/escapes re-render through the typed writer first.
 #[inline]
 fn emit_interp_field_raw(buf: &mut Vec<u8>, val: &[u8]) {
     if val.is_empty() { return; }
     match val[0] {
         b'"' if val.len() >= 2 => {
-            // String: inner content is already JSON-escaped
-            buf.extend_from_slice(&val[1..val.len()-1]);
+            // String: inner content is already JSON-escaped; `\/` / `\uXXXX`
+            // must be re-encoded the way jq's output encoder would (#1027).
+            let content = &val[1..val.len()-1];
+            if raw_contains_noncanon_escape(content) {
+                jq_jit::value::push_string_content_canon(buf, content);
+            } else {
+                buf.extend_from_slice(content);
+            }
         }
         b't' => buf.extend_from_slice(b"true"),
         b'f' => buf.extend_from_slice(b"false"),
-        b'n' => buf.extend_from_slice(b"null"),
+        b'n' if val == b"null" => buf.extend_from_slice(b"null"),
         b'[' | b'{' => {
-            // Array/object: tojson — need to escape " and \ for embedding
+            // Array/object: tojson — escape " and \ for embedding. A nested
+            // non-canonical number lexeme or string escape re-renders through
+            // the typed tojson writer first so "\([1e3])" matches eval (#1021).
+            if raw_contains_non_canonical_number(val) || raw_contains_noncanon_escape(val) {
+                if let Ok(v) = json_to_value(unsafe { std::str::from_utf8_unchecked(val) }) {
+                    let s = jq_jit::value::value_to_json_tojson(&v);
+                    for &b in s.as_bytes() {
+                        match b {
+                            b'"' => buf.extend_from_slice(b"\\\""),
+                            b'\\' => buf.extend_from_slice(b"\\\\"),
+                            _ => buf.push(b),
+                        }
+                    }
+                    return;
+                }
+            }
             for &b in val {
                 match b {
                     b'"' => buf.extend_from_slice(b"\\\""),
@@ -916,14 +1012,7 @@ fn emit_interp_field_raw(buf: &mut Vec<u8>, val: &[u8]) {
                 }
             }
         }
-        _ => {
-            // Number: re-format for jq compat
-            if let Some(n) = parse_json_num(val) {
-                push_jq_number_bytes(buf, n);
-            } else {
-                buf.extend_from_slice(val);
-            }
-        }
+        _ => push_interp_num_canon(buf, val),
     }
 }
 
@@ -2168,6 +2257,9 @@ fn emit_resolved_value(
             }
         }
         ResolvedRemap::StringChain(ref parts) => {
+            // Per-record escape gate (#1027 cost control): no backslash/DEL
+            // anywhere means no string part can need re-encoding.
+            let strings_clean = memchr::memchr2(b'\\', 0x7F, raw).is_none();
             buf.push(b'"');
             for part in parts {
                 match part {
@@ -2178,9 +2270,16 @@ fn emit_resolved_value(
                         let (vs, ve) = ranges[*idx];
                         let val = &raw[vs..ve];
                         if val.len() >= 2 && val[0] == b'"' && val[val.len()-1] == b'"' {
-                            // String field: emit unquoted inner content
-                            // Need to check for backslash escapes inside
-                            buf.extend_from_slice(&val[1..val.len()-1]);
+                            // String field: emit unquoted inner content,
+                            // re-encoding non-canonical escapes (#1027).
+                            let content = &val[1..val.len()-1];
+                            if strings_clean {
+                                buf.extend_from_slice(content);
+                            } else if raw_contains_noncanon_escape(content) {
+                                jq_jit::value::push_string_content_canon(buf, content);
+                            } else {
+                                buf.extend_from_slice(content);
+                            }
                         } else {
                             // Non-string field used in string concatenation — emit as-is
                             buf.extend_from_slice(val);
@@ -2190,11 +2289,20 @@ fn emit_resolved_value(
                         let (vs, ve) = ranges[*idx];
                         let val = &raw[vs..ve];
                         if val.len() >= 2 && val[0] == b'"' && val[val.len()-1] == b'"' {
-                            // Already a string — emit inner content
-                            buf.extend_from_slice(&val[1..val.len()-1]);
+                            // Already a string — emit inner content,
+                            // re-encoding non-canonical escapes (#1027).
+                            let content = &val[1..val.len()-1];
+                            if strings_clean {
+                                buf.extend_from_slice(content);
+                            } else if raw_contains_noncanon_escape(content) {
+                                jq_jit::value::push_string_content_canon(buf, content);
+                            } else {
+                                buf.extend_from_slice(content);
+                            }
                         } else {
-                            // Number/bool/null — emit raw bytes as string representation
-                            buf.extend_from_slice(val);
+                            // Number/bool/null — tostring form; a NaN/Infinity
+                            // or non-canonical lexeme re-renders (#1021).
+                            push_interp_num_canon(buf, val);
                         }
                     }
                     ResolvedStringChainPart::FieldArithToString(idx, ref ops) => {
@@ -7448,7 +7556,16 @@ fn real_main() {
                                     RawApplyOutcome::Emit
                                 }
                                 ("json" | "text", None) => {
-                                    // @json/@text on non-string scalars: wrap raw bytes in quotes
+                                    // @json/@text on non-string scalars: wrap raw bytes in
+                                    // quotes. A composite needs its inner quotes escaped, and
+                                    // a NaN/Infinity or non-canonical number lexeme must be
+                                    // normalised, not echoed (#1021) — both defer to the
+                                    // typed path.
+                                    if matches!(val.first(), Some(b'{') | Some(b'['))
+                                        || raw_contains_non_canonical_number(val)
+                                    {
+                                        return RawApplyOutcome::Bail;
+                                    }
                                     compact_buf.push(b'"');
                                     if raw_contains_noncanon_escape(val) { push_raw_canon_escapes(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
                                     compact_buf.extend_from_slice(b"\"\n");
@@ -7665,6 +7782,10 @@ fn real_main() {
                         }
                         // Extract all needed fields
                         if json_object_get_fields_raw_buf(raw, 0, &field_names, &mut ranges_buf) {
+                            // One scan amortizes the per-field escape checks:
+                            // a record with no backslash/DEL anywhere cannot
+                            // need string re-encoding (#1027 cost control).
+                            let strings_clean = memchr::memchr2(b'\\', 0x7F, raw).is_none();
                             compact_buf.push(b'"');
                             let mut field_idx = 0;
                             for (i, (is_lit, _)) in interp_parts.iter().enumerate() {
@@ -7674,29 +7795,15 @@ fn real_main() {
                                     let (vs, ve) = ranges_buf[field_idx];
                                     field_idx += 1;
                                     let val = &raw[vs..ve];
-                                    if val[0] == b'"' && val.len() >= 2 {
-                                        // String: copy inner content (already JSON-escaped)
-                                        compact_buf.extend_from_slice(&val[1..val.len()-1]);
-                                    } else if val[0] == b'[' || val[0] == b'{' {
-                                        // Container: embed JSON text, re-escaping for the
-                                        // surrounding string literal so the output stays
-                                        // valid JSON. Whitespace is copied as-is, which is
-                                        // fine since json_object_get_fields_raw_buf returns
-                                        // the compact slice from input.
-                                        for &b in val {
-                                            match b {
-                                                b'"' => compact_buf.extend_from_slice(b"\\\""),
-                                                b'\\' => compact_buf.extend_from_slice(b"\\\\"),
-                                                b'\n' => compact_buf.extend_from_slice(b"\\n"),
-                                                b'\r' => compact_buf.extend_from_slice(b"\\r"),
-                                                b'\t' => compact_buf.extend_from_slice(b"\\t"),
-                                                c if c < 0x20 => { let _ = write!(compact_buf, "\\u{:04x}", c); }
-                                                _ => compact_buf.push(b),
-                                            }
-                                        }
+                                    // Shared emitters: strings re-encode
+                                    // non-canonical escapes (#1027); numbers
+                                    // keep canonical lexemes and re-render
+                                    // NaN/Infinity/non-canonical ones (#1021);
+                                    // composites re-escape for embedding.
+                                    if strings_clean {
+                                        emit_interp_field_raw_clean(&mut compact_buf, val);
                                     } else {
-                                        // Number/bool/null: copy as-is (jq tostring behavior)
-                                        if raw_contains_noncanon_escape(val) { push_raw_canon_escapes(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
+                                        emit_interp_field_raw(&mut compact_buf, val);
                                     }
                                 }
                             }
@@ -7784,6 +7891,8 @@ fn real_main() {
                                 let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                                 process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                             } else {
+                                // Per-record escape gate (#1027 cost control).
+                                let strings_clean = memchr::memchr2(b'\\', 0x7F, raw).is_none();
                                 compact_buf.push(b'"');
                                 for &(idx, typ, ai) in &actions {
                                     match typ {
@@ -7792,7 +7901,15 @@ fn real_main() {
                                             let (vs, ve) = ranges_buf[idx];
                                             let val = &raw[vs..ve];
                                             // val is guaranteed quoted-string here.
-                                            compact_buf.extend_from_slice(&val[1..val.len()-1]);
+                                            // Re-encode non-canonical escapes (#1027).
+                                            let content = &val[1..val.len()-1];
+                                            if strings_clean {
+                                                compact_buf.extend_from_slice(content);
+                                            } else if raw_contains_noncanon_escape(content) {
+                                                jq_jit::value::push_string_content_canon(&mut compact_buf, content);
+                                            } else {
+                                                compact_buf.extend_from_slice(content);
+                                            }
                                         }
                                         _ => {
                                             // FieldArithToString: parse number, apply ops, format
@@ -12279,14 +12396,16 @@ fn real_main() {
                                     compact_buf.extend_from_slice(b"5\n");
                                 }
                                 _ => {
-                                    // Number: format with push_jq_number_bytes, count the bytes
-                                    if let Some(n) = parse_json_num(val) {
-                                        let start_len = compact_buf.len();
-                                        push_jq_number_bytes(&mut compact_buf, n);
-                                        let formatted_len = compact_buf.len() - start_len;
-                                        compact_buf.truncate(start_len);
+                                    // Number: tostring preserves the canonical literal
+                                    // lexeme, so the length is the lexeme's byte count
+                                    // ("1.50" -> 4, not 3). Non-canonical / 16+ digit
+                                    // lexemes defer to the generic path (#1021).
+                                    if parse_json_num(val).is_some()
+                                        && !raw_contains_non_canonical_number(val)
+                                        && val.iter().filter(|c| c.is_ascii_digit()).count() <= 15
+                                    {
                                         let mut ibuf = itoa::Buffer::new();
-                                        compact_buf.extend_from_slice(ibuf.format(formatted_len).as_bytes());
+                                        compact_buf.extend_from_slice(ibuf.format(val.len()).as_bytes());
                                         compact_buf.push(b'\n');
                                     } else {
                                         let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
@@ -19970,6 +20089,13 @@ fn real_main() {
                                 RawApplyOutcome::Emit
                             }
                             ("json" | "text", None) => {
+                                // Composite / non-canonical number lexeme: defer to the
+                                // typed path (inner-quote escaping, NaN -> null; #1021).
+                                if matches!(val.first(), Some(b'{') | Some(b'['))
+                                    || raw_contains_non_canonical_number(val)
+                                {
+                                    return RawApplyOutcome::Bail;
+                                }
                                 compact_buf.push(b'"');
                                 if raw_contains_noncanon_escape(val) { push_raw_canon_escapes(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
                                 compact_buf.extend_from_slice(b"\"\n");
@@ -20185,6 +20311,8 @@ fn real_main() {
                         return Ok(());
                     }
                     if json_object_get_fields_raw_buf(raw, 0, &field_names, &mut ranges_buf) {
+                        // See the NDJSON twin: per-record escape gate (#1027).
+                        let strings_clean = memchr::memchr2(b'\\', 0x7F, raw).is_none();
                         compact_buf.push(b'"');
                         let mut field_idx = 0;
                         for (i, (is_lit, _)) in interp_parts.iter().enumerate() {
@@ -20194,22 +20322,12 @@ fn real_main() {
                                 let (vs, ve) = ranges_buf[field_idx];
                                 field_idx += 1;
                                 let val = &raw[vs..ve];
-                                if val[0] == b'"' && val.len() >= 2 {
-                                    compact_buf.extend_from_slice(&val[1..val.len()-1]);
-                                } else if val[0] == b'[' || val[0] == b'{' {
-                                    for &b in val {
-                                        match b {
-                                            b'"' => compact_buf.extend_from_slice(b"\\\""),
-                                            b'\\' => compact_buf.extend_from_slice(b"\\\\"),
-                                            b'\n' => compact_buf.extend_from_slice(b"\\n"),
-                                            b'\r' => compact_buf.extend_from_slice(b"\\r"),
-                                            b'\t' => compact_buf.extend_from_slice(b"\\t"),
-                                            c if c < 0x20 => { let _ = write!(compact_buf, "\\u{:04x}", c); }
-                                            _ => compact_buf.push(b),
-                                        }
-                                    }
+                                // Shared emitter (see the NDJSON twin): #1027 /
+                                // #1021 canonicalisation in one place.
+                                if strings_clean {
+                                    emit_interp_field_raw_clean(&mut compact_buf, val);
                                 } else {
-                                    if raw_contains_noncanon_escape(val) { push_raw_canon_escapes(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
+                                    emit_interp_field_raw(&mut compact_buf, val);
                                 }
                             }
                         }
@@ -20291,6 +20409,8 @@ fn real_main() {
                             let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                             process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         } else {
+                            // Per-record escape gate (#1027 cost control).
+                            let strings_clean = memchr::memchr2(b'\\', 0x7F, raw).is_none();
                             compact_buf.push(b'"');
                             for &(idx, typ, ai) in &actions {
                                 match typ {
@@ -20298,7 +20418,15 @@ fn real_main() {
                                     1 => {
                                         let (vs, ve) = ranges_buf[idx];
                                         let val = &raw[vs..ve];
-                                        compact_buf.extend_from_slice(&val[1..val.len()-1]);
+                                        // Re-encode non-canonical escapes (#1027).
+                                        let content = &val[1..val.len()-1];
+                                        if strings_clean {
+                                            compact_buf.extend_from_slice(content);
+                                        } else if raw_contains_noncanon_escape(content) {
+                                            jq_jit::value::push_string_content_canon(&mut compact_buf, content);
+                                        } else {
+                                            compact_buf.extend_from_slice(content);
+                                        }
                                     }
                                     _ => {
                                         let (vs, ve) = ranges_buf[idx];
@@ -21032,13 +21160,15 @@ fn real_main() {
                             b't' => { compact_buf.extend_from_slice(b"4\n"); }
                             b'f' => { compact_buf.extend_from_slice(b"5\n"); }
                             _ => {
-                                if let Some(n) = parse_json_num(val) {
-                                    let start_len = compact_buf.len();
-                                    push_jq_number_bytes(&mut compact_buf, n);
-                                    let formatted_len = compact_buf.len() - start_len;
-                                    compact_buf.truncate(start_len);
+                                // Number length = canonical lexeme byte count
+                                // ("1.50" -> 4); non-canonical / 16+ digit
+                                // lexemes defer (#1021, see NDJSON twin).
+                                if parse_json_num(val).is_some()
+                                    && !raw_contains_non_canonical_number(val)
+                                    && val.iter().filter(|c| c.is_ascii_digit()).count() <= 15
+                                {
                                     let mut ibuf = itoa::Buffer::new();
-                                    compact_buf.extend_from_slice(ibuf.format(formatted_len).as_bytes());
+                                    compact_buf.extend_from_slice(ibuf.format(val.len()).as_bytes());
                                     compact_buf.push(b'\n');
                                 } else {
                                     let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -2112,9 +2112,11 @@ pub fn apply_with_entries_tostring_raw(
     buf: &mut Vec<u8>,
 ) -> RawApplyOutcome {
     // `tostring` on a number must use jq's canonical repr (`2e3` -> `"2E+3"`,
-    // not `"2000"`). The raw helper stringifies the f64 form, so bail to the
-    // generic path whenever a value holds a non-canonical number (#729).
-    if raw_contains_non_canonical_number(raw) {
+    // not `"2000"`), and string values/keys holding `\/` / `\uXXXX` escapes
+    // need re-encoding (#1027) — bail to the generic path for both (#729).
+    if raw_contains_non_canonical_number(raw)
+        || crate::value::raw_contains_noncanon_escape(raw)
+    {
         return RawApplyOutcome::Bail;
     }
     if json_object_values_tostring(raw, 0, buf) {
@@ -2698,9 +2700,15 @@ pub fn apply_field_unary_num_raw(
                         return RawApplyOutcome::Bail;
                     }
                     match parse_json_num(val) {
-                        Some(n) => {
+                        Some(_) => {
+                            // The non-canonical check above guarantees the
+                            // lexeme is already in jq's output form — copy it
+                            // verbatim. The old parse + reformat round-trip
+                            // dropped the literal repr ("1.50" became "1.5",
+                            // #1021). parse_json_num stays as the
+                            // numbers-only gate (strings/bools/null bail).
                             buf.push(b'"');
-                            push_jq_number_bytes(buf, n);
+                            buf.extend_from_slice(val);
                             buf.extend_from_slice(b"\"\n");
                         }
                         None => return RawApplyOutcome::Bail,

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -8006,16 +8006,18 @@ extern "C" fn jit_rt_strbuf_append_val(env: *mut JitEnv, val: *const Value) {
             Value::False => buf.push_str("false"),
             Value::True => buf.push_str("true"),
             Value::Num(n, NumRepr(repr)) => {
-                if let Some(r) = repr {
-                    buf.push_str(r);
-                } else {
-                    // Write directly to the string's byte buffer — avoids intermediate String
-                    let bytes = buf.as_mut_vec();
-                    crate::value::push_jq_number_bytes(bytes, *n);
-                }
+                // Mirror eval's interpolation, which runs tostring semantics
+                // (#560): a parsed NaN/Infinity lexeme ("nan", "infinity") or
+                // a non-canonical literal ("1e3") retained as repr must not
+                // be echoed verbatim — jq prints null / the clamped max
+                // double / the canonical uppercase-E form (#1021).
+                crate::value::push_num_tojson_str(buf, *n, repr.as_ref());
             }
             v => {
-                let s = crate::value::value_to_json(v);
+                // Composites carry reprs on nested numbers too — use the
+                // tojson writer so "\([1e3])" matches eval's "[1E+3]" and a
+                // nested parsed NaN renders null (#1021).
+                let s = crate::value::value_to_json_tojson(v);
                 buf.push_str(&s);
             }
         }

--- a/src/value.rs
+++ b/src/value.rs
@@ -2520,6 +2520,21 @@ pub fn json_object_update_field_slice(
 pub fn json_object_values_tostring(
     b: &[u8], pos: usize, buf: &mut Vec<u8>,
 ) -> bool {
+    // Wrapper: roll back partial output when the walk bails mid-object —
+    // the caller falls back to the generic path and would otherwise emit
+    // the partial bytes in front of the real record (#1021).
+    let start_len = buf.len();
+    if json_object_values_tostring_inner(b, pos, buf) {
+        true
+    } else {
+        buf.truncate(start_len);
+        false
+    }
+}
+
+fn json_object_values_tostring_inner(
+    b: &[u8], pos: usize, buf: &mut Vec<u8>,
+) -> bool {
     if pos >= b.len() || b[pos] != b'{' { return false; }
     buf.push(b'{');
     let mut i = pos + 1;
@@ -2560,6 +2575,11 @@ pub fn json_object_values_tostring(
                 i += 1;
             }
             buf.extend_from_slice(&b[val_start..i]);
+        } else if b[i] == b'{' || b[i] == b'[' {
+            // Composite: jq's tostring is the tojson text with inner quotes
+            // escaped for the surrounding string — defer to the generic path
+            // (the verbatim wrap emitted invalid JSON, #1021).
+            return false;
         } else {
             // Number, bool, null — find end, wrap in quotes
             let end = match skip_json_value(b, val_start) {
@@ -2567,18 +2587,20 @@ pub fn json_object_values_tostring(
                 Err(_) => return false,
             };
             let val_bytes = &b[val_start..end];
-            buf.push(b'"');
-            // For numbers, use push_jq_number_bytes for jq-compatible formatting
-            if b[val_start] == b'-' || b[val_start].is_ascii_digit() {
-                if let Ok(n) = unsafe { std::str::from_utf8_unchecked(val_bytes) }.parse::<f64>() {
-                    push_jq_number_bytes(buf, n);
-                } else {
-                    buf.extend_from_slice(val_bytes);
-                }
-            } else {
-                // true, false, null
-                buf.extend_from_slice(val_bytes);
+            // A 16+ digit lexeme exceeds f64 exactness — the typed path
+            // renders its f64 form (no decnum), so verbatim copy would
+            // diverge from the engine. Defer to the generic path.
+            if (b[val_start] == b'-' || b[val_start].is_ascii_digit())
+                && val_bytes.iter().filter(|c| c.is_ascii_digit()).count() > 15
+            {
+                return false;
             }
+            buf.push(b'"');
+            // The caller bails on non-canonical number lexemes, so a number
+            // here is already in jq's output form — copy it verbatim. The
+            // old parse + push_jq_number_bytes round-trip dropped the
+            // literal repr ("1.50" became "1.5", #1021).
+            buf.extend_from_slice(val_bytes);
             buf.push(b'"');
             i = end;
         }
@@ -4022,7 +4044,7 @@ pub fn raw_contains_noncanon_escape(b: &[u8]) -> bool {
 /// output encoder. A malformed escape falls back to the verbatim copy with
 /// only `\/` rewritten — the pre-existing behavior — so these emit sites
 /// never start erroring on input the raw path previously passed through.
-fn push_string_content_canon(buf: &mut Vec<u8>, content: &[u8]) {
+pub fn push_string_content_canon(buf: &mut Vec<u8>, content: &[u8]) {
     let mut tok = Vec::with_capacity(content.len() + 2);
     tok.push(b'"');
     tok.extend_from_slice(content);
@@ -6278,6 +6300,38 @@ pub fn value_to_json_tojson(v: &Value) -> String {
     out
 }
 
+/// Append a number in tojson/tostring form: a valid, exactly round-tripping
+/// literal repr is kept in jq's canonical (uppercase-E decnum) form; anything
+/// else — a computed value, a NaN/Infinity lexeme (`nan`, `infinity`), or a
+/// repr that doesn't round-trip — takes the canonical f64 writer (`null` for
+/// NaN, the clamped max double for Infinity). Shared by `tojson`/`tostring`,
+/// the JIT string-interpolation buffer, and `@json`/`@text` so a parsed-input
+/// NaN or non-canonical lexeme cannot leak through one formatter after being
+/// fixed in another (#771, #1021).
+pub fn push_num_tojson_str(out: &mut String, n: f64, repr: Option<&Rc<str>>) {
+    if let Some(r) = repr.filter(|r| is_valid_json_number(r) && repr_is_exact_for_f64(r, n)) {
+        if let Some(canonical) = normalize_jq_repr(r) {
+            out.push_str(&canonical);
+        } else {
+            out.push_str(r);
+        }
+    } else if let Some(canonical) = repr
+        .filter(|r| is_valid_json_number(r) && n.is_finite() && n != 0.0)
+        .and_then(|r| normalize_jq_repr(r))
+        .filter(|c| c.as_str().parse::<f64>().ok() == Some(n))
+    {
+        // Subnormal-edge case (#616): `repr_is_exact_for_f64` is too
+        // conservative for tiny exponents (< -323), but the literal
+        // can still round-trip through f64 — e.g. `5e-324` is the
+        // canonical form for the smallest positive subnormal. Prefer
+        // the normalised repr when it parses back to the same bits;
+        // otherwise fall through to the lossy f64 dtoa form.
+        out.push_str(&canonical);
+    } else {
+        push_jq_number_str(out, n);
+    }
+}
+
 fn push_value_tojson(v: &Value, out: &mut String, depth: usize) {
     if depth > MAX_JSON_DEPTH {
         out.push_str("\"<skipped: too deep>\"");
@@ -6287,30 +6341,7 @@ fn push_value_tojson(v: &Value, out: &mut String, depth: usize) {
         Value::Null => out.push_str("null"),
         Value::False => out.push_str("false"),
         Value::True => out.push_str("true"),
-        Value::Num(n, NumRepr(repr)) => {
-            if let Some(r) = repr.as_ref().filter(|r| is_valid_json_number(r) && repr_is_exact_for_f64(r, *n)) {
-                if let Some(canonical) = normalize_jq_repr(r) {
-                    out.push_str(&canonical);
-                } else {
-                    out.push_str(r);
-                }
-            } else if let Some(canonical) = repr
-                .as_ref()
-                .filter(|r| is_valid_json_number(r) && n.is_finite() && *n != 0.0)
-                .and_then(|r| normalize_jq_repr(r))
-                .filter(|c| c.as_str().parse::<f64>().ok() == Some(*n))
-            {
-                // Subnormal-edge case (#616): `repr_is_exact_for_f64` is too
-                // conservative for tiny exponents (< -323), but the literal
-                // can still round-trip through f64 — e.g. `5e-324` is the
-                // canonical form for the smallest positive subnormal. Prefer
-                // the normalised repr when it parses back to the same bits;
-                // otherwise fall through to the lossy f64 dtoa form.
-                out.push_str(&canonical);
-            } else {
-                push_jq_number_str(out, *n);
-            }
-        }
+        Value::Num(n, NumRepr(repr)) => push_num_tojson_str(out, *n, repr.as_ref()),
         Value::Str(s) => push_json_string(out, s),
         Value::Arr(a) => {
             out.push('[');

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -13462,3 +13462,33 @@ null
 .x
 {"x":"ab"}
 "a\u007fb"
+
+# Issue #1021: parsed-input NaN normalizes through @json/@text/interpolation
+[(.a | @json), (.a | @text), "\(.a)"]
+{"a":nan}
+["null","null","null"]
+
+# Issue #1021: parsed Infinity and non-canonical lexemes render canonically in interpolation
+"\(.a)|\(.b)|\(.c)"
+{"a":infinity,"b":1e3,"c":5e-324}
+"1.7976931348623157e+308|1E+3|5E-324"
+
+# Issue #1021: composites in interpolation use tojson number formatting
+"\(.a)"
+{"a":[1e3,{"k":nan}]}
+"[1E+3,{\"k\":null}]"
+
+# Issue #1021: @json/@text on composites escape inner quotes
+[(.a | @text), (.a | @json)]
+{"a":{"k":1}}
+["{\"k\":1}","{\"k\":1}"]
+
+# Issue #1021: tostring preserves the literal repr through the raw fast paths
+[(.a | tostring), (.a | tostring | length)]
+{"a":1.50}
+["1.50",4]
+
+# Issue #1021: with_entries tostring keeps reprs and escapes composites correctly
+with_entries(.value |= tostring)
+{"a":1.50,"b":"x"}
+{"a":"1.50","b":"x"}


### PR DESCRIPTION
## Summary

A NaN that entered via JSON-input parsing keeps its source lexeme as the retained repr, and several serializers echoed that repr verbatim: `.a | @json` on `{"a":nan}` printed `"nan"` — an invalid JSON token — where jq prints `"null"`. Investigating the issue surfaced the full leak family on the same mechanism:

- `"infinity"` / non-canonical finite lexemes (`"1e3"` where jq canonicalises to `"1E+3"`, `0.0000001` → `1E-7`, `5e-324` → `5E-324`) through `@json` / `@text` / string interpolation
- `\uXXXX` string escapes through interpolation and string concat (#1027 residue on different emitters)
- `@json`/`@text` on composites emitted inner quotes **unescaped** (`"{"k":1}"` — invalid JSON output)
- `tostring`'s parse-and-reformat dropped literal reprs (`1.50` → `"1.5"`; jq keeps `"1.50"`), including through `with_entries` and `tostring | length`

## Changes

All sites now route through shared canonical writers instead of per-site ad-hoc echo:

- **value**: extract the tojson number writer as `push_num_tojson_str`, shared by tojson, the JIT string buffer, and the raw emitters. `json_object_values_tostring` keeps canonical lexemes verbatim, defers composites (invalid-JSON wrap) and 16+-digit lexemes, and rolls back partial output when bailing mid-object.
- **jit**: `jit_rt_strbuf_append_val` pushed the repr verbatim; numbers now use `push_num_tojson_str`, composites `value_to_json_tojson`.
- **bin**: `@json`/`@text` raw arms bail to the typed path for composites and non-canonical lexemes; the interpolation and string-concat loops (NDJSON + file-content twins) and the StringChain remap arms route through `emit_interp_field_raw` / `push_interp_num_canon`.
- **fast_path**: standalone `.field | tostring` and `tostring | length` emit/count the canonical lexeme verbatim; `with_entries`-tostring bails on escape-bearing records.

## Verification

- Differential battery: 25 inputs (NaN / ±Infinity / canonical & non-canonical lexemes / subnormal & max-double / `\u` escapes / composites / -0.0 / 21-digit integer) × 20 filter shapes = **500 cases vs system jq 1.8.1, all match**.
- `cargo build --release`: zero warnings. `cargo test --release`: full suite green, including 6 new regression groups.
- **Hot-path A/B** (same-machine, interleaved best-of-5 vs main, 2M-record NDJSON): tracked shapes `.name + "_x"`, `.name + ":" + (.x|tostring)`, `.x * 2 | tostring`, `.x | tostring | length` neutral; two shapes carry +0.01s (`"\(.a) \(.msg)"` 0.11→0.12, `select | string-chain` 0.15→0.16) — the residual is the per-record escape scan that correct output requires; mitigated with per-record gates and an all-digits fast path (was +18% before mitigation).

Closes #1021

🤖 Generated with [Claude Code](https://claude.com/claude-code)
