### PR TITLE
fix(parser): reject the slice form in the postfix dotted bracket

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2498,9 +2498,35 @@ impl Parser {
                             }
                         }
                         Token::LBracket => {
-                            // .expr.[] or .expr.[key] — handle like LBracket postfix
-                            // Don't advance — let the LBracket case handle it
-                            continue;
+                            // .expr.[] or .expr.[key] — like the LBracket
+                            // postfix below, EXCEPT that jq's dotted bracket
+                            // form only carries an index/iterate: the slice
+                            // form (.a.[lo:hi]) is a compile error in jq 1.8,
+                            // while the undotted .a[lo:hi] is fine (#1023).
+                            self.advance();
+                            if self.eat(&Token::RBracket) {
+                                let optional = self.eat(&Token::Question);
+                                expr = if optional {
+                                    Expr::EachOpt { input_expr: Box::new(expr) }
+                                } else {
+                                    Expr::Each { input_expr: Box::new(expr) }
+                                };
+                            } else {
+                                if self.at(&Token::Colon) {
+                                    anyhow::bail!("syntax error, unexpected ':'");
+                                }
+                                let key = self.parse_pipe()?;
+                                if self.at(&Token::Colon) {
+                                    anyhow::bail!("syntax error, unexpected ':', expecting '|' or ',' or ']'");
+                                }
+                                self.expect(&Token::RBracket)?;
+                                let optional = self.eat(&Token::Question);
+                                expr = if optional {
+                                    Expr::IndexOpt { expr: Box::new(expr), key: Box::new(key) }
+                                } else {
+                                    Expr::Index { expr: Box::new(expr), key: Box::new(key) }
+                                };
+                            }
                         }
                         _ => {
                             // Just a trailing dot - this shouldn't normally happen after a postfix

--- a/tests/optional_dot_slice_reject.rs
+++ b/tests/optional_dot_slice_reject.rs
@@ -1,0 +1,53 @@
+//! Issue #1023: jq's postfix dotted bracket form (`.a.[...]`) only carries an
+//! index or iterate — the slice form (`.a.[lo:hi]`) is a compile error in
+//! jq 1.8, while the undotted `.a[lo:hi]` and the bare leading `.[lo:hi]`
+//! both parse. The regression harness skips exit-3 cases, so assert the
+//! compile rejection by shelling out.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn run(filter: &str) -> i32 {
+    let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
+    let mut child = Command::new(jq_jit)
+        .arg("-c")
+        .arg(filter)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn jq-jit");
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(b"{\"a\":[1,2,3]}")
+        .unwrap();
+    child
+        .wait_with_output()
+        .expect("wait failed")
+        .status
+        .code()
+        .expect("no exit code")
+}
+
+#[test]
+fn dotted_bracket_slice_is_a_compile_error() {
+    for f in [
+        ".a.[0:1]",
+        ".a.[1:]",
+        ".a.[:2]",
+        ".a.b.[0:1]",
+        ".[0:1].[0:1]",
+        ".a.[0:1]?",
+    ] {
+        assert_eq!(run(f), 3, "{} must be rejected at compile time", f);
+    }
+}
+
+#[test]
+fn undotted_slice_and_dotted_index_iterate_still_parse() {
+    for f in [".a[0:1]", ".a | .[0:1]", ".a.[0]", ".a.[]", ".a.[]?", ".a.[0]?"] {
+        assert_eq!(run(f), 0, "{} must keep parsing and running", f);
+    }
+}

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -13492,3 +13492,8 @@ null
 with_entries(.value |= tostring)
 {"a":1.50,"b":"x"}
 {"a":"1.50","b":"x"}
+
+# Issue #1023: postfix dotted bracket rejects the slice form like jq (index/iterate still fine)
+[try (.a | .[0:1]) catch "e", .a.[0], first(.a.[])]
+{"a":[1,2,3]}
+[[1],1,1]


### PR DESCRIPTION
## Summary

jq's postfix dotted bracket (`.a.[...]`) only carries an index or iterate; the slice form (`.a.[lo:hi]`, `.a.[lo:]`, `.a.[:hi]`) is a **compile error** in jq 1.8, while the undotted `.a[lo:hi]` and the bare leading `.[lo:hi]` both parse. jq-jit forwarded the dotted bracket to the generic postfix-bracket handler, which permits slices, so `.a.[0:1]` compiled and ran where jq rejects it (#1023, parser over-acceptance).

## Changes

Parse the dotted bracket in its own arm with the slice form rejected (`syntax error, unexpected ':'`); index, iterate, and their optional (`?`) variants are unchanged.

## Verification

- 17-shape acceptance matrix vs system jq 1.8.1 (dotted/undotted × index/iterate/slice/optional, piped and bare leading forms, `$__loc__.[0:1]`) — exit codes all match.
- `cargo build --release`: zero warnings. `cargo test --release`: full suite green.
- New shell-out test (`tests/optional_dot_slice_reject.rs`) asserts the exit-3 compile rejection — the regression harness skips exit-3 cases — plus a regression group for the still-valid forms.

Closes #1023

🤖 Generated with [Claude Code](https://claude.com/claude-code)