### PR TITLE
fix(datetime): normalize out-of-range broken-down-time fields in strftime

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -4218,6 +4218,31 @@ fn strip_expanded_year_sign(s: String) -> String {
     String::from_utf8(out).expect("removing ASCII '+' preserves UTF-8")
 }
 
+/// jq's strftime feeds a broken-down array through `timegm` before
+/// formatting, which normalizes out-of-range fields (month/min/sec/mday
+/// carry and borrow across neighbours) and recomputes wday/yday (#1022).
+/// macOS libc — the project's reference baseline — fails timegm for results
+/// landing before year 1900 and leaves the raw fields in place; mirror that
+/// by returning `None` when the normalized result is pre-1900 (or beyond
+/// chrono's representable range), so the caller formats the raw fields.
+fn strftime_normalize(t: &BrokenTime) -> Option<BrokenTime> {
+    use chrono::{Datelike, Timelike};
+    let dt = mktime_normalize(t)?;
+    if dt.year() < 1900 {
+        return None;
+    }
+    Some(BrokenTime {
+        year: dt.year(),
+        mon: dt.month0() as i32,
+        mday: dt.day() as i32,
+        hour: dt.hour() as i32,
+        min: dt.minute() as i32,
+        sec: dt.second() as i32,
+        wday: dt.weekday().num_days_from_sunday() as i32,
+        yday: dt.ordinal0() as i32,
+    })
+}
+
 fn rt_strftime(v: &Value, fmt: &Value) -> Result<Value> {
     let fmt_str = match fmt {
         Value::Str(f) => f.as_ref(),
@@ -4231,6 +4256,7 @@ fn rt_strftime(v: &Value, fmt: &Value) -> Result<Value> {
                 }
             }
             let t = time_arr_to_broken(a)?;
+            let t = strftime_normalize(&t).unwrap_or(t);
             Ok(Value::from_str(&format_broken(&t, fmt_str)))
         }
         Value::Num(n, _) => {

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -13497,3 +13497,23 @@ with_entries(.value |= tostring)
 [try (.a | .[0:1]) catch "e", .a.[0], first(.a.[])]
 {"a":[1,2,3]}
 [[1],1,1]
+
+# Issue #1022: strftime normalizes out-of-range broken-down fields like timegm (month carry)
+[2023,13,1,0,0,0,0,0] | strftime("%Y-%m-%d")
+null
+"2024-02-01"
+
+# Issue #1022: minute/second carry and mday borrow normalize; wday/yday recompute
+[([2023,5,1,0,70,0,0,0] | strftime("%H:%M")), ([2023,5,1,0,0,90,0,0] | strftime("%M:%S")), ([2023,5,-1,0,0,0,0,0] | strftime("%Y-%m-%d")), ([2023,0,32,0,0,0,9,999] | strftime("%a %j"))]
+null
+["01:10","01:30","2023-05-30","Wed 032"]
+
+# Issue #1022: short arrays normalize too (mday=0 borrows into previous year)
+[2024] | strftime("%Y-%m-%d")
+null
+"2023-12-31"
+
+# Issue #1022: results landing before 1900 keep the raw year (macOS timegm failure baseline); carries landing >= 1900 normalize
+[([1898,13,1,0,0,0,0,0] | strftime("%Y")), ([1899,13,1,0,0,0,0,0] | strftime("%Y-%m-%d"))]
+null
+["1898","1900-02-01"]


### PR DESCRIPTION
## Summary

jq feeds a broken-down array through `timegm` before formatting, so out-of-range month/min/sec/mday values carry and borrow across neighbouring fields and wday/yday are recomputed from the normalized date. jq-jit formatted the raw fields: `[2023,13,1,0,0,0,0,0] | strftime("%Y-%m-%d")` printed `2023-12-01` where jq prints `2024-02-01` (#1022).

## Changes

Normalize through the existing `mktime_normalize` calendar walk before formatting (new `strftime_normalize`, which also recomputes wday/yday). macOS libc — the project's reference baseline — fails `timegm` for results landing before year 1900 and formats the raw fields; mirrored by skipping normalization for pre-1900 results, so `[1898,13,1]` keeps the raw year while `[1899,13,1]` (which lands in 1900) normalizes. `mktime` and the epoch-input path are untouched.

## Verification

- 23-case battery vs system jq 1.8.1 (TZ=UTC): carry/borrow in every field, short arrays (`[2024]` → `2023-12-31`), leap-day carry, second-60 carry, week numbers, wday/yday recomputation, the 1899/1900/1901 boundary, fractional seconds — all match.
- `cargo build --release`: zero warnings. `cargo test --release`: full suite green with 4 new regression groups.
- Tests pinned in `regression.test` only — the timegm failure boundary is libc-dependent, so per the corpus convention these stay out of the cross-OS `corpus.test`.

## Known residual (pre-existing)

When normalization fails (pre-1900 results), out-of-range fields format clamped (`1800-12-01`) rather than libc's raw rendering (`1800-14-01`), and raw wday/yday cannot override the date-derived `%a`/`%j` — chrono cannot represent month 14 or a contradictory weekday. Same class as the existing `[] | strftime` clamp.

Closes #1022

🤖 Generated with [Claude Code](https://claude.com/claude-code)