### PR TITLE
fix(test-harness): drop the order-insensitive sorted-line fallback

### DIFF
--- a/tests/common/jq_test_format.rs
+++ b/tests/common/jq_test_format.rs
@@ -238,22 +238,12 @@ pub fn run_test(case: &TestCase) -> TestResult {
                     };
                 }
 
-                let mut actual_lines: Vec<&str> = actual_normalized.lines().collect();
-                let mut expected_lines: Vec<&str> = expected_normalized.lines().collect();
-                actual_lines.sort();
-                expected_lines.sort();
-
-                if actual_lines == expected_lines {
-                    return TestResult {
-                        test_num: case.test_num,
-                        filter: case.filter.clone(),
-                        input: case.input.clone(),
-                        expected: case.expected.clone(),
-                        actual: actual_raw,
-                        status: TestStatus::Pass,
-                    };
-                }
-
+                // No order-insensitive fallback: jq's output order is
+                // deterministic semantics (generator emission order, object
+                // key insertion order), and the bug class most likely to
+                // reorder outputs — a fast-path or JIT divergence from the
+                // generic evaluator — is exactly what a sorted comparison
+                // would mask (#1025).
                 return TestResult {
                     test_num: case.test_num,
                     filter: case.filter.clone(),


### PR DESCRIPTION
## Summary

When the exact normalized comparison failed, the harness sorted both actual and expected output lines and reported **Pass** on a multiset match (`tests/common/jq_test_format.rs`). jq's output order is deterministic semantics — generator emission order, object key insertion order — and the bug class most likely to reorder outputs (fast-path or JIT divergence from the generic evaluator) is exactly what the fallback silently masked, in both `regression.test` and the differential corpus (#1025).

## Changes

Remove the fallback; an exact-mismatch now fails. Per the issue's step 1-2: running the full suite with the fallback removed surfaces **zero** currently-masked cases, so no expectations needed re-pinning and no per-case order-insensitivity marker turned out to be necessary.

## Verification

`cargo build --release`: zero warnings. `cargo test --release`: full suite green (official 509, regression, differential, fuzz, selfdiff, contracts) with the exact comparison only.

Closes #1025

🤖 Generated with [Claude Code](https://claude.com/claude-code)