### PR TITLE
release v1.8.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jq-jit"
-version = "1.8.2"
+version = "1.8.3"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jq-jit"
-version = "1.8.2"
+version = "1.8.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A JIT-compiling implementation of jq using Cranelift"

--- a/docs/benchmark-history.md
+++ b/docs/benchmark-history.md
@@ -6,268 +6,268 @@ Recent slice (last 5 columns). Full history lives in
 
 ```text
 --- NDJSON workloads (2M objects) ---
-  Benchmark                    v1.7.0  v1.7.1  v1.8.0  v1.8.1  v1.8.2
+  Benchmark                    v1.7.1  v1.8.0  v1.8.1  v1.8.2  v1.8.3
   ---                          ------  ------  ------  ------  ------
   empty                        0.017s  0.017s  0.017s  0.017s  0.017s
-  identity -c                  0.086s  0.084s  0.084s  0.083s  0.085s
-  identity (pretty)            0.106s  0.102s  0.099s  0.103s  0.110s
-  field access .name           0.093s  0.090s  0.089s  0.103s  0.110s
-  nested .x,.y,.name           0.147s  0.146s  0.149s  0.171s  0.184s
-  arithmetic .x + .y           0.083s  0.082s  0.079s  0.083s  0.087s
-  select .x > 1500000          0.084s  0.080s  0.077s  0.082s  0.086s
-  string concat                0.092s  0.092s  0.088s  0.090s  0.096s
-  object construct             0.114s  0.110s  0.109s  0.124s  0.135s
-  array construct              0.105s  0.105s  0.100s  0.123s  0.135s
-  .[]                          0.102s  0.101s  0.098s  0.111s  0.117s
-  to_entries                   0.163s  0.154s  0.150s  0.169s  0.149s
-  keys                         0.105s  0.100s  0.098s  0.101s  0.104s
-  keys_unsorted                0.094s  0.092s  0.090s  0.094s  0.100s
-  length                       0.084s  0.087s  0.084s  0.086s  0.086s
-  has("x")                     0.037s  0.036s  0.035s  0.038s  0.037s
-  type                         0.023s  0.022s  0.021s  0.022s  0.020s
-  del(.name)                   0.101s  0.099s  0.098s  0.113s  0.115s
-  @csv                         0.118s  0.117s  0.119s  0.125s  0.119s
-  split/join                   0.090s  0.089s  0.086s  0.089s  0.089s
-  select|field                 0.097s  0.094s  0.093s  0.098s  0.100s
-  select|remap                 0.099s  0.097s  0.093s  0.097s  0.101s
-  computed remap               0.191s  0.187s  0.186s  0.206s  0.222s
-  [.x,.y]|add                  0.083s  0.083s  0.081s  0.082s  0.086s
-  [.x,.y]|avg                  0.106s  0.106s  0.105s  0.105s  0.111s
-  map(*2)|add                  0.104s  0.102s  0.099s  0.104s  0.106s
-  keys|length                  0.255s  0.251s  0.249s  0.252s  0.263s
-  .+{z=0}                      0.146s  0.145s  0.142s  0.147s  0.154s
-  split|first                  0.089s  0.088s  0.086s  0.087s  0.086s
-  slice[0..5]                  0.094s  0.094s  0.088s  0.091s  0.093s
-  dynkey {(.name)}             0.104s  0.106s  0.100s  0.114s  0.113s
-  .x += 1                      0.121s  0.122s  0.124s  0.127s  0.128s
-  {a}+{b} merge                0.130s  0.129s  0.128s  0.148s  0.161s
-  .x*2+1                       0.060s  0.059s  0.057s  0.059s  0.061s
-  .x+.y*2                      0.100s  0.096s  0.094s  0.095s  0.100s
-  .x > .y                      0.077s  0.076s  0.074s  0.078s  0.081s
-  to_entries|len               0.397s  0.397s  0.389s  0.393s  0.387s
-  .x|.+1 (pipe)                0.059s  0.056s  0.055s  0.057s  0.058s
-  .x|.*2|.+1                   0.060s  0.058s  0.056s  0.059s  0.061s
-  .name|.+"_x"                 0.094s  0.092s  0.088s  0.092s  0.095s
-  .x>N | not                   0.049s  0.048s  0.047s  0.050s  0.049s
-  and (2 cmp)                  0.080s  0.080s  0.078s  0.081s  0.084s
-  if-then-else                 0.052s  0.051s  0.049s  0.052s  0.053s
-  sel(and)|field               0.076s  0.076s  0.073s  0.077s  0.080s
-  sel(and)|remap               0.077s  0.077s  0.074s  0.078s  0.080s
-  arith|cmp                    0.054s  0.053s  0.051s  0.053s  0.055s
-  if cmp .field                0.113s  0.110s  0.108s  0.113s  0.119s
-  split|length                 0.089s  0.088s  0.085s  0.087s  0.089s
-  [x,y]|min                    0.090s  0.089s  0.087s  0.090s  0.095s
-  [x,y]|max                    0.095s  0.092s  0.090s  0.094s  0.100s
-  [x,y]|sort|.[0]              0.089s  0.088s  0.085s  0.089s  0.095s
-  .name|len>5                  0.090s  0.089s  0.088s  0.091s  0.087s
-  sel(len>5)|.x                0.107s  0.107s  0.105s  0.106s  0.110s
-  if .x>.y .name               0.093s  0.088s  0.088s  0.089s  0.092s
-  sel(.x>.y)|.name             0.071s  0.070s  0.067s  0.071s  0.075s
-  .x*2|tostring                0.057s  0.055s  0.053s  0.056s  0.059s
-  .x*.x+1                      0.067s  0.064s  0.063s  0.066s  0.068s
-  {k=.name,v=tostr}            0.144s  0.145s  0.138s  0.157s  0.167s
-  str add chain                0.385s  0.378s  0.372s  0.380s  0.396s
-  if>.y .name|empty            0.073s  0.072s  0.070s  0.073s  0.075s
-  if .x%2==0                   0.055s  0.054s  0.052s  0.054s  0.055s
-  if .x*2+1>1M                 0.056s  0.054s  0.052s  0.054s  0.056s
-  sel(.x%2==0)|.name           0.084s  0.081s  0.080s  0.084s  0.083s
-  sel(.x*2+1>1M)               0.159s  0.154s  0.151s  0.157s  0.156s
-  .x|@json                     0.047s  0.047s  0.046s  0.048s  0.051s
-  .x|@text                     0.048s  0.047s  0.045s  0.048s  0.050s
-  .name|@json                  0.101s  0.101s  0.099s  0.102s  0.107s
-  sel|[arr]                    0.149s  0.144s  0.140s  0.160s  0.172s
-  sel(and)|[arr]               0.079s  0.076s  0.076s  0.079s  0.081s
-  if>.y [arr]                  0.179s  0.174s  0.178s  0.198s  0.205s
-  if sw then .f                0.139s  0.135s  0.132s  0.139s  0.147s
-  dynkey {(.n)=.x*2}           0.115s  0.112s  0.111s  0.116s  0.118s
-  sel(and)|.x*.y               0.077s  0.078s  0.074s  0.079s  0.080s
-  sel>N|str chain              0.155s  0.153s  0.151s  0.153s  0.157s
-  .f+"_"+arith_ts              0.133s  0.132s  0.130s  0.133s  0.133s
-  sel(sw)|str ch               0.307s  0.298s  0.301s  0.303s  0.312s
-  split|rev|join               0.117s  0.112s  0.111s  0.112s  0.114s
-  dynkey+static                0.338s  0.332s  0.332s  0.339s  0.340s
-  if>.y str chain              0.171s  0.168s  0.167s  0.170s  0.171s
-  remap+str chain              0.156s  0.154s  0.145s  0.160s  0.162s
-  sel(len>8)                   0.162s  0.159s  0.154s  0.159s  0.161s
-  up|split|join                0.095s  0.100s  0.095s  0.096s  0.097s
-  .name|index                  0.118s  0.117s  0.114s  0.121s  0.120s
-  .name|index+1                0.122s  0.122s  0.117s  0.122s  0.126s
-  .name|rindex                 0.127s  0.125s  0.122s  0.124s  0.129s
-  .name|indices                0.155s  0.149s  0.145s  0.159s  0.150s
-  [x,y]|sort                   0.153s  0.154s  0.152s  0.168s  0.175s
-  .name|scan                   0.207s  0.213s  0.208s  0.206s  0.205s
-  .name|gsub                   0.167s  0.166s  0.162s  0.168s  0.167s
-  walk(if num .+1)             0.141s  0.137s  0.136s  0.137s  0.141s
-  tojson                       0.104s  0.105s  0.100s  0.107s  0.115s
-  {name,x}                     0.128s  0.128s  0.123s  0.150s  0.154s
-  .z//.name                    0.154s  0.155s  0.146s  0.164s  0.175s
-  .x|=test(re)                 0.172s  0.170s  0.165s  0.170s  0.172s
-  ./sep|first                  0.182s  0.180s  0.173s  0.179s  0.186s
-  .y=(.x*2)                    0.174s  0.175s  0.172s  0.176s  0.179s
-  .y=(.x+.y)                   0.228s  0.226s  0.224s  0.232s  0.235s
-  objects                      0.134s  0.137s  0.130s  0.125s  0.137s
-  .tag|=if..then N             0.627s  0.614s  0.590s  0.607s  0.635s
-  .x=(.x+1)                    0.124s  0.126s  0.123s  0.128s  0.131s
-  sel>N|.y+=1                  0.122s  0.120s  0.119s  0.122s  0.124s
-  sel(and)|.x+=1               0.109s  0.109s  0.106s  0.106s  0.108s
-  sel(sw)|.x+=1                0.159s  0.156s  0.156s  0.164s  0.169s
-  match(re)                    0.362s  0.368s  0.355s  0.363s  0.379s
-  capture(re)                  0.302s  0.299s  0.294s  0.299s  0.306s
-  first(.name,.x)              0.094s  0.095s  0.092s  0.106s  0.109s
-  if .x==null                  0.046s  0.046s  0.045s  0.047s  0.047s
-  we(sw(.key))                 0.108s  0.107s  0.104s  0.109s  0.118s
-  sel(sw or ew)                0.205s  0.199s  0.198s  0.206s  0.205s
-  path(.name,.x)               0.278s  0.271s  0.264s  0.273s  0.320s
-  sel(str+num+num)             0.150s  0.151s  0.145s  0.150s  0.151s
-  nested if|field              0.077s  0.077s  0.074s  0.078s  0.083s
-  .f|floor|.*2                 0.060s  0.061s  0.058s  0.062s  0.062s
-  split|len>1                  0.115s  0.113s  0.110s  0.117s  0.114s
-  .name|len|.*2                0.103s  0.100s  0.097s  0.101s  0.102s
-  if len>5 .x .y               0.113s  0.115s  0.110s  0.112s  0.115s
-  sel(len>5)|remap             0.201s  0.199s  0.198s  0.199s  0.209s
-  .x|tostr|len                 0.059s  0.058s  0.057s  0.060s  0.061s
-  if .x>.y .x .y               0.094s  0.094s  0.091s  0.093s  0.099s
-  split|last|tonum             0.096s  0.095s  0.092s  0.097s  0.095s
-  split|rev|.[0]               0.091s  0.090s  0.089s  0.092s  0.091s
-  split|.[0]+.[1]              0.113s  0.112s  0.109s  0.112s  0.114s
-  .[]|strings                  0.105s  0.104s  0.106s  0.108s  0.108s
-  .[]|numbers                  0.124s  0.124s  0.125s  0.126s  0.125s
-  [x,y]|any(>1M)               0.082s  0.083s  0.079s  0.082s  0.086s
-  sel(dc|sw)                   0.098s  0.098s  0.094s  0.099s  0.098s
-  [[x,y],[n]]|flat             0.464s  0.456s  0.450s  0.459s  0.520s
-  .x|floor|.*2                 0.061s  0.061s  0.059s  0.062s  0.060s
-  tojson|fromjson              0.082s  0.084s  0.080s  0.086s  0.086s
-  [.x]|add                     0.059s  0.059s  0.057s  0.064s  0.066s
-  if>N {o}+.                   0.138s  0.136s  0.127s  0.137s  0.135s
-  if>N .+{o}                   0.136s  0.132s  0.131s  0.132s  0.134s
-  if .n=="s" .+{o}             0.157s  0.159s  0.154s  0.162s  0.162s
-  sel(.n>"s")                  0.091s  0.087s  0.085s  0.088s  0.092s
-  [x,y,z]|min                  0.307s  0.312s  0.305s  0.313s  0.311s
-  if .n|len>5 l s              0.100s  0.099s  0.095s  0.100s  0.101s
-  if .x|flr>N b s              0.055s  0.054s  0.053s  0.055s  0.055s
-  if .n|test l e               0.105s  0.104s  0.102s  0.109s  0.103s
-  if .n|sw l e                 0.082s  0.084s  0.080s  0.085s  0.086s
-  if .n|ew l e                 0.085s  0.083s  0.080s  0.084s  0.083s
-  .n|len|tostr                 0.090s  0.092s  0.085s  0.090s  0.089s
+  identity -c                  0.084s  0.084s  0.083s  0.085s  0.085s
+  identity (pretty)            0.102s  0.099s  0.103s  0.110s  0.106s
+  field access .name           0.090s  0.089s  0.103s  0.110s  0.114s
+  nested .x,.y,.name           0.146s  0.149s  0.171s  0.184s  0.200s
+  arithmetic .x + .y           0.082s  0.079s  0.083s  0.087s  0.084s
+  select .x > 1500000          0.080s  0.077s  0.082s  0.086s  0.081s
+  string concat                0.092s  0.088s  0.090s  0.096s  0.093s
+  object construct             0.110s  0.109s  0.124s  0.135s  0.137s
+  array construct              0.105s  0.100s  0.123s  0.135s  0.136s
+  .[]                          0.101s  0.098s  0.111s  0.117s  0.116s
+  to_entries                   0.154s  0.150s  0.169s  0.149s  0.148s
+  keys                         0.100s  0.098s  0.101s  0.104s  0.103s
+  keys_unsorted                0.092s  0.090s  0.094s  0.100s  0.099s
+  length                       0.087s  0.084s  0.086s  0.086s  0.084s
+  has("x")                     0.036s  0.035s  0.038s  0.037s  0.039s
+  type                         0.022s  0.021s  0.022s  0.020s  0.020s
+  del(.name)                   0.099s  0.098s  0.113s  0.115s  0.113s
+  @csv                         0.117s  0.119s  0.125s  0.119s  0.118s
+  split/join                   0.089s  0.086s  0.089s  0.089s  0.088s
+  select|field                 0.094s  0.093s  0.098s  0.100s  0.097s
+  select|remap                 0.097s  0.093s  0.097s  0.101s  0.102s
+  computed remap               0.187s  0.186s  0.206s  0.222s  0.224s
+  [.x,.y]|add                  0.083s  0.081s  0.082s  0.086s  0.084s
+  [.x,.y]|avg                  0.106s  0.105s  0.105s  0.111s  0.112s
+  map(*2)|add                  0.102s  0.099s  0.104s  0.106s  0.102s
+  keys|length                  0.251s  0.249s  0.252s  0.263s  0.253s
+  .+{z=0}                      0.145s  0.142s  0.147s  0.154s  0.150s
+  split|first                  0.088s  0.086s  0.087s  0.086s  0.086s
+  slice[0..5]                  0.094s  0.088s  0.091s  0.093s  0.091s
+  dynkey {(.name)}             0.106s  0.100s  0.114s  0.113s  0.117s
+  .x += 1                      0.122s  0.124s  0.127s  0.128s  0.128s
+  {a}+{b} merge                0.129s  0.128s  0.148s  0.161s  0.166s
+  .x*2+1                       0.059s  0.057s  0.059s  0.061s  0.062s
+  .x+.y*2                      0.096s  0.094s  0.095s  0.100s  0.100s
+  .x > .y                      0.076s  0.074s  0.078s  0.081s  0.078s
+  to_entries|len               0.397s  0.389s  0.393s  0.387s  0.387s
+  .x|.+1 (pipe)                0.056s  0.055s  0.057s  0.058s  0.058s
+  .x|.*2|.+1                   0.058s  0.056s  0.059s  0.061s  0.061s
+  .name|.+"_x"                 0.092s  0.088s  0.092s  0.095s  0.093s
+  .x>N | not                   0.048s  0.047s  0.050s  0.049s  0.051s
+  and (2 cmp)                  0.080s  0.078s  0.081s  0.084s  0.085s
+  if-then-else                 0.051s  0.049s  0.052s  0.053s  0.053s
+  sel(and)|field               0.076s  0.073s  0.077s  0.080s  0.079s
+  sel(and)|remap               0.077s  0.074s  0.078s  0.080s  0.080s
+  arith|cmp                    0.053s  0.051s  0.053s  0.055s  0.054s
+  if cmp .field                0.110s  0.108s  0.113s  0.119s  0.122s
+  split|length                 0.088s  0.085s  0.087s  0.089s  0.086s
+  [x,y]|min                    0.089s  0.087s  0.090s  0.095s  0.093s
+  [x,y]|max                    0.092s  0.090s  0.094s  0.100s  0.097s
+  [x,y]|sort|.[0]              0.088s  0.085s  0.089s  0.095s  0.093s
+  .name|len>5                  0.089s  0.088s  0.091s  0.087s  0.085s
+  sel(len>5)|.x                0.107s  0.105s  0.106s  0.110s  0.108s
+  if .x>.y .name               0.088s  0.088s  0.089s  0.092s  0.092s
+  sel(.x>.y)|.name             0.070s  0.067s  0.071s  0.075s  0.071s
+  .x*2|tostring                0.055s  0.053s  0.056s  0.059s  0.057s
+  .x*.x+1                      0.064s  0.063s  0.066s  0.068s  0.067s
+  {k=.name,v=tostr}            0.145s  0.138s  0.157s  0.167s  0.170s
+  str add chain                0.378s  0.372s  0.380s  0.396s  0.385s
+  if>.y .name|empty            0.072s  0.070s  0.073s  0.075s  0.074s
+  if .x%2==0                   0.054s  0.052s  0.054s  0.055s  0.054s
+  if .x*2+1>1M                 0.054s  0.052s  0.054s  0.056s  0.057s
+  sel(.x%2==0)|.name           0.081s  0.080s  0.084s  0.083s  0.084s
+  sel(.x*2+1>1M)               0.154s  0.151s  0.157s  0.156s  0.153s
+  .x|@json                     0.047s  0.046s  0.048s  0.051s  0.060s
+  .x|@text                     0.047s  0.045s  0.048s  0.050s  0.060s
+  .name|@json                  0.101s  0.099s  0.102s  0.107s  0.104s
+  sel|[arr]                    0.144s  0.140s  0.160s  0.172s  0.180s
+  sel(and)|[arr]               0.076s  0.076s  0.079s  0.081s  0.080s
+  if>.y [arr]                  0.174s  0.178s  0.198s  0.205s  0.217s
+  if sw then .f                0.135s  0.132s  0.139s  0.147s  0.142s
+  dynkey {(.n)=.x*2}           0.112s  0.111s  0.116s  0.118s  0.119s
+  sel(and)|.x*.y               0.078s  0.074s  0.079s  0.080s  0.079s
+  sel>N|str chain              0.153s  0.151s  0.153s  0.157s  0.166s
+  .f+"_"+arith_ts              0.132s  0.130s  0.133s  0.133s  0.137s
+  sel(sw)|str ch               0.298s  0.301s  0.303s  0.312s  0.309s
+  split|rev|join               0.112s  0.111s  0.112s  0.114s  0.116s
+  dynkey+static                0.332s  0.332s  0.339s  0.340s  0.351s
+  if>.y str chain              0.168s  0.167s  0.170s  0.171s  0.173s
+  remap+str chain              0.154s  0.145s  0.160s  0.162s  0.178s
+  sel(len>8)                   0.159s  0.154s  0.159s  0.161s  0.161s
+  up|split|join                0.100s  0.095s  0.096s  0.097s  0.096s
+  .name|index                  0.117s  0.114s  0.121s  0.120s  0.118s
+  .name|index+1                0.122s  0.117s  0.122s  0.126s  0.121s
+  .name|rindex                 0.125s  0.122s  0.124s  0.129s  0.129s
+  .name|indices                0.149s  0.145s  0.159s  0.150s  0.147s
+  [x,y]|sort                   0.154s  0.152s  0.168s  0.175s  0.178s
+  .name|scan                   0.213s  0.208s  0.206s  0.205s  0.204s
+  .name|gsub                   0.166s  0.162s  0.168s  0.167s  0.164s
+  walk(if num .+1)             0.137s  0.136s  0.137s  0.141s  0.142s
+  tojson                       0.105s  0.100s  0.107s  0.115s  0.117s
+  {name,x}                     0.128s  0.123s  0.150s  0.154s  0.166s
+  .z//.name                    0.155s  0.146s  0.164s  0.175s  0.174s
+  .x|=test(re)                 0.170s  0.165s  0.170s  0.172s  0.174s
+  ./sep|first                  0.180s  0.173s  0.179s  0.186s  0.180s
+  .y=(.x*2)                    0.175s  0.172s  0.176s  0.179s  0.179s
+  .y=(.x+.y)                   0.226s  0.224s  0.232s  0.235s  0.237s
+  objects                      0.137s  0.130s  0.125s  0.137s  0.146s
+  .tag|=if..then N             0.614s  0.590s  0.607s  0.635s  0.624s
+  .x=(.x+1)                    0.126s  0.123s  0.128s  0.131s  0.127s
+  sel>N|.y+=1                  0.120s  0.119s  0.122s  0.124s  0.125s
+  sel(and)|.x+=1               0.109s  0.106s  0.106s  0.108s  0.108s
+  sel(sw)|.x+=1                0.156s  0.156s  0.164s  0.169s  0.165s
+  match(re)                    0.368s  0.355s  0.363s  0.379s  0.372s
+  capture(re)                  0.299s  0.294s  0.299s  0.306s  0.303s
+  first(.name,.x)              0.095s  0.092s  0.106s  0.109s  0.116s
+  if .x==null                  0.046s  0.045s  0.047s  0.047s  0.048s
+  we(sw(.key))                 0.107s  0.104s  0.109s  0.118s  0.117s
+  sel(sw or ew)                0.199s  0.198s  0.206s  0.205s  0.199s
+  path(.name,.x)               0.271s  0.264s  0.273s  0.320s  0.300s
+  sel(str+num+num)             0.151s  0.145s  0.150s  0.151s  0.154s
+  nested if|field              0.077s  0.074s  0.078s  0.083s  0.079s
+  .f|floor|.*2                 0.061s  0.058s  0.062s  0.062s  0.062s
+  split|len>1                  0.113s  0.110s  0.117s  0.114s  0.110s
+  .name|len|.*2                0.100s  0.097s  0.101s  0.102s  0.102s
+  if len>5 .x .y               0.115s  0.110s  0.112s  0.115s  0.114s
+  sel(len>5)|remap             0.199s  0.198s  0.199s  0.209s  0.203s
+  .x|tostr|len                 0.058s  0.057s  0.060s  0.061s  0.059s
+  if .x>.y .x .y               0.094s  0.091s  0.093s  0.099s  0.096s
+  split|last|tonum             0.095s  0.092s  0.097s  0.095s  0.094s
+  split|rev|.[0]               0.090s  0.089s  0.092s  0.091s  0.091s
+  split|.[0]+.[1]              0.112s  0.109s  0.112s  0.114s  0.111s
+  .[]|strings                  0.104s  0.106s  0.108s  0.108s  0.105s
+  .[]|numbers                  0.124s  0.125s  0.126s  0.125s  0.124s
+  [x,y]|any(>1M)               0.083s  0.079s  0.082s  0.086s  0.084s
+  sel(dc|sw)                   0.098s  0.094s  0.099s  0.098s  0.095s
+  [[x,y],[n]]|flat             0.456s  0.450s  0.459s  0.520s  0.488s
+  .x|floor|.*2                 0.061s  0.059s  0.062s  0.060s  0.062s
+  tojson|fromjson              0.084s  0.080s  0.086s  0.086s  0.084s
+  [.x]|add                     0.059s  0.057s  0.064s  0.066s  0.071s
+  if>N {o}+.                   0.136s  0.127s  0.137s  0.135s  0.137s
+  if>N .+{o}                   0.132s  0.131s  0.132s  0.134s  0.133s
+  if .n=="s" .+{o}             0.159s  0.154s  0.162s  0.162s  0.159s
+  sel(.n>"s")                  0.087s  0.085s  0.088s  0.092s  0.088s
+  [x,y,z]|min                  0.312s  0.305s  0.313s  0.311s  0.313s
+  if .n|len>5 l s              0.099s  0.095s  0.100s  0.101s  0.101s
+  if .x|flr>N b s              0.054s  0.053s  0.055s  0.055s  0.056s
+  if .n|test l e               0.104s  0.102s  0.109s  0.103s  0.104s
+  if .n|sw l e                 0.084s  0.080s  0.085s  0.086s  0.083s
+  if .n|ew l e                 0.083s  0.080s  0.084s  0.083s  0.084s
+  .n|len|tostr                 0.092s  0.085s  0.090s  0.089s  0.089s
 
 --- String operations (2M objects) ---
-  Benchmark                    v1.7.0  v1.7.1  v1.8.0  v1.8.1  v1.8.2
+  Benchmark                    v1.7.1  v1.8.0  v1.8.1  v1.8.2  v1.8.3
   ---                          ------  ------  ------  ------  ------
-  ascii_downcase               0.104s  0.104s  0.100s  0.104s  0.095s
-  ascii_upcase                 0.103s  0.102s  0.099s  0.101s  0.094s
-  ltrimstr                     0.097s  0.096s  0.093s  0.096s  0.097s
-  rtrimstr                     0.097s  0.097s  0.095s  0.099s  0.095s
-  split                        0.162s  0.164s  0.156s  0.166s  0.158s
-  case+split                   0.121s  0.116s  0.113s  0.117s  0.116s
-  join                         0.093s  0.094s  0.091s  0.092s  0.094s
-  startswith                   0.095s  0.094s  0.090s  0.096s  0.090s
-  endswith                     0.096s  0.097s  0.091s  0.096s  0.090s
-  tostring                     0.063s  0.062s  0.060s  0.073s  0.068s
-  tonumber                     0.110s  0.109s  0.108s  0.108s  0.110s
-  string interpolation         0.118s  0.119s  0.114s  0.120s  0.115s
+  ascii_downcase               0.104s  0.100s  0.104s  0.095s  0.092s
+  ascii_upcase                 0.102s  0.099s  0.101s  0.094s  0.094s
+  ltrimstr                     0.096s  0.093s  0.096s  0.097s  0.095s
+  rtrimstr                     0.097s  0.095s  0.099s  0.095s  0.097s
+  split                        0.164s  0.156s  0.166s  0.158s  0.157s
+  case+split                   0.116s  0.113s  0.117s  0.116s  0.116s
+  join                         0.094s  0.091s  0.092s  0.094s  0.096s
+  startswith                   0.094s  0.090s  0.096s  0.090s  0.090s
+  endswith                     0.097s  0.091s  0.096s  0.090s  0.088s
+  tostring                     0.062s  0.060s  0.073s  0.068s  0.064s
+  tonumber                     0.109s  0.108s  0.108s  0.110s  0.108s
+  string interpolation         0.119s  0.114s  0.120s  0.115s  0.127s
 
 --- String ops (200K objects) ---
-  Benchmark                    v1.7.0  v1.7.1  v1.8.0  v1.8.1  v1.8.2
+  Benchmark                    v1.7.1  v1.8.0  v1.8.1  v1.8.2  v1.8.3
   ---                          ------  ------  ------  ------  ------
-  test (regex)                 0.014s  0.014s  0.014s  0.014s  0.015s
-  match (regex)                0.032s  0.033s  0.033s  0.032s  0.033s
-  @base64                      0.012s  0.012s  0.011s  0.012s  0.012s
-  @uri                         0.012s  0.012s  0.011s  0.012s  0.013s
-  @html                        0.012s  0.012s  0.011s  0.012s  0.013s
-  @csv (array)                 0.016s  0.016s  0.015s  0.016s  0.015s
-  @tsv (array)                 0.015s  0.015s  0.014s  0.015s  0.015s
-  gsub                         0.019s  0.019s  0.018s  0.019s  0.018s
-  case+gsub                    0.180s  0.176s  0.177s  0.182s  0.179s
-  case+test                    0.120s  0.118s  0.114s  0.122s  0.117s
-  ltrim+tonum+arith            0.111s  0.111s  0.107s  0.111s  0.110s
+  test (regex)                 0.014s  0.014s  0.014s  0.015s  0.014s
+  match (regex)                0.033s  0.033s  0.032s  0.033s  0.033s
+  @base64                      0.012s  0.011s  0.012s  0.012s  0.011s
+  @uri                         0.012s  0.011s  0.012s  0.013s  0.011s
+  @html                        0.012s  0.011s  0.012s  0.013s  0.012s
+  @csv (array)                 0.016s  0.015s  0.016s  0.015s  0.016s
+  @tsv (array)                 0.015s  0.014s  0.015s  0.015s  0.015s
+  gsub                         0.019s  0.018s  0.019s  0.018s  0.018s
+  case+gsub                    0.176s  0.177s  0.182s  0.179s  0.181s
+  case+test                    0.118s  0.114s  0.122s  0.117s  0.118s
+  ltrim+tonum+arith            0.111s  0.107s  0.111s  0.110s  0.110s
 
 --- Numeric & math (2M objects) ---
-  Benchmark                    v1.7.0  v1.7.1  v1.8.0  v1.8.1  v1.8.2
+  Benchmark                    v1.7.1  v1.8.0  v1.8.1  v1.8.2  v1.8.3
   ---                          ------  ------  ------  ------  ------
-  floor                        0.057s  0.056s  0.054s  0.057s  0.056s
-  sqrt                         0.079s  0.078s  0.077s  0.080s  0.081s
-  modulo                       0.059s  0.057s  0.055s  0.059s  0.058s
-  if-elif-else                 0.123s  0.123s  0.123s  0.126s  0.130s
-  select|del                   0.091s  0.091s  0.087s  0.097s  0.097s
-  select|merge                 0.121s  0.118s  0.114s  0.119s  0.123s
-  select(test)|merge           0.021s  0.021s  0.020s  0.022s  0.021s
+  floor                        0.056s  0.054s  0.057s  0.056s  0.058s
+  sqrt                         0.078s  0.077s  0.080s  0.081s  0.079s
+  modulo                       0.057s  0.055s  0.059s  0.058s  0.059s
+  if-elif-else                 0.123s  0.123s  0.126s  0.130s  0.131s
+  select|del                   0.091s  0.087s  0.097s  0.097s  0.096s
+  select|merge                 0.118s  0.114s  0.119s  0.123s  0.121s
+  select(test)|merge           0.021s  0.020s  0.022s  0.021s  0.021s
 
 --- Array generators ---
-  Benchmark                    v1.7.0  v1.7.1  v1.8.0  v1.8.1  v1.8.2
+  Benchmark                    v1.7.1  v1.8.0  v1.8.1  v1.8.2  v1.8.3
   ---                          ------  ------  ------  ------  ------
-  range(2M) | length           0.012s  0.011s  0.011s  0.012s  0.012s
-  reverse(2M)                  0.018s  0.018s  0.017s  0.018s  0.018s
-  sort(2M)                     0.023s  0.023s  0.022s  0.024s  0.023s
-  unique(1M)                   0.030s  0.030s  0.029s  0.031s  0.033s
-  flatten(500K)                0.011s  0.011s  0.010s  0.011s  0.011s
-  min, max(2M)                 0.019s  0.020s  0.017s  0.020s  0.021s
-  add numbers(2M)              0.013s  0.013s  0.012s  0.013s  0.013s
-  any/all(2M)                  0.029s  0.028s  0.028s  0.028s  0.029s
-  limit(10; range(10M))        0.003s  0.002s  0.002s  0.002s  0.002s
-  first(range(10M))            0.003s  0.002s  0.002s  0.002s  0.002s
-  last(range(2M))              0.003s  0.002s  0.002s  0.002s  0.002s
-  indices(1M)                  0.017s  0.017s  0.016s  0.016s  0.017s
+  range(2M) | length           0.011s  0.011s  0.012s  0.012s  0.011s
+  reverse(2M)                  0.018s  0.017s  0.018s  0.018s  0.018s
+  sort(2M)                     0.023s  0.022s  0.024s  0.023s  0.024s
+  unique(1M)                   0.030s  0.029s  0.031s  0.033s  0.033s
+  flatten(500K)                0.011s  0.010s  0.011s  0.011s  0.010s
+  min, max(2M)                 0.020s  0.017s  0.020s  0.021s  0.020s
+  add numbers(2M)              0.013s  0.012s  0.013s  0.013s  0.013s
+  any/all(2M)                  0.028s  0.028s  0.028s  0.029s  0.028s
+  limit(10; range(10M))        0.002s  0.002s  0.002s  0.002s  0.002s
+  first(range(10M))            0.002s  0.002s  0.002s  0.002s  0.002s
+  last(range(2M))              0.002s  0.002s  0.002s  0.002s  0.002s
+  indices(1M)                  0.017s  0.016s  0.016s  0.017s  0.017s
 
 --- Reduce & foreach ---
-  Benchmark                    v1.7.0  v1.7.1  v1.8.0  v1.8.1  v1.8.2
+  Benchmark                    v1.7.1  v1.8.0  v1.8.1  v1.8.2  v1.8.3
   ---                          ------  ------  ------  ------  ------
   reduce (sum)                 0.009s  0.009s  0.009s  0.009s  0.009s
   reduce (array build)         0.004s  0.004s  0.004s  0.004s  0.004s
-  reduce (obj build)           0.010s  0.009s  0.009s  0.010s  0.009s
-  reduce (setpath)             0.016s  0.016s  0.016s  0.017s  0.016s
-  foreach (running sum)        0.010s  0.010s  0.009s  0.010s  0.010s
+  reduce (obj build)           0.009s  0.009s  0.010s  0.009s  0.010s
+  reduce (setpath)             0.016s  0.016s  0.017s  0.016s  0.016s
+  foreach (running sum)        0.010s  0.009s  0.010s  0.010s  0.010s
   foreach + emit               0.010s  0.010s  0.010s  0.010s  0.010s
-  reduce (sum-of-squares)      0.034s  0.033s  0.032s  0.033s  0.033s
-  reduce (conditional)         0.035s  0.035s  0.033s  0.035s  0.036s
-  reduce (product)             0.034s  0.034s  0.035s  0.034s  0.035s
-  foreach (conditional)        0.010s  0.010s  0.010s  0.010s  0.011s
-  until (100M)                 0.305s  0.303s  0.301s  0.301s  0.308s
-  reduce (harmonic)            0.033s  0.033s  0.032s  0.032s  0.033s
-  reduce (floor pipe)          0.033s  0.033s  0.032s  0.033s  0.033s
-  reduce (sqrt pipe)           0.033s  0.033s  0.032s  0.033s  0.033s
-  reduce (sin+cos)             0.052s  0.052s  0.051s  0.052s  0.052s
+  reduce (sum-of-squares)      0.033s  0.032s  0.033s  0.033s  0.033s
+  reduce (conditional)         0.035s  0.033s  0.035s  0.036s  0.035s
+  reduce (product)             0.034s  0.035s  0.034s  0.035s  0.034s
+  foreach (conditional)        0.010s  0.010s  0.010s  0.011s  0.010s
+  until (100M)                 0.303s  0.301s  0.301s  0.308s  0.312s
+  reduce (harmonic)            0.033s  0.032s  0.032s  0.033s  0.035s
+  reduce (floor pipe)          0.033s  0.032s  0.033s  0.033s  0.033s
+  reduce (sqrt pipe)           0.033s  0.032s  0.033s  0.033s  0.034s
+  reduce (sin+cos)             0.052s  0.051s  0.052s  0.052s  0.052s
 
 --- Object operations ---
-  Benchmark                    v1.7.0  v1.7.1  v1.8.0  v1.8.1  v1.8.2
+  Benchmark                    v1.7.1  v1.8.0  v1.8.1  v1.8.2  v1.8.3
   ---                          ------  ------  ------  ------  ------
   large obj construct          0.004s  0.004s  0.004s  0.004s  0.004s
   large obj keys               0.011s  0.011s  0.011s  0.011s  0.011s
   large obj to_entries         0.012s  0.012s  0.012s  0.012s  0.012s
-  with_entries                 0.009s  0.009s  0.008s  0.009s  0.009s
+  with_entries                 0.009s  0.008s  0.009s  0.009s  0.009s
 
 --- Assignment operators ---
-  Benchmark                    v1.7.0  v1.7.1  v1.8.0  v1.8.1  v1.8.2
+  Benchmark                    v1.7.1  v1.8.0  v1.8.1  v1.8.2  v1.8.3
   ---                          ------  ------  ------  ------  ------
   .[] |= f (100K)              0.005s  0.005s  0.005s  0.005s  0.005s
-  .[] += 1 (100K)              0.005s  0.006s  0.005s  0.005s  0.005s
+  .[] += 1 (100K)              0.006s  0.005s  0.005s  0.005s  0.005s
   .[k] = v reduce(50K)         0.008s  0.008s  0.008s  0.008s  0.008s
-  p126-shape nested reduce     -       -       0.103s  0.110s  0.120s
-  p126-shape w/ mutate         -       -       0.105s  0.112s  0.129s
-  p150-shape serial mutate     -       -       0.010s  0.012s  0.011s
+  p126-shape nested reduce     -       0.103s  0.110s  0.120s  0.121s
+  p126-shape w/ mutate         -       0.105s  0.112s  0.129s  0.124s
+  p150-shape serial mutate     -       0.010s  0.012s  0.011s  0.012s
 
 --- String-heavy generators ---
-  Benchmark                    v1.7.0  v1.7.1  v1.8.0  v1.8.1  v1.8.2
+  Benchmark                    v1.7.1  v1.8.0  v1.8.1  v1.8.2  v1.8.3
   ---                          ------  ------  ------  ------  ------
-  gsub(100K)                   0.027s  0.026s  0.026s  0.027s  0.029s
-  join large(100K)             0.005s  0.006s  0.005s  0.006s  0.006s
-  explode/implode(100K)        0.027s  0.028s  0.027s  0.028s  0.028s
-  reduce str concat(100K)      0.008s  0.008s  0.007s  0.008s  0.008s
+  gsub(100K)                   0.026s  0.026s  0.027s  0.029s  0.028s
+  join large(100K)             0.006s  0.005s  0.006s  0.006s  0.006s
+  explode/implode(100K)        0.028s  0.027s  0.028s  0.028s  0.027s
+  reduce str concat(100K)      0.008s  0.007s  0.008s  0.008s  0.008s
 
 --- Try-catch & alternative ---
-  Benchmark                    v1.7.0  v1.7.1  v1.8.0  v1.8.1  v1.8.2
+  Benchmark                    v1.7.1  v1.8.0  v1.8.1  v1.8.2  v1.8.3
   ---                          ------  ------  ------  ------  ------
-  alternative //               0.035s  0.035s  0.034s  0.035s  0.032s
-  try-catch                    0.024s  0.024s  0.023s  0.023s  0.024s
+  alternative //               0.035s  0.034s  0.035s  0.032s  0.033s
+  try-catch                    0.024s  0.023s  0.023s  0.024s  0.024s
   label-break                  0.004s  0.004s  0.004s  0.004s  0.004s
 
 --- Type conversion ---
-  Benchmark                    v1.7.0  v1.7.1  v1.8.0  v1.8.1  v1.8.2
+  Benchmark                    v1.7.1  v1.8.0  v1.8.1  v1.8.2  v1.8.3
   ---                          ------  ------  ------  ------  ------
   tojson/fromjson(100K)        0.022s  0.022s  0.022s  0.022s  0.022s
-  null propagation(2M)         0.091s  0.093s  0.090s  0.092s  0.092s
+  null propagation(2M)         0.093s  0.090s  0.092s  0.092s  0.090s
 
 --- jaq-derived ---
-  Benchmark                    v1.7.0  v1.7.1  v1.8.0  v1.8.1  v1.8.2
+  Benchmark                    v1.7.1  v1.8.0  v1.8.1  v1.8.2  v1.8.3
   ---                          ------  ------  ------  ------  ------
   jaq: reverse                 -       -       -       -       -
   jaq: sort                    -       -       -       -       -
@@ -294,9 +294,9 @@ Recent slice (last 5 columns). Full history lives in
   jaq: str-slice               -       -       -       -       -
 
 --- Memoization (jqx) ---
-  Benchmark                    v1.7.0  v1.7.1  v1.8.0  v1.8.1  v1.8.2
+  Benchmark                    v1.7.1  v1.8.0  v1.8.1  v1.8.2  v1.8.3
   ---                          ------  ------  ------  ------  ------
   memo fib (1K)                0.003s  0.003s  0.003s  0.003s  0.003s
-  memo collatz sum (10K)       0.016s  0.016s  0.016s  0.017s  0.016s
+  memo collatz sum (10K)       0.016s  0.016s  0.017s  0.016s  0.014s
   memo by .id (100K, 1K keys)  0.020s  0.020s  0.020s  0.020s  0.020s
 ```

--- a/docs/benchmark-history.tsv
+++ b/docs/benchmark-history.tsv
@@ -5574,3 +5574,223 @@ Type conversion	null propagation(2M)	v1.8.2	0.092
 Memoization (jqx)	memo fib (1K)	v1.8.2	0.003
 Memoization (jqx)	memo collatz sum (10K)	v1.8.2	0.016
 Memoization (jqx)	memo by .id (100K, 1K keys)	v1.8.2	0.020
+NDJSON workloads (2M objects)	empty	v1.8.3	0.017
+NDJSON workloads (2M objects)	identity -c	v1.8.3	0.085
+NDJSON workloads (2M objects)	identity (pretty)	v1.8.3	0.106
+NDJSON workloads (2M objects)	field access .name	v1.8.3	0.114
+NDJSON workloads (2M objects)	nested .x,.y,.name	v1.8.3	0.200
+NDJSON workloads (2M objects)	arithmetic .x + .y	v1.8.3	0.084
+NDJSON workloads (2M objects)	select .x > 1500000	v1.8.3	0.081
+NDJSON workloads (2M objects)	string concat	v1.8.3	0.093
+NDJSON workloads (2M objects)	object construct	v1.8.3	0.137
+NDJSON workloads (2M objects)	array construct	v1.8.3	0.136
+NDJSON workloads (2M objects)	.[]	v1.8.3	0.116
+NDJSON workloads (2M objects)	to_entries	v1.8.3	0.148
+NDJSON workloads (2M objects)	keys	v1.8.3	0.103
+NDJSON workloads (2M objects)	keys_unsorted	v1.8.3	0.099
+NDJSON workloads (2M objects)	length	v1.8.3	0.084
+NDJSON workloads (2M objects)	has("x")	v1.8.3	0.039
+NDJSON workloads (2M objects)	type	v1.8.3	0.020
+NDJSON workloads (2M objects)	del(.name)	v1.8.3	0.113
+NDJSON workloads (2M objects)	@csv	v1.8.3	0.118
+NDJSON workloads (2M objects)	split/join	v1.8.3	0.088
+NDJSON workloads (2M objects)	select|field	v1.8.3	0.097
+NDJSON workloads (2M objects)	select|remap	v1.8.3	0.102
+NDJSON workloads (2M objects)	computed remap	v1.8.3	0.224
+NDJSON workloads (2M objects)	[.x,.y]|add	v1.8.3	0.084
+NDJSON workloads (2M objects)	[.x,.y]|avg	v1.8.3	0.112
+NDJSON workloads (2M objects)	map(*2)|add	v1.8.3	0.102
+NDJSON workloads (2M objects)	keys|length	v1.8.3	0.253
+NDJSON workloads (2M objects)	.+{z=0}	v1.8.3	0.150
+NDJSON workloads (2M objects)	split|first	v1.8.3	0.086
+NDJSON workloads (2M objects)	slice[0..5]	v1.8.3	0.091
+NDJSON workloads (2M objects)	dynkey {(.name)}	v1.8.3	0.117
+NDJSON workloads (2M objects)	.x += 1	v1.8.3	0.128
+NDJSON workloads (2M objects)	{a}+{b} merge	v1.8.3	0.166
+NDJSON workloads (2M objects)	.x*2+1	v1.8.3	0.062
+NDJSON workloads (2M objects)	.x+.y*2	v1.8.3	0.100
+NDJSON workloads (2M objects)	.x > .y	v1.8.3	0.078
+NDJSON workloads (2M objects)	to_entries|len	v1.8.3	0.387
+NDJSON workloads (2M objects)	.x|.+1 (pipe)	v1.8.3	0.058
+NDJSON workloads (2M objects)	.x|.*2|.+1	v1.8.3	0.061
+NDJSON workloads (2M objects)	.name|.+"_x"	v1.8.3	0.093
+NDJSON workloads (2M objects)	.x>N | not	v1.8.3	0.051
+NDJSON workloads (2M objects)	and (2 cmp)	v1.8.3	0.085
+NDJSON workloads (2M objects)	if-then-else	v1.8.3	0.053
+NDJSON workloads (2M objects)	sel(and)|field	v1.8.3	0.079
+NDJSON workloads (2M objects)	sel(and)|remap	v1.8.3	0.080
+NDJSON workloads (2M objects)	arith|cmp	v1.8.3	0.054
+NDJSON workloads (2M objects)	if cmp .field	v1.8.3	0.122
+NDJSON workloads (2M objects)	split|length	v1.8.3	0.086
+NDJSON workloads (2M objects)	[x,y]|min	v1.8.3	0.093
+NDJSON workloads (2M objects)	[x,y]|max	v1.8.3	0.097
+NDJSON workloads (2M objects)	[x,y]|sort|.[0]	v1.8.3	0.093
+NDJSON workloads (2M objects)	.name|len>5	v1.8.3	0.085
+NDJSON workloads (2M objects)	sel(len>5)|.x	v1.8.3	0.108
+NDJSON workloads (2M objects)	if .x>.y .name	v1.8.3	0.092
+NDJSON workloads (2M objects)	sel(.x>.y)|.name	v1.8.3	0.071
+NDJSON workloads (2M objects)	.x*2|tostring	v1.8.3	0.057
+NDJSON workloads (2M objects)	.x*.x+1	v1.8.3	0.067
+NDJSON workloads (2M objects)	{k=.name,v=tostr}	v1.8.3	0.170
+NDJSON workloads (2M objects)	str add chain	v1.8.3	0.385
+NDJSON workloads (2M objects)	if>.y .name|empty	v1.8.3	0.074
+NDJSON workloads (2M objects)	if .x%2==0	v1.8.3	0.054
+NDJSON workloads (2M objects)	if .x*2+1>1M	v1.8.3	0.057
+NDJSON workloads (2M objects)	sel(.x%2==0)|.name	v1.8.3	0.084
+NDJSON workloads (2M objects)	sel(.x*2+1>1M)	v1.8.3	0.153
+NDJSON workloads (2M objects)	.x|@json	v1.8.3	0.060
+NDJSON workloads (2M objects)	.x|@text	v1.8.3	0.060
+NDJSON workloads (2M objects)	.name|@json	v1.8.3	0.104
+NDJSON workloads (2M objects)	sel|[arr]	v1.8.3	0.180
+NDJSON workloads (2M objects)	sel(and)|[arr]	v1.8.3	0.080
+NDJSON workloads (2M objects)	if>.y [arr]	v1.8.3	0.217
+NDJSON workloads (2M objects)	if sw then .f	v1.8.3	0.142
+NDJSON workloads (2M objects)	dynkey {(.n)=.x*2}	v1.8.3	0.119
+NDJSON workloads (2M objects)	sel(and)|.x*.y	v1.8.3	0.079
+NDJSON workloads (2M objects)	sel>N|str chain	v1.8.3	0.166
+NDJSON workloads (2M objects)	.f+"_"+arith_ts	v1.8.3	0.137
+NDJSON workloads (2M objects)	sel(sw)|str ch	v1.8.3	0.309
+NDJSON workloads (2M objects)	split|rev|join	v1.8.3	0.116
+NDJSON workloads (2M objects)	dynkey+static	v1.8.3	0.351
+NDJSON workloads (2M objects)	if>.y str chain	v1.8.3	0.173
+NDJSON workloads (2M objects)	remap+str chain	v1.8.3	0.178
+NDJSON workloads (2M objects)	sel(len>8)	v1.8.3	0.161
+NDJSON workloads (2M objects)	up|split|join	v1.8.3	0.096
+NDJSON workloads (2M objects)	.name|index	v1.8.3	0.118
+NDJSON workloads (2M objects)	.name|index+1	v1.8.3	0.121
+NDJSON workloads (2M objects)	.name|rindex	v1.8.3	0.129
+NDJSON workloads (2M objects)	.name|indices	v1.8.3	0.147
+NDJSON workloads (2M objects)	[x,y]|sort	v1.8.3	0.178
+NDJSON workloads (2M objects)	.name|scan	v1.8.3	0.204
+NDJSON workloads (2M objects)	.name|gsub	v1.8.3	0.164
+NDJSON workloads (2M objects)	walk(if num .+1)	v1.8.3	0.142
+NDJSON workloads (2M objects)	tojson	v1.8.3	0.117
+NDJSON workloads (2M objects)	{name,x}	v1.8.3	0.166
+NDJSON workloads (2M objects)	.z//.name	v1.8.3	0.174
+NDJSON workloads (2M objects)	.x|=test(re)	v1.8.3	0.174
+NDJSON workloads (2M objects)	./sep|first	v1.8.3	0.180
+NDJSON workloads (2M objects)	.y=(.x*2)	v1.8.3	0.179
+NDJSON workloads (2M objects)	.y=(.x+.y)	v1.8.3	0.237
+NDJSON workloads (2M objects)	objects	v1.8.3	0.146
+NDJSON workloads (2M objects)	.tag|=if..then N	v1.8.3	0.624
+NDJSON workloads (2M objects)	.x=(.x+1)	v1.8.3	0.127
+NDJSON workloads (2M objects)	sel>N|.y+=1	v1.8.3	0.125
+NDJSON workloads (2M objects)	sel(and)|.x+=1	v1.8.3	0.108
+NDJSON workloads (2M objects)	sel(sw)|.x+=1	v1.8.3	0.165
+NDJSON workloads (2M objects)	match(re)	v1.8.3	0.372
+NDJSON workloads (2M objects)	capture(re)	v1.8.3	0.303
+NDJSON workloads (2M objects)	first(.name,.x)	v1.8.3	0.116
+NDJSON workloads (2M objects)	if .x==null	v1.8.3	0.048
+NDJSON workloads (2M objects)	we(sw(.key))	v1.8.3	0.117
+NDJSON workloads (2M objects)	sel(sw or ew)	v1.8.3	0.199
+NDJSON workloads (2M objects)	path(.name,.x)	v1.8.3	0.300
+NDJSON workloads (2M objects)	sel(str+num+num)	v1.8.3	0.154
+NDJSON workloads (2M objects)	nested if|field	v1.8.3	0.079
+NDJSON workloads (2M objects)	.f|floor|.*2	v1.8.3	0.062
+NDJSON workloads (2M objects)	split|len>1	v1.8.3	0.110
+NDJSON workloads (2M objects)	.name|len|.*2	v1.8.3	0.102
+NDJSON workloads (2M objects)	if len>5 .x .y	v1.8.3	0.114
+NDJSON workloads (2M objects)	sel(len>5)|remap	v1.8.3	0.203
+NDJSON workloads (2M objects)	.x|tostr|len	v1.8.3	0.059
+NDJSON workloads (2M objects)	if .x>.y .x .y	v1.8.3	0.096
+NDJSON workloads (2M objects)	split|last|tonum	v1.8.3	0.094
+NDJSON workloads (2M objects)	split|rev|.[0]	v1.8.3	0.091
+NDJSON workloads (2M objects)	split|.[0]+.[1]	v1.8.3	0.111
+NDJSON workloads (2M objects)	.[]|strings	v1.8.3	0.105
+NDJSON workloads (2M objects)	.[]|numbers	v1.8.3	0.124
+NDJSON workloads (2M objects)	[x,y]|any(>1M)	v1.8.3	0.084
+NDJSON workloads (2M objects)	sel(dc|sw)	v1.8.3	0.095
+NDJSON workloads (2M objects)	[[x,y],[n]]|flat	v1.8.3	0.488
+NDJSON workloads (2M objects)	.x|floor|.*2	v1.8.3	0.062
+NDJSON workloads (2M objects)	tojson|fromjson	v1.8.3	0.084
+NDJSON workloads (2M objects)	[.x]|add	v1.8.3	0.071
+NDJSON workloads (2M objects)	if>N {o}+.	v1.8.3	0.137
+NDJSON workloads (2M objects)	if>N .+{o}	v1.8.3	0.133
+NDJSON workloads (2M objects)	if .n=="s" .+{o}	v1.8.3	0.159
+NDJSON workloads (2M objects)	sel(.n>"s")	v1.8.3	0.088
+NDJSON workloads (2M objects)	[x,y,z]|min	v1.8.3	0.313
+NDJSON workloads (2M objects)	if .n|len>5 l s	v1.8.3	0.101
+NDJSON workloads (2M objects)	if .x|flr>N b s	v1.8.3	0.056
+NDJSON workloads (2M objects)	if .n|test l e	v1.8.3	0.104
+NDJSON workloads (2M objects)	if .n|sw l e	v1.8.3	0.083
+NDJSON workloads (2M objects)	if .n|ew l e	v1.8.3	0.084
+NDJSON workloads (2M objects)	.n|len|tostr	v1.8.3	0.089
+String operations (2M objects)	ascii_downcase	v1.8.3	0.092
+String operations (2M objects)	ascii_upcase	v1.8.3	0.094
+String operations (2M objects)	ltrimstr	v1.8.3	0.095
+String operations (2M objects)	rtrimstr	v1.8.3	0.097
+String operations (2M objects)	split	v1.8.3	0.157
+String operations (2M objects)	case+split	v1.8.3	0.116
+String operations (2M objects)	join	v1.8.3	0.096
+String operations (2M objects)	startswith	v1.8.3	0.090
+String operations (2M objects)	endswith	v1.8.3	0.088
+String operations (2M objects)	tostring	v1.8.3	0.064
+String operations (2M objects)	tonumber	v1.8.3	0.108
+String operations (2M objects)	string interpolation	v1.8.3	0.127
+String ops (200K objects)	test (regex)	v1.8.3	0.014
+String ops (200K objects)	match (regex)	v1.8.3	0.033
+String ops (200K objects)	@base64	v1.8.3	0.011
+String ops (200K objects)	@uri	v1.8.3	0.011
+String ops (200K objects)	@html	v1.8.3	0.012
+String ops (200K objects)	@csv (array)	v1.8.3	0.016
+String ops (200K objects)	@tsv (array)	v1.8.3	0.015
+String ops (200K objects)	gsub	v1.8.3	0.018
+String ops (200K objects)	case+gsub	v1.8.3	0.181
+String ops (200K objects)	case+test	v1.8.3	0.118
+String ops (200K objects)	ltrim+tonum+arith	v1.8.3	0.110
+Numeric & math (2M objects)	floor	v1.8.3	0.058
+Numeric & math (2M objects)	sqrt	v1.8.3	0.079
+Numeric & math (2M objects)	modulo	v1.8.3	0.059
+Numeric & math (2M objects)	if-elif-else	v1.8.3	0.131
+Numeric & math (2M objects)	select|del	v1.8.3	0.096
+Numeric & math (2M objects)	select|merge	v1.8.3	0.121
+Numeric & math (2M objects)	select(test)|merge	v1.8.3	0.021
+Array generators	range(2M) | length	v1.8.3	0.011
+Array generators	reverse(2M)	v1.8.3	0.018
+Array generators	sort(2M)	v1.8.3	0.024
+Array generators	unique(1M)	v1.8.3	0.033
+Array generators	flatten(500K)	v1.8.3	0.010
+Array generators	min, max(2M)	v1.8.3	0.020
+Array generators	add numbers(2M)	v1.8.3	0.013
+Array generators	any/all(2M)	v1.8.3	0.028
+Array generators	limit(10; range(10M))	v1.8.3	0.002
+Array generators	first(range(10M))	v1.8.3	0.002
+Array generators	last(range(2M))	v1.8.3	0.002
+Array generators	indices(1M)	v1.8.3	0.017
+Reduce & foreach	reduce (sum)	v1.8.3	0.009
+Reduce & foreach	reduce (array build)	v1.8.3	0.004
+Reduce & foreach	reduce (obj build)	v1.8.3	0.010
+Reduce & foreach	reduce (setpath)	v1.8.3	0.016
+Reduce & foreach	foreach (running sum)	v1.8.3	0.010
+Reduce & foreach	foreach + emit	v1.8.3	0.010
+Reduce & foreach	reduce (sum-of-squares)	v1.8.3	0.033
+Reduce & foreach	reduce (conditional)	v1.8.3	0.035
+Reduce & foreach	reduce (product)	v1.8.3	0.034
+Reduce & foreach	foreach (conditional)	v1.8.3	0.010
+Reduce & foreach	until (100M)	v1.8.3	0.312
+Reduce & foreach	reduce (harmonic)	v1.8.3	0.035
+Reduce & foreach	reduce (floor pipe)	v1.8.3	0.033
+Reduce & foreach	reduce (sqrt pipe)	v1.8.3	0.034
+Reduce & foreach	reduce (sin+cos)	v1.8.3	0.052
+Object operations	large obj construct	v1.8.3	0.004
+Object operations	large obj keys	v1.8.3	0.011
+Object operations	large obj to_entries	v1.8.3	0.012
+Object operations	with_entries	v1.8.3	0.009
+Assignment operators	.[] |= f (100K)	v1.8.3	0.005
+Assignment operators	.[] += 1 (100K)	v1.8.3	0.005
+Assignment operators	.[k] = v reduce(50K)	v1.8.3	0.008
+Assignment operators	p126-shape nested reduce	v1.8.3	0.121
+Assignment operators	p126-shape w/ mutate	v1.8.3	0.124
+Assignment operators	p150-shape serial mutate	v1.8.3	0.012
+String-heavy generators	gsub(100K)	v1.8.3	0.028
+String-heavy generators	join large(100K)	v1.8.3	0.006
+String-heavy generators	explode/implode(100K)	v1.8.3	0.027
+String-heavy generators	reduce str concat(100K)	v1.8.3	0.008
+Try-catch & alternative	alternative //	v1.8.3	0.033
+Try-catch & alternative	try-catch	v1.8.3	0.024
+Try-catch & alternative	label-break	v1.8.3	0.004
+Type conversion	tojson/fromjson(100K)	v1.8.3	0.022
+Type conversion	null propagation(2M)	v1.8.3	0.090
+Memoization (jqx)	memo fib (1K)	v1.8.3	0.003
+Memoization (jqx)	memo collatz sum (10K)	v1.8.3	0.014
+Memoization (jqx)	memo by .id (100K, 1K keys)	v1.8.3	0.020


### PR DESCRIPTION
Patch release: 70+ fixes and refactors since v1.8.2 (serialization canonicalization, path provenance, module system, CLI arg handling, datetime normalization, typed dispatch refactor series).

- Benchmark history columns appended for v1.8.3 (`docs/benchmark-history.{tsv,md}`).
- Bench gate: regressed 1.05–1.20 on number-serialization shapes (`@text`/`@json` ~1.20, string interpolation ~1.09, tostring chain ~1.07). Same-machine A/B bisects the cost to the #1072 correctness fix (canonical number writer on the emit path). Recorded in #1077; release continues per the ≤1.30 gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)