### PR TITLE
perf(fast-path): classify value canonicality in the boundary scan to recover raw-passthrough regressions

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -276,6 +276,31 @@ silently null になる）。`tests/enforce_collect_loadvar_exhaustive.rs` が
 `src/ir.rs` の `Expr` enum を parse して、walker 本体に各 variant が出現することを
 強制する。
 
+### Classified boundary scan（clean フラグ）の契約
+
+raw passthrough のホットパス（field access / multi-field / array・object
+construct / cond-chain）は、フィールド境界スキャン
+（`value.rs::skip_json_value_classify` / `json_object_get_field_raw_classified` /
+`json_object_get_fields_raw_buf_classified`）が値の **verbatim-safety** を
+同じ 1 パスで分類し、apply 関数が emit closure に `clean: bool` を渡す。
+
+- `clean == true` の保証: その値は**スカラ**で、バックスラッシュ escape
+  なし・DEL (0x7F) なし・非 canonical 数値 lexeme（`e/E` 指数、`+` 符号、
+  special float、`.000000` run #611）なし。emit 側は dup-key /
+  compactness / escape / number-canon の各ゲートを**スキップして
+  `extend_from_slice` してよい**。
+- composite（`{`/`[`）は常に `clean == false`（dup-key・整形の判定は
+  emit パイプラインに残る）。
+- `clean == false` 側のゲート（`raw_value_bails_canon` → Bail、または
+  per-value の escape/number ゲート）は従来どおり必須。**clean 判定を
+  緩める変更（新しい「これも clean」扱い）は、ゲートが守っていた
+  canonicalisation 全種（#729 / #780 / #1027 / #446 / #615）と突き合わせて
+  からにする**。
+- 背景: v1.8.1 (#753) / v1.8.2 (#800) が per-value スキャンを積んで
+  Value 構築系ベンチが 15〜35% 劣化した。スキャンは境界スキャンに
+  融合済みなので、新しい per-value ゲートを足す時は classify に
+  畳めないか先に検討する。
+
 ### `paths` / `paths(f)` は root を落とす
 
 jq の `paths` は `path(..) | select(length > 0)`。scalar 入力で空 path `[]` を yield しない。派生する `paths(f)` も同じ不変性を持つ。rewrite を書き直す時は `length > 0` の guard を必ず最後に挟む。

--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -1036,7 +1036,7 @@ fn emit_resolved_branch_output(
             buf.extend_from_slice(b"null");
         }
         ResolvedBranchOutput::Computed(ref resolved) => {
-            emit_resolved_value(buf, resolved, raw, ranges);
+            emit_resolved_value(buf, resolved, raw, ranges, false);
         }
     }
 }
@@ -1253,7 +1253,7 @@ fn emit_remap_value(
         RemapExpr::FieldLength(f) => {
             let idx = field_idx[f.as_str()];
             let resolved = ResolvedRemap::FieldLength(idx);
-            emit_resolved_value(buf, &resolved, raw, ranges);
+            emit_resolved_value(buf, &resolved, raw, ranges, false);
         }
         RemapExpr::FieldSplitJoin(f, sep, rep) => {
             let idx = field_idx[f.as_str()];
@@ -1263,22 +1263,22 @@ fn emit_remap_value(
         RemapExpr::FieldStringCase(f, is_upper) => {
             let idx = field_idx[f.as_str()];
             let resolved = ResolvedRemap::FieldStringCase(idx, *is_upper);
-            emit_resolved_value(buf, &resolved, raw, ranges);
+            emit_resolved_value(buf, &resolved, raw, ranges, false);
         }
         RemapExpr::FieldSplitLength(f, sep) => {
             let idx = field_idx[f.as_str()];
             let resolved = ResolvedRemap::FieldSplitLength(idx, sep.as_bytes().to_vec());
-            emit_resolved_value(buf, &resolved, raw, ranges);
+            emit_resolved_value(buf, &resolved, raw, ranges, false);
         }
         RemapExpr::FieldStrBuiltin(f, op, arg) => {
             let idx = field_idx[f.as_str()];
             let resolved = ResolvedRemap::FieldStrBuiltin(idx, *op, arg.as_bytes().to_vec());
-            emit_resolved_value(buf, &resolved, raw, ranges);
+            emit_resolved_value(buf, &resolved, raw, ranges, false);
         }
         RemapExpr::FieldSplitIndex(f, sep, sidx) => {
             let idx = field_idx[f.as_str()];
             let resolved = ResolvedRemap::FieldSplitIndex(idx, sep.as_bytes().to_vec(), *sidx);
-            emit_resolved_value(buf, &resolved, raw, ranges);
+            emit_resolved_value(buf, &resolved, raw, ranges, false);
         }
         RemapExpr::FieldOpFieldToString(f1, op, f2) => {
             let idx1 = field_idx[f1.as_str()];
@@ -1308,7 +1308,7 @@ fn emit_remap_value(
         RemapExpr::FieldSlice(f, from, to) => {
             let idx = field_idx[f.as_str()];
             let resolved = ResolvedRemap::FieldSlice(idx, *from, *to);
-            emit_resolved_value(buf, &resolved, raw, ranges);
+            emit_resolved_value(buf, &resolved, raw, ranges, false);
         }
         RemapExpr::FieldArray(ref exprs) => {
             buf.push(b'[');
@@ -1320,12 +1320,12 @@ fn emit_remap_value(
         }
         RemapExpr::BoolExpr(_, _, _) | RemapExpr::FieldType(_) | RemapExpr::FieldNegate(_) | RemapExpr::ArithCmp(_, _, _, _) => {
             let resolved = resolve_one_remap(rexpr, field_idx);
-            emit_resolved_value(buf, &resolved, raw, ranges);
+            emit_resolved_value(buf, &resolved, raw, ranges, false);
         }
         RemapExpr::CondChain(_, _) => {
             // Resolve and emit (slow path, used for non-pre-resolved paths)
             let resolved = resolve_one_remap(rexpr, field_idx);
-            emit_resolved_value(buf, &resolved, raw, ranges);
+            emit_resolved_value(buf, &resolved, raw, ranges, false);
         }
         RemapExpr::StringInterp(parts) => {
             buf.push(b'"');
@@ -1355,7 +1355,7 @@ fn emit_remap_value(
         }
         RemapExpr::StringChain(_) => {
             let resolved = resolve_one_remap(rexpr, field_idx);
-            emit_resolved_value(buf, &resolved, raw, ranges);
+            emit_resolved_value(buf, &resolved, raw, ranges, false);
         }
     }
 }
@@ -1686,12 +1686,18 @@ fn resolved_would_error(
 }
 
 /// Emit a pre-resolved remap value — no HashMap lookups, just direct index access.
+///
+/// `clean` is the apply-site's record-level verbatim-safety verdict (from the
+/// classified boundary scan): when true, every range in `ranges` is a scalar
+/// jq would output unchanged, so passthrough cells skip their per-value
+/// canonicalisation gates. Callers without that proof pass `false`.
 #[inline]
 fn emit_resolved_value(
     buf: &mut Vec<u8>,
     resolved: &ResolvedRemap,
     raw: &[u8],
     ranges: &[(usize, usize)],
+    clean: bool,
 ) {
     use jq_jit::ir::BinOp;
     match *resolved {
@@ -1702,7 +1708,9 @@ fn emit_resolved_value(
             // number lexeme (`1e10`, `2e3`) would leak; re-render through Value
             // to obtain jq's canonical repr (#729). Scalars/strings/composites
             // without such a literal copy as-is (the common, hot path).
-            if raw_contains_non_canonical_number(val) {
+            if clean {
+                buf.extend_from_slice(val);
+            } else if raw_contains_non_canonical_number(val) {
                 match json_to_value(unsafe { std::str::from_utf8_unchecked(val) }) {
                     Ok(v) => buf.extend_from_slice(value_to_json_precise(&v).as_bytes()),
                     Err(_) => buf.extend_from_slice(val),
@@ -2210,7 +2218,7 @@ fn emit_resolved_value(
             buf.push(b'[');
             for (i, elem) in elements.iter().enumerate() {
                 if i > 0 { buf.push(b','); }
-                emit_resolved_value(buf, elem, raw, ranges);
+                emit_resolved_value(buf, elem, raw, ranges, false);
             }
             buf.push(b']');
         }
@@ -2355,7 +2363,7 @@ fn eval_resolved_bool(resolved: &ResolvedRemap, raw: &[u8], ranges: &[(usize, us
         _ => {
             // Evaluate as JSON and check truthiness
             let mut tmp = Vec::new();
-            emit_resolved_value(&mut tmp, resolved, raw, ranges);
+            emit_resolved_value(&mut tmp, resolved, raw, ranges, false);
             // JSON truthiness: null and false are falsy, everything else is truthy
             if tmp == b"null" || tmp == b"false" { Some(false) } else { Some(true) }
         }
@@ -5498,13 +5506,13 @@ fn real_main() {
                                     compact_buf.extend_from_slice(b"{\n  ");
                                     compact_buf.extend_from_slice(key_val);
                                     compact_buf.extend_from_slice(b": ");
-                                    emit_resolved_value(&mut compact_buf, &resolved_val, raw, &ranges_buf);
+                                    emit_resolved_value(&mut compact_buf, &resolved_val, raw, &ranges_buf, false);
                                     compact_buf.extend_from_slice(b"\n}\n");
                                 } else {
                                     compact_buf.push(b'{');
                                     compact_buf.extend_from_slice(key_val);
                                     compact_buf.push(b':');
-                                    emit_resolved_value(&mut compact_buf, &resolved_val, raw, &ranges_buf);
+                                    emit_resolved_value(&mut compact_buf, &resolved_val, raw, &ranges_buf, false);
                                     compact_buf.extend_from_slice(b"}\n");
                                 }
                             } else {
@@ -5570,20 +5578,20 @@ fn real_main() {
                                     compact_buf.extend_from_slice(b"{\n  ");
                                     compact_buf.extend_from_slice(key_val);
                                     compact_buf.extend_from_slice(b": ");
-                                    emit_resolved_value(&mut compact_buf, &resolved_dk_val, raw, &ranges_buf);
+                                    emit_resolved_value(&mut compact_buf, &resolved_dk_val, raw, &ranges_buf, false);
                                     for (i, resolved) in resolved_static.iter().enumerate() {
                                         compact_buf.extend_from_slice(&static_key_bufs_pretty[i]);
-                                        emit_resolved_value(&mut compact_buf, resolved, raw, &ranges_buf);
+                                        emit_resolved_value(&mut compact_buf, resolved, raw, &ranges_buf, false);
                                     }
                                     compact_buf.extend_from_slice(b"\n}\n");
                                 } else {
                                     compact_buf.push(b'{');
                                     compact_buf.extend_from_slice(key_val);
                                     compact_buf.push(b':');
-                                    emit_resolved_value(&mut compact_buf, &resolved_dk_val, raw, &ranges_buf);
+                                    emit_resolved_value(&mut compact_buf, &resolved_dk_val, raw, &ranges_buf, false);
                                     for (i, resolved) in resolved_static.iter().enumerate() {
                                         compact_buf.extend_from_slice(&static_key_bufs[i]);
-                                        emit_resolved_value(&mut compact_buf, resolved, raw, &ranges_buf);
+                                        emit_resolved_value(&mut compact_buf, resolved, raw, &ranges_buf, false);
                                     }
                                     compact_buf.extend_from_slice(b"}\n");
                                 }
@@ -6367,8 +6375,16 @@ fn real_main() {
                 } else if let Some(ref fa_field) = field_access {
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        let outcome = apply_field_access_raw(raw, fa_field, |bytes| {
-                            emit_raw_ln!(&mut compact_buf, bytes);
+                        let outcome = apply_field_access_raw(raw, fa_field, |bytes, clean| {
+                            // `clean` scalars are verbatim-safe (no dup keys,
+                            // already compact, no escape to re-encode) — skip
+                            // the emit_raw_ln! gates.
+                            if clean {
+                                compact_buf.extend_from_slice(bytes);
+                                compact_buf.push(b'\n');
+                            } else {
+                                emit_raw_ln!(&mut compact_buf, bytes);
+                            }
                         });
                         if let RawApplyOutcome::Bail = outcome {
                             let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
@@ -6422,20 +6438,20 @@ fn real_main() {
                             // jq type error (e.g. str + num). The raw scanner only handles
                             // num+num / str+str arithmetic; everything else goes generic.
                             |ranges, raw| resolved.iter().any(|r| resolved_would_error(r, raw, ranges)),
-                            |ranges, raw| {
+                            |ranges, raw, all_clean| {
                                 if use_pretty_buf {
                                     compact_buf.extend_from_slice(b"[\n");
                                     for (i, res) in resolved.iter().enumerate() {
                                         if i > 0 { compact_buf.extend_from_slice(b",\n"); }
                                         compact_buf.extend_from_slice(b"  ");
-                                        emit_resolved_value(&mut compact_buf, res, raw, ranges);
+                                        emit_resolved_value(&mut compact_buf, res, raw, ranges, all_clean);
                                     }
                                     compact_buf.extend_from_slice(b"\n]\n");
                                 } else {
                                     compact_buf.push(b'[');
                                     for (i, res) in resolved.iter().enumerate() {
                                         if i > 0 { compact_buf.push(b','); }
-                                        emit_resolved_value(&mut compact_buf, res, raw, ranges);
+                                        emit_resolved_value(&mut compact_buf, res, raw, ranges, all_clean);
                                     }
                                     compact_buf.extend_from_slice(b"]\n");
                                 }
@@ -6460,7 +6476,7 @@ fn real_main() {
                             raw,
                             &af_refs,
                             &mut ranges_buf,
-                            |ranges, raw| {
+                            |ranges, raw, all_clean| {
                                 if use_pretty_buf {
                                     compact_buf.extend_from_slice(b"[\n");
                                     for (i, (vs, ve)) in ranges.iter().enumerate() {
@@ -6470,7 +6486,7 @@ fn real_main() {
                                         if val[0] == b'{' || val[0] == b'[' {
                                             push_json_pretty_raw_at(&mut compact_buf, val, 2, false, 1);
                                         } else {
-                                            if raw_contains_noncanon_escape(val) { push_raw_canon_escapes(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
+                                            if !all_clean && raw_contains_noncanon_escape(val) { push_raw_canon_escapes(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
                                         }
                                     }
                                     compact_buf.extend_from_slice(b"\n]\n");
@@ -6478,7 +6494,7 @@ fn real_main() {
                                     compact_buf.push(b'[');
                                     for (i, (vs, ve)) in ranges.iter().enumerate() {
                                         if i > 0 { compact_buf.push(b','); }
-                                        { let _vv = &raw[*vs..*ve]; if raw_contains_noncanon_escape(_vv) { push_raw_canon_escapes(&mut compact_buf, _vv); } else { compact_buf.extend_from_slice(_vv); } }
+                                        { let _vv = &raw[*vs..*ve]; if !all_clean && raw_contains_noncanon_escape(_vv) { push_raw_canon_escapes(&mut compact_buf, _vv); } else { compact_buf.extend_from_slice(_vv); } }
                                     }
                                     compact_buf.extend_from_slice(b"]\n");
                                 }
@@ -6503,7 +6519,14 @@ fn real_main() {
                             raw,
                             &mf_refs,
                             &mut ranges_buf,
-                            |bytes| { emit_raw_ln!(&mut compact_buf, bytes); },
+                            |bytes, clean| {
+                                if clean {
+                                    compact_buf.extend_from_slice(bytes);
+                                    compact_buf.push(b'\n');
+                                } else {
+                                    emit_raw_ln!(&mut compact_buf, bytes);
+                                }
+                            },
                         );
                         if let RawApplyOutcome::Bail = outcome {
                             let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
@@ -6529,7 +6552,7 @@ fn real_main() {
                                 raw,
                                 &input_fields,
                                 &mut ranges_buf,
-                                |ranges, raw| {
+                                |ranges, raw, all_clean| {
                                     compact_buf.extend_from_slice(b"{\n");
                                     for (i, (vs, ve)) in ranges.iter().enumerate() {
                                         if i > 0 { compact_buf.extend_from_slice(b",\n"); }
@@ -6540,7 +6563,7 @@ fn real_main() {
                                         if val[0] == b'{' || val[0] == b'[' {
                                             push_json_pretty_raw_at(&mut compact_buf, val, 2, false, 1);
                                         } else {
-                                            if raw_contains_noncanon_escape(val) { push_raw_canon_escapes(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
+                                            if !all_clean && raw_contains_noncanon_escape(val) { push_raw_canon_escapes(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
                                         }
                                     }
                                     compact_buf.extend_from_slice(b"\n}\n");
@@ -6572,10 +6595,10 @@ fn real_main() {
                                 raw,
                                 &input_fields,
                                 &mut ranges_buf,
-                                |ranges, raw| {
+                                |ranges, raw, all_clean| {
                                     for (i, (vs, ve)) in ranges.iter().enumerate() {
                                         compact_buf.extend_from_slice(&key_prefixes[i]);
-                                        { let _vv = &raw[*vs..*ve]; if raw_contains_noncanon_escape(_vv) { push_raw_canon_escapes(&mut compact_buf, _vv); } else { compact_buf.extend_from_slice(_vv); } }
+                                        { let _vv = &raw[*vs..*ve]; if !all_clean && raw_contains_noncanon_escape(_vv) { push_raw_canon_escapes(&mut compact_buf, _vv); } else { compact_buf.extend_from_slice(_vv); } }
                                     }
                                     compact_buf.extend_from_slice(b"}\n");
                                 },
@@ -6618,10 +6641,10 @@ fn real_main() {
                             &field_refs,
                             &mut ranges_buf,
                             |ranges, raw| resolved.iter().any(|r| resolved_would_error(r, raw, ranges)),
-                            |ranges, raw| {
+                            |ranges, raw, all_clean| {
                                 for (i, res) in resolved.iter().enumerate() {
                                     compact_buf.extend_from_slice(&key_prefixes[i]);
-                                    emit_resolved_value(&mut compact_buf, res, raw, ranges);
+                                    emit_resolved_value(&mut compact_buf, res, raw, ranges, all_clean);
                                 }
                                 compact_buf.extend_from_slice(obj_close);
                             },
@@ -6659,11 +6682,11 @@ fn real_main() {
                             &field_refs,
                             &mut ranges_buf,
                             |ranges, raw| resolved.iter().any(|r| resolved_would_error(r, raw, ranges)),
-                            |ranges, raw| {
+                            |ranges, raw, all_clean| {
                                 compact_buf.push(b'[');
                                 for (i, res) in resolved.iter().enumerate() {
                                     if i > 0 { compact_buf.push(b','); }
-                                    emit_resolved_value(&mut compact_buf, res, raw, ranges);
+                                    emit_resolved_value(&mut compact_buf, res, raw, ranges, all_clean);
                                 }
                                 compact_buf.extend_from_slice(b"]\n");
                             },
@@ -7725,7 +7748,7 @@ fn real_main() {
                                 if i > 0 { compact_buf.extend_from_slice(&escaped_sep); }
                                 // Emit each element as a string (tostring semantics)
                                 num_buf.clear();
-                                emit_resolved_value(&mut num_buf, res, raw, &ranges);
+                                emit_resolved_value(&mut num_buf, res, raw, &ranges, false);
                                 // If it's a JSON string, strip quotes; otherwise use as-is
                                 if num_buf.len() >= 2 && num_buf[0] == b'"' && num_buf[num_buf.len()-1] == b'"' {
                                     compact_buf.extend_from_slice(&num_buf[1..num_buf.len()-1]);
@@ -8194,7 +8217,7 @@ fn real_main() {
                                 }
                                 return Ok(());
                             }
-                            emit_resolved_value(&mut compact_buf, &resolved, raw, &ranges_buf);
+                            emit_resolved_value(&mut compact_buf, &resolved, raw, &ranges_buf, false);
                             compact_buf.push(b'\n');
                             if compact_buf.len() >= 1 << 17 {
                                 let _ = out.write_all(&compact_buf);
@@ -8615,7 +8638,7 @@ fn real_main() {
                     let mut ranges_buf = vec![(0usize, 0usize); field_refs.len()];
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        if json_object_get_fields_raw_buf(raw, 0, &field_refs, &mut ranges_buf) {
+                        if let Some(all_clean) = jq_jit::value::json_object_get_fields_raw_buf_classified(raw, 0, &field_refs, &mut ranges_buf) {
                             let mut output = None;
                             let mut output_idx = 0usize;
                             let mut needs_generic = false;
@@ -8788,7 +8811,21 @@ fn real_main() {
                                     if use_pretty_buf && (val[0] == b'{' || val[0] == b'[') {
                                         push_json_pretty_raw(&mut compact_buf, val, 2, false);
                                     } else {
-                                        if raw_contains_noncanon_escape(val) { push_raw_canon_escapes(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
+                                        // A passthrough field value with a non-canonical number lexeme
+                                        // (`1e3`, `nan`) must re-render through Value to match jq's
+                                        // canonical output (#729 class); escapes re-encode (#780/#1027).
+                                        if all_clean {
+                                            compact_buf.extend_from_slice(val);
+                                        } else if raw_contains_non_canonical_number(val) {
+                                            match json_to_value(unsafe { std::str::from_utf8_unchecked(val) }) {
+                                                Ok(v) => compact_buf.extend_from_slice(value_to_json_precise(&v).as_bytes()),
+                                                Err(_) => compact_buf.extend_from_slice(val),
+                                            }
+                                        } else if raw_contains_noncanon_escape(val) {
+                                            push_raw_canon_escapes(&mut compact_buf, val);
+                                        } else {
+                                            compact_buf.extend_from_slice(val);
+                                        }
                                     }
                                     compact_buf.push(b'\n');
                                 }
@@ -8801,7 +8838,7 @@ fn real_main() {
                                     if let Some((ref kp, ref res, close)) = resolved_data {
                                         for (j, rv) in res.iter().enumerate() {
                                             compact_buf.extend_from_slice(&kp[j]);
-                                            emit_resolved_value(&mut compact_buf, rv, raw, &ranges_buf);
+                                            emit_resolved_value(&mut compact_buf, rv, raw, &ranges_buf, all_clean);
                                         }
                                         compact_buf.extend_from_slice(close);
                                     }
@@ -8813,7 +8850,7 @@ fn real_main() {
                                         else_computed.as_ref()
                                     };
                                     if let Some(rv) = resolved_remap {
-                                        emit_resolved_value(&mut compact_buf, rv, raw, &ranges_buf);
+                                        emit_resolved_value(&mut compact_buf, rv, raw, &ranges_buf, all_clean);
                                         compact_buf.push(b'\n');
                                     }
                                 }
@@ -9379,7 +9416,7 @@ fn real_main() {
                             compact_buf.push(b'[');
                             for (i, res) in resolved.iter().enumerate() {
                                 if i > 0 { compact_buf.push(b','); }
-                                emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf);
+                                emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf, false);
                             }
                             compact_buf.extend_from_slice(b"]\n");
                         } else {
@@ -9677,7 +9714,7 @@ fn real_main() {
                                 let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                                 process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                             } else {
-                                emit_resolved_value(&mut compact_buf, &resolved, raw, &ranges_buf);
+                                emit_resolved_value(&mut compact_buf, &resolved, raw, &ranges_buf, false);
                                 compact_buf.push(b'\n');
                             }
                         }
@@ -9740,7 +9777,7 @@ fn real_main() {
                             } else {
                                 for (i, res) in resolved.iter().enumerate() {
                                     compact_buf.extend_from_slice(&key_prefixes[i]);
-                                    emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf);
+                                    emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf, false);
                                 }
                                 compact_buf.extend_from_slice(obj_close);
                             }
@@ -10207,7 +10244,7 @@ fn real_main() {
                                 if !resolved.iter().any(|res| resolved_would_error(res, raw, &ranges_buf)) {
                                     for (i, res) in resolved.iter().enumerate() {
                                         compact_buf.extend_from_slice(&key_prefixes[i]);
-                                        emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf);
+                                        emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf, false);
                                     }
                                     compact_buf.extend_from_slice(obj_close);
                                     handled = true;
@@ -10262,7 +10299,7 @@ fn real_main() {
                                     compact_buf.push(b'{');
                                     compact_buf.extend_from_slice(key_raw);
                                     compact_buf.push(b':');
-                                    emit_resolved_value(&mut compact_buf, &resolved_val, raw, &ranges_buf);
+                                    emit_resolved_value(&mut compact_buf, &resolved_val, raw, &ranges_buf, false);
                                     compact_buf.extend_from_slice(b"}\n");
                                 }
                             }
@@ -10327,10 +10364,10 @@ fn real_main() {
                                     compact_buf.push(b'{');
                                     compact_buf.extend_from_slice(key_raw);
                                     compact_buf.push(b':');
-                                    emit_resolved_value(&mut compact_buf, &resolved_dk_val, raw, &ranges_buf);
+                                    emit_resolved_value(&mut compact_buf, &resolved_dk_val, raw, &ranges_buf, false);
                                     for (i, res) in resolved_static.iter().enumerate() {
                                         compact_buf.extend_from_slice(&static_key_prefixes[i]);
-                                        emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf);
+                                        emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf, false);
                                     }
                                     compact_buf.extend_from_slice(b"}\n");
                                 }
@@ -10387,7 +10424,7 @@ fn real_main() {
                                 compact_buf.push(b'[');
                                 for (i, res) in resolved.iter().enumerate() {
                                     if i > 0 { compact_buf.push(b','); }
-                                    emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf);
+                                    emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf, false);
                                 }
                                 compact_buf.extend_from_slice(b"]\n");
                                 handled = true;
@@ -10452,7 +10489,7 @@ fn real_main() {
                                 compact_buf.push(b'[');
                                 for (i, res) in resolved.iter().enumerate() {
                                     if i > 0 { compact_buf.push(b','); }
-                                    emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf);
+                                    emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf, false);
                                 }
                                 compact_buf.extend_from_slice(b"]\n");
                                 handled = true;
@@ -10601,7 +10638,7 @@ fn real_main() {
                                     } else if json_object_get_fields_raw_buf(raw, 0, &gen_field_refs, &mut ranges_buf) {
                                         let res = gen_resolved.as_ref().unwrap();
                                         if !resolved_would_error(res, raw, &ranges_buf) {
-                                            emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf);
+                                            emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf, false);
                                             compact_buf.push(b'\n');
                                             handled = true;
                                         }
@@ -10918,7 +10955,7 @@ fn real_main() {
                                     if pass {
                                         for (i, res) in resolved.iter().enumerate() {
                                             compact_buf.extend_from_slice(&key_prefixes[i]);
-                                            emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf);
+                                            emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf, false);
                                         }
                                         compact_buf.extend_from_slice(obj_close);
                                     }
@@ -10983,7 +11020,7 @@ fn real_main() {
                                     if !pass {
                                         handled = true;
                                     } else if !resolved_would_error(&resolved, raw, &ranges_buf) {
-                                        emit_resolved_value(&mut compact_buf, &resolved, raw, &ranges_buf);
+                                        emit_resolved_value(&mut compact_buf, &resolved, raw, &ranges_buf, false);
                                         compact_buf.push(b'\n');
                                         handled = true;
                                     }
@@ -11058,7 +11095,7 @@ fn real_main() {
                                         compact_buf.push(b'[');
                                         for (i, res) in resolved.iter().enumerate() {
                                             if i > 0 { compact_buf.push(b','); }
-                                            emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf);
+                                            emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf, false);
                                         }
                                         compact_buf.extend_from_slice(b"]\n");
                                         handled = true;
@@ -11130,7 +11167,7 @@ fn real_main() {
                                 compact_buf.push(b'[');
                                 for (i, res) in resolved.iter().enumerate() {
                                     if i > 0 { compact_buf.push(b','); }
-                                    emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf);
+                                    emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf, false);
                                 }
                                 compact_buf.extend_from_slice(b"]\n");
                             }
@@ -11597,7 +11634,7 @@ fn real_main() {
                                     {
                                         for (i, (prefix, res)) in key_prefixes.iter().zip(resolved.iter()).enumerate() {
                                             compact_buf.extend_from_slice(prefix);
-                                            emit_resolved_value(&mut compact_buf, res, raw, &ranges);
+                                            emit_resolved_value(&mut compact_buf, res, raw, &ranges, false);
                                             let _ = i;
                                         }
                                         compact_buf.extend_from_slice(obj_close);
@@ -11671,7 +11708,7 @@ fn real_main() {
                                         compact_buf.push(b'[');
                                         for (i, res) in resolved.iter().enumerate() {
                                             if i > 0 { compact_buf.push(b','); }
-                                            emit_resolved_value(&mut compact_buf, res, raw, &ranges);
+                                            emit_resolved_value(&mut compact_buf, res, raw, &ranges, false);
                                         }
                                         compact_buf.extend_from_slice(b"]\n");
                                         handled = true;
@@ -14537,13 +14574,13 @@ fn real_main() {
                                 compact_buf.extend_from_slice(b"{\n  ");
                                 compact_buf.extend_from_slice(key_val);
                                 compact_buf.extend_from_slice(b": ");
-                                emit_resolved_value(&mut compact_buf, &resolved_val, raw, &ranges_buf);
+                                emit_resolved_value(&mut compact_buf, &resolved_val, raw, &ranges_buf, false);
                                 compact_buf.extend_from_slice(b"\n}\n");
                             } else {
                                 compact_buf.push(b'{');
                                 compact_buf.extend_from_slice(key_val);
                                 compact_buf.push(b':');
-                                emit_resolved_value(&mut compact_buf, &resolved_val, raw, &ranges_buf);
+                                emit_resolved_value(&mut compact_buf, &resolved_val, raw, &ranges_buf, false);
                                 compact_buf.extend_from_slice(b"}\n");
                             }
                         } else {
@@ -14608,20 +14645,20 @@ fn real_main() {
                                 compact_buf.extend_from_slice(b"{\n  ");
                                 compact_buf.extend_from_slice(key_val);
                                 compact_buf.extend_from_slice(b": ");
-                                emit_resolved_value(&mut compact_buf, &resolved_dk_val, raw, &ranges_buf);
+                                emit_resolved_value(&mut compact_buf, &resolved_dk_val, raw, &ranges_buf, false);
                                 for (i, resolved) in resolved_static.iter().enumerate() {
                                     compact_buf.extend_from_slice(&static_key_bufs_pretty[i]);
-                                    emit_resolved_value(&mut compact_buf, resolved, raw, &ranges_buf);
+                                    emit_resolved_value(&mut compact_buf, resolved, raw, &ranges_buf, false);
                                 }
                                 compact_buf.extend_from_slice(b"\n}\n");
                             } else {
                                 compact_buf.push(b'{');
                                 compact_buf.extend_from_slice(key_val);
                                 compact_buf.push(b':');
-                                emit_resolved_value(&mut compact_buf, &resolved_dk_val, raw, &ranges_buf);
+                                emit_resolved_value(&mut compact_buf, &resolved_dk_val, raw, &ranges_buf, false);
                                 for (i, resolved) in resolved_static.iter().enumerate() {
                                     compact_buf.extend_from_slice(&static_key_bufs[i]);
-                                    emit_resolved_value(&mut compact_buf, resolved, raw, &ranges_buf);
+                                    emit_resolved_value(&mut compact_buf, resolved, raw, &ranges_buf, false);
                                 }
                                 compact_buf.extend_from_slice(b"}\n");
                             }
@@ -15292,8 +15329,13 @@ fn real_main() {
                 let content_bytes = content.as_bytes();
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    let outcome = apply_field_access_raw(raw, fa_field, |bytes| {
-                        emit_raw_ln!(&mut compact_buf, bytes);
+                    let outcome = apply_field_access_raw(raw, fa_field, |bytes, clean| {
+                        if clean {
+                            compact_buf.extend_from_slice(bytes);
+                            compact_buf.push(b'\n');
+                        } else {
+                            emit_raw_ln!(&mut compact_buf, bytes);
+                        }
                     });
                     if let RawApplyOutcome::Bail = outcome {
                         let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
@@ -15346,20 +15388,20 @@ fn real_main() {
                         &field_refs,
                         &mut ranges_buf,
                         |ranges, raw| resolved.iter().any(|r| resolved_would_error(r, raw, ranges)),
-                        |ranges, raw| {
+                        |ranges, raw, all_clean| {
                             if use_pretty_buf {
                                 compact_buf.extend_from_slice(b"[\n");
                                 for (i, res) in resolved.iter().enumerate() {
                                     if i > 0 { compact_buf.extend_from_slice(b",\n"); }
                                     compact_buf.extend_from_slice(b"  ");
-                                    emit_resolved_value(&mut compact_buf, res, raw, ranges);
+                                    emit_resolved_value(&mut compact_buf, res, raw, ranges, all_clean);
                                 }
                                 compact_buf.extend_from_slice(b"\n]\n");
                             } else {
                                 compact_buf.push(b'[');
                                 for (i, res) in resolved.iter().enumerate() {
                                     if i > 0 { compact_buf.push(b','); }
-                                    emit_resolved_value(&mut compact_buf, res, raw, ranges);
+                                    emit_resolved_value(&mut compact_buf, res, raw, ranges, all_clean);
                                 }
                                 compact_buf.extend_from_slice(b"]\n");
                             }
@@ -15385,7 +15427,7 @@ fn real_main() {
                         raw,
                         &af_refs,
                         &mut ranges_buf,
-                        |ranges, raw| {
+                        |ranges, raw, all_clean| {
                             if use_pretty_buf {
                                 compact_buf.extend_from_slice(b"[\n");
                                 for (i, (vs, ve)) in ranges.iter().enumerate() {
@@ -15395,7 +15437,7 @@ fn real_main() {
                                     if val[0] == b'{' || val[0] == b'[' {
                                         push_json_pretty_raw_at(&mut compact_buf, val, 2, false, 1);
                                     } else {
-                                        if raw_contains_noncanon_escape(val) { push_raw_canon_escapes(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
+                                        if !all_clean && raw_contains_noncanon_escape(val) { push_raw_canon_escapes(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
                                     }
                                 }
                                 compact_buf.extend_from_slice(b"\n]\n");
@@ -15403,7 +15445,7 @@ fn real_main() {
                                 compact_buf.push(b'[');
                                 for (i, (vs, ve)) in ranges.iter().enumerate() {
                                     if i > 0 { compact_buf.push(b','); }
-                                    { let _vv = &raw[*vs..*ve]; if raw_contains_noncanon_escape(_vv) { push_raw_canon_escapes(&mut compact_buf, _vv); } else { compact_buf.extend_from_slice(_vv); } }
+                                    { let _vv = &raw[*vs..*ve]; if !all_clean && raw_contains_noncanon_escape(_vv) { push_raw_canon_escapes(&mut compact_buf, _vv); } else { compact_buf.extend_from_slice(_vv); } }
                                 }
                                 compact_buf.extend_from_slice(b"]\n");
                             }
@@ -15429,7 +15471,14 @@ fn real_main() {
                         raw,
                         &mf_refs,
                         &mut ranges_buf,
-                        |bytes| { emit_raw_ln!(&mut compact_buf, bytes); },
+                        |bytes, clean| {
+                            if clean {
+                                compact_buf.extend_from_slice(bytes);
+                                compact_buf.push(b'\n');
+                            } else {
+                                emit_raw_ln!(&mut compact_buf, bytes);
+                            }
+                        },
                     );
                     if let RawApplyOutcome::Bail = outcome {
                         let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
@@ -15697,7 +15746,7 @@ fn real_main() {
                             }
                             return Ok(());
                         }
-                        emit_resolved_value(&mut compact_buf, &resolved, raw, &ranges_buf);
+                        emit_resolved_value(&mut compact_buf, &resolved, raw, &ranges_buf, false);
                         compact_buf.push(b'\n');
                         if compact_buf.len() >= 1 << 17 {
                             let _ = out.write_all(&compact_buf);
@@ -16096,7 +16145,7 @@ fn real_main() {
                 let mut ranges_buf = vec![(0usize, 0usize); field_refs.len()];
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    if json_object_get_fields_raw_buf(raw, 0, &field_refs, &mut ranges_buf) {
+                    if let Some(all_clean) = jq_jit::value::json_object_get_fields_raw_buf_classified(raw, 0, &field_refs, &mut ranges_buf) {
                         let mut output = None;
                         let mut output_idx = 0usize;
                         let mut needs_generic = false;
@@ -16263,7 +16312,21 @@ fn real_main() {
                                 if use_pretty_buf && (val[0] == b'{' || val[0] == b'[') {
                                     push_json_pretty_raw(&mut compact_buf, val, 2, false);
                                 } else {
-                                    if raw_contains_noncanon_escape(val) { push_raw_canon_escapes(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
+                                    // A passthrough field value with a non-canonical number lexeme
+                                    // (`1e3`, `nan`) must re-render through Value to match jq's
+                                    // canonical output (#729 class); escapes re-encode (#780/#1027).
+                                    if all_clean {
+                                        compact_buf.extend_from_slice(val);
+                                    } else if raw_contains_non_canonical_number(val) {
+                                        match json_to_value(unsafe { std::str::from_utf8_unchecked(val) }) {
+                                            Ok(v) => compact_buf.extend_from_slice(value_to_json_precise(&v).as_bytes()),
+                                            Err(_) => compact_buf.extend_from_slice(val),
+                                        }
+                                    } else if raw_contains_noncanon_escape(val) {
+                                        push_raw_canon_escapes(&mut compact_buf, val);
+                                    } else {
+                                        compact_buf.extend_from_slice(val);
+                                    }
                                 }
                                 compact_buf.push(b'\n');
                             }
@@ -16276,7 +16339,7 @@ fn real_main() {
                                 if let Some((ref kp, ref res, close)) = resolved_data {
                                     for (j, rv) in res.iter().enumerate() {
                                         compact_buf.extend_from_slice(&kp[j]);
-                                        emit_resolved_value(&mut compact_buf, rv, raw, &ranges_buf);
+                                        emit_resolved_value(&mut compact_buf, rv, raw, &ranges_buf, all_clean);
                                     }
                                     compact_buf.extend_from_slice(close);
                                 }
@@ -16288,7 +16351,7 @@ fn real_main() {
                                     else_computed2.as_ref()
                                 };
                                 if let Some(rv) = resolved_remap {
-                                    emit_resolved_value(&mut compact_buf, rv, raw, &ranges_buf);
+                                    emit_resolved_value(&mut compact_buf, rv, raw, &ranges_buf, all_clean);
                                     compact_buf.push(b'\n');
                                 }
                             }
@@ -16840,7 +16903,7 @@ fn real_main() {
                         compact_buf.push(b'[');
                         for (i, res) in resolved.iter().enumerate() {
                             if i > 0 { compact_buf.push(b','); }
-                            emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf);
+                            emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf, false);
                         }
                         compact_buf.extend_from_slice(b"]\n");
                     } else {
@@ -17134,7 +17197,7 @@ fn real_main() {
                             let v = json_to_value(unsafe { std::str::from_utf8_unchecked(raw) })?;
                             process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         } else {
-                            emit_resolved_value(&mut compact_buf, &resolved, raw, &ranges_buf);
+                            emit_resolved_value(&mut compact_buf, &resolved, raw, &ranges_buf, false);
                             compact_buf.push(b'\n');
                         }
                     }
@@ -17197,7 +17260,7 @@ fn real_main() {
                         } else {
                             for (i, res) in resolved.iter().enumerate() {
                                 compact_buf.extend_from_slice(&key_prefixes[i]);
-                                emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf);
+                                emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf, false);
                             }
                             compact_buf.extend_from_slice(obj_close);
                         }
@@ -17636,7 +17699,7 @@ fn real_main() {
                             if !resolved.iter().any(|res| resolved_would_error(res, raw, &ranges_buf)) {
                                 for (i, res) in resolved.iter().enumerate() {
                                     compact_buf.extend_from_slice(&key_prefixes[i]);
-                                    emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf);
+                                    emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf, false);
                                 }
                                 compact_buf.extend_from_slice(obj_close);
                                 handled = true;
@@ -17691,7 +17754,7 @@ fn real_main() {
                                 compact_buf.push(b'{');
                                 compact_buf.extend_from_slice(key_raw);
                                 compact_buf.push(b':');
-                                emit_resolved_value(&mut compact_buf, &resolved_val, raw, &ranges_buf);
+                                emit_resolved_value(&mut compact_buf, &resolved_val, raw, &ranges_buf, false);
                                 compact_buf.extend_from_slice(b"}\n");
                             }
                         }
@@ -17756,10 +17819,10 @@ fn real_main() {
                                 compact_buf.push(b'{');
                                 compact_buf.extend_from_slice(key_raw);
                                 compact_buf.push(b':');
-                                emit_resolved_value(&mut compact_buf, &resolved_dk_val, raw, &ranges_buf);
+                                emit_resolved_value(&mut compact_buf, &resolved_dk_val, raw, &ranges_buf, false);
                                 for (i, res) in resolved_static.iter().enumerate() {
                                     compact_buf.extend_from_slice(&static_key_prefixes[i]);
-                                    emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf);
+                                    emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf, false);
                                 }
                                 compact_buf.extend_from_slice(b"}\n");
                             }
@@ -17808,7 +17871,7 @@ fn real_main() {
                             compact_buf.push(b'[');
                             for (i, res) in resolved.iter().enumerate() {
                                 if i > 0 { compact_buf.push(b','); }
-                                emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf);
+                                emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf, false);
                             }
                             compact_buf.extend_from_slice(b"]\n");
                             handled = true;
@@ -17869,7 +17932,7 @@ fn real_main() {
                             compact_buf.push(b'[');
                             for (i, res) in resolved.iter().enumerate() {
                                 if i > 0 { compact_buf.push(b','); }
-                                emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf);
+                                emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf, false);
                             }
                             compact_buf.extend_from_slice(b"]\n");
                             handled = true;
@@ -17995,7 +18058,7 @@ fn real_main() {
                                 } else if json_object_get_fields_raw_buf(raw, 0, &gen_field_refs, &mut ranges_buf) {
                                     let res = gen_resolved.as_ref().unwrap();
                                     if !resolved_would_error(res, raw, &ranges_buf) {
-                                        emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf);
+                                        emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf, false);
                                         compact_buf.push(b'\n');
                                         handled = true;
                                     }
@@ -18298,7 +18361,7 @@ fn real_main() {
                                 if pass {
                                     for (i, res) in resolved.iter().enumerate() {
                                         compact_buf.extend_from_slice(&key_prefixes[i]);
-                                        emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf);
+                                        emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf, false);
                                     }
                                     compact_buf.extend_from_slice(obj_close);
                                 }
@@ -18359,7 +18422,7 @@ fn real_main() {
                                 if !pass {
                                     handled = true;
                                 } else if !resolved_would_error(&resolved, raw, &ranges_buf) {
-                                    emit_resolved_value(&mut compact_buf, &resolved, raw, &ranges_buf);
+                                    emit_resolved_value(&mut compact_buf, &resolved, raw, &ranges_buf, false);
                                     compact_buf.push(b'\n');
                                     handled = true;
                                 }
@@ -18426,7 +18489,7 @@ fn real_main() {
                                     compact_buf.push(b'[');
                                     for (i, res) in resolved.iter().enumerate() {
                                         if i > 0 { compact_buf.push(b','); }
-                                        emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf);
+                                        emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf, false);
                                     }
                                     compact_buf.extend_from_slice(b"]\n");
                                     handled = true;
@@ -18498,7 +18561,7 @@ fn real_main() {
                             compact_buf.push(b'[');
                             for (i, res) in resolved.iter().enumerate() {
                                 if i > 0 { compact_buf.push(b','); }
-                                emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf);
+                                emit_resolved_value(&mut compact_buf, res, raw, &ranges_buf, false);
                             }
                             compact_buf.extend_from_slice(b"]\n");
                         }
@@ -18937,7 +19000,7 @@ fn real_main() {
                                 {
                                     for (prefix, res) in key_prefixes.iter().zip(resolved.iter()) {
                                         compact_buf.extend_from_slice(prefix);
-                                        emit_resolved_value(&mut compact_buf, res, raw, &ranges);
+                                        emit_resolved_value(&mut compact_buf, res, raw, &ranges, false);
                                     }
                                     compact_buf.extend_from_slice(obj_close);
                                     handled = true;
@@ -19009,7 +19072,7 @@ fn real_main() {
                                     compact_buf.push(b'[');
                                     for (i, res) in resolved.iter().enumerate() {
                                         if i > 0 { compact_buf.push(b','); }
-                                        emit_resolved_value(&mut compact_buf, res, raw, &ranges);
+                                        emit_resolved_value(&mut compact_buf, res, raw, &ranges, false);
                                     }
                                     compact_buf.extend_from_slice(b"]\n");
                                     handled = true;
@@ -19038,7 +19101,7 @@ fn real_main() {
                             raw,
                             &input_fields,
                             &mut ranges_buf,
-                            |ranges, raw| {
+                            |ranges, raw, all_clean| {
                                 compact_buf.extend_from_slice(b"{\n");
                                 for (i, (vs, ve)) in ranges.iter().enumerate() {
                                     if i > 0 { compact_buf.extend_from_slice(b",\n"); }
@@ -19049,7 +19112,7 @@ fn real_main() {
                                     if val[0] == b'{' || val[0] == b'[' {
                                         push_json_pretty_raw_at(&mut compact_buf, val, 2, false, 1);
                                     } else {
-                                        if raw_contains_noncanon_escape(val) { push_raw_canon_escapes(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
+                                        if !all_clean && raw_contains_noncanon_escape(val) { push_raw_canon_escapes(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
                                     }
                                 }
                                 compact_buf.extend_from_slice(b"\n}\n");
@@ -19081,10 +19144,10 @@ fn real_main() {
                             raw,
                             &input_fields,
                             &mut ranges_buf,
-                            |ranges, raw| {
+                            |ranges, raw, all_clean| {
                                 for (i, (vs, ve)) in ranges.iter().enumerate() {
                                     compact_buf.extend_from_slice(&key_prefixes[i]);
-                                    { let _vv = &raw[*vs..*ve]; if raw_contains_noncanon_escape(_vv) { push_raw_canon_escapes(&mut compact_buf, _vv); } else { compact_buf.extend_from_slice(_vv); } }
+                                    { let _vv = &raw[*vs..*ve]; if !all_clean && raw_contains_noncanon_escape(_vv) { push_raw_canon_escapes(&mut compact_buf, _vv); } else { compact_buf.extend_from_slice(_vv); } }
                                 }
                                 compact_buf.extend_from_slice(b"}\n");
                             },
@@ -19128,10 +19191,10 @@ fn real_main() {
                         &field_refs,
                         &mut ranges_buf,
                         |ranges, raw| resolved.iter().any(|r| resolved_would_error(r, raw, ranges)),
-                        |ranges, raw| {
+                        |ranges, raw, all_clean| {
                             for (i, res) in resolved.iter().enumerate() {
                                 compact_buf.extend_from_slice(&key_prefixes[i]);
-                                emit_resolved_value(&mut compact_buf, res, raw, ranges);
+                                emit_resolved_value(&mut compact_buf, res, raw, ranges, all_clean);
                             }
                             compact_buf.extend_from_slice(obj_close);
                         },
@@ -19170,11 +19233,11 @@ fn real_main() {
                         &field_refs,
                         &mut ranges_buf,
                         |ranges, raw| resolved.iter().any(|r| resolved_would_error(r, raw, ranges)),
-                        |ranges, raw| {
+                        |ranges, raw, all_clean| {
                             compact_buf.push(b'[');
                             for (i, res) in resolved.iter().enumerate() {
                                 if i > 0 { compact_buf.push(b','); }
-                                emit_resolved_value(&mut compact_buf, res, raw, ranges);
+                                emit_resolved_value(&mut compact_buf, res, raw, ranges, all_clean);
                             }
                             compact_buf.extend_from_slice(b"]\n");
                         },
@@ -20258,7 +20321,7 @@ fn real_main() {
                         for (i, res) in resolved.iter().enumerate() {
                             if i > 0 { compact_buf.extend_from_slice(&escaped_sep); }
                             num_buf.clear();
-                            emit_resolved_value(&mut num_buf, res, raw, &ranges);
+                            emit_resolved_value(&mut num_buf, res, raw, &ranges, false);
                             if num_buf.len() >= 2 && num_buf[0] == b'"' && num_buf[num_buf.len()-1] == b'"' {
                                 compact_buf.extend_from_slice(&num_buf[1..num_buf.len()-1]);
                             } else {

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -178,34 +178,44 @@ pub enum RawApplyOutcome {
 /// dup-key / pretty-print pipeline (e.g. the `emit_raw_ln!` macro in
 /// `bin/jq-jit.rs`) without forcing two simultaneous `&mut` borrows of the
 /// output buffer.
+///
+/// `emit`'s second argument is the value's verbatim-safety verdict from the
+/// boundary scan ([`skip_json_value_classify`]): `true` means the bytes are a
+/// scalar jq would output unchanged, so the apply-site may append them
+/// directly and skip its dup-key / compactness / escape gating.
 pub fn apply_field_access_raw<E>(
     raw: &[u8],
     field: &str,
     mut emit: E,
 ) -> RawApplyOutcome
 where
-    E: FnMut(&[u8]),
+    E: FnMut(&[u8], bool),
 {
     match raw.first().copied() {
         Some(b'{') => {
-            match json_object_get_field_raw(raw, 0, field) {
-                // A non-canonical number in the field value (`1e10`,
-                // `0.0000001`, `nan`) must be re-rendered through Value to
-                // match jq's canonical output, so bail to the generic path
-                // rather than echoing the source lexeme (#729).
-                Some((vs, ve)) => {
+            match crate::value::json_object_get_field_raw_classified(raw, 0, field) {
+                Some((vs, ve, clean)) => {
                     let v = &raw[vs..ve];
-                    if raw_contains_non_canonical_number(v) {
-                        return RawApplyOutcome::Bail;
+                    if clean {
+                        emit(v, true);
+                    } else {
+                        // A non-canonical number in the field value (`1e10`,
+                        // `0.0000001`, `nan`) or a surrogate escape must be
+                        // re-rendered through Value to match jq's canonical
+                        // output, so bail to the generic path rather than
+                        // echoing the source lexeme (#729 / #615).
+                        if crate::value::raw_value_bails_canon(v) {
+                            return RawApplyOutcome::Bail;
+                        }
+                        emit(v, false);
                     }
-                    emit(v);
                 }
-                None => emit(b"null"),
+                None => emit(b"null", true),
             }
             RawApplyOutcome::Emit
         }
         Some(b'n') => {
-            emit(b"null");
+            emit(b"null", true);
             RawApplyOutcome::Emit
         }
         // Non-object, non-null: jq raises a type error. Hand off to the
@@ -241,17 +251,23 @@ pub fn apply_multi_field_access_raw<E>(
     mut emit: E,
 ) -> RawApplyOutcome
 where
-    E: FnMut(&[u8]),
+    E: FnMut(&[u8], bool),
 {
-    if json_object_get_fields_raw_buf(raw, 0, fields, ranges_buf) {
+    if let Some(all_clean) =
+        crate::value::json_object_get_fields_raw_buf_classified(raw, 0, fields, ranges_buf)
+    {
         // A non-canonical number in any emitted field value must be
         // re-rendered through Value to match jq's canonical output; bail to
-        // the generic path rather than echo the source lexeme (#729).
-        if ranges_buf.iter().any(|(vs, ve)| raw_contains_non_canonical_number(&raw[*vs..*ve])) {
+        // the generic path rather than echo the source lexeme (#729). When
+        // the boundary scan already proved every value verbatim-safe, skip
+        // the per-value gates entirely.
+        if !all_clean
+            && ranges_buf.iter().any(|(vs, ve)| crate::value::raw_value_bails_canon(&raw[*vs..*ve]))
+        {
             return RawApplyOutcome::Bail;
         }
         for (vs, ve) in ranges_buf.iter() {
-            emit(&raw[*vs..*ve]);
+            emit(&raw[*vs..*ve], all_clean);
         }
         RawApplyOutcome::Emit
     } else {
@@ -293,11 +309,13 @@ pub fn apply_object_compute_raw<C, E>(
 ) -> RawApplyOutcome
 where
     C: FnOnce(&[(usize, usize)], &[u8]) -> bool,
-    E: FnOnce(&[(usize, usize)], &[u8]),
+    E: FnOnce(&[(usize, usize)], &[u8], bool),
 {
-    if !json_object_get_fields_raw_buf(raw, 0, fields, ranges_buf) {
+    let Some(all_clean) =
+        crate::value::json_object_get_fields_raw_buf_classified(raw, 0, fields, ranges_buf)
+    else {
         return RawApplyOutcome::Bail;
-    }
+    };
     let ranges = &ranges_buf[..fields.len()];
     if bail_check(ranges, raw) {
         return RawApplyOutcome::Bail;
@@ -306,10 +324,14 @@ where
     // lexeme through a passthrough cell (`{x:.b}` with `.b == 2e3`), so bail to
     // the generic path which re-renders it canonically (#729). Computed cells
     // (`.b + 0`) over-bail harmlessly — the generic path yields the same value.
-    if ranges.iter().any(|(vs, ve)| raw_contains_non_canonical_number(&raw[*vs..*ve])) {
+    // When the boundary scan already proved every value verbatim-safe, skip
+    // the per-value gates.
+    if !all_clean
+        && ranges.iter().any(|(vs, ve)| crate::value::raw_value_bails_canon(&raw[*vs..*ve]))
+    {
         return RawApplyOutcome::Bail;
     }
-    emit(ranges, raw);
+    emit(ranges, raw, all_clean);
     RawApplyOutcome::Emit
 }
 
@@ -3998,18 +4020,22 @@ pub fn apply_full_object_fields_raw<E>(
     emit_structural: E,
 ) -> RawApplyOutcome
 where
-    E: FnOnce(&[(usize, usize)], &[u8]),
+    E: FnOnce(&[(usize, usize)], &[u8], bool),
 {
-    if json_object_get_fields_raw_buf(raw, 0, fields, ranges_buf) {
+    if let Some(all_clean) =
+        crate::value::json_object_get_fields_raw_buf_classified(raw, 0, fields, ranges_buf)
+    {
         // A non-canonical number in any field value must be re-rendered through
         // Value to match jq's canonical output; bail to the generic path rather
-        // than echo the source lexeme (#729).
-        if ranges_buf[..fields.len()].iter()
-            .any(|(vs, ve)| raw_contains_non_canonical_number(&raw[*vs..*ve]))
+        // than echo the source lexeme (#729). When the boundary scan already
+        // proved every value verbatim-safe, skip the per-value gates.
+        if !all_clean
+            && ranges_buf[..fields.len()].iter()
+                .any(|(vs, ve)| crate::value::raw_value_bails_canon(&raw[*vs..*ve]))
         {
             return RawApplyOutcome::Bail;
         }
-        emit_structural(&ranges_buf[..fields.len()], raw);
+        emit_structural(&ranges_buf[..fields.len()], raw, all_clean);
         RawApplyOutcome::Emit
     } else {
         RawApplyOutcome::Bail
@@ -4044,7 +4070,7 @@ where
             Some((vs, ve)) => {
                 let v = &raw[vs..ve];
                 // Canonicalise non-canonical numbers via the generic path (#729).
-                if raw_contains_non_canonical_number(v) {
+                if crate::value::raw_value_bails_canon(v) {
                     return RawApplyOutcome::Bail;
                 }
                 emit(v);

--- a/src/value.rs
+++ b/src/value.rs
@@ -1096,6 +1096,15 @@ pub fn json_object_get_num(b: &[u8], pos: usize, field: &str) -> Option<f64> {
 /// Returns Some((start, end)) byte offsets of the field's value, or None if not found
 /// or the input isn't a JSON object. Used for field access fast paths.
 pub fn json_object_get_field_raw(b: &[u8], pos: usize, field: &str) -> Option<(usize, usize)> {
+    json_object_get_field_raw_classified(b, pos, field).map(|(s, e, _)| (s, e))
+}
+
+/// [`json_object_get_field_raw`] variant that also classifies the matched
+/// value's verbatim-safety in the same walk (see
+/// [`skip_json_value_classify`]); the third tuple element is that `clean`
+/// flag. Lets the raw passthrough apply-sites skip every per-value
+/// canonicalisation scan on clean data without a second pass.
+pub fn json_object_get_field_raw_classified(b: &[u8], pos: usize, field: &str) -> Option<(usize, usize, bool)> {
     if pos >= b.len() || b[pos] != b'{' { return None; }
     let field_bytes = field.as_bytes();
     // jq dedupes duplicate input keys last-wins (#233 / #325). After
@@ -1108,7 +1117,7 @@ pub fn json_object_get_field_raw(b: &[u8], pos: usize, field: &str) -> Option<(u
     let mut i = pos + 1;
     while i < b.len() && matches!(b[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
     if i < b.len() && b[i] == b'}' { return None; }
-    let mut last_match: Option<(usize, usize)> = None;
+    let mut last_match: Option<(usize, usize, bool)> = None;
     loop {
         if i >= b.len() || b[i] != b'"' { return last_match; }
         let key_start = i + 1;
@@ -1124,10 +1133,13 @@ pub fn json_object_get_field_raw(b: &[u8], pos: usize, field: &str) -> Option<(u
         i += 1;
         while i < b.len() && matches!(b[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
         let val_start = i;
-        let val_end = match skip_json_value(b, i) { Ok(end) => end, Err(_) => return last_match };
-        if key_matches {
-            last_match = Some((val_start, val_end));
-        }
+        let val_end = if key_matches {
+            let (end, vclean) = match skip_json_value_classify(b, i) { Ok(r) => r, Err(_) => return last_match };
+            last_match = Some((val_start, end, vclean));
+            end
+        } else {
+            match skip_json_value(b, i) { Ok(end) => end, Err(_) => return last_match }
+        };
         i = val_end;
         while i < b.len() && matches!(b[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
         if i >= b.len() { return last_match; }
@@ -3783,7 +3795,17 @@ pub fn json_object_get_fields_raw(b: &[u8], pos: usize, input_fields: &[&str]) -
 /// Returns true if all fields were found; false otherwise.
 /// `out` must have length >= `input_fields.len()`.
 pub fn json_object_get_fields_raw_buf(b: &[u8], pos: usize, input_fields: &[&str], out: &mut [(usize, usize)]) -> bool {
-    if pos >= b.len() || b[pos] != b'{' { return false; }
+    json_object_get_fields_raw_buf_classified(b, pos, input_fields, out).is_some()
+}
+
+/// [`json_object_get_fields_raw_buf`] variant that also classifies every
+/// matched value's verbatim-safety in the same walk (see
+/// [`skip_json_value_classify`]). Returns `None` on the same conditions the
+/// boolean variant returns `false`; on success, `Some(all_clean)` where
+/// `all_clean` is true when every matched value can be emitted with a plain
+/// copy — letting the apply-sites skip all per-value canonicalisation scans.
+pub fn json_object_get_fields_raw_buf_classified(b: &[u8], pos: usize, input_fields: &[&str], out: &mut [(usize, usize)]) -> Option<bool> {
+    if pos >= b.len() || b[pos] != b'{' { return None; }
     let n = input_fields.len();
     debug_assert!(out.len() >= n);
     // jq dedupes duplicate input keys last-wins (#233 / #325): the
@@ -3814,11 +3836,12 @@ pub fn json_object_get_fields_raw_buf(b: &[u8], pos: usize, input_fields: &[&str
     };
     let mut early_exit_attempted = false;
     let mut found_mask: u64 = 0;
+    let mut all_clean = true;
     let mut i = pos + 1;
     while i < b.len() && matches!(b[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
-    if i < b.len() && b[i] == b'}' { return false; }
+    if i < b.len() && b[i] == b'}' { return None; }
     loop {
-        if i >= b.len() || b[i] != b'"' { return false; }
+        if i >= b.len() || b[i] != b'"' { return None; }
         let key_start = i + 1;
         let mut j = key_start;
         while j < b.len() {
@@ -3834,24 +3857,25 @@ pub fn json_object_get_fields_raw_buf(b: &[u8], pos: usize, input_fields: &[&str
         }
         i = j + 1;
         while i < b.len() && matches!(b[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
-        if i >= b.len() || b[i] != b':' { return false; }
+        if i >= b.len() || b[i] != b':' { return None; }
         i += 1;
         while i < b.len() && matches!(b[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
         if let Some(idx) = matched_idx {
             let val_start = i;
-            let val_end = match skip_json_value(b, i) { Ok(end) => end, Err(_) => return false };
+            let (val_end, vclean) = match skip_json_value_classify(b, i) { Ok(r) => r, Err(_) => return None };
             out[idx] = (val_start, val_end);
             found_mask |= 1u64 << idx;
+            all_clean &= vclean;
             i = val_end;
         } else {
-            i = match skip_json_value(b, i) { Ok(end) => end, Err(_) => return false };
+            i = match skip_json_value(b, i) { Ok(end) => end, Err(_) => return None };
         }
         while i < b.len() && matches!(b[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
-        if i >= b.len() { return false; }
+        if i >= b.len() { return None; }
         if b[i] == b'}' {
-            return found_mask.count_ones() as usize == n;
+            return if found_mask.count_ones() as usize == n { Some(all_clean) } else { None };
         }
-        if b[i] != b',' { return false; }
+        if b[i] != b',' { return None; }
         i += 1;
         while i < b.len() && matches!(b[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
         // All requested fields seen and there are more keys ahead →
@@ -3868,7 +3892,7 @@ pub fn json_object_get_fields_raw_buf(b: &[u8], pos: usize, input_fields: &[&str
         {
             early_exit_attempted = true;
             if no_target_first_byte_in_remainder(b, i, &first_bytes_small[..n]) {
-                return true;
+                return Some(all_clean);
             }
         }
     }
@@ -4001,14 +4025,15 @@ fn walk_json_nums_inner(buf: &mut Vec<u8>, b: &[u8], pos: &mut usize, op: u8, op
 /// Callers gate the (slightly slower) normalising copy on this so
 /// backslash-free input — the overwhelmingly common case — keeps its single
 /// `extend_from_slice`.
-#[inline]
+#[inline(always)]
 pub fn raw_contains_noncanon_escape(b: &[u8]) -> bool {
     // Cheapest pre-filter first: no backslash or DEL means nothing to
-    // canonicalise. A two-byte `memchr2` still has low per-call setup, which
-    // matters because this gates every raw string output — one call per
-    // record on the NDJSON field-access hot paths, where the value almost
-    // never contains `\` or 0x7F.
-    let Some(first) = memchr::memchr2(b'\\', 0x7F, b) else {
+    // canonicalise. This gates every raw string output — one call per record
+    // on the NDJSON field-access hot paths, where the value is typically a
+    // handful of bytes and almost never contains `\` or 0x7F — so short
+    // inputs take an inlined loop instead of paying `memchr2`'s per-call
+    // setup.
+    let Some(first) = find_backslash_or_del(b) else {
         return false;
     };
     if b[first] == 0x7F {
@@ -4744,6 +4769,93 @@ pub fn skip_json_value(b: &[u8], pos: usize) -> Result<usize> {
             Ok(i)
         }
         c => bail!("Unexpected character '{}' at position {}", c as char, pos),
+    }
+}
+
+/// [`skip_json_value`] fused with a verbatim-safety classification for the
+/// raw passthrough hot paths. Returns `(end, clean)`: `clean` is true when
+/// the value's raw bytes can be emitted by the raw-byte fast paths with a
+/// plain copy — a scalar with no backslash escape, no DEL byte (0x7F), and
+/// no number lexeme jq would re-render (`e`/`E` exponent, `+` sign,
+/// special-float spelling, `.000000` run; #729/#780/#1027/#446). Composites
+/// always report `clean = false` (their dup-key / compactness questions
+/// stay with the emit pipeline), so the classification never costs more
+/// than the boundary scan the caller was already paying.
+#[inline]
+pub fn skip_json_value_classify(b: &[u8], pos: usize) -> Result<(usize, bool)> {
+    if pos >= b.len() { bail!("Unexpected end of JSON"); }
+    match b[pos] {
+        b'n' => {
+            if b.get(pos..pos+4) == Some(b"null") { Ok((pos + 4, true)) }
+            else if let Some((_, adv)) = try_special_float_token(b, pos, false) { Ok((pos + adv, false)) }
+            else { bail!("Invalid JSON at position {}", pos) }
+        }
+        b't' => { if b.get(pos..pos+4) == Some(b"true") { Ok((pos + 4, true)) } else { bail!("Invalid JSON at position {}", pos) } }
+        b'f' => { if b.get(pos..pos+5) == Some(b"false") { Ok((pos + 5, true)) } else { bail!("Invalid JSON at position {}", pos) } }
+        b'"' => {
+            // Mirrors skip_json_value's string arm; additionally flags DEL
+            // (jq escapes it on output, #446) and any backslash escape
+            // (precise escape classification is left to the dirty-path
+            // gates — most data has none, and a single flag keeps this walk
+            // as cheap as the plain boundary scan).
+            let mut clean = true;
+            let mut i = pos + 1;
+            loop {
+                let rest = &b[i..];
+                match memchr::memchr2(b'"', b'\\', rest) {
+                    Some(offset) => {
+                        let mut ctl = false;
+                        let mut del = false;
+                        for &c in &rest[..offset] {
+                            ctl |= c < 0x20;
+                            del |= c == 0x7F;
+                        }
+                        if ctl {
+                            bail!("Invalid string: control characters from U+0000 through U+001F must be escaped");
+                        }
+                        if del { clean = false; }
+                        if rest[offset] == b'"' { return Ok((i + offset + 1, clean)); }
+                        // '\' : consume escape pair
+                        if i + offset + 1 >= b.len() { bail!("Unterminated string escape"); }
+                        clean = false;
+                        i += offset + 2;
+                    }
+                    None => bail!("Unterminated string"),
+                }
+            }
+        }
+        b'-' | b'+' | b'0'..=b'9' => {
+            // Mirrors skip_json_value's number arm; flags the lexeme shapes
+            // [`raw_composite_canon_class`] would classify as non-canonical
+            // (`+` sign, special floats, any exponent, `.000000` run, #611).
+            let mut i = pos;
+            let mut clean = b[i] != b'+';
+            if b[i] == b'-' || b[i] == b'+' {
+                if let Some((_, adv)) = try_special_float_token(b, pos + 1, false) {
+                    return Ok((pos + 1 + adv, false));
+                }
+                i += 1;
+            }
+            let digits_start = i;
+            while i < b.len() && b[i].is_ascii_digit() { i += 1; }
+            if i < b.len() && b[i] == b'.' {
+                if i > digits_start && b.get(i + 1..i + 7) == Some(&[b'0'; 6][..]) {
+                    clean = false;
+                }
+                i += 1;
+                while i < b.len() && b[i].is_ascii_digit() { i += 1; }
+            }
+            if i < b.len() && (b[i] == b'e' || b[i] == b'E') {
+                clean = false;
+                i += 1;
+                if i < b.len() && (b[i] == b'+' || b[i] == b'-') { i += 1; }
+                while i < b.len() && b[i].is_ascii_digit() { i += 1; }
+            }
+            Ok((i, clean))
+        }
+        // Composites and the remaining special-float spellings (`N`/`i`/`I`)
+        // delegate to the plain walker and report dirty.
+        _ => skip_json_value(b, pos).map(|end| (end, false)),
     }
 }
 
@@ -6048,6 +6160,88 @@ pub fn raw_composite_canon_class(bytes: &[u8]) -> CompositeCanon {
         }
     }
     if saw_noncanon_escape { CompositeCanon::NoncanonEscape } else { CompositeCanon::Clean }
+}
+
+/// Per-value bail gate for the scalar-dominated raw passthrough hot paths
+/// (field access, multi-field access, object/array construction). Decides
+/// the same bail-to-generic question as [`raw_contains_non_canonical_number`]
+/// but dispatches on the first byte so the common shapes pay the minimum
+/// scan: a plain integer one vectorisable all-digits pass, a backslash-free
+/// string one `memchr`, and `true`/`false`/`null` nothing at all. A string
+/// only bails on a surrogate `\uDXXX` escape (#615) — the one string shape
+/// the emit-side canonicaliser cannot reproduce (jq errors on a lone high
+/// surrogate); `\/`, non-surrogate `\uXXXX`, and DEL stay on the fast path
+/// and are re-encoded by the emit site's [`raw_contains_noncanon_escape`]
+/// gate.
+#[inline(always)]
+pub fn raw_value_bails_canon(v: &[u8]) -> bool {
+    match v.first() {
+        Some(c) if c.is_ascii_digit() || *c == b'-' => {
+            // A plain integer is always canonical; only lexemes carrying
+            // `.`/`e`/`E`/`+` (or a `-nan`/`-inf` spelling) need the full
+            // classifier.
+            !v.iter().all(|&x| x.is_ascii_digit() || x == b'-')
+                && raw_contains_non_canonical_number(v)
+        }
+        Some(b'"') => raw_string_has_surrogate_escape(v),
+        Some(b't') | Some(b'f') => false,
+        // `null` passes; the bare `nan` special-float spelling bails.
+        Some(b'n') => v != b"null",
+        // Composites and the remaining special-float spellings (`NaN`,
+        // `Infinity`, ...) keep the full single-pass classifier.
+        _ => raw_contains_non_canonical_number(v),
+    }
+}
+
+/// Locate the first `\` or DEL (0x7F) byte. Hybrid scanner for the raw
+/// passthrough gates: values on the NDJSON hot paths are usually a few
+/// bytes, where `memchr2`'s per-call setup costs more than a plain inlined
+/// loop; longer inputs still get `memchr2`'s vectorised throughput.
+#[inline(always)]
+fn find_backslash_or_del(b: &[u8]) -> Option<usize> {
+    if b.len() <= 64 {
+        b.iter().position(|&x| x == b'\\' || x == 0x7F)
+    } else {
+        memchr::memchr2(b'\\', 0x7F, b)
+    }
+}
+
+/// Single-byte variant of [`find_backslash_or_del`], same hybrid rationale.
+#[inline(always)]
+fn find_backslash(b: &[u8]) -> Option<usize> {
+    if b.len() <= 64 {
+        b.iter().position(|&x| x == b'\\')
+    } else {
+        memchr::memchr(b'\\', b)
+    }
+}
+
+/// True if the raw string token `v` (quotes included) contains a surrogate
+/// `\uD8XX`–`\uDFXX` escape. Escape-aware (an escaped backslash cannot pair
+/// with a following `u`), mirroring the surrogate detection inside
+/// [`raw_composite_canon_class`].
+#[inline(always)]
+pub fn raw_string_has_surrogate_escape(v: &[u8]) -> bool {
+    let mut i = 0;
+    while let Some(off) = find_backslash(&v[i..]) {
+        let p = i + off;
+        if p + 5 < v.len()
+            && v[p + 1] == b'u'
+            && (v[p + 2] == b'D' || v[p + 2] == b'd')
+            && matches!(v[p + 3],
+                b'8' | b'9' | b'A' | b'B' | b'C' | b'D' | b'E' | b'F'
+                     | b'a' | b'b' | b'c' | b'd' | b'e' | b'f')
+        {
+            return true;
+        }
+        // Skip the whole escape pair so `\\` does not pair with a following
+        // `u`.
+        i = p + 2;
+        if i >= v.len() {
+            return false;
+        }
+    }
+    false
 }
 
 /// Append a single JSON value's raw bytes `val` to `buf`, canonicalising number

--- a/tests/contract_fast_path.rs
+++ b/tests/contract_fast_path.rs
@@ -201,7 +201,7 @@ fn execute_cb_field_access_invokes_callback_once() {
 #[test]
 fn raw_field_access_object_emits_value_bytes() {
     let mut emitted: Vec<Vec<u8>> = Vec::new();
-    let outcome = apply_field_access_raw(b"{\"x\":42,\"y\":7}", "x", |b| emitted.push(b.to_vec()));
+    let outcome = apply_field_access_raw(b"{\"x\":42,\"y\":7}", "x", |b, _| emitted.push(b.to_vec()));
     assert!(matches!(outcome, RawApplyOutcome::Emit));
     assert_eq!(emitted, vec![b"42".to_vec()]);
 }
@@ -209,7 +209,7 @@ fn raw_field_access_object_emits_value_bytes() {
 #[test]
 fn raw_field_access_object_missing_key_emits_null_literal() {
     let mut emitted: Vec<Vec<u8>> = Vec::new();
-    let outcome = apply_field_access_raw(b"{\"y\":7}", "x", |b| emitted.push(b.to_vec()));
+    let outcome = apply_field_access_raw(b"{\"y\":7}", "x", |b, _| emitted.push(b.to_vec()));
     assert!(matches!(outcome, RawApplyOutcome::Emit));
     assert_eq!(emitted, vec![b"null".to_vec()]);
 }
@@ -217,7 +217,7 @@ fn raw_field_access_object_missing_key_emits_null_literal() {
 #[test]
 fn raw_field_access_null_input_emits_null_literal() {
     let mut emitted: Vec<Vec<u8>> = Vec::new();
-    let outcome = apply_field_access_raw(b"null", "x", |b| emitted.push(b.to_vec()));
+    let outcome = apply_field_access_raw(b"null", "x", |b, _| emitted.push(b.to_vec()));
     assert!(matches!(outcome, RawApplyOutcome::Emit));
     assert_eq!(emitted, vec![b"null".to_vec()]);
 }
@@ -236,7 +236,7 @@ fn raw_field_access_non_object_non_null_bails() {
         b"[1,2,3]".as_slice(),
     ] {
         let mut emitted: Vec<Vec<u8>> = Vec::new();
-        let outcome = apply_field_access_raw(raw, "x", |b| emitted.push(b.to_vec()));
+        let outcome = apply_field_access_raw(raw, "x", |b, _| emitted.push(b.to_vec()));
         assert!(
             matches!(outcome, RawApplyOutcome::Bail),
             "expected Bail for input {:?}, got {:?}",
@@ -343,7 +343,7 @@ fn raw_multi_field_complete_object_emits_each_field() {
         b"{\"a\":1,\"b\":2,\"c\":3}",
         &["a", "b", "c"],
         &mut ranges_buf,
-        |bytes| emitted.push(bytes.to_vec()),
+        |bytes, _| emitted.push(bytes.to_vec()),
     );
     assert!(matches!(outcome, RawApplyOutcome::Emit));
     assert_eq!(emitted, vec![b"1".to_vec(), b"2".to_vec(), b"3".to_vec()]);
@@ -359,7 +359,7 @@ fn raw_multi_field_partial_object_bails() {
         b"{\"a\":1,\"c\":3}",
         &["a", "b", "c"],
         &mut ranges_buf,
-        |bytes| emitted.push(bytes.to_vec()),
+        |bytes, _| emitted.push(bytes.to_vec()),
     );
     assert!(matches!(outcome, RawApplyOutcome::Bail));
     assert!(emitted.is_empty());
@@ -375,7 +375,7 @@ fn raw_multi_field_null_input_bails() {
         b"null",
         &["a", "b"],
         &mut ranges_buf,
-        |bytes| emitted.push(bytes.to_vec()),
+        |bytes, _| emitted.push(bytes.to_vec()),
     );
     assert!(matches!(outcome, RawApplyOutcome::Bail));
     assert!(emitted.is_empty());
@@ -395,7 +395,7 @@ fn raw_multi_field_non_object_non_null_input_bails() {
             raw,
             &["a", "b"],
             &mut ranges_buf,
-            |bytes| emitted.push(bytes.to_vec()),
+            |bytes, _| emitted.push(bytes.to_vec()),
         );
         assert!(
             matches!(outcome, RawApplyOutcome::Bail),
@@ -421,7 +421,7 @@ fn raw_full_object_fields_complete_object_invokes_emit_once() {
         b"{\"a\":1,\"b\":2,\"c\":3}",
         &["a", "b", "c"],
         &mut ranges_buf,
-        |ranges, raw| {
+        |ranges, raw, _| {
             calls += 1;
             for (vs, ve) in ranges {
                 collected.push(raw[*vs..*ve].to_vec());
@@ -441,7 +441,7 @@ fn raw_full_object_fields_partial_object_bails_without_calling_emit() {
         b"{\"a\":1,\"c\":3}",
         &["a", "b", "c"],
         &mut ranges_buf,
-        |_, _| { calls += 1; },
+        |_, _, _| { calls += 1; },
     );
     assert!(matches!(outcome, RawApplyOutcome::Bail));
     assert_eq!(calls, 0, "Bail must not invoke emit_array");
@@ -455,7 +455,7 @@ fn raw_full_object_fields_null_input_bails_without_calling_emit() {
         b"null",
         &["a", "b"],
         &mut ranges_buf,
-        |_, _| { calls += 1; },
+        |_, _, _| { calls += 1; },
     );
     assert!(matches!(outcome, RawApplyOutcome::Bail));
     assert_eq!(calls, 0);
@@ -475,7 +475,7 @@ fn raw_full_object_fields_non_object_non_null_input_bails() {
             raw,
             &["a", "b"],
             &mut ranges_buf,
-            |_, _| { calls += 1; },
+            |_, _, _| { calls += 1; },
         );
         assert!(
             matches!(outcome, RawApplyOutcome::Bail),
@@ -623,7 +623,7 @@ fn raw_object_compute_full_object_invokes_emit_after_inner_check() {
         &["a", "b"],
         &mut ranges_buf,
         |_, _| { bail_calls += 1; false }, // inner check passes
-        |_, _| { emit_calls += 1; },
+        |_, _, _| { emit_calls += 1; },
     );
     assert!(matches!(outcome, RawApplyOutcome::Emit));
     assert_eq!(bail_calls, 1, "bail_check must run exactly once on outer success");
@@ -641,7 +641,7 @@ fn raw_object_compute_outer_bail_skips_inner_and_emit() {
         &["a", "b"],
         &mut ranges_buf,
         |_, _| { bail_calls += 1; false },
-        |_, _| { emit_calls += 1; },
+        |_, _, _| { emit_calls += 1; },
     );
     assert!(matches!(outcome, RawApplyOutcome::Bail));
     assert_eq!(bail_calls, 0, "outer bail must skip the inner check");
@@ -658,7 +658,7 @@ fn raw_object_compute_inner_bail_skips_emit() {
         &["a", "b"],
         &mut ranges_buf,
         |_, _| true, // inner says bail
-        |_, _| { emit_calls += 1; },
+        |_, _, _| { emit_calls += 1; },
     );
     assert!(matches!(outcome, RawApplyOutcome::Bail));
     assert_eq!(emit_calls, 0, "inner bail must skip emit");
@@ -677,7 +677,7 @@ fn raw_object_compute_partial_object_outer_bails() {
         &["a", "b"],
         &mut ranges_buf,
         |_, _| { bail_calls += 1; false },
-        |_, _| { emit_calls += 1; },
+        |_, _, _| { emit_calls += 1; },
     );
     assert!(matches!(outcome, RawApplyOutcome::Bail));
     assert_eq!(bail_calls, 0);

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -4251,3 +4251,11 @@ null
 # #1049: only interpolated segments are formatted; unknown names error on interpolation
 [@base64 "a\(1)b", try (@invalid "a\(1)b") catch .]
 null
+
+# perf-recovery classify gate: cond-chain field output canonicalizes number lexemes
+if .b == 1 then .a elif .n == "q" then "x" else .a end
+{"a":1e3,"b":1,"n":"t"}
+
+# perf-recovery classify gate: mixed dirty values on array construct
+[.a, .b]
+{"a":"x\/y","b":2e3}

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -13517,3 +13517,18 @@ null
 [([1898,13,1,0,0,0,0,0] | strftime("%Y")), ([1899,13,1,0,0,0,0,0] | strftime("%Y-%m-%d"))]
 null
 ["1898","1900-02-01"]
+
+# Multi-branch cond-chain field output canonicalizes a non-canonical number lexeme (#729 class)
+if .b == 1 then .a elif .n == "q" then "x" else .a end
+{"a":1e3,"b":1,"n":"t"}
+1E+3
+
+# Multi-branch cond-chain field output renders a parsed NaN as null
+if .b == 1 then .a elif .n == "q" then "x" else .a end
+{"a":nan,"b":1,"n":"t"}
+null
+
+# Classified raw passthrough: dirty values still canonicalize on multi-field array construct
+[.a, .b]
+{"a":"x\/y","b":2e3}
+["x/y",2E+3]


### PR DESCRIPTION
## Summary

Recovers the v1.8.0 → v1.8.2 raw-passthrough performance regression (the Value-construction NDJSON bench family, 15–35%).

### Root cause (bisected, same-machine A/B)

| Culprit | Landed in | Effect |
|---|---|---|
| #753 — canonicalize number reprs in raw-byte passthrough | v1.8.1 | array construct +19%, field access +18% |
| #800 — decode escaped solidus on raw serialization paths | v1.8.2 | field access +18%, array construct +21% (half recovered by the later perf(output) commits) |
| #911 — while/until generator-condition fork | v1.8.2 | path() +13%, layout-shift only (while/until is not on the path() execution path) |

Each emitted value paid 2–4 small per-value scans (canon bail gate, dup-key, compactness, escape gate); on ~10-byte scalars the scan setup dominates, costing ~10–20ns/record on a ~55ns/record loop.

### Fix

Fold the classification into the field-boundary scan the getters already perform. `skip_json_value_classify` decides verbatim-safety (scalar, no backslash escape, no DEL, no non-canonical number lexeme) during the walk it had to do anyway; the classified getters surface it as a `clean` flag; apply-sites thread it to their emit closures, which skip every per-value gate on clean data. Dirty data keeps the existing gates (escape re-encode, number re-render, surrogate bail). Composites always classify dirty, so dup-key / compactness / pretty handling is unchanged.

### Results (same-machine interleaved A/B vs v1.8.0, best of 7, 2M-record NDJSON)

| bench | before | after |
|---|---|---|
| field access `.name` | 1.24x | **0.87x** |
| array construct `[.name,.x]` | 1.35x | **1.00x** |
| `{a}+{b}` merge | 1.24x | **0.97x** |
| object construct | 1.16x | 1.05x |
| computed remap | 1.13x | 1.06x |
| multi-field `.x,.y,.name` | — | **0.60x** vs pre-fix main |
| `path(.name,.x)` | 1.15x | ~1.05–1.08x (#911 layout lottery, accepted) |

Full `bench/comprehensive.sh` (220 lines vs v1.8.3 history column): 18 lines >5% faster, 13 lines >5% "slower" — all either 1ms-quantization on 8–15ms micro-lines or cross-day drift; same-machine A/B on those shapes (arith 1.009, cond chain 1.014) shows no real regression.

### Also includes

- **Correctness fix surfaced en route**: multi-branch cond-chain `BranchOutput::Field` emitters copied non-canonical number lexemes verbatim (`1e3`, `nan` → invalid JSON, present since v1.8.0); both apply-sites now re-render through Value (#729 class). The single-branch cond fast paths have the same pre-existing leak — left for a follow-up.
- Clean-flag contract documented in `docs/maintenance.md`.
- Regression tests + differential corpus entries appended.

### Verification

- `cargo build --release`: zero warnings
- `cargo test --release`: 624 passed, 0 failed (official, regression, differential, fuzz, selfdiff, contracts)
- Edge-case differential vs jq 1.8.1 over escape/number/surrogate/dup-key/whitespace shapes on all touched paths: parity

🤖 Generated with [Claude Code](https://claude.com/claude-code)