### PR TITLE
feat(jit): direct JitOp interpreter backend (#1059 Phase 1)

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -131,6 +131,34 @@ JIT_INTERP_DIFF_LIMIT=200 cargo test --release --test selfdiff_jit_interp -- --n
 理由を書いて allowlist する。allowlist は audit trail なので、ケースを直したら
 必ずエントリも消す（ハーネスは「known なのに今 pass した」も検知して落ちる）。
 
+### JitOp backend self-diff（`tests/selfdiff_jitop_backend.rs` / #1059）
+
+JitOp lowering の 2 backend — Cranelift codegen と直接実行 interpreter
+（`jit::JitProgram`）— が同じ線形 op 列から同じ結果を返すかを
+`tests/regression.test` 全件で突き合わせる true backend diff。knob は:
+
+- `JQJIT_FORCE_JITOP_INTERP=1` — raw-byte fast path / typed fast path を
+  止め、flatten 可能な filter を JitOp interpreter で実行（不可なら eval に
+  fallback）
+- `JQJIT_FORCE_CRANELIFT=1` — 同じルーティングで backend だけ Cranelift
+  （入力サイズの JIT heuristics を無視して必ずコンパイル）
+
+両側は同一の lowering / 同一の fast path 構成なので、ここの divergence は
+「同じ op 列のどちらかの実行が間違っている」ことを意味する。allowlist は
+空維持が原則（直す、waiver しない）。
+
+```bash
+cargo test --release --test selfdiff_jitop_backend
+JITOP_BACKEND_DIFF_LIMIT=200 cargo test --release --test selfdiff_jitop_backend -- --nocapture
+```
+
+注意: `JQJIT_FORCE_CRANELIFT` は小入力でも必ず JIT するため、通常の
+dispatch では eval に流れて不可視だった「lowering vs eval」の divergence
+（literal repr の消失、`combinations`/`modf` の phantom builtin、try-catch
+内の builtin エラー消失など）がこのモードでは表に出る。それらは backend
+diff（このハーネス）では両側一致なので落ちない — lowering 側の既存バグは
+別 issue として追う。
+
 ### テスト出力
 
 `cargo test --release` だけだと regression 通過数が非表示。必ず `--nocapture`:

--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -190,6 +190,38 @@ fn force_interpreter_enabled() -> bool {
     })
 }
 
+/// Self-diff knob (issue #1059): when `JQJIT_FORCE_JITOP_INTERP` is set in
+/// the environment, the binary disables raw-byte fast paths, skips Cranelift
+/// JIT compilation, and routes every flattenable filter through the direct
+/// JitOp interpreter backend (`jq_jit::jit::JitProgram`); filters the
+/// flattener rejects fall back to the tree-walking eval path. The
+/// `tests/selfdiff_jitop_interp.rs` harness shells out twice with the same
+/// arguments and asserts identical stdout / exit-code class.
+fn force_jitop_interp_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var_os("JQJIT_FORCE_JITOP_INTERP")
+            .map(|v| !v.is_empty() && v != "0")
+            .unwrap_or(false)
+    })
+}
+
+/// Self-diff knob (issue #1059), the Cranelift-side counterpart of
+/// `JQJIT_FORCE_JITOP_INTERP`: disables raw-byte fast paths and pins every
+/// flattenable filter to the Cranelift-compiled backend (compile regardless
+/// of input-size heuristics); non-flattenable filters fall back to eval.
+/// Routing is otherwise identical to the JitOp-interpreter mode, so the
+/// `tests/selfdiff_jitop_backend.rs` harness diffs the two *backends* over
+/// the same lowering with no fast-path asymmetry.
+fn force_cranelift_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var_os("JQJIT_FORCE_CRANELIFT")
+            .map(|v| !v.is_empty() && v != "0")
+            .unwrap_or(false)
+    })
+}
+
 /// Layer-pinning knob (issue #685): when `JQJIT_DISABLE_RAW_BYTE` is set,
 /// every `detect_*` raw-byte fast path in this binary is skipped and the
 /// dispatch falls through to `process_input` / `Filter::execute_cb`. JIT
@@ -2752,6 +2784,18 @@ fn real_main() {
     if force_interp {
         jq_jit::interpreter::set_force_interpreter(true);
     }
+    // JitOp interpreter backend knob (#1059). The broader force flags win:
+    // --force-interp/JQJIT_FORCE_INTERPRETER pins eval, --force-jit pins
+    // Cranelift, so the env var only takes effect when neither is set.
+    let force_jitop = force_jitop_interp_enabled() && !force_interp && !force_jit;
+    if force_jitop {
+        jq_jit::interpreter::set_force_jitop_interp(true);
+    }
+    // Cranelift-side counterpart (#1059): same routing, compiled backend.
+    let force_cranelift = force_cranelift_enabled() && !force_interp && !force_jit && !force_jitop;
+    if force_cranelift {
+        jq_jit::interpreter::set_force_cranelift(true);
+    }
     // Layer-pinning knob (issue #685). `disable_raw_byte` is consumed
     // locally below where `use_raw_fast_paths` is computed; the simplify
     // knob threads into `interpreter::set_disable_simplify` so the
@@ -2923,6 +2967,14 @@ fn real_main() {
     if force_interp {
         // Self-diff mode (#323) / --force-interp — leave jit_fn empty and
         // let execute / execute_cb take the eval path.
+    } else if force_jitop {
+        // Self-diff mode (#1059) — build the JitOp program instead of
+        // Cranelift-compiling; non-flattenable filters fall back to eval.
+        filter.compile_jitop_program();
+    } else if force_cranelift {
+        // Self-diff mode (#1059) — pin the Cranelift backend regardless of
+        // input-size heuristics; non-flattenable filters fall back to eval.
+        filter.compile_jit();
     } else if force_jit {
         // --force-jit bypasses the heuristics entirely.
         filter.compile_jit();
@@ -3036,6 +3088,8 @@ fn real_main() {
     let use_raw_fast_paths = (use_compact_buf || use_pretty_buf)
         && !color_output
         && !force_interp
+        && !force_jitop
+        && !force_cranelift
         && !disable_raw_byte;
 
     // JQJIT_TRACE: emit a single [trace] line naming the first fast path that

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -26,6 +26,45 @@ pub fn force_interpreter() -> bool {
     FORCE_INTERPRETER.load(std::sync::atomic::Ordering::Relaxed)
 }
 
+/// Self-diff knob for issue #1059: when set, [`Filter::execute`] and
+/// [`Filter::execute_cb`] skip the typed fast path and the Cranelift JIT and
+/// run every flattenable filter on the direct JitOp interpreter backend
+/// ([`crate::jit::JitProgram`]); filters the flattener rejects fall back to
+/// the tree-walking eval path. The binary sets this once at startup when
+/// `JQJIT_FORCE_JITOP_INTERP` is in the environment;
+/// tests/selfdiff_jitop_interp.rs shells out twice — once with it, once
+/// without — and asserts identical output.
+static FORCE_JITOP_INTERP: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+pub fn set_force_jitop_interp(on: bool) {
+    FORCE_JITOP_INTERP.store(on, std::sync::atomic::Ordering::Relaxed);
+}
+
+pub fn force_jitop_interp() -> bool {
+    FORCE_JITOP_INTERP.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+/// Self-diff knob for issue #1059, the Cranelift-side counterpart of
+/// [`force_jitop_interp`]: when set, [`Filter::execute`] and
+/// [`Filter::execute_cb`] skip the typed fast path and run every flattenable
+/// filter on the Cranelift-compiled function; non-flattenable filters fall
+/// back to the tree-walking eval path. Routing is otherwise identical to the
+/// JitOp-interpreter mode, so diffing the two pins the *backends* against
+/// each other over the same lowering with no fast-path asymmetry.
+/// The binary sets this once at startup when `JQJIT_FORCE_CRANELIFT` is in
+/// the environment; see tests/selfdiff_jitop_backend.rs.
+static FORCE_CRANELIFT: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+pub fn set_force_cranelift(on: bool) {
+    FORCE_CRANELIFT.store(on, std::sync::atomic::Ordering::Relaxed);
+}
+
+pub fn force_cranelift() -> bool {
+    FORCE_CRANELIFT.load(std::sync::atomic::Ordering::Relaxed)
+}
+
 /// Layer-pinning knob for issue #685: when set, [`simplify_expr`] returns its
 /// input unchanged, disabling every fast-path-detection rewrite (the (b)
 /// layer in `docs/maintenance.md` §2). Used by
@@ -323,6 +362,9 @@ pub struct Filter {
     jit_fn: Option<crate::jit::JitFilterFn>,
     /// JIT compiler kept alive to own the compiled code.
     _jit_compiler: Option<Box<crate::jit::JitCompiler>>,
+    /// JitOp program for the direct interpreter backend (#1059). Only built
+    /// when `JQJIT_FORCE_JITOP_INTERP` routes execution through it.
+    jit_program: Option<crate::jit::JitProgram>,
     lib_dirs: Vec<String>,
     /// Cached eval environment to avoid re-allocating per call.
     cached_env: std::cell::RefCell<Option<crate::eval::EnvRef>>,
@@ -2535,6 +2577,7 @@ impl Filter {
             simplified,
             jit_fn,
             _jit_compiler: jit_compiler,
+            jit_program: None,
             lib_dirs: lib_dirs.to_vec(),
             cached_env: std::cell::RefCell::new(None),
             memo_slots,
@@ -2602,6 +2645,20 @@ impl Filter {
     /// Returns true if this filter has a JIT-compiled function.
     pub fn has_jit(&self) -> bool {
         self.jit_fn.is_some()
+    }
+
+    /// Build the JitOp program for the direct interpreter backend (#1059).
+    /// Mirrors `compile_jit` but stops at the shared lowering — no Cranelift
+    /// codegen. No-op if the flattener rejects the filter; execution then
+    /// falls back to the tree-walking eval path.
+    pub fn compile_jitop_program(&mut self) {
+        if self.jit_program.is_some() { return; }
+        let (ref expr, ref funcs) = self.parsed;
+        if crate::jit::is_jit_compilable_with_funcs(expr, funcs) {
+            if let Ok(prog) = crate::jit::JitProgram::compile(expr, funcs) {
+                self.jit_program = Some(prog);
+            }
+        }
     }
 
     /// Returns true if this filter has loop constructs that benefit from JIT.
@@ -11551,18 +11608,28 @@ impl Filter {
     /// Execute the filter against an input value, collecting all results.
     pub fn execute(&self, input: &Value) -> Result<Vec<Value>> {
         let forced = force_interpreter();
+        let forced_jitop = force_jitop_interp();
+        let forced_cranelift = force_cranelift();
         // Typed fast path (issue #83): probed ahead of JIT / eval. Only
         // migrated filter shapes return `Some`; every other shape or
         // unhandled input type returns `None` and falls through to the
         // authoritative generic path below.
-        if !forced {
+        if !forced && !forced_jitop && !forced_cranelift {
             if let Some(verdict) = self.try_typed_fast_path(input) {
                 return verdict.map(|v| vec![v]);
             }
         }
 
+        // JitOp interpreter backend (#1059): forced mode routes every
+        // program-compilable filter through the direct interpreter.
+        if forced_jitop {
+            if let Some(ref prog) = self.jit_program {
+                return crate::jit::execute_program(prog, input);
+            }
+        }
+
         // Try JIT execution first
-        if !forced {
+        if !forced && !forced_jitop {
             if let Some(jit_fn) = self.jit_fn {
                 return crate::jit::execute_jit(jit_fn, input);
             }
@@ -11597,18 +11664,27 @@ impl Filter {
     /// Returns Ok(true) if all values were processed, Ok(false) if stopped early.
     pub fn execute_cb(&self, input: &Value, cb: &mut dyn FnMut(&Value) -> Result<bool>) -> Result<bool> {
         let forced = force_interpreter();
+        let forced_jitop = force_jitop_interp();
+        let forced_cranelift = force_cranelift();
         // Typed fast path (issue #83) — see `execute` for rationale. The
         // current pilot emits a single value, so hitting it closes out the
         // generator: we invoke `cb` once with the verdict and return its
         // continue/stop decision to the caller.
-        if !forced {
+        if !forced && !forced_jitop && !forced_cranelift {
             if let Some(verdict) = self.try_typed_fast_path(input) {
                 let val = verdict?;
                 return cb(&val);
             }
         }
 
-        if !forced {
+        // JitOp interpreter backend (#1059) — see `execute` for rationale.
+        if forced_jitop {
+            if let Some(ref prog) = self.jit_program {
+                return crate::jit::execute_program_cb(prog, input, cb);
+            }
+        }
+
+        if !forced && !forced_jitop {
             if let Some(jit_fn) = self.jit_fn {
                 return crate::jit::execute_jit_cb(jit_fn, input, cb);
             }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -9,60 +9,68 @@ use anyhow::Result;
 use crate::ir::{BuiltinOp, CompiledFunc};
 use crate::value::Value;
 
-/// Self-diff knob for issue #323: when set, [`Filter::execute`] and
-/// [`Filter::execute_cb`] skip the typed fast path and JIT and run the generic
-/// tree-walking interpreter, regardless of whether `compile_jit` was called.
-/// The binary sets this once at startup when `JQJIT_FORCE_INTERPRETER` is in
-/// the environment; tests/selfdiff_jit_interp.rs shells out twice — once with it,
-/// once without — and asserts identical output.
-static FORCE_INTERPRETER: std::sync::atomic::AtomicBool =
-    std::sync::atomic::AtomicBool::new(false);
+/// Forced-execution-mode bits, packed into a single atomic so the
+/// per-record [`Filter::execute`] / [`Filter::execute_cb`] paths pay one
+/// relaxed load regardless of how many force knobs exist (the ~55ns/record
+/// NDJSON loops notice every extra load — see the classified-boundary-scan
+/// notes in docs/maintenance.md).
+///
+/// - `FORCE_EVAL_BIT` — self-diff knob for issue #323
+///   (`JQJIT_FORCE_INTERPRETER`): skip the typed fast path and JIT and run
+///   the generic tree-walking interpreter, regardless of whether
+///   `compile_jit` was called. See tests/selfdiff_jit_interp.rs.
+/// - `FORCE_JITOP_BIT` — self-diff knob for issue #1059
+///   (`JQJIT_FORCE_JITOP_INTERP`): skip the typed fast path and the
+///   Cranelift JIT and run every flattenable filter on the direct JitOp
+///   interpreter backend ([`crate::jit::JitProgram`]); filters the
+///   flattener rejects fall back to the tree-walking eval path.
+/// - `FORCE_CRANELIFT_BIT` — the Cranelift-side counterpart
+///   (`JQJIT_FORCE_CRANELIFT`): identical routing, compiled backend.
+///   Diffing the two pins the *backends* against each other over the same
+///   lowering with no fast-path asymmetry. See
+///   tests/selfdiff_jitop_backend.rs.
+///
+/// The binary sets these once at startup from the environment / CLI flags.
+const FORCE_EVAL_BIT: u8 = 1;
+const FORCE_JITOP_BIT: u8 = 2;
+const FORCE_CRANELIFT_BIT: u8 = 4;
+
+static FORCED_MODE: std::sync::atomic::AtomicU8 = std::sync::atomic::AtomicU8::new(0);
+
+fn set_forced_mode_bit(bit: u8, on: bool) {
+    if on {
+        FORCED_MODE.fetch_or(bit, std::sync::atomic::Ordering::Relaxed);
+    } else {
+        FORCED_MODE.fetch_and(!bit, std::sync::atomic::Ordering::Relaxed);
+    }
+}
+
+fn forced_mode() -> u8 {
+    FORCED_MODE.load(std::sync::atomic::Ordering::Relaxed)
+}
 
 pub fn set_force_interpreter(on: bool) {
-    FORCE_INTERPRETER.store(on, std::sync::atomic::Ordering::Relaxed);
+    set_forced_mode_bit(FORCE_EVAL_BIT, on);
 }
 
 pub fn force_interpreter() -> bool {
-    FORCE_INTERPRETER.load(std::sync::atomic::Ordering::Relaxed)
+    forced_mode() & FORCE_EVAL_BIT != 0
 }
 
-/// Self-diff knob for issue #1059: when set, [`Filter::execute`] and
-/// [`Filter::execute_cb`] skip the typed fast path and the Cranelift JIT and
-/// run every flattenable filter on the direct JitOp interpreter backend
-/// ([`crate::jit::JitProgram`]); filters the flattener rejects fall back to
-/// the tree-walking eval path. The binary sets this once at startup when
-/// `JQJIT_FORCE_JITOP_INTERP` is in the environment;
-/// tests/selfdiff_jitop_interp.rs shells out twice — once with it, once
-/// without — and asserts identical output.
-static FORCE_JITOP_INTERP: std::sync::atomic::AtomicBool =
-    std::sync::atomic::AtomicBool::new(false);
-
 pub fn set_force_jitop_interp(on: bool) {
-    FORCE_JITOP_INTERP.store(on, std::sync::atomic::Ordering::Relaxed);
+    set_forced_mode_bit(FORCE_JITOP_BIT, on);
 }
 
 pub fn force_jitop_interp() -> bool {
-    FORCE_JITOP_INTERP.load(std::sync::atomic::Ordering::Relaxed)
+    forced_mode() & FORCE_JITOP_BIT != 0
 }
 
-/// Self-diff knob for issue #1059, the Cranelift-side counterpart of
-/// [`force_jitop_interp`]: when set, [`Filter::execute`] and
-/// [`Filter::execute_cb`] skip the typed fast path and run every flattenable
-/// filter on the Cranelift-compiled function; non-flattenable filters fall
-/// back to the tree-walking eval path. Routing is otherwise identical to the
-/// JitOp-interpreter mode, so diffing the two pins the *backends* against
-/// each other over the same lowering with no fast-path asymmetry.
-/// The binary sets this once at startup when `JQJIT_FORCE_CRANELIFT` is in
-/// the environment; see tests/selfdiff_jitop_backend.rs.
-static FORCE_CRANELIFT: std::sync::atomic::AtomicBool =
-    std::sync::atomic::AtomicBool::new(false);
-
 pub fn set_force_cranelift(on: bool) {
-    FORCE_CRANELIFT.store(on, std::sync::atomic::Ordering::Relaxed);
+    set_forced_mode_bit(FORCE_CRANELIFT_BIT, on);
 }
 
 pub fn force_cranelift() -> bool {
-    FORCE_CRANELIFT.load(std::sync::atomic::Ordering::Relaxed)
+    forced_mode() & FORCE_CRANELIFT_BIT != 0
 }
 
 /// Layer-pinning knob for issue #685: when set, [`simplify_expr`] returns its
@@ -11607,9 +11615,10 @@ impl Filter {
 
     /// Execute the filter against an input value, collecting all results.
     pub fn execute(&self, input: &Value) -> Result<Vec<Value>> {
-        let forced = force_interpreter();
-        let forced_jitop = force_jitop_interp();
-        let forced_cranelift = force_cranelift();
+        let mode = forced_mode();
+        let forced = mode & FORCE_EVAL_BIT != 0;
+        let forced_jitop = mode & FORCE_JITOP_BIT != 0;
+        let forced_cranelift = mode & FORCE_CRANELIFT_BIT != 0;
         // Typed fast path (issue #83): probed ahead of JIT / eval. Only
         // migrated filter shapes return `Some`; every other shape or
         // unhandled input type returns `None` and falls through to the
@@ -11663,9 +11672,10 @@ impl Filter {
     /// Execute the filter with a callback for each result (avoids Vec allocation).
     /// Returns Ok(true) if all values were processed, Ok(false) if stopped early.
     pub fn execute_cb(&self, input: &Value, cb: &mut dyn FnMut(&Value) -> Result<bool>) -> Result<bool> {
-        let forced = force_interpreter();
-        let forced_jitop = force_jitop_interp();
-        let forced_cranelift = force_cranelift();
+        let mode = forced_mode();
+        let forced = mode & FORCE_EVAL_BIT != 0;
+        let forced_jitop = mode & FORCE_JITOP_BIT != 0;
+        let forced_cranelift = mode & FORCE_CRANELIFT_BIT != 0;
         // Typed fast path (issue #83) — see `execute` for rationale. The
         // current pilot emits a single value, so hitting it closes out the
         // generator: we invoke `cb` once with the verdict and return its

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -9136,6 +9136,66 @@ fn optimize_clone_yield(mut ops: Vec<JitOp>) -> Vec<JitOp> {
     ops
 }
 
+/// Outcome of the shared Expr -> JitOp lowering (`flatten_filter`): the
+/// linear op sequence plus the resource counts both backends need to set up
+/// an execution frame (value slots, i64/f64 vars, jump labels).
+struct FlattenedFilter {
+    ops: Vec<JitOp>,
+    num_slots: SlotId,
+    num_vars: u32,
+    num_labels: LabelId,
+    /// Hoisted constants referenced by raw pointer from `LoadConst` /
+    /// `FieldBinopConst` ops inside `ops`; must outlive any execution.
+    value_constants: Vec<Box<Value>>,
+}
+
+/// Shared lowering for both execution backends (Cranelift codegen and the
+/// direct JitOp interpreter, #1059): inline function calls, flatten to the
+/// linear JitOp sequence, publish closure ops for runtime delegation, and
+/// run the clone+yield peephole pass.
+fn flatten_filter(expr: &Expr, funcs: &[CompiledFunc]) -> Result<FlattenedFilter> {
+    let mut fl = Flattener::new();
+    fl.funcs = funcs.to_vec();
+    // Pre-inline function calls and apply semantic optimizations.
+    // Always run to catch to_entries|from_entries and similar rewrites.
+    let inlined = fl.inline_func_calls(expr);
+    // Recursive def left an un-inlined FuncCall in the tree. The JIT
+    // can't safely emit a recursive call (no host-stack management),
+    // and pressing on would produce a partial code path that returns
+    // garbage. Bail so the binary falls back to eval, which already
+    // handles recursion via `stacker::maybe_grow` (#648).
+    if fl.has_unresolved_recursion {
+        bail!("Expression not JIT-compilable: contains recursive function call");
+    }
+    let input_slot = fl.alloc_slot(); // slot 0 = input ptr (read-only, owned by caller)
+    // Use input_slot directly — flatten_gen only reads it, never writes/drops it.
+    // Both backends handle Drop{slot:0} as a no-op.
+    if !fl.flatten_gen(&inlined, input_slot) {
+        bail!("Expression not JIT-compilable");
+    }
+    // Sub-trees can request a JIT bailout mid-flatten (e.g. a reduce
+    // source whose `flatten_gen_with_each_output` would silently emit
+    // no loop body — see #683 and the Reduce arm in flatten_scalar).
+    // Bail here so the binary falls back to the interpreter.
+    if fl.has_unresolved_recursion {
+        bail!("Expression not JIT-compilable: subtree requested bailout");
+    }
+    fl.emit(JitOp::ReturnContinue);
+
+    // Store closure ops for runtime access
+    if !fl.closure_ops.is_empty() {
+        JIT_CLOSURE_OPS.with(|cell| unsafe { *cell.get() = fl.closure_ops.clone(); });
+    }
+
+    Ok(FlattenedFilter {
+        ops: optimize_clone_yield(fl.ops),
+        num_slots: fl.next_slot,
+        num_vars: fl.next_var,
+        num_labels: fl.next_label,
+        value_constants: fl.value_constants,
+    })
+}
+
 pub struct JitCompiler {
     module: JITModule,
     ctx: cranelift_codegen::Context,
@@ -9260,47 +9320,14 @@ impl JitCompiler {
     }
 
     pub fn compile_with_funcs(&mut self, expr: &Expr, funcs: &[CompiledFunc]) -> Result<JitFilterFn> {
-        // Phase 1: Flatten
-        let mut fl = Flattener::new();
-        fl.funcs = funcs.to_vec();
-        // Pre-inline function calls and apply semantic optimizations.
-        // Always run to catch to_entries|from_entries and similar rewrites.
-        let inlined = fl.inline_func_calls(expr);
-        // Recursive def left an un-inlined FuncCall in the tree. The JIT
-        // can't safely emit a recursive call (no host-stack management),
-        // and pressing on would produce a partial code path that returns
-        // garbage. Bail so the binary falls back to eval, which already
-        // handles recursion via `stacker::maybe_grow` (#648).
-        if fl.has_unresolved_recursion {
-            bail!("Expression not JIT-compilable: contains recursive function call");
-        }
-        let compile_expr = &inlined;
-        let input_slot = fl.alloc_slot(); // slot 0 = input ptr (read-only, owned by caller)
-        // Use input_slot directly — flatten_gen only reads it, never writes/drops it.
-        // The codegen handles Drop{slot:0} as a no-op.
-        if !fl.flatten_gen(compile_expr, input_slot) {
-            bail!("Expression not JIT-compilable");
-        }
-        // Sub-trees can request a JIT bailout mid-flatten (e.g. a reduce
-        // source whose `flatten_gen_with_each_output` would silently emit
-        // no loop body — see #683 and the Reduce arm in flatten_scalar).
-        // Bail here so the binary falls back to the interpreter.
-        if fl.has_unresolved_recursion {
-            bail!("Expression not JIT-compilable: subtree requested bailout");
-        }
-        fl.emit(JitOp::ReturnContinue);
-
-        // Store closure ops for runtime access
-        if !fl.closure_ops.is_empty() {
-            JIT_CLOSURE_OPS.with(|cell| unsafe { *cell.get() = fl.closure_ops.clone(); });
-        }
-
-        let ops = optimize_clone_yield(fl.ops);
-        let num_slots = fl.next_slot;
-        let num_vars = fl.next_var;
-        let num_labels = fl.next_label;
+        // Phase 1: Flatten (shared with the JitOp interpreter backend)
+        let flat = flatten_filter(expr, funcs)?;
+        let ops = flat.ops;
+        let num_slots = flat.num_slots;
+        let num_vars = flat.num_vars;
+        let num_labels = flat.num_labels;
         // Transfer hoisted value constants to compiler lifetime
-        self._value_constants.extend(fl.value_constants);
+        self._value_constants.extend(flat.value_constants);
 
         // Phase 2: Cranelift codegen
         let ptr_ty = types::I64;
@@ -10789,13 +10816,17 @@ fn with_jit_env<R>(f: impl FnOnce(&mut JitEnv) -> R) -> R {
 }
 
 
-pub fn execute_jit(func: JitFilterFn, input: &Value) -> Result<Vec<Value>> {
+/// Raw generator callback shared by every filter backend.
+type RawYieldCb = unsafe extern "C" fn(*const Value, *mut u8) -> i64;
+
+/// Shared non-streaming driver: run a filter backend (compiled function or
+/// JitOp interpreter) against the collect callback and convert the terminal
+/// status into the legacy `Vec<Value>` shape.
+fn execute_collect(run: impl FnOnce(&mut JitEnv, RawYieldCb, *mut u8) -> i64) -> Result<Vec<Value>> {
     with_jit_env(|env| {
         let mut results: Vec<Value> = Vec::new();
-        let result = unsafe {
-            func(input as *const Value, env, collect_callback,
-                 &mut results as *mut Vec<Value> as *mut u8)
-        };
+        let ctx = &mut results as *mut Vec<Value> as *mut u8;
+        let result = run(env, collect_callback, ctx);
         if result == GEN_ERROR {
             // This non-streaming entry returns errors as Value::Error, a
             // string-shaped channel — keep the legacy text until the
@@ -10807,6 +10838,10 @@ pub fn execute_jit(func: JitFilterFn, input: &Value) -> Result<Vec<Value>> {
         }
         Ok(results)
     })
+}
+
+pub fn execute_jit(func: JitFilterFn, input: &Value) -> Result<Vec<Value>> {
+    execute_collect(|env, cb, ctx| unsafe { func(input as *const Value, env, cb, ctx) })
 }
 
 /// Streaming callback context for execute_jit_cb.
@@ -10834,8 +10869,10 @@ unsafe extern "C" fn stream_callback(value: *const Value, ctx: *mut u8) -> i64 {
     }
 }
 
-/// Execute JIT filter with streaming callback (avoids Vec allocation).
-pub fn execute_jit_cb(func: JitFilterFn, input: &Value, cb: &mut dyn FnMut(&Value) -> Result<bool>) -> Result<bool> {
+/// Shared streaming driver: run a filter backend (compiled function or JitOp
+/// interpreter) with a per-value callback, avoiding the Vec allocation.
+fn execute_stream(run: impl FnOnce(&mut JitEnv, RawYieldCb, *mut u8) -> i64,
+                  cb: &mut dyn FnMut(&Value) -> Result<bool>) -> Result<bool> {
     with_jit_env(|env| {
         // Store the fat pointer as raw bytes to avoid lifetime issues.
         // Safety: sctx lives only within this scope, same as cb.
@@ -10847,10 +10884,7 @@ pub fn execute_jit_cb(func: JitFilterFn, input: &Value, cb: &mut dyn FnMut(&Valu
             had_error: false,
             error: None,
         };
-        let result = unsafe {
-            func(input as *const Value, env, stream_callback,
-                 &mut sctx as *mut StreamCtx as *mut u8)
-        };
+        let result = run(env, stream_callback, &mut sctx as *mut StreamCtx as *mut u8);
         if sctx.had_error {
             if let Some(e) = sctx.error {
                 return Err(e);
@@ -10863,6 +10897,505 @@ pub fn execute_jit_cb(func: JitFilterFn, input: &Value, cb: &mut dyn FnMut(&Valu
         }
         Ok(true)
     })
+}
+
+/// Execute JIT filter with streaming callback (avoids Vec allocation).
+pub fn execute_jit_cb(func: JitFilterFn, input: &Value, cb: &mut dyn FnMut(&Value) -> Result<bool>) -> Result<bool> {
+    execute_stream(|env, raw_cb, ctx| unsafe { func(input as *const Value, env, raw_cb, ctx) }, cb)
+}
+
+// ============================================================================
+// JitOp direct interpreter (#1059 Phase 1)
+//
+// A switch-loop backend over the same linear JitOp sequence the Cranelift
+// codegen consumes. Both backends share the lowering (`flatten_filter`) and
+// the runtime helpers (`jit_rt_*`), so the semantics of every op are defined
+// in exactly one place; the codegen's inline fast paths (trivial clone/drop,
+// Num+Num arithmetic, null field access) are pure shortcuts of the same
+// helper semantics and are simply not replicated here.
+// ============================================================================
+
+/// A flattened filter ready for direct interpretation: the JitOp sequence
+/// plus a label -> op-index table.
+pub struct JitProgram {
+    ops: Vec<JitOp>,
+    num_slots: SlotId,
+    num_vars: u32,
+    /// LabelId -> index of its `Label` op in `ops`. Jumps land on the Label
+    /// op itself (a no-op for the interpreter).
+    label_pc: Vec<usize>,
+    /// Keeps the `LoadConst` / `FieldBinopConst` pointer targets inside
+    /// `ops` alive for the lifetime of the program.
+    _value_constants: Vec<Box<Value>>,
+}
+
+impl JitProgram {
+    /// Lower an expression to a directly interpretable JitOp program.
+    /// Fails for exactly the shapes `JitCompiler::compile_with_funcs`
+    /// rejects — the two backends share `flatten_filter`.
+    pub fn compile(expr: &Expr, funcs: &[CompiledFunc]) -> Result<JitProgram> {
+        let flat = flatten_filter(expr, funcs)?;
+        let mut label_pc = vec![usize::MAX; flat.num_labels as usize];
+        for (i, op) in flat.ops.iter().enumerate() {
+            if let JitOp::Label { id } = op {
+                label_pc[*id as usize] = i;
+            }
+        }
+        // Every label referenced by a branch must have been emitted —
+        // jumping to an unemitted label would silently fall off the end of
+        // the program instead of failing loudly. (Allocated-but-unreferenced
+        // labels are fine; the codegen tolerates those too.)
+        {
+            let check = |l: LabelId| -> Result<()> {
+                if label_pc[l as usize] == usize::MAX {
+                    bail!("JitOp program references unemitted label {}", l);
+                }
+                Ok(())
+            };
+            for op in &flat.ops {
+                match op {
+                    JitOp::IfTruthy { then_label, else_label, .. }
+                    | JitOp::TypeCmpBranch { then_label, else_label, .. } => {
+                        check(*then_label)?;
+                        check(*else_label)?;
+                    }
+                    JitOp::Jump { label }
+                    | JitOp::JumpIfError { label } => check(*label)?,
+                    JitOp::BranchKind { arr_label, obj_label, other_label, .. } => {
+                        check(*arr_label)?;
+                        check(*obj_label)?;
+                        check(*other_label)?;
+                    }
+                    JitOp::LoopCheck { body_label, done_label, .. } => {
+                        check(*body_label)?;
+                        check(*done_label)?;
+                    }
+                    JitOp::BranchOnVar { nonzero_label, zero_label, .. } => {
+                        check(*nonzero_label)?;
+                        check(*zero_label)?;
+                    }
+                    JitOp::CheckError { catch_label, .. } => check(*catch_label)?,
+                    _ => {}
+                }
+            }
+        }
+        Ok(JitProgram {
+            ops: flat.ops,
+            num_slots: flat.num_slots,
+            num_vars: flat.num_vars,
+            label_pc,
+            _value_constants: flat.value_constants,
+        })
+    }
+
+    /// Execute the program. Same contract as a compiled `JitFilterFn`:
+    /// yields each output through `cb`, returns `GEN_CONTINUE` on normal
+    /// completion, the callback's verdict when it stops the stream, or
+    /// `GEN_ERROR` with the error transferred to `env.error`.
+    ///
+    /// Slot discipline mirrors the compiled stack frame: writes are
+    /// `ptr::write` (never dropping the previous occupant) and `Drop` ops
+    /// are the only deallocation points, so the buffer must not run element
+    /// destructors on exit. Null-initialization keeps never-written slots
+    /// valid; the flattener guarantees write-before-read for everything it
+    /// emits.
+    fn run(&self, input: &Value, env: &mut JitEnv, cb: RawYieldCb, ctx: *mut u8) -> i64 {
+        use std::mem::MaybeUninit;
+
+        let mut slots: Vec<MaybeUninit<Value>> = (0..self.num_slots)
+            .map(|_| MaybeUninit::new(Value::Null))
+            .collect();
+        let mut vars: Vec<i64> = vec![0; self.num_vars as usize];
+        let env_ptr: *mut JitEnv = env;
+
+        let slots_ptr = slots.as_mut_ptr();
+        let input_ptr = input as *const Value as *mut Value;
+        // Slot 0 aliases the caller's input (read-only by flattener
+        // contract); slots 1.. point into the frame buffer.
+        let sp = move |s: SlotId| -> *mut Value {
+            if s == 0 { input_ptr } else { unsafe { (*slots_ptr.add(s as usize)).as_mut_ptr() } }
+        };
+        let lp = |l: LabelId| -> usize { self.label_pc[l as usize] };
+        let fbits = |v: i64| -> f64 { f64::from_bits(v as u64) };
+        let tbits = |v: f64| -> i64 { v.to_bits() as i64 };
+
+        let ops = &self.ops;
+        let mut pc = 0usize;
+        while pc < ops.len() {
+            match &ops[pc] {
+                JitOp::Clone { dst, src } => jit_rt_clone(sp(*dst), sp(*src)),
+                JitOp::LoadConst { dst, const_ptr } => jit_rt_clone(sp(*dst), *const_ptr),
+                JitOp::Drop { slot } => {
+                    if *slot != 0 { jit_rt_drop(sp(*slot)); }
+                }
+                JitOp::Null { dst } => unsafe { std::ptr::write(sp(*dst), Value::Null) },
+                JitOp::True { dst } => unsafe { std::ptr::write(sp(*dst), Value::True) },
+                JitOp::False { dst } => unsafe { std::ptr::write(sp(*dst), Value::False) },
+                JitOp::Num { dst, val, repr } => {
+                    let v = match repr {
+                        Some(r) => Value::number_with_repr(*val, r.clone()),
+                        None => Value::number(*val),
+                    };
+                    unsafe { std::ptr::write(sp(*dst), v) }
+                }
+                JitOp::Str { dst, val } => unsafe {
+                    std::ptr::write(sp(*dst), Value::Str(crate::value::KeyStr::from(val.as_str())))
+                },
+                JitOp::Index { dst, base, key } => {
+                    jit_rt_index(sp(*dst), sp(*base), sp(*key));
+                }
+                JitOp::IndexField { dst, base, field } => {
+                    jit_rt_index_field(sp(*dst), sp(*base), field.as_ptr(), field.len());
+                }
+                JitOp::BinOp { dst, op, lhs, rhs } => {
+                    jit_rt_binop(sp(*dst), binop_to_i32(*op), sp(*lhs), sp(*rhs));
+                }
+                JitOp::AddMove { dst, lhs, rhs } => {
+                    jit_rt_add_move(sp(*dst), sp(*lhs), sp(*rhs));
+                }
+                JitOp::FieldBinopField { dst, base, field_a, field_b, op } => {
+                    jit_rt_field_binop_field(
+                        sp(*dst), sp(*base),
+                        field_a.as_ptr(), field_a.len(),
+                        field_b.as_ptr(), field_b.len(),
+                        *op,
+                    );
+                }
+                JitOp::FieldBinopConst { dst, base, field, const_ptr, op, field_is_lhs } => {
+                    jit_rt_field_binop_const(
+                        sp(*dst), sp(*base),
+                        field.as_ptr(), field.len(),
+                        *const_ptr, *op, *field_is_lhs as i32,
+                    );
+                }
+                JitOp::UnaryOp { dst, op, src } => {
+                    jit_rt_unaryop(sp(*dst), unaryop_to_i32(*op), sp(*src));
+                }
+                JitOp::Negate { dst, src } => {
+                    // Mirror the codegen's inline Num path: `0.0 - x`
+                    // normalizes -0 to +0 (#919) and drops any literal repr,
+                    // exactly like the compiled fast path. Non-Num inputs
+                    // take the runtime helper.
+                    let neg = match unsafe { &*sp(*src) } {
+                        Value::Num(n, _) => Some(0.0 - *n),
+                        _ => None,
+                    };
+                    match neg {
+                        Some(n) => unsafe { std::ptr::write(sp(*dst), Value::number(n)) },
+                        None => { jit_rt_negate(sp(*dst), sp(*src)); }
+                    }
+                }
+                JitOp::Not { dst, src } => {
+                    jit_rt_not(sp(*dst), sp(*src));
+                }
+                JitOp::Yield { output } => {
+                    let r = unsafe { cb(sp(*output), ctx) };
+                    if r <= 0 { return r; }
+                }
+                JitOp::YieldFieldRef { base, field } => {
+                    let r = jit_rt_yield_field_ref(sp(*base), field.as_ptr(), field.len(), cb, ctx);
+                    if r <= 0 { return r; }
+                }
+                JitOp::IfTruthy { src, then_label, else_label } => {
+                    let truthy = unsafe { (*sp(*src)).is_truthy() };
+                    pc = lp(if truthy { *then_label } else { *else_label });
+                    continue;
+                }
+                JitOp::FieldIsTruthy { base, field, dst_var } => {
+                    vars[*dst_var as usize] =
+                        jit_rt_field_is_truthy(sp(*base), field.as_ptr(), field.len());
+                }
+                JitOp::FieldCmpNum { base, field, value, op, dst_var } => {
+                    vars[*dst_var as usize] =
+                        jit_rt_field_cmp_num(sp(*base), field.as_ptr(), field.len(), *value, *op);
+                }
+                JitOp::TypeCmpBranch { src, tags, then_label, else_label } => {
+                    // Same tag-bitmask test as the codegen: bit N of `tags`
+                    // matches Value discriminant byte N.
+                    let tag = unsafe { *(sp(*src) as *const u8) };
+                    let hit = (1u64 << (tag as u32 & 63)) & (*tags as u64) != 0;
+                    pc = lp(if hit { *then_label } else { *else_label });
+                    continue;
+                }
+                JitOp::Jump { label } => {
+                    pc = lp(*label);
+                    continue;
+                }
+                JitOp::Label { .. } => {}
+                JitOp::GetKind { dst_var, src } => {
+                    vars[*dst_var as usize] = jit_rt_kind(sp(*src));
+                }
+                JitOp::GetLen { dst_var, src } => {
+                    vars[*dst_var as usize] = jit_rt_len(sp(*src));
+                }
+                JitOp::BranchKind { kind_var, arr_label, obj_label, other_label } => {
+                    pc = lp(match vars[*kind_var as usize] {
+                        5 => *arr_label,
+                        6 => *obj_label,
+                        _ => *other_label,
+                    });
+                    continue;
+                }
+                JitOp::LoopCheck { idx_var, len_var, body_label, done_label } => {
+                    let go = vars[*idx_var as usize] < vars[*len_var as usize];
+                    pc = lp(if go { *body_label } else { *done_label });
+                    continue;
+                }
+                JitOp::ArrayGet { dst, arr, idx_var } => {
+                    jit_rt_array_get(sp(*dst), sp(*arr), vars[*idx_var as usize]);
+                }
+                JitOp::ObjGetByIdx { dst, obj, idx_var } => {
+                    jit_rt_obj_get_idx(sp(*dst), sp(*obj), vars[*idx_var as usize]);
+                }
+                JitOp::IncVar { var } => {
+                    vars[*var as usize] += 1;
+                }
+                JitOp::InitVar { var } => {
+                    vars[*var as usize] = 0;
+                }
+                JitOp::GetVar { dst, var_index } => {
+                    jit_rt_get_var(sp(*dst), env_ptr, u32::from(var_index.0));
+                }
+                JitOp::SetVar { var_index, src } => {
+                    jit_rt_set_var(env_ptr, u32::from(var_index.0), sp(*src));
+                }
+                JitOp::TakeVar { dst, var_index } => {
+                    jit_rt_take_var(sp(*dst), env_ptr, u32::from(var_index.0));
+                }
+                JitOp::MoveToVar { var_index, src } => {
+                    jit_rt_move_to_var(env_ptr, u32::from(var_index.0), sp(*src));
+                }
+                JitOp::PathExtract { element, container, key } => {
+                    // Errors surface via env.error_flag; the flattener
+                    // auto-attaches CheckError/JumpIfError after fallible ops.
+                    jit_rt_path_extract(sp(*element), sp(*container), sp(*key));
+                }
+                JitOp::PathInsert { container, key, val } => {
+                    jit_rt_path_insert(sp(*container), sp(*key), sp(*val));
+                }
+                JitOp::TakeByIdx { dst, container, idx_var } => {
+                    jit_rt_take_by_idx(sp(*dst), sp(*container), vars[*idx_var as usize]);
+                }
+                JitOp::PutByIdx { container, idx_var, val } => {
+                    jit_rt_put_by_idx(sp(*container), vars[*idx_var as usize], sp(*val));
+                }
+                JitOp::SetPathMut { container, path, val } => {
+                    jit_rt_setpath_mut(sp(*container), sp(*path), sp(*val));
+                }
+                JitOp::CollectBegin => jit_rt_collect_begin(env_ptr),
+                JitOp::CollectPush { src } => jit_rt_collect_push(env_ptr, sp(*src)),
+                JitOp::CollectFinish { dst } => jit_rt_collect_finish(sp(*dst), env_ptr),
+                JitOp::ObjNew { dst, cap } => jit_rt_obj_new(sp(*dst), *cap as usize),
+                JitOp::ObjInsert { obj, key, val } => {
+                    let status = jit_rt_obj_insert(sp(*obj), sp(*key), sp(*val));
+                    if status != 0 {
+                        jit_rt_propagate_error(env_ptr);
+                        return GEN_ERROR;
+                    }
+                }
+                JitOp::ObjInsertStrKey { obj, key, val } => {
+                    jit_rt_obj_insert_str_key(sp(*obj), key.as_ptr(), key.len(), sp(*val));
+                }
+                JitOp::ObjPushStrKey { obj, key, val } => {
+                    jit_rt_obj_push_str_key(sp(*obj), key.as_ptr(), key.len(), sp(*val));
+                }
+                JitOp::ObjCopyField { obj, src, obj_key, src_field } => {
+                    jit_rt_obj_copy_field(
+                        sp(*obj), sp(*src),
+                        obj_key.as_ptr(), obj_key.len(),
+                        src_field.as_ptr(), src_field.len(),
+                    );
+                }
+                JitOp::ObjFromFields { dst, src, pairs } => {
+                    let table: Vec<(*const u8, usize, *const u8, usize)> = pairs.iter()
+                        .map(|(ok, sf)| (ok.as_ptr(), ok.len(), sf.as_ptr(), sf.len()))
+                        .collect();
+                    jit_rt_obj_from_fields(sp(*dst), sp(*src), table.as_ptr(), table.len());
+                }
+                JitOp::IsNullOrFalse { dst_var, src } => {
+                    vars[*dst_var as usize] = jit_rt_is_null_or_false(sp(*src));
+                }
+                JitOp::BranchOnVar { var, nonzero_label, zero_label } => {
+                    let nz = vars[*var as usize] != 0;
+                    pc = lp(if nz { *nonzero_label } else { *zero_label });
+                    continue;
+                }
+                JitOp::ToF64Var { dst_var, src } => {
+                    vars[*dst_var as usize] = tbits(jit_rt_to_f64(sp(*src)));
+                }
+                JitOp::F64Less { dst_var, a_var, b_var } => {
+                    let r = fbits(vars[*a_var as usize]) < fbits(vars[*b_var as usize]);
+                    vars[*dst_var as usize] = r as i64;
+                }
+                JitOp::F64Equal { dst_var, a_var, b_var } => {
+                    // Ordered equality: a NaN operand yields 0 (flags a NaN
+                    // limit count), matching the codegen's fcmp Equal.
+                    let r = fbits(vars[*a_var as usize]) == fbits(vars[*b_var as usize]);
+                    vars[*dst_var as usize] = r as i64;
+                }
+                JitOp::F64Add { dst_var, a_var, b_var } => {
+                    vars[*dst_var as usize] = tbits(fbits(vars[*a_var as usize]) + fbits(vars[*b_var as usize]));
+                }
+                JitOp::F64Sub { dst_var, a_var, b_var } => {
+                    vars[*dst_var as usize] = tbits(fbits(vars[*a_var as usize]) - fbits(vars[*b_var as usize]));
+                }
+                JitOp::F64Mul { dst_var, a_var, b_var } => {
+                    vars[*dst_var as usize] = tbits(fbits(vars[*a_var as usize]) * fbits(vars[*b_var as usize]));
+                }
+                JitOp::F64Div { dst_var, a_var, b_var } => {
+                    vars[*dst_var as usize] = tbits(fbits(vars[*a_var as usize]) / fbits(vars[*b_var as usize]));
+                }
+                JitOp::F64Rem { dst_var, a_var, b_var } => {
+                    // jq's `%` truncates both operands toward zero before the
+                    // remainder (#183) — same formula as the codegen:
+                    // trunc(a) - trunc(trunc(a)/trunc(b)) * trunc(b).
+                    let a_t = fbits(vars[*a_var as usize]).trunc();
+                    let b_t = fbits(vars[*b_var as usize]).trunc();
+                    let q = (a_t / b_t).trunc();
+                    vars[*dst_var as usize] = tbits(a_t - q * b_t);
+                }
+                JitOp::F64Neg { dst_var, src_var } => {
+                    vars[*dst_var as usize] = tbits(-fbits(vars[*src_var as usize]));
+                }
+                JitOp::F64Math { dst_var, src_var, kind } => {
+                    let x = fbits(vars[*src_var as usize]);
+                    let r = match kind {
+                        0 => x.floor(),
+                        1 => x.ceil(),
+                        2 => x.sqrt(),
+                        3 => x.abs(),
+                        4 => x.trunc(),
+                        5 => x.round_ties_even(),
+                        _ => unreachable!(),
+                    };
+                    vars[*dst_var as usize] = tbits(r);
+                }
+                JitOp::F64Libm { dst_var, src_var, func } => {
+                    let x = fbits(vars[*src_var as usize]);
+                    let r = match func {
+                        0 => sys_sin(x), 1 => sys_cos(x), 2 => sys_tan(x),
+                        3 => sys_asin(x), 4 => sys_acos(x), 5 => sys_atan(x),
+                        6 => sys_exp(x), 7 => sys_exp2(x),
+                        8 => sys_log(x), 9 => sys_log2(x), 10 => sys_log10(x),
+                        11 => sys_cbrt(x),
+                        _ => unreachable!(),
+                    };
+                    vars[*dst_var as usize] = tbits(r);
+                }
+                JitOp::F64Cmp { dst_var, a_var, b_var, cc } => {
+                    let a = fbits(vars[*a_var as usize]);
+                    let b = fbits(vars[*b_var as usize]);
+                    // Ordering (cc 0-3) follows jq's sort total order — NaN
+                    // ranks below every number (#1062). Equality (cc 4-5)
+                    // stays IEEE. Mirrors the codegen's formulas exactly.
+                    let r = match cc {
+                        0 => !(a.is_nan() || a < b),            // Ge
+                        1 => !a.is_nan() && (b.is_nan() || a > b), // Gt
+                        2 => !(!a.is_nan() && (b.is_nan() || a > b)), // Le
+                        3 => a.is_nan() || a < b,               // Lt
+                        4 => a == b,                            // Eq
+                        5 => a != b,                            // Ne
+                        _ => unreachable!(),
+                    };
+                    vars[*dst_var as usize] = r as i64;
+                }
+                JitOp::RangeCheck { dst_var, cur_var, to_var, step_var } => {
+                    let cur = fbits(vars[*cur_var as usize]);
+                    let to = fbits(vars[*to_var as usize]);
+                    let step = fbits(vars[*step_var as usize]);
+                    let selected = if step > 0.0 { cur < to } else { cur > to };
+                    vars[*dst_var as usize] = (selected && step != 0.0) as i64;
+                }
+                JitOp::F64Const { dst_var, val } => {
+                    vars[*dst_var as usize] = tbits(*val);
+                }
+                JitOp::F64Move { dst_var, src_var } => {
+                    vars[*dst_var as usize] = vars[*src_var as usize];
+                }
+                JitOp::F64Num { dst, src_var } => {
+                    jit_rt_f64_to_num(sp(*dst), fbits(vars[*src_var as usize]));
+                }
+                JitOp::StrBufNew => jit_rt_strbuf_new(env_ptr),
+                JitOp::StrBufAppendLit { val } => {
+                    jit_rt_strbuf_append_lit(env_ptr, val.as_ptr(), val.len());
+                }
+                JitOp::StrBufAppendVal { src } => {
+                    jit_rt_strbuf_append_val(env_ptr, sp(*src));
+                }
+                JitOp::StrBufFinish { dst } => jit_rt_strbuf_finish(sp(*dst), env_ptr),
+                JitOp::TryCatchBegin => jit_rt_try_begin(env_ptr),
+                JitOp::TryCatchEnd => jit_rt_try_end(env_ptr),
+                JitOp::CheckError { error_dst, catch_label } => {
+                    if env.error_flag != 0 {
+                        // get_error returns 0 for a non-catchable halt
+                        // (#182, #1043) — propagate it out like ReturnError
+                        // instead of entering the catch handler.
+                        let caught = jit_rt_get_error(sp(*error_dst), env_ptr);
+                        if caught != 0 {
+                            pc = lp(*catch_label);
+                            continue;
+                        }
+                        jit_rt_propagate_error(env_ptr);
+                        return GEN_ERROR;
+                    }
+                }
+                JitOp::JumpIfError { label } => {
+                    if env.error_flag != 0 {
+                        pc = lp(*label);
+                        continue;
+                    }
+                }
+                JitOp::ReturnContinue => return GEN_CONTINUE,
+                JitOp::ReturnError => {
+                    jit_rt_propagate_error(env_ptr);
+                    return GEN_ERROR;
+                }
+                JitOp::CallBuiltin { dst, builtin, args } => {
+                    if args.is_empty() {
+                        jit_rt_call_builtin(sp(*dst), builtin, std::ptr::null(), 0);
+                    } else {
+                        // Clone args into a temporary frame (the callee
+                        // borrows them); dropping the Vec afterwards mirrors
+                        // the codegen's per-arg jit_rt_drop calls.
+                        let cloned: Vec<Value> = args.iter()
+                            .map(|a| unsafe { (*sp(*a)).clone() })
+                            .collect();
+                        jit_rt_call_builtin(sp(*dst), builtin, cloned.as_ptr(), cloned.len());
+                    }
+                }
+                JitOp::ThrowError { msg } => {
+                    jit_rt_throw_error(sp(*msg), env_ptr);
+                    // Don't return here — CheckError or ReturnError handles it.
+                }
+                JitOp::CollectRange { dst, n } => {
+                    let n_f64 = jit_rt_to_f64(sp(*n));
+                    jit_rt_collect_range(sp(*dst), n_f64);
+                }
+                JitOp::ArrPush { arr, val } => {
+                    jit_rt_arr_push(sp(*arr), sp(*val));
+                }
+                JitOp::TraceMutate { kind, slot } => {
+                    let kind_byte = match kind {
+                        MutateKind::Assign => 0,
+                        MutateKind::Update => 1,
+                    };
+                    jit_rt_trace_mutate(kind_byte, sp(*slot));
+                }
+            }
+            pc += 1;
+        }
+        GEN_CONTINUE
+    }
+}
+
+/// Execute a JitProgram, collecting all outputs (mirror of `execute_jit`).
+pub fn execute_program(prog: &JitProgram, input: &Value) -> Result<Vec<Value>> {
+    execute_collect(|env, cb, ctx| prog.run(input, env, cb, ctx))
+}
+
+/// Execute a JitProgram with a streaming callback (mirror of `execute_jit_cb`).
+pub fn execute_program_cb(prog: &JitProgram, input: &Value, cb: &mut dyn FnMut(&Value) -> Result<bool>) -> Result<bool> {
+    execute_stream(|env, raw_cb, ctx| prog.run(input, env, raw_cb, ctx), cb)
 }
 
 #[cfg(test)]
@@ -10898,5 +11431,38 @@ mod tests {
         let r = execute_jit(f, &Value::number(7.0)).unwrap();
         assert_eq!(r.len(), 1);
         assert!(matches!(&r[0], Value::Num(n, _) if *n == 7.0));
+    }
+
+    #[test]
+    fn test_program_identity() {
+        let p = JitProgram::compile(&Expr::Input, &[]).unwrap();
+        let r = execute_program(&p, &Value::number(42.0)).unwrap();
+        assert_eq!(r.len(), 1);
+        assert!(matches!(&r[0], Value::Num(n, _) if *n == 42.0));
+    }
+
+    #[test]
+    fn test_program_literal() {
+        let p = JitProgram::compile(&Expr::Literal(Literal::Str("hello".into())), &[]).unwrap();
+        let r = execute_program(&p, &Value::Null).unwrap();
+        assert_eq!(r.len(), 1);
+        assert!(matches!(&r[0], Value::Str(s) if s.as_str() == "hello"));
+    }
+
+    #[test]
+    fn test_program_streaming_stop() {
+        // `.[]` over an array, stopping after the first output — exercises
+        // the Yield early-return path of the interpreter loop.
+        let expr = Expr::Each { input_expr: Box::new(Expr::Input) };
+        let p = JitProgram::compile(&expr, &[]).unwrap();
+        let input = crate::value::json_to_value("[1,2,3]").unwrap();
+        let mut seen = Vec::new();
+        let done = execute_program_cb(&p, &input, &mut |v| {
+            seen.push(v.clone());
+            Ok(false)
+        }).unwrap();
+        assert!(done);
+        assert_eq!(seen.len(), 1);
+        assert!(matches!(&seen[0], Value::Num(n, _) if *n == 1.0));
     }
 }

--- a/tests/selfdiff_jitop_backend.rs
+++ b/tests/selfdiff_jitop_backend.rs
@@ -1,18 +1,21 @@
-//! Self-diff harness (issue #323): run every regression case through the JIT
-//! / fast-path dispatch *and* through the generic tree-walking interpreter,
-//! and assert identical stdout + exit-code class.
+//! Backend self-diff harness (issue #1059 Phase 1): run every regression
+//! case through BOTH backends of the shared JitOp lowering — the direct
+//! JitOp interpreter (`JQJIT_FORCE_JITOP_INTERP=1`) and the Cranelift
+//! codegen (`JQJIT_FORCE_CRANELIFT=1`) — and assert identical stdout +
+//! exit-code class.
 //!
-//! Differential testing against `jq-1.8.1` (`tests/diff_corpus.rs`) catches
-//! external divergences only. This harness catches the *internal* class —
-//! the JIT path and the interpreter path inside jq-jit drifting apart on the
-//! same filter — without depending on an external `jq` binary.
+//! The two knobs configure *identical* routing (raw-byte fast paths off,
+//! typed fast path off, non-flattenable filters falling back to eval) and
+//! differ only in which backend executes the flattened JitOp sequence, so
+//! any divergence here is a true backend bug: one of the two executions of
+//! the same linear op sequence is wrong.
 //!
-//! The runtime knob is `JQJIT_FORCE_INTERPRETER=1`: the binary then disables
-//! all raw-byte fast paths, skips JIT compilation, and routes
-//! `Filter::execute` / `Filter::execute_cb` through the generic interpreter
-//! (see `jq_jit::interpreter::set_force_interpreter`).
+//! This complements `tests/selfdiff_jit_interp.rs` (default dispatch vs
+//! tree-walking eval): that harness pins the lowering + fast-path layers
+//! against eval semantics, this one pins the two lowering backends against
+//! each other.
 //!
-//! Set `JIT_INTERP_DIFF_LIMIT=N` to truncate the corpus during local
+//! Set `JITOP_BACKEND_DIFF_LIMIT=N` to truncate the corpus during local
 //! development; the default runs every case in `tests/regression.test`.
 
 mod common;
@@ -63,15 +66,23 @@ struct RunOutput {
     is_error: bool,
 }
 
-fn run_once(bin: &str, filter: &str, input: &str, force_interp: bool) -> Option<RunOutput> {
+/// Backend selector for one subprocess run.
+#[derive(Clone, Copy)]
+enum Backend {
+    JitopInterp,
+    Cranelift,
+}
+
+fn run_once(bin: &str, filter: &str, input: &str, backend: Backend) -> Option<RunOutput> {
     let lib_dir = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/modules");
     let mut cmd = Command::new(bin);
     cmd.arg("-L").arg(lib_dir).arg("-c").arg(filter);
     cmd.env_remove("JQJIT_FORCE_INTERPRETER");
     cmd.env_remove("JQJIT_FORCE_JITOP_INTERP");
     cmd.env_remove("JQJIT_FORCE_CRANELIFT");
-    if force_interp {
-        cmd.env("JQJIT_FORCE_INTERPRETER", "1");
+    match backend {
+        Backend::JitopInterp => { cmd.env("JQJIT_FORCE_JITOP_INTERP", "1"); }
+        Backend::Cranelift => { cmd.env("JQJIT_FORCE_CRANELIFT", "1"); }
     }
     cmd.stdin(std::process::Stdio::piped());
     cmd.stdout(std::process::Stdio::piped());
@@ -139,29 +150,19 @@ fn normalize(output: &str) -> String {
     lines.join("\n")
 }
 
-/// Cases the harness flags but does not fail on. Each entry pins a specific
-/// regression-test line to the underlying-divergence note that explains it.
-/// New divergences are NOT silently allowed — they have to be added here with
-/// rationale, which is the point: the allowlist is the audit trail of "we
-/// know about this, here's why we haven't fixed it yet."
-///
-/// Current entries (#323):
-/// - `tojson` on numbers that overflow `f64` (`1e1000` → `±INFINITY`):
-///   the raw-byte fast path on stdin lexes the digits and emits the
-///   canonicalised literal (`"1E+1000"`); the interpreter routes through
-///   `Value::Num(f64, repr)` and `push_jq_number_str` saturates non-finite
-///   values to `±1.7976931348623157e+308`. Plumbing the original `repr`
-///   through `value_to_json_tojson` is the obvious local fix, but doing so
-///   without also flipping `have_decnum` to `true` breaks the upstream
-///   `tests/official/jq.test` decnum consistency check (#443). Tracked
-///   in #415.
-const KNOWN_DIVERGENCES: &[usize] = &[2230, 2235, 2240, 2366, 2371];
+/// Cases the harness flags but does not fail on. Both sides execute the
+/// same JitOp sequence, so this list is expected to stay empty — a true
+/// backend divergence is a bug in one of the two executions and should be
+/// fixed, not allowlisted. The mechanism is kept for parity with the other
+/// self-diff harnesses in case a platform-specific divergence ever needs a
+/// documented waiver.
+const KNOWN_DIVERGENCES: &[usize] = &[];
 
 /// Per-case verdict, produced in parallel and folded sequentially so the
-/// counters and reporting stay identical to the original serial loop.
+/// counters and reporting stay identical across the self-diff harnesses.
 enum Outcome {
-    /// Agreed (jit == interp). `Some(line)` if the case is on the allowlist
-    /// yet agreed anyway — counts as a pass *and* flags a stale entry.
+    /// Agreed (cranelift == jitop interp). `Some(line)` if the case is on the
+    /// allowlist yet agreed anyway — counts as a pass *and* flags a stale entry.
     Pass(Option<usize>),
     KnownDiverged,
     SpawnFail(String),
@@ -169,7 +170,7 @@ enum Outcome {
 }
 
 #[test]
-fn jit_vs_interpreter_self_diff() {
+fn jitop_interp_vs_cranelift_self_diff() {
     let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
 
     let corpus_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/regression.test");
@@ -178,7 +179,7 @@ fn jit_vs_interpreter_self_diff() {
     let mut cases = parse_corpus(&content);
     assert!(!cases.is_empty(), "regression corpus is empty");
 
-    if let Ok(limit) = std::env::var("JIT_INTERP_DIFF_LIMIT") {
+    if let Ok(limit) = std::env::var("JITOP_BACKEND_DIFF_LIMIT") {
         if let Ok(n) = limit.parse::<usize>() {
             cases.truncate(n);
         }
@@ -191,45 +192,45 @@ fn jit_vs_interpreter_self_diff() {
     let mut unexpected_pass: Vec<usize> = Vec::new();
     let mut failures: Vec<String> = Vec::new();
 
-    // Each case spawns two isolated jq-jit subprocesses (JIT vs forced
+    // Each case spawns two isolated jq-jit subprocesses (Cranelift vs JitOp
     // interpreter); no shared in-process state, so fan out across cores and
     // fold the verdicts back in input order.
     let outcomes = common::parallel::par_map(&cases, |case| {
         let known = KNOWN_DIVERGENCES.contains(&case.line);
-        let jit = run_once(jq_jit, &case.filter, &case.input, false);
-        let interp = run_once(jq_jit, &case.filter, &case.input, true);
+        let cranelift = run_once(jq_jit, &case.filter, &case.input, Backend::Cranelift);
+        let jitop = run_once(jq_jit, &case.filter, &case.input, Backend::JitopInterp);
 
-        let (Some(jit), Some(interp)) = (jit, interp) else {
+        let (Some(cranelift), Some(jitop)) = (cranelift, jitop) else {
             return Outcome::SpawnFail(format!(
                 "  line {}: spawn failure\n    filter: {}\n    input:  {}",
                 case.line, case.filter, case.input
             ));
         };
 
-        if jit.is_error && interp.is_error {
+        if cranelift.is_error && jitop.is_error {
             return Outcome::Pass(known.then_some(case.line));
         }
-        if jit.is_error != interp.is_error {
+        if cranelift.is_error != jitop.is_error {
             if known {
                 return Outcome::KnownDiverged;
             }
             return Outcome::Fail(format!(
-                "  line {}: error-class mismatch (jit error={}, interp error={})\n    filter: {}\n    input:  {}\n    jit:    {}\n    interp: {}",
-                case.line, jit.is_error, interp.is_error, case.filter, case.input,
-                jit.stdout.trim(), interp.stdout.trim()
+                "  line {}: error-class mismatch (cranelift error={}, jitop error={})\n    filter: {}\n    input:  {}\n    cranelift: {}\n    jitop:     {}",
+                case.line, cranelift.is_error, jitop.is_error, case.filter, case.input,
+                cranelift.stdout.trim(), jitop.stdout.trim()
             ));
         }
 
-        let jit_norm = normalize(&jit.stdout);
-        let interp_norm = normalize(&interp.stdout);
-        if jit_norm == interp_norm {
+        let cranelift_norm = normalize(&cranelift.stdout);
+        let jitop_norm = normalize(&jitop.stdout);
+        if cranelift_norm == jitop_norm {
             Outcome::Pass(known.then_some(case.line))
         } else if known {
             Outcome::KnownDiverged
         } else {
             Outcome::Fail(format!(
-                "  line {}: value mismatch\n    filter: {}\n    input:  {}\n    jit:    {}\n    interp: {}",
-                case.line, case.filter, case.input, jit_norm, interp_norm
+                "  line {}: value mismatch\n    filter: {}\n    input:  {}\n    cranelift: {}\n    jitop:     {}",
+                case.line, case.filter, case.input, cranelift_norm, jitop_norm
             ))
         }
     });
@@ -255,7 +256,7 @@ fn jit_vs_interpreter_self_diff() {
     }
 
     eprintln!();
-    eprintln!("=== JIT vs interpreter self-diff ===");
+    eprintln!("=== JitOp interpreter vs Cranelift backend self-diff ===");
     eprintln!("PASS:        {}", pass);
     eprintln!("FAIL:        {}", fail);
     eprintln!("SPAWN:       {}", spawn_fail);
@@ -273,7 +274,7 @@ fn jit_vs_interpreter_self_diff() {
     assert_eq!(
         fail + spawn_fail,
         0,
-        "{} self-diff divergences out of {}",
+        "{} backend self-diff divergences out of {}",
         fail + spawn_fail,
         cases.len()
     );

--- a/tests/selfdiff_layers.rs
+++ b/tests/selfdiff_layers.rs
@@ -85,29 +85,38 @@ impl Config {
         }
     }
 
-    /// Env vars that switch this config on. Always sets/clears all three
-    /// knobs so a leaked env from the caller can't poison the matrix.
-    fn env(self) -> [(&'static str, Option<&'static str>); 3] {
+    /// Env vars that switch this config on. Always sets/clears every knob
+    /// (including the backend-pinning ones, #1059) so a leaked env from the
+    /// caller can't poison the matrix.
+    fn env(self) -> [(&'static str, Option<&'static str>); 5] {
         match self {
             Config::Baseline => [
                 ("JQJIT_DISABLE_RAW_BYTE", None),
                 ("JQJIT_DISABLE_SIMPLIFY", None),
                 ("JQJIT_FORCE_INTERPRETER", None),
+                ("JQJIT_FORCE_JITOP_INTERP", None),
+                ("JQJIT_FORCE_CRANELIFT", None),
             ],
             Config::NoRawByte => [
                 ("JQJIT_DISABLE_RAW_BYTE", Some("1")),
                 ("JQJIT_DISABLE_SIMPLIFY", None),
                 ("JQJIT_FORCE_INTERPRETER", None),
+                ("JQJIT_FORCE_JITOP_INTERP", None),
+                ("JQJIT_FORCE_CRANELIFT", None),
             ],
             Config::NoSimplify => [
                 ("JQJIT_DISABLE_RAW_BYTE", None),
                 ("JQJIT_DISABLE_SIMPLIFY", Some("1")),
                 ("JQJIT_FORCE_INTERPRETER", None),
+                ("JQJIT_FORCE_JITOP_INTERP", None),
+                ("JQJIT_FORCE_CRANELIFT", None),
             ],
             Config::PureInterp => [
                 ("JQJIT_DISABLE_RAW_BYTE", Some("1")),
                 ("JQJIT_DISABLE_SIMPLIFY", Some("1")),
                 ("JQJIT_FORCE_INTERPRETER", Some("1")),
+                ("JQJIT_FORCE_JITOP_INTERP", None),
+                ("JQJIT_FORCE_CRANELIFT", None),
             ],
         }
     }


### PR DESCRIPTION
## Summary

Phase 1 of #1059: a **direct JitOp interpreter** — a switch-loop backend over the same linear JitOp sequence the Cranelift codegen consumes. Both backends now share a single lowering (`flatten_filter`) and the same `jit_rt_*` runtime helpers, so the semantics of every op are defined in exactly one place.

Default-mode behavior is unchanged: the new backend only runs when explicitly forced via the new env knob.

## Design

- **Shared lowering**: the Expr → JitOp phase of `compile_with_funcs` is extracted into `flatten_filter()`, consumed by both `JitCompiler` (Cranelift) and the new `JitProgram` (interpreter). Bail conditions are identical by construction.
- **`JitProgram::run`**: same contract as a compiled `JitFilterFn` (yield callback, `JitEnv` error state, `GEN_*` statuses). Slots mirror the compiled stack-frame discipline (`ptr::write` stores, `Drop` ops as the only deallocation points → `Vec<MaybeUninit<Value>>`, no element destructors on exit); i64/f64 vars mirror Cranelift variables (f64 stored as bits).
- **Helper reuse**: ops execute via the existing `extern "C"` runtime helpers. The codegen's inline fast paths are pure shortcuts of the helper semantics with one exception the interpreter replicates explicitly: `Negate`'s `0.0 - x` normalization of `-0` (#919).
- **Loud failure on lowering bugs**: program build validates that every branch-target label was emitted, instead of silently falling off the end of the op sequence.
- **Symmetric self-diff knobs**:
  - `JQJIT_FORCE_JITOP_INTERP=1` — pin the JitOp interpreter backend
  - `JQJIT_FORCE_CRANELIFT=1` — pin the Cranelift backend, same routing (raw-byte + typed fast paths disabled, non-flattenable filters fall back to eval, size heuristics ignored)

  Diffing the two is a **true backend diff**: any divergence means one of the two executions of the same op sequence is wrong. This is the harness shape #1059 Phase 4 calls for, available from Phase 1.
- The forced-mode flags are packed into a single `AtomicU8` so the per-record `execute`/`execute_cb` paths pay one relaxed load, same as before the new knobs existed.

## Correctness gates

- `tests/selfdiff_jitop_backend.rs` (new, runs in CI via `cargo test`): JitOp interpreter vs Cranelift over the full regression corpus — **2446/2446 PASS, empty allowlist**.
- Full suite green: official 509, regression, differential, fuzz, self-diff (eval vs default), layer matrix, contracts — 40 test binaries, 0 failures.
- Existing self-diff harnesses now also scrub the new env knobs so a leaked environment can't poison their matrices.

## Benchmarks

Default mode (knob off) — same-machine interleaved best-of-7 A/B against main on the rows flagged by the comprehensive run:

| row (2M-record NDJSON) | main | branch | ratio |
|---|---|---|---|
| `.[] \| strings` | 0.121s | 0.123s | 1.019 |
| `.name` (raw fast path) | 0.100s | 0.096s | 0.968 |

Both within the known layout-lottery band (the best-of-7 spread on this machine is ~±7%); the comprehensive run's other deltas vs the v1.8.3 history column reproduce on main itself (post-release merges #1079/#1080 + cross-run machine drift).

Phase 1 baseline — forced-mode comparison, 2M-record NDJSON, same machine, best-of-5 interleaved (user CPU):

| filter | default | eval (tree-walk) | **JitOp interp** | Cranelift | interp/eval |
|---|---|---|---|---|---|
| `.name` | 0.095s | 0.661s | **0.196s** | 0.175s | **0.30x** |
| `.x + .y` | 0.101s | 0.735s | **0.219s** | 0.202s | **0.30x** |
| `{n: .name, v: .x}` | 0.127s | 0.840s | **0.298s** | 0.288s | **0.36x** |
| `[.x, .y] \| any(. > 1000000)` | 0.098s | 0.746s | **0.433s** | 0.312s | **0.58x** |
| `if .x > .y then .x else .y end` | 0.111s | 0.791s | **0.266s** | 0.226s | **0.34x** |
| `select(.x > 1000000)` | 0.132s | 0.745s | **0.247s** | 0.219s | **0.33x** |
| `.name \| length` | 0.113s | 0.692s | **0.213s** | 0.179s | **0.31x** |

The interpreted backend runs **1.7–3.3x faster than the tree-walking evaluator** on these shapes (the issue projected 30–50%), and lands within 1.1–1.4x of Cranelift-compiled code — a solid starting point for Phase 2 routing decisions.

## Pre-existing divergences surfaced (not introduced here)

Building the harness initially against *default* dispatch surfaced ~94 regression-corpus cases where the **JIT lowering disagrees with eval** — all reproducible on main with `--force-jit`, invisible in CI because default dispatch routes sub-4KB inputs to eval. Classes: literal-repr loss through `tojson` (`1.0 | tojson` → `"1"`), phantom builtins (`combinations`/`modf` flatten but have no runtime dispatch → `unknown builtin` error), error-shape/loss inside `try-catch` around delegated builtins, `label/break` edge cases, `tonumber` edge cases. These affect the Cranelift backend and the new interpreter identically (shared lowering), so the backend diff stays green; they should be tracked as separate lowering issues.

## Phase plan status (#1059)

- **Phase 1 (this PR)**: JitOp interpreter MVP + env knob + backend self-diff in CI ✅
- Phase 2 (routing below the JIT threshold) and beyond: follow-ups, gated on per-shape A/B.

Refs #1059

🤖 Generated with [Claude Code](https://claude.com/claude-code)
