### PR TITLE
fix(jit): bail flattener on builtins with no runtime dispatch arm

### DIFF
--- a/src/jit.rs
+++ b/src/jit.rs
@@ -336,6 +336,13 @@ fn is_scalar(expr: &Expr) -> bool {
                 | (BuiltinOp::ToStream, _) | (BuiltinOp::FromStream, _)
                 | (BuiltinOp::TruncateStream, _) => false,
                 (BuiltinOp::Add, 1) => false,
+                // Builtins with no generic runtime dispatch arm (eval-only,
+                // e.g. combinations/modf) must bail to eval: emitting
+                // CallBuiltin for them is the phantom "unknown builtin"
+                // class (#1082). InputLineNumber/InputFilename are exempt —
+                // flatten_scalar routes them to dedicated JitBuiltin arms.
+                _ if !matches!(op, BuiltinOp::InputLineNumber | BuiltinOp::InputFilename)
+                    && crate::runtime::RtBuiltin::from_builtin(*op).is_none() => false,
                 _ => args.iter().all(is_scalar),
             }
         }

--- a/tests/jit_phantom_builtin_bail.rs
+++ b/tests/jit_phantom_builtin_bail.rs
@@ -1,0 +1,70 @@
+//! Issue #1082: `combinations` and `modf` flattened to a `CallBuiltin` JitOp
+//! but `jit_rt_call_builtin` has no dispatch arm for them, so the JIT path
+//! errored with `unknown builtin` at runtime. Default dispatch masked the bug
+//! for small inputs (< 4KB routes to eval) but large inputs hit it.
+//!
+//! The fix makes the flattener bail on any `CallBuiltin` whose op has no
+//! generic runtime dispatch arm (`RtBuiltin::from_builtin` returns `None`),
+//! so the filter falls back to eval. These tests pin the behavior under
+//! `--force-jit`, which routes everything flattenable through the JIT.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn run_force_jit(filter: &str, stdin: &str) -> (String, String, Option<i32>) {
+    let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
+    let mut child = Command::new(jq_jit)
+        .args(["--force-jit", "-c", filter])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn jq-jit");
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(stdin.as_bytes())
+        .unwrap();
+    let out = child.wait_with_output().expect("wait failed");
+    (
+        String::from_utf8_lossy(&out.stdout).trim_end().to_string(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+        out.status.code(),
+    )
+}
+
+#[test]
+fn combinations_collect_force_jit() {
+    let (stdout, stderr, code) = run_force_jit("[combinations]", "[[1,2],[3,4]]");
+    assert_eq!(stdout, "[[1,3],[1,4],[2,3],[2,4]]", "stderr: {stderr:?}");
+    assert_eq!(code, Some(0));
+}
+
+#[test]
+fn combinations_stream_force_jit() {
+    let (stdout, stderr, code) = run_force_jit("combinations", "[[1,2],[3,4]]");
+    assert_eq!(stdout, "[1,3]\n[1,4]\n[2,3]\n[2,4]", "stderr: {stderr:?}");
+    assert_eq!(code, Some(0));
+}
+
+#[test]
+fn combinations_n_force_jit() {
+    let (stdout, stderr, code) = run_force_jit("[combinations(2)]", "[[1,2]]");
+    assert_eq!(stdout, "[[[1,2],[1,2]]]", "stderr: {stderr:?}");
+    assert_eq!(code, Some(0));
+}
+
+#[test]
+fn modf_force_jit() {
+    let (stdout, stderr, code) = run_force_jit("modf", "1.5");
+    assert_eq!(stdout, "[0.5,1]", "stderr: {stderr:?}");
+    assert_eq!(code, Some(0));
+}
+
+#[test]
+fn modf_negative_tojson_force_jit() {
+    let (stdout, stderr, code) = run_force_jit("modf | tojson", "-1");
+    assert_eq!(stdout, "\"[-0,-1]\"", "stderr: {stderr:?}");
+    assert_eq!(code, Some(0));
+}


### PR DESCRIPTION
## Summary

`combinations` and `modf` flattened to a `CallBuiltin` JitOp but `jit_rt_call_builtin` has no dispatch arm for them, so the JIT path errored with `unknown builtin: combinations (nargs=1)` at runtime — the same phantom shape as the historical `dateadd`/`datesub` case (#131). Default dispatch masked this for small inputs (< 4KB routes to eval) but it fired on large inputs and under `--force-jit`.

## Fix

Option 1 from the issue, generalized to close the class: `is_scalar` now rejects any `CallBuiltin` whose op has no generic runtime dispatch arm (`RtBuiltin::from_builtin` returns `None`), so the filter falls back to eval. `InputLineNumber`/`InputFilename` are exempt because `flatten_scalar` routes them to dedicated `JitBuiltin` arms.

## Audit

Diffing the `BuiltinOp` and `RtBuiltin` name keyspaces, the unmapped names are: `combinations`, `modf`, `del`, `pick`, `walk`, `skip`, `fromcsv*`, `fromtsv*`, `tostream`, `fromstream`, `truncate_stream`, `input_filename`, `input_line_number`. All except `combinations`/`modf` were already excluded by the filter-argument list or special-cased; the new guard covers those two and any future unmapped name automatically.

## Verification

- All 11 affected regression corpus lines (1426–1471, 2255) now agree across `JQJIT_FORCE_CRANELIFT`, `JQJIT_FORCE_JITOP_INTERP`, and `JQJIT_FORCE_INTERPRETER`.
- New shell-out test `tests/jit_phantom_builtin_bail.rs` pins `--force-jit` behavior for `combinations` (collect/stream/n-ary) and `modf`.
- `cargo build --release` zero warnings; `cargo test --release` all 63 suites pass.

Closes #1082

🤖 Generated with [Claude Code](https://claude.com/claude-code)