### PR TITLE
fix(jit): surface delegated-builtin errors through try/catch with eval's wording

### DIFF
--- a/src/jit.rs
+++ b/src/jit.rs
@@ -297,7 +297,7 @@ fn can_scalar_collect(expr: &Expr) -> bool {
         }
         Expr::Empty => true,
         Expr::Range { from, to, step } => {
-            is_scalar(from) && is_scalar(to) && step.as_ref().is_none_or(|s| is_scalar(s))
+            is_scalar(from) && is_scalar(to) && range_step_is_safe(step.as_deref())
         }
         Expr::Collect { generator } => can_scalar_collect(generator),
         Expr::LetBinding { value, body, .. } => {
@@ -322,6 +322,31 @@ fn can_scalar_collect(expr: &Expr) -> bool {
 /// the first-iteration machinery.
 fn range_from_may_carry_repr(from: &Expr) -> bool {
     !matches!(from, Expr::Literal(Literal::Num(_, None)))
+}
+
+/// True when the expression is provably a number at compile time.
+fn expr_is_num_literal(e: &Expr) -> bool {
+    matches!(e, Expr::Literal(Literal::Num(..)))
+}
+
+/// #1084: a non-numeric `step` needs eval's lazy semantics (yield the first
+/// item, then surface "X and Y cannot be added" on the increment — or
+/// nothing at all when the loop condition fails under jq's total order).
+/// The f64 loop can't express that, so provably non-numeric literal steps
+/// bail to eval. Dynamic steps stay on the JIT path: they are numeric in
+/// practice (where the loop is exact), and bailing them would silently
+/// drop loops in emission contexts that ignore a `false` return (the
+/// nested in-place reduce shapes, cf. #683).
+fn range_step_is_safe(step: Option<&Expr>) -> bool {
+    match step {
+        None => true,
+        Some(Expr::Literal(lit)) => matches!(lit, Literal::Num(..)),
+        // Array/object/string constructions are provably non-numeric.
+        Some(Expr::Collect { .. })
+        | Some(Expr::ObjectConstruct { .. })
+        | Some(Expr::StringInterpolation { .. }) => false,
+        Some(_) => true,
+    }
 }
 
 fn is_scalar(expr: &Expr) -> bool {
@@ -585,6 +610,11 @@ enum JitOp {
 
     // Range loop
     ToF64Var { dst_var: u32, src: SlotId },
+    /// ToF64Var that raises "Range bounds must be numeric" on a non-number
+    /// instead of coercing to 0.0. Used for range bounds that are not
+    /// provably numeric at compile time (#1084) — same single FFI call as
+    /// the unchecked form, so dynamic-bound range loops pay nothing extra.
+    ToF64VarRangeBound { dst_var: u32, src: SlotId },
     F64Less { dst_var: u32, a_var: u32, b_var: u32 },
     F64Equal { dst_var: u32, a_var: u32, b_var: u32 },
     F64Add { dst_var: u32, a_var: u32, b_var: u32 },
@@ -1094,6 +1124,7 @@ impl Flattener {
             JitOp::Index { .. } | JitOp::IndexField { .. } |
             JitOp::BinOp { .. } | JitOp::AddMove { .. } | JitOp::UnaryOp { .. } |
             JitOp::Negate { .. } | JitOp::CallBuiltin { .. } |
+            JitOp::ToF64VarRangeBound { .. } |
             JitOp::ThrowError { .. } |
             // The fused field-op runtimes index `.field` on the base and return
             // GEN_ERROR for a non-object base ("Cannot index <type> with string").
@@ -2032,7 +2063,7 @@ impl Flattener {
                 // dynamic init falls back to the boxed reduce path that surfaces
                 // jq's "X and Y cannot be added" error.
                 let is_fused_range_f64 = if let Expr::Range { from, to, step } = source.as_ref() {
-                    is_scalar(from) && is_scalar(to) && step.as_ref().is_none_or(|s| is_scalar(s))
+                    is_scalar(from) && is_scalar(to) && range_step_is_safe(step.as_deref())
                         // Reprless init only: an empty range yields the init
                         // verbatim in eval (`reduce range(0) as $x (0.0; ...)`
                         // → `0.0`), which the f64 round-trip would drop. #1083
@@ -2061,8 +2092,7 @@ impl Flattener {
                         let step_v = self.alloc_var();
                         let cmp = self.alloc_var();
                         let acc_f64 = self.alloc_var();
-                        self.emit(JitOp::ToF64Var { dst_var: cur, src: from_val });
-                        self.emit(JitOp::ToF64Var { dst_var: to_v, src: to_val });
+                        self.emit_range_bound_vars(cur, from_val, Some(from), to_v, to_val, Some(to));
                         self.emit(JitOp::ToF64Var { dst_var: step_v, src: step_val });
                         // The MoveToVar at the start of this Reduce arm consumed
                         // `acc_val` and replaced the slot with Null, so reading
@@ -2073,7 +2103,7 @@ impl Flattener {
                         self.emit(JitOp::GetVar { dst: acc_init, var_index: *acc_index });
                         self.emit(JitOp::ToF64Var { dst_var: acc_f64, src: acc_init });
                         self.emit(JitOp::Drop { slot: acc_init });
-                        self.emit(JitOp::Drop { slot: from_val });
+                                self.emit(JitOp::Drop { slot: from_val });
                         self.emit(JitOp::Drop { slot: to_val });
                         self.emit(JitOp::Drop { slot: step_val });
                         let head = self.alloc_label();
@@ -2235,6 +2265,14 @@ impl Flattener {
                         Expr::Literal(Literal::Num(n, None)) if *n == 0.0);
                     if is_from_zero && step.is_none() {
                         let n_slot = self.flatten_scalar(to, input_slot);
+                        // #1084: a non-numeric bound must raise "Range
+                        // bounds must be numeric" instead of being coerced.
+                        if !expr_is_num_literal(to) {
+                            let zero = self.alloc_slot();
+                            self.emit(JitOp::Num { dst: zero, val: 0.0, repr: None });
+                            self.emit_range_bounds_guard_slots(zero, n_slot);
+                            self.emit(JitOp::Drop { slot: zero });
+                        }
                         let out = self.alloc_slot();
                         self.emit(JitOp::CollectRange { dst: out, n: n_slot });
                         self.emit(JitOp::Drop { slot: n_slot });
@@ -2864,6 +2902,9 @@ impl Flattener {
             }
 
             Expr::Range { from, to, step } => {
+                // #1084: non-numeric steps need eval's lazy add-error
+                // semantics; bail the whole filter to eval.
+                if !range_step_is_safe(step.as_deref()) { return false; }
                 let step_scalar = step.as_ref().is_none_or(|s| is_scalar(s));
                 if !is_scalar(from) || !is_scalar(to) || !step_scalar {
                     // Convert to nested evaluation:
@@ -2883,7 +2924,8 @@ impl Flattener {
                     self.emit(JitOp::Num { dst: s, val: 1.0, repr: None });
                     s
                 };
-                self.emit_range_loop(from_val, to_val, step_val, range_from_may_carry_repr(from));
+                let check = !(expr_is_num_literal(from) && expr_is_num_literal(to));
+                self.emit_range_loop(from_val, to_val, step_val, range_from_may_carry_repr(from), check);
                 self.emit(JitOp::Drop { slot: from_val });
                 self.emit(JitOp::Drop { slot: to_val });
                 self.emit(JitOp::Drop { slot: step_val });
@@ -2962,9 +3004,20 @@ impl Flattener {
                 self.try_depth -= 1;
                 self.try_catch_target = old_target;
                 self.emit(JitOp::Jump { label: done_label });
-                // Catch: non-match → empty (just drop error)
+                // Catch: jq's internal no-match error → empty; everything
+                // else (type errors, bad regexes) rethrows so an enclosing
+                // try/catch sees the canonical message instead of silence.
+                // self.emit wires the rethrow's CheckError to the enclosing
+                // target (try_catch_target was restored above). #1084
                 self.emit(JitOp::Label { id: catch_label });
                 self.emit(JitOp::TryCatchEnd);
+                let guard_out = self.alloc_slot();
+                self.emit(JitOp::CallBuiltin {
+                    dst: guard_out,
+                    builtin: JitBuiltin::Rt(crate::runtime::RtBuiltin::RethrowUnlessNoMatch),
+                    args: vec![error_slot],
+                });
+                self.emit(JitOp::Drop { slot: guard_out });
                 self.emit(JitOp::Drop { slot: error_slot });
                 self.emit(JitOp::Label { id: done_label });
                 self.emit(JitOp::Drop { slot: inp });
@@ -3439,6 +3492,17 @@ impl Flattener {
             }
 
             Expr::Limit { count, generator } => {
+                // jq validates the count with type-specific behavior the f64
+                // counter can't express: null/false/true take the
+                // "doesn't support negative count" branch, strings/arrays/
+                // objects surface "X and number (1) cannot be subtracted"
+                // lazily — only once the generator yields (#806). ToF64Var
+                // would silently coerce all of those to 0. Only a numeric
+                // literal count (the overwhelmingly common case) is provably
+                // safe; everything else bails to eval. #1084
+                if !matches!(count.as_ref(), Expr::Literal(Literal::Num(..))) {
+                    return false;
+                }
                 // Pre-check: generator must be compilable
                 {
                     let mut test = self.test_flattener();
@@ -3843,7 +3907,7 @@ impl Flattener {
                 self.emit(JitOp::Drop { slot: mid });
                 ok
             }
-            Expr::Range { from, to, step } if is_scalar(from) && is_scalar(to) && step.as_ref().is_none_or(|s| is_scalar(s)) => {
+            Expr::Range { from, to, step } if is_scalar(from) && is_scalar(to) && range_step_is_safe(step.as_deref()) => {
                 let from_val = self.flatten_scalar(from, input_slot);
                 let to_val = self.flatten_scalar(to, input_slot);
                 let step_val = if let Some(s) = step {
@@ -3857,8 +3921,7 @@ impl Flattener {
                 let to_v = self.alloc_var();
                 let step_v = self.alloc_var();
                 let cmp = self.alloc_var();
-                self.emit(JitOp::ToF64Var { dst_var: cur, src: from_val });
-                self.emit(JitOp::ToF64Var { dst_var: to_v, src: to_val });
+                self.emit_range_bound_vars(cur, from_val, Some(from), to_v, to_val, Some(to));
                 self.emit(JitOp::ToF64Var { dst_var: step_v, src: step_val });
                 let first = self.range_first_flag(range_from_may_carry_repr(from), from_val);
                 self.emit(JitOp::Drop { slot: to_val });
@@ -4079,6 +4142,7 @@ impl Flattener {
             }
             Expr::Range { from, to, step } => {
                 if !is_scalar(from) || !is_scalar(to) { return false; }
+                if !range_step_is_safe(step.as_deref()) { return false; }
                 if let Some(s) = step { if !is_scalar(s) { return false; } }
                 // Pre-check: can we compile the body (right)?
                 {
@@ -4099,8 +4163,7 @@ impl Flattener {
                 let to_v = self.alloc_var();
                 let step_v = self.alloc_var();
                 let cmp = self.alloc_var();
-                self.emit(JitOp::ToF64Var { dst_var: cur, src: from_val });
-                self.emit(JitOp::ToF64Var { dst_var: to_v, src: to_val });
+                self.emit_range_bound_vars(cur, from_val, Some(from), to_v, to_val, Some(to));
                 self.emit(JitOp::ToF64Var { dst_var: step_v, src: step_val });
                 let first = self.range_first_flag(range_from_may_carry_repr(from), from_val);
                 self.emit(JitOp::Drop { slot: to_val });
@@ -4373,13 +4436,74 @@ impl Flattener {
         }
     }
 
-    fn emit_range_loop(&mut self, f_slot: SlotId, t_slot: SlotId, s_slot: SlotId, track_first: bool) {
+    /// #1084: validate range bounds before the f64 loop unless both are
+    /// provably numeric literals. The unboxed counter silently coerces
+    /// non-numbers to 0.0 where eval raises "Range bounds must be numeric";
+    /// the guard is one fallible builtin call per range *invocation* (not
+    /// per iteration), wired into the enclosing try/catch by self.emit.
+    fn emit_range_bounds_guard_slots(&mut self, from_val: SlotId, to_val: SlotId) {
+        let out = self.alloc_slot();
+        self.emit(JitOp::CallBuiltin {
+            dst: out,
+            builtin: JitBuiltin::Rt(crate::runtime::RtBuiltin::RangeBoundsGuard),
+            args: vec![from_val, to_val],
+        });
+        self.emit(JitOp::Drop { slot: out });
+    }
+
+    /// Unbox a range bound into an f64 var: checked (raises "Range bounds
+    /// must be numeric") unless the bound is a numeric literal. Same single
+    /// FFI call either way — dynamic-bound loops pay nothing extra.
+    /// Unbox both range bounds into f64 vars. Bounds that are not numeric
+    /// literals use the checked conversion (raises "Range bounds must be
+    /// numeric") — same single FFI call as the unchecked form. The pending-
+    /// error check is emitted ONCE for the pair (raw pushes bypass emit()'s
+    /// per-op CheckError), so a dynamic-bound range invocation pays one
+    /// branch, not two.
+    fn emit_range_bound_vars(
+        &mut self,
+        cur_var: u32, from_val: SlotId, from: Option<&Expr>,
+        to_var: u32, to_val: SlotId, to: Option<&Expr>,
+    ) {
+        let from_lit = from.is_some_and(expr_is_num_literal);
+        let to_lit = to.is_some_and(expr_is_num_literal);
+        if from_lit {
+            self.ops.push(JitOp::ToF64Var { dst_var: cur_var, src: from_val });
+        } else {
+            self.ops.push(JitOp::ToF64VarRangeBound { dst_var: cur_var, src: from_val });
+        }
+        if to_lit {
+            self.ops.push(JitOp::ToF64Var { dst_var: to_var, src: to_val });
+        } else {
+            self.ops.push(JitOp::ToF64VarRangeBound { dst_var: to_var, src: to_val });
+        }
+        if from_lit && to_lit {
+            return;
+        }
+        if let Some((catch_label, error_slot)) = self.try_catch_target {
+            self.ops.push(JitOp::CheckError { error_dst: error_slot, catch_label });
+        } else {
+            let error_label = self.alloc_label();
+            let ok_label = self.alloc_label();
+            self.ops.push(JitOp::JumpIfError { label: error_label });
+            self.ops.push(JitOp::Jump { label: ok_label });
+            self.ops.push(JitOp::Label { id: error_label });
+            self.ops.push(JitOp::ReturnError);
+            self.ops.push(JitOp::Label { id: ok_label });
+        }
+    }
+
+    fn emit_range_loop(&mut self, f_slot: SlotId, t_slot: SlotId, s_slot: SlotId, track_first: bool, check_bounds: bool) {
         let cur_var = self.alloc_var();
         let to_var = self.alloc_var();
         let step_var = self.alloc_var();
         let cmp_var = self.alloc_var();
-        self.emit(JitOp::ToF64Var { dst_var: cur_var, src: f_slot });
-        self.emit(JitOp::ToF64Var { dst_var: to_var, src: t_slot });
+        if check_bounds {
+            self.emit_range_bound_vars(cur_var, f_slot, None, to_var, t_slot, None);
+        } else {
+            self.emit(JitOp::ToF64Var { dst_var: cur_var, src: f_slot });
+            self.emit(JitOp::ToF64Var { dst_var: to_var, src: t_slot });
+        }
         self.emit(JitOp::ToF64Var { dst_var: step_var, src: s_slot });
         // The caller owns f_slot/t_slot/s_slot and drops them after the
         // loop, so the first-item Clone below can read f_slot directly.
@@ -4411,6 +4535,8 @@ impl Flattener {
 
     /// Handle range(from; to; step) where some args are generators.
     fn flatten_range_gen(&mut self, from: &Expr, to: &Expr, step: Option<&Expr>, input_slot: SlotId) -> bool {
+        // #1084: non-numeric steps need eval's lazy add-error semantics.
+        if !range_step_is_safe(step) { return false; }
         // Build a fully scalar range call wrapped in appropriate generator nesting
         // For each combination of (from_val, to_val, step_val), emit range loop
         if is_scalar(from) && is_scalar(to) && step.is_none_or(is_scalar) {
@@ -4424,7 +4550,8 @@ impl Flattener {
                 self.emit(JitOp::Num { dst: v, val: 1.0, repr: None });
                 v
             };
-            self.emit_range_loop(fv, tv, sv, range_from_may_carry_repr(from));
+            let check = !(expr_is_num_literal(from) && expr_is_num_literal(to));
+            self.emit_range_loop(fv, tv, sv, range_from_may_carry_repr(from), check);
             self.emit(JitOp::Drop { slot: fv });
             self.emit(JitOp::Drop { slot: tv });
             self.emit(JitOp::Drop { slot: sv });
@@ -4454,17 +4581,17 @@ impl Flattener {
                 if let Some(s) = step_ref {
                     if is_scalar(s) {
                         let sv = this.flatten_scalar(s, input_slot);
-                        this.emit_range_loop(fv, tv, sv, from_track);
+                        this.emit_range_loop(fv, tv, sv, from_track, true);
                         this.emit(JitOp::Drop { slot: sv });
                     } else {
                         this.flatten_gen_with_each_output(s, input_slot, &|this2, sv| {
-                            this2.emit_range_loop(fv, tv, sv, from_track);
+                            this2.emit_range_loop(fv, tv, sv, from_track, true);
                         });
                     }
                 } else {
                     let sv = this.alloc_slot();
                     this.emit(JitOp::Num { dst: sv, val: 1.0, repr: None });
-                    this.emit_range_loop(fv, tv, sv, from_track);
+                    this.emit_range_loop(fv, tv, sv, from_track, true);
                     this.emit(JitOp::Drop { slot: sv });
                 }
             });
@@ -4476,7 +4603,7 @@ impl Flattener {
         let tv = self.flatten_scalar(to, input_slot);
         if let Some(s) = step {
             let ok = self.flatten_gen_with_each_output(s, input_slot, &|this, sv| {
-                this.emit_range_loop(fv, tv, sv, from_track);
+                this.emit_range_loop(fv, tv, sv, from_track, true);
             });
             self.emit(JitOp::Drop { slot: fv });
             self.emit(JitOp::Drop { slot: tv });
@@ -4495,17 +4622,17 @@ impl Flattener {
             if let Some(s) = step {
                 if is_scalar(s) {
                     let sv = self.flatten_scalar(s, input_slot);
-                    self.emit_range_loop(fv, tv, sv, true);
+                    self.emit_range_loop(fv, tv, sv, true, true);
                     self.emit(JitOp::Drop { slot: sv });
                 } else {
                     self.flatten_gen_with_each_output(s, input_slot, &|this, sv| {
-                        this.emit_range_loop(fv, tv, sv, true);
+                        this.emit_range_loop(fv, tv, sv, true, true);
                     });
                 }
             } else {
                 let sv = self.alloc_slot();
                 self.emit(JitOp::Num { dst: sv, val: 1.0, repr: None });
-                self.emit_range_loop(fv, tv, sv, true);
+                self.emit_range_loop(fv, tv, sv, true, true);
                 self.emit(JitOp::Drop { slot: sv });
             }
             self.emit(JitOp::Drop { slot: tv });
@@ -4516,17 +4643,17 @@ impl Flattener {
                 if let Some(s) = step_ref {
                     if is_scalar(s) {
                         let sv = this.flatten_scalar(s, input_slot);
-                        this.emit_range_loop(fv, tv, sv, true);
+                        this.emit_range_loop(fv, tv, sv, true, true);
                         this.emit(JitOp::Drop { slot: sv });
                     } else {
                         this.flatten_gen_with_each_output(s, input_slot, &|this2, sv| {
-                            this2.emit_range_loop(fv, tv, sv, true);
+                            this2.emit_range_loop(fv, tv, sv, true, true);
                         });
                     }
                 } else {
                     let sv = this.alloc_slot();
                     this.emit(JitOp::Num { dst: sv, val: 1.0, repr: None });
-                    this.emit_range_loop(fv, tv, sv, true);
+                    this.emit_range_loop(fv, tv, sv, true, true);
                     this.emit(JitOp::Drop { slot: sv });
                 }
             });
@@ -4801,6 +4928,7 @@ impl Flattener {
             }
             Expr::Range { from, to, step } => {
                 if !is_scalar(from) || !is_scalar(to) { return false; }
+                if !range_step_is_safe(step.as_deref()) { return false; }
                 if let Some(s) = step { if !is_scalar(s) { return false; } }
                 let from_val = self.flatten_scalar(from, input_slot);
                 let to_val = self.flatten_scalar(to, input_slot);
@@ -4815,8 +4943,7 @@ impl Flattener {
                 let to_v = self.alloc_var();
                 let step_v = self.alloc_var();
                 let cmp = self.alloc_var();
-                self.emit(JitOp::ToF64Var { dst_var: cur, src: from_val });
-                self.emit(JitOp::ToF64Var { dst_var: to_v, src: to_val });
+                self.emit_range_bound_vars(cur, from_val, Some(from), to_v, to_val, Some(to));
                 self.emit(JitOp::ToF64Var { dst_var: step_v, src: step_val });
                 let first = self.range_first_flag(range_from_may_carry_repr(from), from_val);
                 self.emit(JitOp::Drop { slot: to_val });
@@ -5314,6 +5441,7 @@ impl Flattener {
             }
             Expr::Range { from, to, step } => {
                 if !is_scalar(from) || !is_scalar(to) { return false; }
+                if !range_step_is_safe(step.as_deref()) { return false; }
                 if let Some(s) = step { if !is_scalar(s) { return false; } }
 
                 // Check if update is a pure f64 expression of . (acc) and $x (loop var)
@@ -5349,8 +5477,7 @@ impl Flattener {
                 let to_v = self.alloc_var();
                 let step_v = self.alloc_var();
                 let cmp = self.alloc_var();
-                self.emit(JitOp::ToF64Var { dst_var: cur, src: from_val });
-                self.emit(JitOp::ToF64Var { dst_var: to_v, src: to_val });
+                self.emit_range_bound_vars(cur, from_val, Some(from), to_v, to_val, Some(to));
                 self.emit(JitOp::ToF64Var { dst_var: step_v, src: step_val });
                 self.emit(JitOp::Drop { slot: to_val });
                 self.emit(JitOp::Drop { slot: step_val });
@@ -5477,7 +5604,7 @@ impl Flattener {
             // call before iterating, which makes deep `range as $x | …` chains
             // allocate one Vec per outer iteration at every nested level (#641).
             Expr::Range { from, to, step }
-                if is_scalar(from) && is_scalar(to) && step.as_ref().is_none_or(|s| is_scalar(s)) =>
+                if is_scalar(from) && is_scalar(to) && range_step_is_safe(step.as_deref()) =>
             {
                 let from_val = self.flatten_scalar(from, input_slot);
                 let to_val = self.flatten_scalar(to, input_slot);
@@ -5492,8 +5619,7 @@ impl Flattener {
                 let to_v = self.alloc_var();
                 let step_v = self.alloc_var();
                 let cmp = self.alloc_var();
-                self.emit(JitOp::ToF64Var { dst_var: cur, src: from_val });
-                self.emit(JitOp::ToF64Var { dst_var: to_v, src: to_val });
+                self.emit_range_bound_vars(cur, from_val, Some(from), to_v, to_val, Some(to));
                 self.emit(JitOp::ToF64Var { dst_var: step_v, src: step_val });
                 let first = self.range_first_flag(range_from_may_carry_repr(from), from_val);
                 self.emit(JitOp::Drop { slot: to_val });
@@ -8139,6 +8265,17 @@ extern "C" fn jit_rt_is_null_or_false(v: *const Value) -> i64 {
 extern "C" fn jit_rt_to_f64(v: *const Value) -> f64 {
     unsafe { match &*v { Value::Num(n, _) => *n, _ => 0.0 } }
 }
+extern "C" fn jit_rt_to_f64_range_bound(v: *const Value) -> f64 {
+    unsafe {
+        match &*v {
+            Value::Num(n, _) => *n,
+            _ => {
+                set_jit_error("Range bounds must be numeric".to_string());
+                0.0
+            }
+        }
+    }
+}
 extern "C" fn jit_rt_f64_to_num(dst: *mut Value, n: f64) {
     unsafe { std::ptr::write(dst, Value::number(n)); }
 }
@@ -9132,7 +9269,7 @@ fn optimize_clone_yield(mut ops: Vec<JitOp>) -> Vec<JitOp> {
             JitOp::GetKind { src, .. } | JitOp::GetLen { src, .. } => {
                 *use_count.entry(*src).or_insert(0) += 1;
             }
-            JitOp::ToF64Var { src, .. } => { *use_count.entry(*src).or_insert(0) += 1; }
+            JitOp::ToF64Var { src, .. } | JitOp::ToF64VarRangeBound { src, .. } => { *use_count.entry(*src).or_insert(0) += 1; }
             _ => {}
         }
     }
@@ -9218,7 +9355,7 @@ fn optimize_clone_yield(mut ops: Vec<JitOp>) -> Vec<JitOp> {
                 JitOp::GetKind { src, .. } | JitOp::GetLen { src, .. } => {
                     *use_count.entry(*src).or_insert(0) += 1;
                 }
-                JitOp::ToF64Var { src, .. } => { *use_count.entry(*src).or_insert(0) += 1; }
+                JitOp::ToF64Var { src, .. } | JitOp::ToF64VarRangeBound { src, .. } => { *use_count.entry(*src).or_insert(0) += 1; }
                 _ => {}
             }
         }
@@ -9430,6 +9567,7 @@ impl JitCompiler {
             ("jit_rt_obj_from_fields", jit_rt_obj_from_fields as *const u8),
             ("jit_rt_is_null_or_false", jit_rt_is_null_or_false as *const u8),
             ("jit_rt_to_f64", jit_rt_to_f64 as *const u8),
+            ("jit_rt_to_f64_range_bound", jit_rt_to_f64_range_bound as *const u8),
             ("jit_rt_f64_to_num", jit_rt_f64_to_num as *const u8),
             ("jit_rt_range_check", jit_rt_range_check as *const u8),
             ("jit_rt_strbuf_new", jit_rt_strbuf_new as *const u8),
@@ -10420,6 +10558,13 @@ impl JitCompiler {
                         let bits = b.ins().bitcast(ptr_ty, cranelift_codegen::ir::MemFlags::new(), f_val);
                         b.def_var(vars[*dst_var as usize], bits);
                     }
+                    JitOp::ToF64VarRangeBound { dst_var, src } => {
+                        let s = slot_addr(&mut b, *src);
+                        let call = b.ins().call(rt["to_f64_range_bound"], &[s]);
+                        let f_val = b.inst_results(call)[0];
+                        let bits = b.ins().bitcast(ptr_ty, cranelift_codegen::ir::MemFlags::new(), f_val);
+                        b.def_var(vars[*dst_var as usize], bits);
+                    }
                     JitOp::F64Less { dst_var, a_var, b_var: bv } => {
                         let a_bits = b.use_var(vars[*a_var as usize]);
                         let b_bits = b.use_var(vars[*bv as usize]);
@@ -10834,6 +10979,7 @@ fn declare_rt_funcs(module: &mut JITModule, map: &mut HashMap<&'static str, Func
     decl!("obj_from_fields", [p, p, p, p], []);
     decl!("is_null_or_false", [p], [p]);
     decl!("to_f64", [p], [f]);
+    decl!("to_f64_range_bound", [p], [f]);
     decl!("f64_to_num", [p, f], []);
     decl!("range_check", [f, f, f], [p]);
     decl!("strbuf_new", [p], []);
@@ -11383,6 +11529,9 @@ impl JitProgram {
                 }
                 JitOp::ToF64Var { dst_var, src } => {
                     vars[*dst_var as usize] = tbits(jit_rt_to_f64(sp(*src)));
+                }
+                JitOp::ToF64VarRangeBound { dst_var, src } => {
+                    vars[*dst_var as usize] = tbits(jit_rt_to_f64_range_bound(sp(*src)));
                 }
                 JitOp::F64Less { dst_var, a_var, b_var } => {
                     let r = fbits(vars[*a_var as usize]) < fbits(vars[*b_var as usize]);

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -149,6 +149,13 @@ crate::ir::named_op_enum! {
         Last => "last",
         Nth => "nth",
         Range => "range",
+        /// JIT-only: validate `range` bounds before the f64 loop (the
+        /// unboxed counter silently coerces non-numbers). #1084
+        RangeBoundsGuard => "_range_bounds_guard",
+        /// JIT-only: the match/capture generator lowering swallows the
+        /// internal no-match error; this arm rethrows everything else so
+        /// genuine type errors stay catchable. #1084
+        RethrowUnlessNoMatch => "_match_rethrow",
         While => "while",
         Until => "until",
         Repeat => "repeat",
@@ -486,6 +493,12 @@ pub fn call_builtin_op(op: RtBuiltin, args: &[Value]) -> Result<Value> {
             }
         }
         RtBuiltin::Sub | RtBuiltin::Gsub => {
+            // eval validates the input before the regex, so a non-string
+            // input wins over a non-string pattern; keep that order and
+            // wording here (#1084).
+            if !matches!(&args[0], Value::Str(_)) {
+                bail!("{} cannot be matched, as it is not a string", errdesc(&args[0]));
+            }
             if args.len() >= 4 {
                 // sub/gsub with flags: input, regex, replacement, flags
                 let pat_str = coerce_regex_pat_str(&args[1])?;
@@ -506,6 +519,29 @@ pub fn call_builtin_op(op: RtBuiltin, args: &[Value]) -> Result<Value> {
             // limit needs special handling as a generator
             Ok(Value::Null)
         }),
+        RtBuiltin::RangeBoundsGuard => {
+            // JIT-only (#1084): the range loops run on unboxed f64 counters
+            // that silently coerce non-numbers, so validate the bounds with
+            // eval's message before entering the loop. args: [from, to].
+            match (&args[0], &args[1]) {
+                (Value::Num(_, _), Value::Num(_, _)) => Ok(Value::Null),
+                _ => bail!("Range bounds must be numeric"),
+            }
+        }
+        RtBuiltin::RethrowUnlessNoMatch => {
+            // JIT-only (#1084): the match/capture generator lowering catches
+            // every error to map jq's internal no-match signal to "no
+            // output"; everything else (type errors, bad regexes) must
+            // propagate so try/catch sees the canonical message.
+            match &args[0] {
+                Value::Str(s) if s.as_str() == "match failed" => Ok(Value::Null),
+                Value::Str(s) => bail!("{}", s.as_str()),
+                other => bail!(
+                    "__jqerror__:{}",
+                    crate::value::value_to_json_precise(other),
+                ),
+            }
+        }
         RtBuiltin::First | RtBuiltin::Last | RtBuiltin::Nth | RtBuiltin::Range | RtBuiltin::While | RtBuiltin::Until | RtBuiltin::Repeat | RtBuiltin::Recurse
         | RtBuiltin::Getpath | RtBuiltin::Setpath | RtBuiltin::Delpaths => {
             // These need special handling
@@ -3814,29 +3850,41 @@ fn rt_sub_gsub(v: &Value, re: &Value, replacement: &Value, global: bool, not_emp
     match (v, re, replacement) {
         (Value::Str(s), Value::Str(r), Value::Str(rep)) => {
             let result = with_regex(r, |regex| {
-                if not_empty {
-                    // With `n`, replace only the non-empty matches. `replace`/
-                    // `replace_all` cannot skip zero-width matches, so walk the
-                    // filtered spans and splice the literal replacement (this
-                    // builtin path takes a plain string replacement). #773
-                    let spans = drop_empty_spans(jq_match_spans(regex, s), true);
-                    let mut out = String::with_capacity(s.len());
-                    let mut last = 0;
-                    for (start, end) in spans {
-                        out.push_str(&s[last..start]);
-                        out.push_str(rep.as_str());
-                        last = end;
-                        if !global { break; }
-                    }
-                    out.push_str(&s[last..]);
-                    out
-                } else if global {
-                    regex.replace_all(s, rep.as_str()).to_string()
-                } else {
-                    regex.replace(s, rep.as_str()).to_string()
+                // Walk jq_match_spans and splice the literal replacement
+                // (this builtin path takes a plain string replacement).
+                // `replace`/`replace_all` cannot be used here: jq
+                // enumerates an empty match adjacent to a non-empty one
+                // for zero-width regexes (`gsub("a*"; "X")` on `"abc"` →
+                // `"XXbXcX"`), which find_iter-based replacement skips
+                // (#444); with `n`, the zero-width matches are dropped
+                // instead (#773).
+                if !global && !not_empty {
+                    // Non-global sub replaces only the leftmost match, which
+                    // find/replace locates identically — skip the full span
+                    // enumeration.
+                    return regex.replace(s, rep.as_str()).to_string();
                 }
+                let spans = drop_empty_spans(jq_match_spans(regex, s), not_empty);
+                let mut out = String::with_capacity(s.len());
+                let mut last = 0;
+                for (start, end) in spans {
+                    out.push_str(&s[last..start]);
+                    out.push_str(rep.as_str());
+                    last = end;
+                    if !global { break; }
+                }
+                out.push_str(&s[last..]);
+                out
             })?;
             Ok(Value::from_string(result))
+        }
+        (other, _, _) if !matches!(other, Value::Str(_)) => {
+            // eval's wording for a non-string input (#1084).
+            bail!("{} cannot be matched, as it is not a string", errdesc(other));
+        }
+        (_, other, _) if !matches!(other, Value::Str(_)) => {
+            // eval's wording for a non-string pattern (#1084).
+            bail!("{} is not a string", errdesc(other));
         }
         _ => bail!("sub/gsub requires string, regex, and replacement"),
     }

--- a/tests/jit_trycatch_delegated_errors.rs
+++ b/tests/jit_trycatch_delegated_errors.rs
@@ -1,0 +1,163 @@
+//! Issue #1084: errors from JIT-delegated builtins were swallowed or
+//! reworded inside try/catch.
+//!
+//! - The match/capture generator lowering caught *every* error to map the
+//!   internal no-match signal to "no output", so genuine type errors
+//!   vanished (catch never ran). The catch now rethrows anything that is
+//!   not the internal "match failed" payload.
+//! - `limit` unboxed its count with a silent f64 coercion, so a
+//!   non-numeric count produced empty output instead of jq's type errors;
+//!   non-numeric-literal counts now bail to eval (which implements jq's
+//!   lazy validation, #806).
+//! - `range` bounds were coerced the same way; bounds that are not numeric
+//!   literals now unbox through a checked conversion raising "Range bounds
+//!   must be numeric". Provably non-numeric literal steps bail to eval for
+//!   its lazy add-error semantics.
+//! - The runtime sub/gsub arm produced its own message ("sub/gsub requires
+//!   string, regex, and replacement") instead of eval's canonical wording,
+//!   and its replace_all-based splicing missed zero-width matches adjacent
+//!   to non-empty ones (`gsub("a*"; "X")` on `"abc"`).
+//!
+//! Default dispatch masked all of this for small inputs; these tests force
+//! both JitOp backends.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn run_backend(filter: &str, stdin: &str, backend_env: &str) -> (String, Option<i32>) {
+    let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
+    let mut child = Command::new(jq_jit)
+        .args(["-c", filter])
+        .env(backend_env, "1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn jq-jit");
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(stdin.as_bytes())
+        .unwrap();
+    let out = child.wait_with_output().expect("wait failed");
+    (
+        String::from_utf8_lossy(&out.stdout).trim_end().to_string(),
+        out.status.code(),
+    )
+}
+
+fn assert_jit(filter: &str, stdin: &str, expected: &str) {
+    for backend in ["JQJIT_FORCE_CRANELIFT", "JQJIT_FORCE_JITOP_INTERP"] {
+        let (stdout, code) = run_backend(filter, stdin, backend);
+        assert_eq!(
+            stdout, expected,
+            "{backend}: filter {filter:?} on {stdin:?} gave {stdout:?}, want {expected:?}"
+        );
+        assert_eq!(code, Some(0), "{backend}: filter {filter:?} exited nonzero");
+    }
+}
+
+#[test]
+fn match_type_errors_are_catchable() {
+    assert_jit(
+        "try (.a | match(\"x\")) catch \"err\"",
+        "{\"a\":1}",
+        "\"err\"",
+    );
+    assert_jit(
+        "try (match(\"a\")) catch .",
+        "null",
+        "\"null (null) cannot be matched, as it is not a string\"",
+    );
+    assert_jit(
+        "try (capture(\"(?<x>.)\")) catch .",
+        "null",
+        "\"null (null) cannot be matched, as it is not a string\"",
+    );
+    assert_jit(
+        "\"abc\" | try match(123) catch .",
+        "null",
+        "\"number not a string or array\"",
+    );
+}
+
+#[test]
+fn match_no_match_is_still_empty() {
+    assert_jit("[match(\"z\"; \"g\")] | length", "\"banana\"", "0");
+    assert_jit("[match(\"a\"; \"g\")] | length", "\"banana\"", "3");
+}
+
+#[test]
+fn limit_count_type_errors_match_eval() {
+    assert_jit(
+        "try (limit(\"a\"; .[])) catch .",
+        "[1,2,3]",
+        "\"string (\\\"a\\\") and number (1) cannot be subtracted\"",
+    );
+    assert_jit(
+        "try (limit(null; .[])) catch .",
+        "[1,2,3]",
+        "\"limit doesn't support negative count\"",
+    );
+    // Numeric literal counts stay on the JIT path.
+    assert_jit("[limit(2; 1,2,3)]", "null", "[1,2]");
+    assert_jit("[limit(0; 1,2)]", "null", "[]");
+}
+
+#[test]
+fn range_bounds_raise_instead_of_coercing() {
+    assert_jit(
+        "try (range(\"x\"; 5)) catch .",
+        "null",
+        "\"Range bounds must be numeric\"",
+    );
+    assert_jit(
+        "try (range(0; \"x\")) catch .",
+        "null",
+        "\"Range bounds must be numeric\"",
+    );
+    assert_jit(
+        "\"x\" | try [range(.)] catch .",
+        "null",
+        "\"Range bounds must be numeric\"",
+    );
+    // Dynamic numeric bounds keep working.
+    assert_jit(". as $n | [range($n)]", "3", "[0,1,2]");
+}
+
+#[test]
+fn range_non_numeric_literal_step_uses_eval_lazy_semantics() {
+    assert_jit(
+        "[try (range(0; 10; \"a\")) catch .]",
+        "null",
+        "[0,\"number (0) and string (\\\"a\\\") cannot be added\"]",
+    );
+    assert_jit(
+        "[try (range(0; 10; [])) catch .]",
+        "null",
+        "[0,\"number (0) and array ([]) cannot be added\"]",
+    );
+}
+
+#[test]
+fn sub_gsub_type_errors_match_eval() {
+    assert_jit(
+        "try ([1] | sub(\"a\"; \"b\")) catch .",
+        "null",
+        "\"array ([1]) cannot be matched, as it is not a string\"",
+    );
+    assert_jit(
+        "try (null | gsub(\"a\"; \"b\")) catch .",
+        "null",
+        "\"null (null) cannot be matched, as it is not a string\"",
+    );
+}
+
+#[test]
+fn gsub_enumerates_empty_matches_adjacent_to_nonempty() {
+    assert_jit("gsub(\"a*\"; \"X\")", "\"abc\"", "\"XXbXcX\"");
+    // `n` flag still drops the zero-width matches.
+    assert_jit("gsub(\"a*\"; \"X\"; \"n\")", "\"abc\"", "\"Xbc\"");
+    assert_jit("sub(\"a\"; \"X\")", "\"abc\"", "\"Xbc\"");
+}


### PR DESCRIPTION
## Summary

Errors from JIT-delegated builtins were swallowed entirely (catch never ran) or carried divergent text under `--force-jit`. Four shapes fixed:

**match/capture** — the generator lowering wrapped the runtime call in an internal try-catch that mapped *every* error to "no output", so genuine type errors vanished. The catch now calls a rethrow arm (`RtBuiltin::RethrowUnlessNoMatch`) that lets only the internal `match failed` payload through as empty; `try (.a | match("x")) catch "err"` now yields `"err"`.

**limit** — the count was unboxed with a silent f64 coercion (`limit("a"; ...)` → empty). jq validates the count with type-specific, lazy behavior (#806: string/array/object error only when the generator yields) that the f64 counter can't express; non-numeric-literal counts bail to eval, numeric literals stay JIT.

**range** — bounds were coerced the same way. Non-literal bounds now unbox through a new `ToF64VarRangeBound` op raising `Range bounds must be numeric` — the same single FFI call as the unchecked conversion, with one shared pending-error check per range *invocation*. Provably non-numeric literal steps bail to eval for its lazy "cannot be added" semantics; dynamic steps keep the JIT loop (bailing them silently dropped loops in nested in-place reduce shapes that ignore a `false` return, the #683 class — caught during corpus verification).

**sub/gsub** — the runtime arm produced `sub/gsub requires string, regex, and replacement` instead of eval's canonical wording and validated the regex before the input. While there: the `replace_all`-based splicing missed zero-width matches adjacent to non-empty ones (`gsub("a*"; "X")` on `"abc"` gave `"XbXcX"` vs jq's `"XXbXcX"`, the #444 class, regression corpus line 6674); it now walks `jq_match_spans` like eval's segment path.

## Verification

- Backend-diff over the whole regression corpus: **67 → 31 divergences**; every #1084 line (1862–1867, 6674, 6985–7005, 7347/7357, 8447–8462, 8644–8664, 8684–8699, 9366–9376) now agrees across eval, Cranelift, and the JitOp interpreter. The remaining 31 belong to #1085–#1090.
- New suite `tests/jit_trycatch_delegated_errors.rs` pins each shape under both forced backends, including no-match-still-empty and `n`-flag sanity.
- `cargo build --release` zero warnings; `cargo test --release` all 65 suites pass.
- **Perf** (same-machine interleaved A/B vs main, best-of-7): p126 nested reduce ratio 1.018 (within the documented layout wobble), `range(2M)|length` 1.000, `reduce (sum 100M)` 1.007. The checked bound conversion costs no extra FFI; the pending-error check is emitted once per range invocation, not per bound.

Closes #1084

🤖 Generated with [Claude Code](https://claude.com/claude-code)