### PR TITLE
fix(jit): close path()/setpath validation gaps and the eager path-collection hang

### DIFF
--- a/src/jit.rs
+++ b/src/jit.rs
@@ -479,8 +479,6 @@ enum JitBuiltin {
     Update { path_idx: usize, update_idx: usize },
     /// `paths(f)` native DFS; filter index into JIT_CLOSURE_OPS.
     PathsFiltered { filter_idx: usize },
-    /// `path(f)` delegated to eval; index into JIT_CLOSURE_OPS.
-    PathExpr { expr_idx: usize },
     /// sort_by/group_by/... with the key expression in JIT_CLOSURE_OPS.
     ClosureOp { kind: ClosureOpKind, expr_idx: usize },
     /// "Cannot iterate over ..." error synthesis for `.[]` on a scalar.
@@ -1133,6 +1131,10 @@ impl Flattener {
             // of erroring once the surrounding _modify pushed it onto the JIT
             // path (#809).
             JitOp::FieldBinopConst { .. } | JitOp::FieldBinopField { .. } |
+            // The in-place reduce setpath: a type-mismatched navigation
+            // (setpath on a scalar acc) sets the error flag instead of
+            // silently no-opping (#1085).
+            JitOp::SetPathMut { .. } |
             // The reduce in-place update/assign navigation: a type-mismatched
             // index (string key on array, number key on object, any key on a
             // scalar) sets the error flag instead of silently navigating to
@@ -3642,6 +3644,19 @@ impl Flattener {
                 if is_scalar(path_expr) {
                     if let Some(path_components) = extract_simple_path(path_expr) {
                         let path_arr = self.build_path_array(&path_components, input_slot);
+                        // #1085: eval validates the navigation while
+                        // building the path (`5 | path(.[0])` raises
+                        // "Cannot index number with number"); the static
+                        // array alone skips that. getpath performs the
+                        // identical walk with identical errors, so run it
+                        // for effect and discard the value.
+                        let probe = self.alloc_slot();
+                        self.emit(JitOp::CallBuiltin {
+                            dst: probe,
+                            builtin: JitBuiltin::Rt(crate::runtime::RtBuiltin::Getpath),
+                            args: vec![input_slot, path_arr],
+                        });
+                        self.emit(JitOp::Drop { slot: probe });
                         self.emit_yield(path_arr);
                         self.emit(JitOp::Drop { slot: path_arr });
                         return true;
@@ -3703,25 +3718,16 @@ impl Flattener {
                         }
                     }
                 }
-                // Delegate complex path expressions to runtime
-                let idx = self.closure_ops.len();
-                self.closure_ops.push((**path_expr).clone());
-                let inp = self.alloc_slot();
-                self.emit(JitOp::Clone { dst: inp, src: input_slot });
-                // path() can produce multiple outputs (generator paths)
-                let arr = self.alloc_slot();
-                self.emit_propagating(JitOp::CallBuiltin {
-                    dst: arr,
-                    builtin: JitBuiltin::PathExpr { expr_idx: idx },
-                    args: vec![inp],
-                });
-                self.emit(JitOp::Drop { slot: inp });
-                // arr is an array of paths; iterate and yield each
-                self.flatten_each_with_action(arr, false, &|s, elem| {
-                    s.emit_yield(elem);
-                });
-                self.emit(JitOp::Drop { slot: arr });
-                true
+                // Complex path expressions: bail the whole filter to eval.
+                // The old delegate collected every path into an array up
+                // front, which (a) hangs on infinite streams eval cuts
+                // lazily (`[limit(5; path(recurse(.a)))]`, #1085), and
+                // (b) predates the eval-side provenance fixes (#880/#953),
+                // erroring on rootless anchors like `. as $x | path($x)`.
+                // The flag forces the bail even from emission contexts
+                // that ignore a false return.
+                self.has_unresolved_recursion = true;
+                false
             }
 
             // `not` as a generator (already handled as scalar but needs generator wrapper)
@@ -7397,42 +7403,20 @@ extern "C" fn jit_rt_unaryop(dst: *mut Value, op: i32, input: *const Value) -> i
                 return 0;
             }
         }
-        // Fast path: from_entries (op 28). Bail to the generic builtin path when the
-        // key resolves to a non-string so the eval path emits jq's type error (issue #73).
+        // Fast path: from_entries (op 28). Delegate to the shared
+        // rt_from_entries: the previous inline copy still honored the
+        // pre-#976 `key_` alias (wrong key precedence vs jq 1.8.1's
+        // `.key // .Key // .name // .Name`) and bailed to a path that
+        // never raised "Cannot use null (null) as object key". #1085
         if op == 28 {
-            if let Value::Arr(a) = &*input {
-                let mut obj = crate::value::new_objmap();
-                let mut ok = true;
-                for entry in a.iter() {
-                    match entry {
-                        Value::Obj(ObjInner(o)) => {
-                            let pick_truthy = |name: &str| -> Option<&Value> {
-                                match o.get(name) {
-                                    Some(v) if !matches!(v, Value::Null | Value::False) => Some(v),
-                                    _ => None,
-                                }
-                            };
-                            let key = pick_truthy("key")
-                                .or_else(|| pick_truthy("key_"))
-                                .or_else(|| pick_truthy("Key"))
-                                .or_else(|| pick_truthy("name"))
-                                .or_else(|| pick_truthy("Name"))
-                                .cloned()
-                                .unwrap_or(Value::Null);
-                            let val = o.get("value").or_else(|| o.get("Value"))
-                                .cloned().unwrap_or(Value::Null);
-                            let key_str = match &key {
-                                Value::Str(s) => crate::value::KeyStr::from(s.as_str()),
-                                _ => { ok = false; break; }
-                            };
-                            obj.insert(key_str, val);
-                        }
-                        _ => { ok = false; break; }
+            if let Value::Arr(_) = &*input {
+                match crate::runtime::rt_from_entries(&*input) {
+                    Ok(v) => { std::ptr::write(dst, v); return 0; }
+                    Err(e) => {
+                        set_jit_error_from(&e);
+                        std::ptr::write(dst, Value::Null);
+                        return GEN_ERROR;
                     }
-                }
-                if ok {
-                    std::ptr::write(dst, Value::object_from_map(obj));
-                    return 0;
                 }
             }
         }
@@ -7710,24 +7694,19 @@ extern "C" fn jit_rt_unaryop(dst: *mut Value, op: i32, input: *const Value) -> i
                 _ => {}
             }
         }
-        // Fast path: transpose (op 26)
+        // Fast path: transpose (op 26). Delegate to the shared rt_transpose:
+        // the previous inline copy null-padded non-array elements where
+        // eval/jq raise "Cannot index <type> with number" (#543). #1085
         if op == 26 {
-            if let Value::Arr(a) = &*input {
-                let max_len = a.iter().filter_map(|v| if let Value::Arr(sub) = v { Some(sub.len()) } else { None }).max().unwrap_or(0);
-                let mut result = Vec::with_capacity(max_len);
-                for i in 0..max_len {
-                    let mut row = Vec::with_capacity(a.len());
-                    for item in a.iter() {
-                        if let Value::Arr(sub) = item {
-                            row.push(sub.get(i).cloned().unwrap_or(Value::Null));
-                        } else {
-                            row.push(Value::Null);
-                        }
+            if let Value::Arr(_) = &*input {
+                match crate::runtime::rt_transpose(&*input) {
+                    Ok(v) => { std::ptr::write(dst, v); return 0; }
+                    Err(e) => {
+                        set_jit_error_from(&e);
+                        std::ptr::write(dst, Value::Null);
+                        return GEN_ERROR;
                     }
-                    result.push(Value::Arr(Rc::new(row)));
                 }
-                std::ptr::write(dst, Value::Arr(Rc::new(result)));
-                return 0;
             }
         }
         // Fast path: infinite (op 34), nan (op 35)
@@ -7856,8 +7835,17 @@ extern "C" fn jit_rt_setpath_mut(container: *mut Value, path: *const Value, val:
         let new_val = std::ptr::read(val);
         std::ptr::write(val, Value::Null);
 
-        if let Value::Arr(p) = path_val {
-            let _ = crate::runtime::rt_setpath_mut(&mut *container, p.as_slice(), new_val);
+        // Surface navigation errors ("Cannot index number with string
+        // \"a\"") through the pending-error flag instead of silently
+        // leaving the accumulator untouched — eval raises here. The op is
+        // marked fallible, so a CheckError follows every emission. #1085
+        let res = if let Value::Arr(p) = path_val {
+            crate::runtime::rt_setpath_mut(&mut *container, p.as_slice(), new_val)
+        } else {
+            Err(anyhow::anyhow!("Path must be specified as an array"))
+        };
+        if let Err(e) = res {
+            set_jit_error_from(&e);
         }
     }
 }
@@ -8914,20 +8902,6 @@ extern "C" fn jit_rt_call_builtin(dst: *mut Value, builtin: *const JitBuiltin,
                 std::ptr::write(dst, Value::Arr(Rc::new(vec![])));
             }
             return 0;
-        }
-
-        // path expression evaluation delegated to eval
-        if let JitBuiltin::PathExpr { expr_idx } = b {
-            let idx: usize = *expr_idx;
-            let path_expr = JIT_CLOSURE_OPS.with(|cell| (&*cell.get()).get(idx).cloned());
-            if let Some(path_expr) = path_expr {
-                let input = if !args.is_empty() { args[0].clone() } else { Value::Null };
-                let env = new_delegated_env(&[&path_expr]);
-                match crate::eval::eval_path_standalone(&path_expr, input, &env) {
-                    Ok(v) => { std::ptr::write(dst, v); return 0; }
-                    Err(e) => { set_jit_error_from(&e); std::ptr::write(dst, Value::Null); return GEN_ERROR; }
-                }
-            }
         }
 
         // delegate to eval-based closure operation (sort_by/group_by/...)

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2171,7 +2171,7 @@ fn rt_to_entries(v: &Value) -> Result<Value> {
     }
 }
 
-fn rt_from_entries(v: &Value) -> Result<Value> {
+pub(crate) fn rt_from_entries(v: &Value) -> Result<Value> {
     match v {
         Value::Arr(a) => {
             let mut obj = new_objmap();
@@ -2232,7 +2232,7 @@ fn rt_from_entries(v: &Value) -> Result<Value> {
     }
 }
 
-fn rt_transpose(v: &Value) -> Result<Value> {
+pub(crate) fn rt_transpose(v: &Value) -> Result<Value> {
     // jq's transpose accepts both arrays and objects (objects iterate
     // their values, like jq's other "iterable" sites). The inner `.[$i]`
     // index against a non-array element fails with the standard

--- a/tests/enforce_closure_op_env_seeding.rs
+++ b/tests/enforce_closure_op_env_seeding.rs
@@ -155,7 +155,9 @@ fn closure_op_dispatchers_seed_delegated_env() {
 
     // Sanity: the known eval-delegating variants must be present (catches
     // a parser breakage or a rename that would silently skip enforcement).
-    for required in ["Assign", "Update", "PathExpr", "PathsFiltered", "ClosureOp"] {
+    // PathExpr was removed in #1085 — complex path() now bails the whole
+    // filter to eval instead of delegating an eager collection.
+    for required in ["Assign", "Update", "PathsFiltered", "ClosureOp"] {
         assert!(
             variants.contains(required),
             "variant parser sanity: expected JitBuiltin::{} in {}",

--- a/tests/jit_path_validation.rs
+++ b/tests/jit_path_validation.rs
@@ -1,0 +1,152 @@
+//! Issue #1085: path()/setpath validation gaps on the JIT path returned
+//! wrong values where eval/jq raise, and `limit(n; path(recurse(.a)))`
+//! hung. The worst class from the #1059 backend self-diff: silently wrong
+//! data, not just wrong error text.
+//!
+//! - `path(<simple path>)` emitted the static path array without walking
+//!   the input, skipping eval's navigation errors. A getpath probe now
+//!   performs the identical walk for effect.
+//! - Complex path expressions were delegated to an eager collect-all,
+//!   which hung on infinite streams eval cuts lazily and predated the
+//!   eval-side provenance fixes (#880/#953) for rootless anchors like
+//!   `. as $x | path($x)`. They now bail the whole filter to eval.
+//! - The in-place reduce setpath (SetPathMut) discarded navigation errors,
+//!   leaving the accumulator untouched.
+//! - The jit_rt_unaryop transpose and from_entries arms drifted from the
+//!   shared rt_ helpers (null-padding instead of "Cannot index", pre-#976
+//!   `key_` alias and missing null-key error).
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn run_backend(filter: &str, stdin: &str, backend_env: &str) -> (String, Option<i32>) {
+    let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
+    let mut child = Command::new(jq_jit)
+        .args(["-c", filter])
+        .env(backend_env, "1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn jq-jit");
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(stdin.as_bytes())
+        .unwrap();
+    let out = child.wait_with_output().expect("wait failed");
+    (
+        String::from_utf8_lossy(&out.stdout).trim_end().to_string(),
+        out.status.code(),
+    )
+}
+
+fn assert_jit(filter: &str, stdin: &str, expected: &str) {
+    for backend in ["JQJIT_FORCE_CRANELIFT", "JQJIT_FORCE_JITOP_INTERP"] {
+        let (stdout, code) = run_backend(filter, stdin, backend);
+        assert_eq!(
+            stdout, expected,
+            "{backend}: filter {filter:?} on {stdin:?} gave {stdout:?}, want {expected:?}"
+        );
+        assert_eq!(code, Some(0), "{backend}: filter {filter:?} exited nonzero");
+    }
+}
+
+#[test]
+fn simple_path_validates_navigation() {
+    assert_jit(
+        "try path(.[0]) catch .",
+        "5",
+        "\"Cannot index number with number\"",
+    );
+    assert_jit(
+        "try path(.x) catch .",
+        "5",
+        "\"Cannot index number with string \\\"x\\\"\"",
+    );
+    // Valid navigations still yield the path.
+    assert_jit("path(.a)", "{\"a\":1}", "[\"a\"]");
+    assert_jit("path(.a.b)", "{\"a\":{\"b\":1}}", "[\"a\",\"b\"]");
+    assert_jit("path(.missing)", "{}", "[\"missing\"]");
+}
+
+#[test]
+fn invalid_path_keys_raise() {
+    assert_jit(
+        "try (path(.[true])) catch .",
+        "null",
+        "\"Cannot index null with boolean\"",
+    );
+    assert_jit(
+        "try (path(.[null])) catch .",
+        "null",
+        "\"Cannot index null with null\"",
+    );
+}
+
+#[test]
+fn rootless_var_anchored_path_yields_empty_prefix() {
+    assert_jit(". as $x | path($x)", "{\"a\":1}", "[]");
+    assert_jit(". as $x | path($x | .a)", "{\"a\":1}", "[\"a\"]");
+}
+
+#[test]
+fn limit_of_infinite_path_stream_terminates() {
+    assert_jit(
+        "[limit(5; path(recurse(.a)))]",
+        "{\"a\":{\"b\":9}}",
+        "[[],[\"a\"],[\"a\",\"a\"],[\"a\",\"a\",\"a\"],[\"a\",\"a\",\"a\",\"a\"]]",
+    );
+}
+
+#[test]
+fn reduce_setpath_surfaces_navigation_errors() {
+    assert_jit(
+        "try (reduce range(1) as $_ (.; setpath([\"a\"]; 99))) catch .",
+        "5",
+        "\"Cannot index number with string \\\"a\\\"\"",
+    );
+    assert_jit(
+        "try (reduce range(1) as $_ (.; setpath([null]; 99))) catch .",
+        "5",
+        "\"Cannot index number with null\"",
+    );
+    // The happy path keeps working in place.
+    assert_jit(
+        "reduce range(3) as $i ({}; setpath([\"k\\($i)\"]; $i)) | length",
+        "null",
+        "3",
+    );
+}
+
+#[test]
+fn transpose_raises_on_non_array_elements() {
+    assert_jit(
+        "try transpose catch .",
+        "[1,2]",
+        "\"Cannot index number with number\"",
+    );
+    assert_jit("transpose", "[[1,2],[3,4]]", "[[1,3],[2,4]]");
+}
+
+#[test]
+fn from_entries_key_precedence_and_null_key() {
+    // jq 1.8.1 resolves the key via .key // .Key // .name // .Name;
+    // `key_` is NOT an alias (#976).
+    assert_jit(
+        "from_entries",
+        "[{\"key_\":\"K_\",\"name\":\"NAME\",\"value\":1}]",
+        "{\"NAME\":1}",
+    );
+    assert_jit(
+        "try from_entries catch .",
+        "[{\"key_\":\"x\",\"value\":1}]",
+        "\"Cannot use null (null) as object key\"",
+    );
+    assert_jit(
+        "from_entries",
+        "[{\"key\":\"a\",\"value\":1}]",
+        "{\"a\":1}",
+    );
+}


### PR DESCRIPTION
## Summary

The worst class from the #1059 backend self-diff: the JIT path returned **silently wrong values** (or hung) where eval/jq raise.

- **`path(<simple path>)`** emitted the static path array without walking the input — `5 | path(.[0])` yielded `[0]` instead of `Cannot index number with number`. A `getpath` probe now performs the identical navigation for effect before the yield.
- **Complex path expressions** (`path($x)`, `path(.[true])`, `path(recurse(.a))`) were delegated to an eval helper that collected *every* path into an array up front: it hung on infinite streams eval cuts lazily (`[limit(5; path(recurse(.a)))]`) and predated the eval-side provenance fixes (#880/#953), erroring on rootless anchors like `. as $x | path($x)`. The arm now bails the whole filter to eval via the `has_unresolved_recursion` flag — safe even from emission contexts that ignore a `false` return. The dead `JitBuiltin::PathExpr` delegate is removed (enforcement test sanity list updated).
- **In-place reduce setpath** (`SetPathMut`) discarded navigation errors, leaving the accumulator untouched: `reduce range(1) as $_ (.; setpath(["a"]; 99))` on `5` returned `5`. The runtime arm surfaces the error through the pending-error flag and the op is marked fallible.
- **transpose / from_entries** `jit_rt_unaryop` arms drifted from the shared rt_ helpers: transpose null-padded non-array elements where eval raises (#543 semantics); from_entries still honored the pre-#976 `key_` alias (wrong key precedence vs jq 1.8.1's `.key // .Key // .name // .Name`) and never raised `Cannot use null (null) as object key`. Both delegate to the rt_ implementations now.

## Verification

- Backend-diff over the whole regression corpus: **31 → 14 divergences**; every #1085 line (7892–7912, 8112/8117, 8724/8729, 9456–9466, 11679/11684, 12747, 13058–13068) now agrees across eval, Cranelift, and the JitOp interpreter. The remaining 14 belong to #1086–#1090.
- New suite `tests/jit_path_validation.rs` pins each shape under both forced backends, including happy-path sanity (path navigation, in-place reduce setpath, transpose, from_entries).
- `cargo build --release` zero warnings; `cargo test --release` all 66 suites pass.
- **Perf** (same-machine interleaved A/B vs main, best-of-7): `reduce (setpath)` ratio 0.94, `.[k]=v reduce(50K)` 1.000, p126 nested reduce 1.009 — the per-iteration CheckError after SetPathMut costs nothing measurable.

Closes #1085

🤖 Generated with [Claude Code](https://claude.com/claude-code)