### PR TITLE
fix(jit): make break catchable through try/catch like eval/jq

### DIFF
--- a/src/jit.rs
+++ b/src/jit.rs
@@ -694,7 +694,11 @@ struct Flattener {
     /// After each fallible op, CheckError is emitted to branch to catch_label on error.
     try_catch_target: Option<(LabelId, SlotId)>,
     /// Label targets for break: var_index → done_label
-    label_targets: HashMap<VarIdx, LabelId>,
+    /// Break targets: label var → (jump target, try_depth at registration).
+    /// The depth lets `break` distinguish a label inside the current try
+    /// (plain jump) from a try sitting between the break and its label
+    /// (the catch intercepts the break, #1086).
+    label_targets: HashMap<VarIdx, (LabelId, u32)>,
     /// Available compiled functions for FuncCall
     funcs: Vec<CompiledFunc>,
     /// Limit state: when inside a `limit(n; gen)`, emit_yield increments counter and breaks.
@@ -3463,7 +3467,7 @@ impl Flattener {
 
             Expr::Label { var_index, body } => {
                 let done_label = self.alloc_label();
-                self.label_targets.insert(*var_index, done_label);
+                self.label_targets.insert(*var_index, (done_label, self.try_depth));
                 let ok = self.flatten_gen(body, input_slot);
                 self.label_targets.remove(var_index);
                 self.emit(JitOp::Label { id: done_label });
@@ -3471,7 +3475,27 @@ impl Flattener {
             }
 
             Expr::Break { var_index, .. } => {
-                if let Some(&done_label) = self.label_targets.get(var_index) {
+                // jq implements `break $label` as a special error value
+                // carrying `__jq`, which try/catch DOES intercept and `?`
+                // suppresses (only the break — siblings keep running). A
+                // direct jump bypasses the enclosing catch, so inside a try
+                // scope the break must be thrown as the `{"__jq": id}`
+                // object instead (matching eval's catch shape, #715). Only
+                // the shape is guaranteed; the id is internal. #1086
+                let label_entry = self.label_targets.get(var_index).copied();
+                let intercepted = self.try_catch_target.is_some()
+                    && label_entry.is_none_or(|(_, label_depth)| self.try_depth > label_depth);
+                if intercepted {
+                    let obj = self.alloc_slot();
+                    self.emit(JitOp::ObjNew { dst: obj, cap: 1 });
+                    let idv = self.alloc_slot();
+                    self.emit(JitOp::Num { dst: idv, val: var_index.0 as f64, repr: None });
+                    self.emit(JitOp::ObjInsertStrKey { obj, key: "__jq".to_string(), val: idv });
+                    self.emit(JitOp::ThrowError { msg: obj });
+                    self.emit(JitOp::Drop { slot: obj });
+                    return true;
+                }
+                if let Some((done_label, _)) = label_entry {
                     self.emit(JitOp::Jump { label: done_label });
                     true
                 } else {

--- a/tests/jit_break_catchable.rs
+++ b/tests/jit_break_catchable.rs
@@ -1,0 +1,92 @@
+//! Issue #1086: label/break unwinding diverged on the JIT path. jq
+//! implements `break $label` as a special error value carrying `__jq`,
+//! which `try/catch` intercepts and `?` suppresses (only the break itself
+//! — sibling outputs keep running). The JIT lowered break as a direct jump
+//! to the label end, bypassing any catch in between.
+//!
+//! Break now throws the `{"__jq": id}` object when a try sits between the
+//! break and its label (depth-tracked at label registration); a label
+//! inside the current try keeps the plain jump, so `def f: label $o |
+//! (10, break $o, 20); try (f, 99) catch "c"` still yields 10, 99.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn run_backend(filter: &str, stdin: &str, backend_env: &str) -> (String, Option<i32>) {
+    let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
+    let mut child = Command::new(jq_jit)
+        .args(["-c", filter])
+        .env(backend_env, "1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn jq-jit");
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(stdin.as_bytes())
+        .unwrap();
+    let out = child.wait_with_output().expect("wait failed");
+    (
+        String::from_utf8_lossy(&out.stdout).trim_end().to_string(),
+        out.status.code(),
+    )
+}
+
+fn assert_jit(filter: &str, expected: &str) {
+    for backend in ["JQJIT_FORCE_CRANELIFT", "JQJIT_FORCE_JITOP_INTERP"] {
+        let (stdout, code) = run_backend(filter, "null", backend);
+        assert_eq!(
+            stdout, expected,
+            "{backend}: filter {filter:?} gave {stdout:?}, want {expected:?}"
+        );
+        assert_eq!(code, Some(0), "{backend}: filter {filter:?} exited nonzero");
+    }
+}
+
+#[test]
+fn break_is_catchable() {
+    assert_jit("label $out | try break $out catch \"c\"", "\"c\"");
+    assert_jit(
+        "[label $out | try break $out catch (type, has(\"__jq\"))]",
+        "[\"object\",true]",
+    );
+    assert_jit(
+        "[label $out | try (1, break $out, 2) catch \"c\"]",
+        "[1,\"c\"]",
+    );
+}
+
+#[test]
+fn optional_suppresses_only_the_break() {
+    assert_jit("[label $out | (break $out)?, 1]", "[1]");
+}
+
+#[test]
+fn caught_break_does_not_exit_enclosing_loops() {
+    assert_jit(
+        "[label $out | range(5) | try (if .==2 then break $out else . end) catch \"x\"]",
+        "[0,1,\"x\",3,4]",
+    );
+}
+
+#[test]
+fn label_inside_try_still_unwinds_by_jump() {
+    // The label sits inside the try: the break unwinds to it normally and
+    // is NOT intercepted by the outer catch.
+    assert_jit(
+        "def f: label $o | (10, break $o, 20); [try (f, 99) catch \"c\"]",
+        "[10,99]",
+    );
+    assert_jit(
+        "[label $a | try (label $b | (1, break $a, 2)) catch \"c\"]",
+        "[1,\"c\"]",
+    );
+}
+
+#[test]
+fn plain_break_unchanged() {
+    assert_jit("[label $out | 1, break $out, 2]", "[1]");
+}


### PR DESCRIPTION
## Summary

jq implements `break $label` as a special error value carrying `__jq`, which `try/catch` intercepts and `?` suppresses (only the break itself — sibling outputs keep running). The JIT lowered break as a direct jump to the label end, bypassing any catch in between: `label $out | try break $out catch "c"` produced no output, and `(break $out)?` swallowed everything after it.

## Fix

Break now throws the `{"__jq": id}` object (matching eval's catch shape from #715; only the shape is guaranteed) when a try sits **between** the break and its label. The label registry records the `try_depth` at registration, so a label *inside* the current try keeps the plain jump — `def f: label $o | (10, break $o, 20); try (f, 99) catch "c"` still yields `10, 99`. (An unconditional throw regressed exactly that corpus line during verification; the depth tracking is what makes both directions correct.)

## Verification

- Backend-diff over the whole regression corpus: **14 → 9 divergences**; all five #1086 lines (10604–10624) plus the function-wrapped label line (11318) agree across eval, Cranelift, and the JitOp interpreter. The remaining 9 belong to #1087–#1090.
- New suite `tests/jit_break_catchable.rs` pins catchability, `?` suppression, loop continuation after a caught break, label-inside-try jump behavior, and plain break.
- `cargo build --release` zero warnings; `cargo test --release` all 67 suites pass.
- No hot-path impact: the new ops are emitted only for break-inside-try shapes; plain breaks compile exactly as before.

Closes #1086

🤖 Generated with [Claude Code](https://claude.com/claude-code)