### PR TITLE
fix(jit): apply jq's total order to fused field-vs-number comparisons

### DIFF
--- a/src/jit.rs
+++ b/src/jit.rs
@@ -6886,12 +6886,25 @@ extern "C" fn jit_rt_field_cmp_num(base: *const Value, key_ptr: *const u8, key_l
                 8 | 10 => 0,      // null > num, null >= num → false
                 _ => 0,
             },
-            // Other types compare as `string > number`, `array > number`,
-            // etc. in jq's ordering. The fast path only supports numeric
-            // operands; falling through to 0 here is the pre-fix behavior
-            // and the wider type-ordering coverage stays on the generic
-            // path.
-            _ => 0,
+            // Other types follow jq's sort total order (null < false <
+            // true < numbers < strings < arrays < objects): booleans rank
+            // below the numeric rhs, strings/arrays/objects above, and
+            // cross-type equality is always false. Returning 0 here made
+            // `select(.x > 3)` drop string fields jq keeps. #1087
+            Some(other) => {
+                use std::cmp::Ordering;
+                let ord = crate::runtime::compare_values(other, &Value::number(rhs));
+                let result = match op {
+                    5 => ord == Ordering::Equal,
+                    6 => ord != Ordering::Equal,
+                    7 => ord == Ordering::Less,
+                    8 => ord == Ordering::Greater,
+                    9 => ord != Ordering::Greater,
+                    10 => ord != Ordering::Less,
+                    _ => return 0,
+                };
+                if result { 1 } else { 0 }
+            }
         }
     }
 }

--- a/tests/jit_field_cmp_total_order.rs
+++ b/tests/jit_field_cmp_total_order.rs
@@ -1,0 +1,70 @@
+//! Issue #1087: the fused `FieldCmpNum` JitOp treated a non-numeric field
+//! as a comparison miss, dropping jq's sort total order (null < false <
+//! true < numbers < strings < arrays < objects) — `select(.x > 3)` on
+//! `{"x":"hi"}` produced no output where jq keeps the object. The helper
+//! now falls back to compare_values for non-numeric fields; the numeric
+//! fast arm is unchanged.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn run_backend(filter: &str, stdin: &str, backend_env: &str) -> (String, Option<i32>) {
+    let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
+    let mut child = Command::new(jq_jit)
+        .args(["-c", filter])
+        .env(backend_env, "1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn jq-jit");
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(stdin.as_bytes())
+        .unwrap();
+    let out = child.wait_with_output().expect("wait failed");
+    (
+        String::from_utf8_lossy(&out.stdout).trim_end().to_string(),
+        out.status.code(),
+    )
+}
+
+fn assert_jit(filter: &str, stdin: &str, expected: &str) {
+    for backend in ["JQJIT_FORCE_CRANELIFT", "JQJIT_FORCE_JITOP_INTERP"] {
+        let (stdout, code) = run_backend(filter, stdin, backend);
+        assert_eq!(
+            stdout, expected,
+            "{backend}: filter {filter:?} on {stdin:?} gave {stdout:?}, want {expected:?}"
+        );
+        assert_eq!(code, Some(0), "{backend}: filter {filter:?} exited nonzero");
+    }
+}
+
+#[test]
+fn string_field_ranks_above_numbers() {
+    assert_jit("select(.x > 3)", "{\"x\":\"hi\"}", "{\"x\":\"hi\"}");
+    assert_jit("select(.x < 3)", "{\"x\":\"hi\"}", "");
+    assert_jit("if .x < 3 then \"lo\" else \"hi\" end", "{\"x\":\"s\"}", "\"hi\"");
+}
+
+#[test]
+fn booleans_rank_below_numbers() {
+    assert_jit("select(.x > 3)", "{\"x\":true}", "");
+    assert_jit("select(.x <= 3)", "{\"x\":false}", "{\"x\":false}");
+}
+
+#[test]
+fn containers_rank_above_numbers() {
+    assert_jit("select(.x >= 3)", "{\"x\":{\"a\":1}}", "{\"x\":{\"a\":1}}");
+    assert_jit("select(.x != 3)", "{\"x\":[1]}", "{\"x\":[1]}");
+    assert_jit("select(.x == 3)", "{\"x\":\"hi\"}", "");
+}
+
+#[test]
+fn numeric_fast_arm_unchanged() {
+    assert_jit("select(.x > 3)", "{\"x\":5}", "{\"x\":5}");
+    assert_jit("select(.x > 3)", "{\"x\":1}", "");
+    assert_jit("select(.x > 3)", "{}", "");
+}


### PR DESCRIPTION
## Summary

`jit_rt_field_cmp_num` returned 0 (comparison miss) for any non-numeric field, dropping jq's sort total order (null < false < true < numbers < strings < arrays < objects): `select(.x > 3)` on `{"x":"hi"}` produced no output where jq keeps the object (regression corpus line 3592).

## Fix

Non-numeric fields now fall back to `compare_values` against the numeric operand (cross-type equality stays false). The numeric fast arm and the null/absent arm are untouched, so the hot select path costs nothing extra.

Audited the sibling fused ops per the issue: `FieldBinopConst` / `FieldBinopField` already route non-numeric operands through `eval_binop` (correct), and `FieldIsTruthy` is type-independent.

## Verification

- Backend-diff over the whole regression corpus: **9 → 8 divergences** (line 3592 agrees; the remaining 8 belong to #1088–#1090).
- New suite `tests/jit_field_cmp_total_order.rs` pins string/boolean/container ranking and the numeric arm under both forced backends.
- `cargo build --release` zero warnings; `cargo test --release` all 67 suites pass.

Closes #1087

🤖 Generated with [Claude Code](https://claude.com/claude-code)