### PR TITLE
fix(jit): stream CallBuiltin argument generators in eval's cartesian order

### DIFF
--- a/src/jit.rs
+++ b/src/jit.rs
@@ -3797,23 +3797,18 @@ impl Flattener {
                     op: *op,
                     args: var_args.iter().map(|(vi, _)| Expr::LoadVar { var_index: *vi }).collect(),
                 };
+                // Wrap arg0 first so it becomes the INNERMOST binding:
+                // eval iterates the first argument fastest
+                // (`[pow(10,20; 1,2)]` → [10,20,100,400]), so the last
+                // argument must be the outermost loop. The previous .rev()
+                // nesting produced the transposed order. #1088
                 let mut rewritten = inner;
-                for (vi, arg) in var_args.iter().rev() {
-                    if is_scalar(arg) {
-                        // Scalar arg: still use LetBinding for uniformity
-                        rewritten = Expr::LetBinding {
-                            var_index: *vi,
-                            value: Box::new((*arg).clone()),
-                            body: Box::new(rewritten),
-                        };
-                    } else {
-                        // Generator arg: wrap in LetBinding
-                        rewritten = Expr::LetBinding {
-                            var_index: *vi,
-                            value: Box::new((*arg).clone()),
-                            body: Box::new(rewritten),
-                        };
-                    }
+                for (vi, arg) in var_args.iter() {
+                    rewritten = Expr::LetBinding {
+                        var_index: *vi,
+                        value: Box::new((*arg).clone()),
+                        body: Box::new(rewritten),
+                    };
                 }
                 self.flatten_gen(&rewritten, input_slot)
             }
@@ -4014,6 +4009,42 @@ impl Flattener {
                 self.flatten_each_with_action(container, true, action);
                 self.emit(JitOp::Drop { slot: container });
                 true
+            }
+            // BinOp with exactly one generator operand: stream it through
+            // `action` per item instead of collecting every output first.
+            // The collect fallback below defeats short-circuiting consumers
+            // — `IN(2, error("x"); 2)` desugars to any((2,error("x")) == 2; .)
+            // and must stop at the first match without evaluating the
+            // error. #1088
+            Expr::BinOp { op, lhs, rhs }
+                if !matches!(op, BinOp::And | BinOp::Or)
+                    && is_scalar(rhs) && !is_scalar(lhs) =>
+            {
+                let rhs_val = self.flatten_scalar(rhs, input_slot);
+                let op_code = *op;
+                let ok = self.flatten_gen_with_each_output(lhs, input_slot, &|s, elem| {
+                    let out = s.alloc_slot();
+                    s.emit(JitOp::BinOp { dst: out, op: op_code, lhs: elem, rhs: rhs_val });
+                    action(s, out);
+                    s.emit(JitOp::Drop { slot: out });
+                });
+                self.emit(JitOp::Drop { slot: rhs_val });
+                ok
+            }
+            Expr::BinOp { op, lhs, rhs }
+                if !matches!(op, BinOp::And | BinOp::Or)
+                    && is_scalar(lhs) && !is_scalar(rhs) =>
+            {
+                let lhs_val = self.flatten_scalar(lhs, input_slot);
+                let op_code = *op;
+                let ok = self.flatten_gen_with_each_output(rhs, input_slot, &|s, elem| {
+                    let out = s.alloc_slot();
+                    s.emit(JitOp::BinOp { dst: out, op: op_code, lhs: lhs_val, rhs: elem });
+                    action(s, out);
+                    s.emit(JitOp::Drop { slot: out });
+                });
+                self.emit(JitOp::Drop { slot: lhs_val });
+                ok
             }
             _ => {
                 // Generic fallback: collect all outputs, then iterate

--- a/tests/jit_callbuiltin_arg_order.rs
+++ b/tests/jit_callbuiltin_arg_order.rs
@@ -1,0 +1,76 @@
+//! Issue #1088: CallBuiltin argument generators were evaluated eagerly and
+//! in the wrong cartesian order on the JIT path.
+//!
+//! - The generator-arg rewrite nested the LetBindings reversed, so
+//!   `[pow(10,20; 1,2)]` produced [10,100,20,400] instead of eval's
+//!   first-argument-fastest [10,20,100,400].
+//! - flatten_gen_with_each_output's generic fallback collected EVERY
+//!   output before iterating, defeating short-circuiting consumers:
+//!   `IN(2, error("x"); 2)` desugars to any((2,error("x")) == 2; .) and
+//!   must stop at the first match without evaluating the error. BinOps
+//!   with one generator operand now stream per item.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn run_backend(filter: &str, stdin: &str, backend_env: &str) -> (String, Option<i32>) {
+    let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
+    let mut child = Command::new(jq_jit)
+        .args(["-c", filter])
+        .env(backend_env, "1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn jq-jit");
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(stdin.as_bytes())
+        .unwrap();
+    let out = child.wait_with_output().expect("wait failed");
+    (
+        String::from_utf8_lossy(&out.stdout).trim_end().to_string(),
+        out.status.code(),
+    )
+}
+
+fn assert_jit(filter: &str, stdin: &str, expected: &str) {
+    for backend in ["JQJIT_FORCE_CRANELIFT", "JQJIT_FORCE_JITOP_INTERP"] {
+        let (stdout, code) = run_backend(filter, stdin, backend);
+        assert_eq!(
+            stdout, expected,
+            "{backend}: filter {filter:?} on {stdin:?} gave {stdout:?}, want {expected:?}"
+        );
+        assert_eq!(code, Some(0), "{backend}: filter {filter:?} exited nonzero");
+    }
+}
+
+#[test]
+fn cartesian_order_matches_eval() {
+    assert_jit("[pow(10,20; 1,2)]", "null", "[10,20,100,400]");
+    assert_jit("[ldexp(1,3; 0,4)]", "null", "[1,3,16,48]");
+    assert_jit(
+        "[fma(1,2; 10,20; 100,200)]",
+        "null",
+        "[110,120,120,140,210,220,220,240]",
+    );
+    assert_jit("[pow(2; 1,2,3)]", "null", "[2,4,8]");
+}
+
+#[test]
+fn in_short_circuits_past_errors() {
+    assert_jit("IN(2, error(\"x\"); 2)", "null", "true");
+    assert_jit(
+        "[.[] | select(.x | IN(1, error; 1))]",
+        "[{\"x\":1},{\"x\":9}]",
+        "[{\"x\":1},{\"x\":9}]",
+    );
+}
+
+#[test]
+fn in_plain_membership_unchanged() {
+    assert_jit("IN(1,2,3; 2)", "null", "true");
+    assert_jit("IN(1; 2)", "null", "false");
+}


### PR DESCRIPTION
## Summary

Two gaps in how the JIT path handled builtins whose arguments are generators:

**Cartesian order** — the generator-arg rewrite nested its LetBindings reversed, making the *first* argument the outermost loop: `[pow(10,20; 1,2)]` produced `[10,100,20,400]` where eval iterates the first argument fastest (`[10,20,100,400]`). Same multiset, wrong order; also hit `ldexp` and `fma`. The bindings now wrap arg0 innermost.

**Eager evaluation defeating short-circuit** — `flatten_gen_with_each_output`'s generic fallback collected *every* generator output before iterating. `IN(2, error("x"); 2)` desugars to `any((2, error("x")) == 2; .)` and must stop at the first match without evaluating the error arm; the collect step ran it anyway (exit 5 instead of `true`). BinOps with exactly one generator operand now stream each computed value through the consumer's action, so `any()`'s existing early-exit jump fires before the error is reached. Both-generator BinOps keep the collect fallback.

## Verification

- Backend-diff over the whole regression corpus: **8 → 3 divergences**; all five #1088 lines (13112–13137) agree across eval, Cranelift, and the JitOp interpreter. The remaining 3 belong to #1089/#1090.
- New suite `tests/jit_callbuiltin_arg_order.rs` pins the cartesian order (pow/ldexp/fma), IN's short-circuit past errors, and plain membership.
- `cargo build --release` zero warnings; `cargo test --release` all 68 suites pass.

Closes #1088

🤖 Generated with [Claude Code](https://claude.com/claude-code)