### PR TITLE
fix(jit): report the effective -L search list from get_search_list

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -2872,6 +2872,10 @@ fn real_main() {
         prefix
     };
 
+    // Publish the effective -L dirs so the JIT's get_search_list dispatch
+    // reports the same list as eval's env-aware arm (#1089).
+    jq_jit::runtime::set_lib_dirs(lib_dirs.clone());
+
     // Create filter without JIT initially — JIT is compiled lazily when input is large enough.
     let mut filter = match Filter::with_options(&filter_str, &lib_dirs, false) {
         Ok(f) => f,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -4850,12 +4850,39 @@ pub fn rt_get_prog_origin() -> Value {
 /// Module search path list. jq-jit doesn't implement `import`/`include`
 /// (see #614), so this returns jq 1.8.1's static defaults; feature-probing
 /// scripts that enumerate the search list still see a shape they recognise.
+/// The effective `-L` search dirs, set once at CLI startup so the JIT's
+/// generic dispatch reports the same list as eval's env-aware arm (#1003 /
+/// #1089). Empty (the default) means "no -L given" → compile-time defaults.
+static LIB_DIRS: std::sync::OnceLock<Vec<String>> = std::sync::OnceLock::new();
+
+pub fn set_lib_dirs(dirs: Vec<String>) {
+    let _ = LIB_DIRS.set(dirs);
+}
+
 pub fn rt_get_search_list() -> Value {
-    Value::Arr(Rc::new(vec![
-        Value::from_str("~/.jq"),
-        Value::from_str("$ORIGIN/../lib/jq"),
-        Value::from_str("$ORIGIN/../lib"),
-    ]))
+    // jq reports the *effective* search list: the `-L` dirs (canonicalised
+    // via realpath when they resolve, else kept as given) when any are
+    // present, otherwise the compile-time defaults — mirroring eval's
+    // GetSearchList arm exactly. #1089
+    let dirs = LIB_DIRS.get().map(|d| d.as_slice()).unwrap_or(&[]);
+    if dirs.is_empty() {
+        return Value::Arr(Rc::new(vec![
+            Value::from_str("~/.jq"),
+            Value::from_str("$ORIGIN/../lib/jq"),
+            Value::from_str("$ORIGIN/../lib"),
+        ]));
+    }
+    let list: Vec<Value> = dirs
+        .iter()
+        .map(|d| {
+            let canon = std::fs::canonicalize(d)
+                .ok()
+                .map(|p| p.to_string_lossy().into_owned())
+                .unwrap_or_else(|| d.clone());
+            Value::from_str(&canon)
+        })
+        .collect();
+    Value::Arr(Rc::new(list))
 }
 
 pub fn rt_builtins() -> Value {

--- a/tests/jit_get_search_list.rs
+++ b/tests/jit_get_search_list.rs
@@ -1,0 +1,40 @@
+//! Issue #1089: the JIT's get_search_list dispatch returned the static
+//! compile-time defaults, ignoring `-L` — eval reports the *effective*
+//! search list (#1003). The CLI now publishes the `-L` dirs to the runtime
+//! so both backends agree.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn run(filter: &str, extra_args: &[&str], backend_env: &str) -> String {
+    let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
+    let mut cmd = Command::new(jq_jit);
+    cmd.args(extra_args).args(["-c", filter]).env(backend_env, "1");
+    let mut child = cmd
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn jq-jit");
+    child.stdin.take().unwrap().write_all(b"0\n").unwrap();
+    let out = child.wait_with_output().expect("wait failed");
+    String::from_utf8_lossy(&out.stdout).trim_end().to_string()
+}
+
+#[test]
+fn search_list_honors_lib_dirs_on_jit_path() {
+    let lib_dir = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/modules");
+    let eval = run("get_search_list", &["-L", lib_dir], "JQJIT_FORCE_INTERPRETER");
+    for backend in ["JQJIT_FORCE_CRANELIFT", "JQJIT_FORCE_JITOP_INTERP"] {
+        let jit = run("get_search_list", &["-L", lib_dir], backend);
+        assert_eq!(jit, eval, "{backend} diverges from eval");
+    }
+    let count = run("get_search_list | length", &["-L", lib_dir], "JQJIT_FORCE_CRANELIFT");
+    assert_eq!(count, "1");
+}
+
+#[test]
+fn search_list_defaults_without_lib_dirs() {
+    let jit = run("get_search_list", &[], "JQJIT_FORCE_CRANELIFT");
+    assert_eq!(jit, "[\"~/.jq\",\"$ORIGIN/../lib/jq\",\"$ORIGIN/../lib\"]");
+}


### PR DESCRIPTION
## Summary

The JIT's `get_search_list` dispatch returned the static compile-time defaults (`~/.jq`, `$ORIGIN/../lib/jq`, `$ORIGIN/../lib`), ignoring `-L` — eval's env-aware arm reports the *effective* list (#1003): the `-L` dirs, canonicalised via realpath when they resolve. With `-L tests/modules`, JIT reported 3 entries where eval reports 1.

## Fix

The CLI publishes the parsed `-L` dirs to a runtime `OnceLock` at startup; `rt_get_search_list` mirrors eval's logic exactly (defaults when no `-L`, canonicalised dirs otherwise).

## Verification

- Backend-diff over the whole regression corpus: **3 → 2 divergences** (line 9768 agrees; the remaining 2 are #1090).
- New suite `tests/jit_get_search_list.rs` pins `-L` parity across backends and the no-`-L` defaults.
- `cargo build --release` zero warnings; `cargo test --release` all 70 suites pass.

Closes #1089

🤖 Generated with [Claude Code](https://claude.com/claude-code)