### PR TITLE
fix(jit): dedup duplicate keys on the identity-output raw passthrough

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -3759,6 +3759,12 @@ fn real_main() {
                     if let Some(raw) = raw_bytes {
                         if std::ptr::eq(result, input) && is_json_compact(raw)
                             && !raw_contains_non_canonical_number(raw)
+                            // jq dedupes input objects last-wins at parse
+                            // time; copying bytes verbatim would leak the
+                            // duplicates (#233 class). The select verdict is
+                            // computed on the parsed (deduped) Value, so only
+                            // the emitted bytes diverge without this. #1090
+                            && !json_value_has_duplicate_keys(raw)
                         {
                             // `\/` in input strings must be canonicalised to `/`
                             // (jq never escapes the solidus, #780). The verbatim

--- a/tests/jit_identity_passthrough_dupkey.rs
+++ b/tests/jit_identity_passthrough_dupkey.rs
@@ -1,0 +1,64 @@
+//! Issue #1090: when a JIT-executed filter yields its input unchanged
+//! (e.g. a passing select), the identity-output raw passthrough copied the
+//! original bytes verbatim — without the last-wins duplicate-key dedup jq
+//! applies at parse time (#233 class). The select verdict itself was
+//! computed on the parsed (deduped) Value, so only the emitted bytes
+//! diverged. The passthrough now routes through the Value serializer when
+//! the raw bytes contain duplicate keys, like the detect_* fast paths.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn run_backend(filter: &str, stdin: &str, backend_env: &str) -> (String, Option<i32>) {
+    let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
+    let mut child = Command::new(jq_jit)
+        .args(["-c", filter])
+        .env(backend_env, "1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn jq-jit");
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(stdin.as_bytes())
+        .unwrap();
+    let out = child.wait_with_output().expect("wait failed");
+    (
+        String::from_utf8_lossy(&out.stdout).trim_end().to_string(),
+        out.status.code(),
+    )
+}
+
+fn assert_jit(filter: &str, stdin: &str, expected: &str) {
+    for backend in ["JQJIT_FORCE_CRANELIFT", "JQJIT_FORCE_JITOP_INTERP"] {
+        let (stdout, code) = run_backend(filter, stdin, backend);
+        assert_eq!(
+            stdout, expected,
+            "{backend}: filter {filter:?} on {stdin:?} gave {stdout:?}, want {expected:?}"
+        );
+        assert_eq!(code, Some(0), "{backend}: filter {filter:?} exited nonzero");
+    }
+}
+
+#[test]
+fn passing_select_dedupes_duplicate_keys() {
+    assert_jit(
+        "select(.a > .b)",
+        "{\"a\":1,\"a\":5,\"b\":3}",
+        "{\"a\":5,\"b\":3}",
+    );
+    assert_jit(
+        "select(.b > .a)",
+        "{\"b\":1,\"a\":5,\"a\":1,\"b\":7}",
+        "{\"b\":7,\"a\":1}",
+    );
+}
+
+#[test]
+fn clean_input_still_passes_through() {
+    assert_jit("select(.a > .b)", "{\"a\":5,\"b\":3}", "{\"a\":5,\"b\":3}");
+    assert_jit("select(.a > .b)", "{\"a\":1,\"b\":3}", "");
+}


### PR DESCRIPTION
## Summary

When a JIT-executed filter yields its input unchanged (e.g. a passing `select`), the identity-output passthrough copied the original bytes verbatim — without the last-wins duplicate-key dedup jq applies at parse time (#233 class). The select verdict was computed on the parsed (deduped) Value, so only the emitted bytes diverged: `{"a":1,"a":5,"b":3} | select(.a > .b)` echoed the duplicates instead of jq's `{"a":5,"b":3}`.

## Fix

Gate the passthrough with `json_value_has_duplicate_keys`, the same check `emit_raw_ln` already applies on the detect_* fast paths; duplicate-key inputs route through the Value serializer.

## Verification

- **The 3-backend sweep over the full regression corpus (eval vs Cranelift vs JitOp interpreter, 2446 cases) now reports ZERO divergences** — this closes the last line from the #1059 backend self-diff backlog (#1082–#1090 complete).
- New suite `tests/jit_identity_passthrough_dupkey.rs` pins the dedup and the clean-input passthrough.
- `cargo build --release` zero warnings; `cargo test --release` all 71 suites pass.
- **Perf** (same-machine interleaved A/B on 2M-line NDJSON, best-of-5): `identity -c` 1.000, `select(.x > .y)` 0.995, `select(and)` 0.992 — no measurable cost (the whole-file identity shortcut already carried the stream-level gate).

Closes #1090

🤖 Generated with [Claude Code](https://claude.com/claude-code)