### PR TITLE
perf(jit): route sub-threshold filters to the JitOp interpreter with a per-class gate (#1059 Phase 2)

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -157,7 +157,16 @@ dispatch では eval に流れて不可視だった「lowering vs eval」の div
 （literal repr の消失、`combinations`/`modf` の phantom builtin、try-catch
 内の builtin エラー消失など）がこのモードでは表に出る。それらは backend
 diff（このハーネス）では両側一致なので落ちない — lowering 側の既存バグは
-別 issue として追う。
+別 issue として追う（#1082–#1090 で一掃済み、3-backend 全量 diff ゼロ）。
+
+#1059 Phase 2 以降、この「lowering vs eval」クラスは通常 dispatch でも
+表に出る: Cranelift heuristics（`JIT_THRESHOLD` / loop constructs / #658
+null-input cap）がコンパイルを見送った filter は、flatten 可能なら
+tree-walking eval ではなく JitOp interpreter で実行される（`src/bin/jq-jit.rs`
+の heuristics チェーン直後の catch-all）。eval に落ちるのは flatten が bail
+する filter（closure / `?//` / path-tracking / `memoize` など）と
+`JQJIT_FORCE_INTERPRETER=1` 時のみ。`JQJIT_TRACE=1` の generic fallback
+ラベルは `jit` / `jitop` / `eval` の 3 値。
 
 ### テスト出力
 

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -161,12 +161,23 @@ diff（このハーネス）では両側一致なので落ちない — lowering
 
 #1059 Phase 2 以降、この「lowering vs eval」クラスは通常 dispatch でも
 表に出る: Cranelift heuristics（`JIT_THRESHOLD` / loop constructs / #658
-null-input cap）がコンパイルを見送った filter は、flatten 可能なら
-tree-walking eval ではなく JitOp interpreter で実行される（`src/bin/jq-jit.rs`
-の heuristics チェーン直後の catch-all）。eval に落ちるのは flatten が bail
-する filter（closure / `?//` / path-tracking / `memoize` など）と
-`JQJIT_FORCE_INTERPRETER=1` 時のみ。`JQJIT_TRACE=1` の generic fallback
-ラベルは `jit` / `jitop` / `eval` の 3 値。
+null-input cap）がコンパイルを見送った filter は、flatten 可能かつ routing
+gate を通れば tree-walking eval ではなく JitOp interpreter で実行される
+（`src/bin/jq-jit.rs` の heuristics チェーン直後の catch-all →
+`Filter::compile_jitop_program_for_routing`）。eval に落ちるのは:
+
+- flatten が bail する filter（closure / path-tracking / `memoize` など）
+- routing gate（`JitProgram::eligible_for_default_routing`）が弾く filter —
+  backward-jump スパン（ループ本体）内で slot Value を materialize する
+  プログラム。`[range(.) | f]` collect や generator 引数 `any`/`all` の
+  expansion 系は per-element dispatch + boxing で eval の fused builtin に
+  1.4〜2.6x 負けるため意図的に除外（straight-line と unboxed f64 var だけの
+  ループは通す）。forced-mode knob 側は ungated compile のままなので
+  backend self-diff の網羅性は不変
+- `JQJIT_FORCE_INTERPRETER=1` 時
+
+`JQJIT_TRACE=1` の generic fallback ラベルは `jit` / `jitop` / `eval` の
+3 値（`tests/jitop_routing.rs` がルーティング決定をガードする）。
 
 ### テスト出力
 

--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -3011,6 +3011,18 @@ fn real_main() {
             }
         }
     }
+    // Phase 2 of #1059: whatever the Cranelift heuristics above left to the
+    // tree-walking evaluator (sub-threshold stdin/file input, the #658
+    // null-input shape, or a loop-construct filter whose codegen bailed)
+    // runs on the JitOp interpreter instead, when the filter flattens fully.
+    // `JitProgram::compile` is the shared lowering only — no codegen — so
+    // there is no compile-cost cliff on small inputs; non-flattenable
+    // filters keep the eval fallback. The forced-mode knobs are excluded so
+    // they keep pinning exactly one backend, and --force-jit keeps its
+    // "Cranelift or eval" debug semantics.
+    if !force_interp && !force_jit && !force_jitop && !force_cranelift && !filter.has_jit() {
+        filter.compile_jitop_program();
+    }
 
     // Use Vec-based buffering for compact output to avoid per-value write_all overhead
     let use_compact_buf = compact && !raw_output && !sort_keys && !join_output;
@@ -3705,7 +3717,13 @@ fn real_main() {
     // from an unmatched detector. `filter.has_jit()` reflects the JIT decision
     // made above (based on input size and loop constructs).
     if !has_raw_fast_path {
-        let fallback = if filter.has_jit() { "jit" } else { "eval" };
+        let fallback = if filter.has_jit() {
+            "jit"
+        } else if filter.has_jitop_program() {
+            "jitop"
+        } else {
+            "eval"
+        };
         jqjit_trace_fast_path(fallback, &filter_text);
     }
 

--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -3014,14 +3014,17 @@ fn real_main() {
     // Phase 2 of #1059: whatever the Cranelift heuristics above left to the
     // tree-walking evaluator (sub-threshold stdin/file input, the #658
     // null-input shape, or a loop-construct filter whose codegen bailed)
-    // runs on the JitOp interpreter instead, when the filter flattens fully.
-    // `JitProgram::compile` is the shared lowering only — no codegen — so
-    // there is no compile-cost cliff on small inputs; non-flattenable
-    // filters keep the eval fallback. The forced-mode knobs are excluded so
-    // they keep pinning exactly one backend, and --force-jit keeps its
-    // "Cranelift or eval" debug semantics.
+    // runs on the JitOp interpreter instead, when the filter flattens fully
+    // and passes the routing gate (no Value-materializing loop bodies —
+    // those shapes measure faster on eval; see
+    // `JitProgram::eligible_for_default_routing`). `JitProgram::compile` is
+    // the shared lowering only — no codegen — so there is no compile-cost
+    // cliff on small inputs; non-flattenable filters keep the eval
+    // fallback. The forced-mode knobs are excluded so they keep pinning
+    // exactly one backend, and --force-jit keeps its "Cranelift or eval"
+    // debug semantics.
     if !force_interp && !force_jit && !force_jitop && !force_cranelift && !filter.has_jit() {
-        filter.compile_jitop_program();
+        filter.compile_jitop_program_for_routing();
     }
 
     // Use Vec-based buffering for compact output to avoid per-value write_all overhead

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -2674,6 +2674,24 @@ impl Filter {
         self.jit_program.is_some()
     }
 
+    /// Like `compile_jitop_program`, but for the default dispatch (#1059
+    /// Phase 2): additionally rejects programs whose loop bodies materialize
+    /// slot Values, where the tree-walking evaluator measures 1.4-2.6x
+    /// faster (see `JitProgram::eligible_for_default_routing`). The
+    /// forced-mode knob keeps the ungated compile so the backend self-diff
+    /// still covers every flattenable filter.
+    pub fn compile_jitop_program_for_routing(&mut self) {
+        if self.jit_program.is_some() { return; }
+        let (ref expr, ref funcs) = self.parsed;
+        if crate::jit::is_jit_compilable_with_funcs(expr, funcs) {
+            if let Ok(prog) = crate::jit::JitProgram::compile(expr, funcs) {
+                if prog.eligible_for_default_routing() {
+                    self.jit_program = Some(prog);
+                }
+            }
+        }
+    }
+
     /// Returns true if this filter has loop constructs that benefit from JIT.
     /// Specifically: Update (.[] |= f), While/Until/Repeat, and Reduce/Foreach
     /// whose source references the input (e.g. `.[]` but not `range(N)`).

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -2669,6 +2669,11 @@ impl Filter {
         }
     }
 
+    /// Returns true if this filter has a compiled JitOp program (#1059).
+    pub fn has_jitop_program(&self) -> bool {
+        self.jit_program.is_some()
+    }
+
     /// Returns true if this filter has loop constructs that benefit from JIT.
     /// Specifically: Update (.[] |= f), While/Until/Repeat, and Reduce/Foreach
     /// whose source references the input (e.g. `.[]` but not `range(N)`).
@@ -11629,9 +11634,13 @@ impl Filter {
             }
         }
 
-        // JitOp interpreter backend (#1059): forced mode routes every
-        // program-compilable filter through the direct interpreter.
-        if forced_jitop {
+        // JitOp interpreter backend (#1059). The program is compiled either
+        // by the forced-mode knob (Phase 1 self-diff) or by the default
+        // sub-threshold routing (Phase 2): whenever the Cranelift heuristics
+        // decline to codegen, the binary builds the JitOp program instead and
+        // execution lands here rather than on the tree-walking eval below.
+        // Only `JQJIT_FORCE_INTERPRETER` skips it (that knob pins eval).
+        if !forced {
             if let Some(ref prog) = self.jit_program {
                 return crate::jit::execute_program(prog, input);
             }
@@ -11688,7 +11697,7 @@ impl Filter {
         }
 
         // JitOp interpreter backend (#1059) — see `execute` for rationale.
-        if forced_jitop {
+        if !forced {
             if let Some(ref prog) = self.jit_program {
                 return crate::jit::execute_program_cb(prog, input, cb);
             }

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -11276,6 +11276,9 @@ pub struct JitProgram {
     /// Keeps the `LoadConst` / `FieldBinopConst` pointer targets inside
     /// `ops` alive for the lifetime of the program.
     _value_constants: Vec<Box<Value>>,
+    /// Whether every loop in the program (backward-jump span) touches only
+    /// unboxed f64 variables — see `eligible_for_default_routing`.
+    var_only_loops: bool,
 }
 
 impl JitProgram {
@@ -11328,13 +11331,90 @@ impl JitProgram {
                 }
             }
         }
+        let var_only_loops = Self::loops_are_var_only(&flat.ops, &label_pc);
         Ok(JitProgram {
             ops: flat.ops,
             num_slots: flat.num_slots,
             num_vars: flat.num_vars,
             label_pc,
             _value_constants: flat.value_constants,
+            var_only_loops,
         })
+    }
+
+    /// Default-dispatch routing gate (#1059 Phase 2). The interpreter wins
+    /// over tree-walking eval when per-record work is op-count-bounded
+    /// (straight-line programs) or loops stay on unboxed f64 variables (the
+    /// constant-range reduce/foreach class). It loses 1.4–2.6x when a loop
+    /// body materializes slot Values each iteration — expansion shapes like
+    /// `[range(.) | f]` or generator-arg `any`/`all`, where eval's fused
+    /// builtins avoid the per-element dispatch + boxing. Those programs are
+    /// still correct (the forced-mode self-diff runs them); they are just
+    /// not routed by default. Cranelift routing is unaffected.
+    pub fn eligible_for_default_routing(&self) -> bool {
+        self.var_only_loops
+    }
+
+    /// True when no op inside a backward-jump span (a loop body) creates,
+    /// clones, yields, or calls on slot Values. Ops on the allowlist only
+    /// move control or unboxed f64/i64 variables; `Drop` is allowed because
+    /// it never appears alone — any value it cleans up was produced by an
+    /// op outside the allowlist, which already disqualifies the span.
+    fn loops_are_var_only(ops: &[JitOp], label_pc: &[usize]) -> bool {
+        let var_only = |op: &JitOp| -> bool {
+            matches!(op,
+                JitOp::Label { .. } | JitOp::Jump { .. } | JitOp::JumpIfError { .. }
+                | JitOp::BranchOnVar { .. } | JitOp::LoopCheck { .. }
+                | JitOp::BranchKind { .. } | JitOp::IfTruthy { .. }
+                | JitOp::TypeCmpBranch { .. } | JitOp::FieldIsTruthy { .. }
+                | JitOp::FieldCmpNum { .. } | JitOp::GetKind { .. }
+                | JitOp::GetLen { .. } | JitOp::IncVar { .. } | JitOp::InitVar { .. }
+                | JitOp::IsNullOrFalse { .. } | JitOp::ToF64Var { .. }
+                | JitOp::ToF64VarRangeBound { .. } | JitOp::RangeCheck { .. }
+                | JitOp::F64Const { .. } | JitOp::F64Move { .. }
+                | JitOp::F64Less { .. } | JitOp::F64Equal { .. }
+                | JitOp::F64Add { .. } | JitOp::F64Sub { .. }
+                | JitOp::F64Mul { .. } | JitOp::F64Div { .. }
+                | JitOp::F64Rem { .. } | JitOp::F64Neg { .. }
+                | JitOp::F64Math { .. } | JitOp::F64Libm { .. }
+                | JitOp::F64Cmp { .. } | JitOp::Drop { .. }
+            )
+        };
+        // A jump at index j targeting a label at pc t <= j loops over [t, j].
+        let mut spans: Vec<(usize, usize)> = Vec::new();
+        for (j, op) in ops.iter().enumerate() {
+            let mut targets: [Option<LabelId>; 3] = [None, None, None];
+            match op {
+                JitOp::Jump { label } | JitOp::JumpIfError { label } => targets[0] = Some(*label),
+                JitOp::IfTruthy { then_label, else_label, .. }
+                | JitOp::TypeCmpBranch { then_label, else_label, .. } => {
+                    targets[0] = Some(*then_label);
+                    targets[1] = Some(*else_label);
+                }
+                JitOp::BranchOnVar { nonzero_label, zero_label, .. } => {
+                    targets[0] = Some(*nonzero_label);
+                    targets[1] = Some(*zero_label);
+                }
+                JitOp::LoopCheck { body_label, done_label, .. } => {
+                    targets[0] = Some(*body_label);
+                    targets[1] = Some(*done_label);
+                }
+                JitOp::BranchKind { arr_label, obj_label, other_label, .. } => {
+                    targets[0] = Some(*arr_label);
+                    targets[1] = Some(*obj_label);
+                    targets[2] = Some(*other_label);
+                }
+                JitOp::CheckError { catch_label, .. } => targets[0] = Some(*catch_label),
+                _ => {}
+            }
+            for t in targets.into_iter().flatten() {
+                let pc = label_pc[t as usize];
+                if pc <= j {
+                    spans.push((pc, j));
+                }
+            }
+        }
+        spans.iter().all(|&(start, end)| ops[start..=end].iter().all(var_only))
     }
 
     /// Execute the program. Same contract as a compiled `JitFilterFn`:

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -7688,12 +7688,14 @@ extern "C" fn jit_rt_unaryop(dst: *mut Value, op: i32, input: *const Value) -> i
                 return 0;
             }
         }
-        // Fast path: unique (op 10)
+        // Fast path: unique (op 10). Dedup must use `values_equal`, not the
+        // total-order comparator: jq keeps adjacent NaNs (`nan != nan`)
+        // while `compare_values` ranks them Equal (#1059 Phase 2 sweep).
         if op == 10 {
             if let Value::Arr(a) = &*input {
                 let mut sorted = a.as_ref().clone();
                 sorted.sort_by(crate::runtime::compare_values);
-                sorted.dedup_by(|a, b| crate::runtime::compare_values(a, b) == std::cmp::Ordering::Equal);
+                sorted.dedup_by(|a, b| crate::runtime::values_equal(a, b));
                 std::ptr::write(dst, Value::Arr(Rc::new(sorted)));
                 return 0;
             }
@@ -8791,6 +8793,17 @@ extern "C" fn jit_rt_call_builtin(dst: *mut Value, builtin: *const JitBuiltin,
                             Value::True => buf.extend_from_slice(b"true"),
                             Value::False => buf.extend_from_slice(b"false"),
                             Value::Num(n, crate::value::NumRepr(repr)) => crate::value::push_value_num_repr_bytes(&mut buf, *n, repr.as_ref()),
+                            // jq rejects arrays/objects as row elements
+                            // (issue #79); mirror eval_format's wording.
+                            Value::Arr(_) | Value::Obj(_) => {
+                                set_jit_error(format!(
+                                    "{} ({}) is not valid in a csv row",
+                                    v.type_name(),
+                                    crate::value::value_to_json(v)
+                                ));
+                                std::ptr::write(dst, Value::Null);
+                                return GEN_ERROR;
+                            }
                             _ => buf.extend_from_slice(crate::value::value_to_json(v).as_bytes()),
                         }
                     }
@@ -8829,6 +8842,17 @@ extern "C" fn jit_rt_call_builtin(dst: *mut Value, builtin: *const JitBuiltin,
                             Value::True => buf.extend_from_slice(b"true"),
                             Value::False => buf.extend_from_slice(b"false"),
                             Value::Num(n, crate::value::NumRepr(repr)) => crate::value::push_value_num_repr_bytes(&mut buf, *n, repr.as_ref()),
+                            // jq uses the same "csv row" wording for @tsv
+                            // (issue #79); mirror eval_format's validation.
+                            Value::Arr(_) | Value::Obj(_) => {
+                                set_jit_error(format!(
+                                    "{} ({}) is not valid in a csv row",
+                                    v.type_name(),
+                                    crate::value::value_to_json(v)
+                                ));
+                                std::ptr::write(dst, Value::Null);
+                                return GEN_ERROR;
+                            }
                             _ => buf.extend_from_slice(crate::value::value_to_json(v).as_bytes()),
                         }
                     }

--- a/tests/coverage_fast_path.rs
+++ b/tests/coverage_fast_path.rs
@@ -159,7 +159,7 @@ fn fast_paths_have_nonzero_corpus_coverage() {
         trace_one(jq_jit, &case.filter, &case.input)
     });
     for name in traced.into_iter().flatten() {
-        if name == "jit" || name == "eval" {
+        if name == "jit" || name == "jitop" || name == "eval" {
             *generic_counts.entry(name).or_insert(0) += 1;
         } else {
             *counts.entry(name).or_insert(0) += 1;

--- a/tests/jitop_routing.rs
+++ b/tests/jitop_routing.rs
@@ -61,6 +61,35 @@ fn non_flattenable_falls_back_to_eval() {
     assert_eq!(label, "eval");
 }
 
+/// The routing gate keeps Value-materializing loop bodies on eval: the
+/// expansion shape `[range(.) | f] | ...` flattens fine (forced-mode
+/// self-diff still runs it) but measures 1.4-2.6x slower on the
+/// interpreter than on eval's fused builtins, so default dispatch must
+/// not route it.
+#[test]
+fn value_materializing_loop_stays_on_eval() {
+    let label = traced_label("[range(.) | . % 1000] | unique | length", "1000", None);
+    assert_eq!(label, "eval");
+}
+
+/// Loops that stay on unboxed f64 variables pass the gate: the
+/// constant-range reduce class (kept on eval by `has_loop_constructs`'
+/// input-referencing-source rule, so it reaches the JitOp catch-all)
+/// measures 1.6-1.8x faster on the interpreter than on eval.
+#[test]
+fn var_only_reduce_loop_routes_to_jitop() {
+    let label = traced_label("reduce range(0; 1000) as $i (0; . + $i)", "null", None);
+    assert_eq!(label, "jitop");
+}
+
+/// Fused `[range(n)]` collect is a single runtime call, not a loop span,
+/// so a straight-line program around it passes the gate too.
+#[test]
+fn straight_line_collect_range_routes_to_jitop() {
+    let label = traced_label("[range(.)] | length", "1000", None);
+    assert_eq!(label, "jitop");
+}
+
 /// `--force-jit` keeps its "Cranelift or eval" debug semantics: the JitOp
 /// routing must not capture it.
 #[test]

--- a/tests/jitop_routing.rs
+++ b/tests/jitop_routing.rs
@@ -1,0 +1,74 @@
+//! Default-dispatch routing guard for #1059 Phase 2: filters that the
+//! Cranelift heuristics decline (sub-threshold input) must run on the JitOp
+//! interpreter when they flatten fully, fall back to tree-walking eval when
+//! the flattener bails, and keep Cranelift under `--force-jit`. The probe is
+//! the `JQJIT_TRACE=1` generic-fallback label (`jit` / `jitop` / `eval`),
+//! which reflects exactly the compile decision made in `src/bin/jq-jit.rs`.
+
+use std::process::Command;
+
+/// Run the binary on a one-line stdin input and return the traced
+/// generic-fallback label (the `matched=` name of the first trace line).
+fn traced_label(filter: &str, input: &str, extra_arg: Option<&str>) -> String {
+    let bin = env!("CARGO_BIN_EXE_jq-jit");
+    let mut cmd = Command::new(bin);
+    if let Some(arg) = extra_arg {
+        cmd.arg(arg);
+    }
+    cmd.arg("-c").arg(filter);
+    cmd.env("JQJIT_TRACE", "1");
+    cmd.env_remove("JQJIT_FORCE_INTERPRETER");
+    cmd.env_remove("JQJIT_FORCE_JITOP_INTERP");
+    cmd.env_remove("JQJIT_FORCE_CRANELIFT");
+    cmd.stdin(std::process::Stdio::piped());
+    cmd.stdout(std::process::Stdio::piped());
+    cmd.stderr(std::process::Stdio::piped());
+    let mut child = cmd.spawn().expect("spawn jq-jit");
+    {
+        use std::io::Write;
+        let mut stdin = child.stdin.take().expect("stdin");
+        let _ = stdin.write_all(input.as_bytes());
+        let _ = stdin.write_all(b"\n");
+    }
+    let out = child.wait_with_output().expect("wait jq-jit");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    for line in stderr.lines() {
+        if let Some((_, name)) = line.rsplit_once("matched=") {
+            return name.trim().to_string();
+        }
+    }
+    panic!("no trace line emitted for filter {:?}; stderr: {}", filter, stderr);
+}
+
+/// A flattenable filter on sub-threshold input lands on the JitOp
+/// interpreter, not tree-walking eval. The filter shape is chosen to miss
+/// every raw-byte / typed fast path so the generic-fallback label is the
+/// one traced.
+#[test]
+fn sub_threshold_flattenable_routes_to_jitop() {
+    let label = traced_label(
+        "(.a.b + 1) as $x | {r: $x, n: (.c | length)}",
+        r#"{"a":{"b":3},"c":[1,2]}"#,
+        None,
+    );
+    assert_eq!(label, "jitop");
+}
+
+/// A filter the flattener rejects keeps the eval fallback.
+#[test]
+fn non_flattenable_falls_back_to_eval() {
+    let label = traced_label("memoize(.a)", r#"{"a":1}"#, None);
+    assert_eq!(label, "eval");
+}
+
+/// `--force-jit` keeps its "Cranelift or eval" debug semantics: the JitOp
+/// routing must not capture it.
+#[test]
+fn force_jit_pins_cranelift() {
+    let label = traced_label(
+        "(.a.b + 1) as $x | {r: $x, n: (.c | length)}",
+        r#"{"a":{"b":3},"c":[1,2]}"#,
+        Some("--force-jit"),
+    );
+    assert_eq!(label, "jit");
+}

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -13592,3 +13592,23 @@ select(.b > 0) | .a | tostring
 select(.b > 0) | .a | tostring
 {"a":1.50,"b":2}
 "1.50"
+
+# #1059 Phase 2: jit unique dedup keeps adjacent NaNs (values_equal, not the total-order comparator)
+[nan, nan] | unique | length
+null
+2
+
+# #1059 Phase 2: jit @csv rejects array cells like eval (issue #79 wording)
+try @csv catch .
+[[1,2]]
+"array ([1,2]) is not valid in a csv row"
+
+# #1059 Phase 2: jit @csv rejects object cells like eval
+try @csv catch .
+[{"a":1}]
+"object ({\"a\":1}) is not valid in a csv row"
+
+# #1059 Phase 2: jit @tsv rejects array/object cells with the csv-row wording
+try @tsv catch .
+[[1,2]]
+"array ([1,2]) is not valid in a csv row"


### PR DESCRIPTION
## Summary

Phase 2 of #1059: filters that the Cranelift heuristics decline to codegen (sub-threshold stdin/file input, the #658 null-input AST cap, codegen bails) now run on the JitOp interpreter instead of tree-walking eval, when the filter flattens fully **and** passes a routing gate. `JitProgram::compile` is the shared lowering only — no codegen — so there is no compile-cost cliff on small inputs.

## Routing gate (per-shape A/B, as planned in #1059)

Same-machine interleaved best-of-N A/B (hyperfine, both orders) per class:

| Class | Routing | A/B result |
|---|---|---|
| Straight-line programs (field/arith/obj-construct/builtin-call) | → jitop | neutral (startup-dominated; 1.00–1.03x both directions) |
| Unboxed-f64-var loops (constant-range reduce) | → jitop | **jitop 1.6–1.8x faster** (`reduce range(0;1e6) as $i (0; .+$i)`: 22.6ms → 12.8ms) |
| Value-materializing loop bodies (`[range(.)|f]` collect, generator-arg `any`/`all`, `map`) | stays eval | eval 1.4–2.6x faster — gated out, neutral vs main |
| Above-threshold / loop-construct filters | Cranelift (unchanged) | 1.00 ± 0.03 |
| Non-flattenable (`memoize`, closures, path-tracking) | eval (unchanged) | — |

Gate implementation: `JitProgram::eligible_for_default_routing` — a program is eligible only if every backward-jump span (loop body) contains allowlisted var/control ops. The forced-mode knobs keep the ungated compile, so `tests/selfdiff_jitop_backend.rs` still covers every flattenable filter.

## Lowering parity fixes surfaced by the routing

Running the differential corpus through the new default dispatch exposed two pre-existing lowering-vs-eval divergences (reachable before this PR via `--force-jit` or above-threshold inputs) — fixed here, verified byte-identical against jq 1.8.1 across all three backends:

- `unique` runtime fast arm deduped with the total-order comparator, collapsing adjacent NaNs (`[nan, nan] | unique` lost an element; jq keeps both since `nan != nan`).
- inline `@csv`/`@tsv` emitters serialized array/object cells instead of raising `<type> (<json>) is not valid in a csv row` (issue #79 wording).

A full lowering-vs-eval sweep over `tests/differential/corpus.test` (1287 cases, FORCE_CRANELIFT vs FORCE_INTERPRETER) now reports zero real divergences.

## Bench

`bench/comprehensive.sh` (220 rows) vs the v1.8.3 history column: no Phase-2-attributable regression. Remaining deltas are cross-day/main-side (`path(.name,.x)` 1.39x vs history reproduces identically on main — same-machine A/B main vs branch is 1.03 ± 0.03) and the known ±5% layout-lottery band (includes raw-byte-fast-path rows this PR cannot affect, e.g. `empty`, `.[]`).

## Tests

- Full suite green (official / regression / differential / fuzz / self-diff ×3 / contracts / metamorphic)
- New `tests/jitop_routing.rs`: 6 cases guarding the routing decision via the `JQJIT_TRACE` fallback label (`jit` / `jitop` / `eval`)
- Regression cases appended for the two parity fixes

Refs #1059 (Phase 2 of 4 — does not close it)
