### PR TITLE
feat(jit): stream non-flattenable subtrees through an eval delegate (#1059 Phase 3)

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -179,6 +179,29 @@ gate を通れば tree-walking eval ではなく JitOp interpreter で実行さ�
 `JQJIT_TRACE=1` の generic fallback ラベルは `jit` / `jitop` / `eval` の
 3 値（`tests/jitop_routing.rs` がルーティング決定をガードする）。
 
+#### streaming eval delegate（#1059 Phase 3 / `JitOp::DelegateGen`）
+
+flatten 不能だったサブツリー（複雑な `path()`、`del`/`pick`/`walk`/`skip`/
+`add(gen)`）は、ノード単位で eval に **streaming 委譲**して flatten を続行
+できる（`emit_delegate_gen` → `jit_rt_delegate_gen`）。yield は生成順に
+cb / collect stack へ流れるので lazy 性と downstream early-stop が保たれる
+（旧 eager delegate の #1085 hang は再発しない）。委譲しない条件:
+
+- `limit(n; …)` 内（per-yield counter が helper 内で回せない）
+- サブツリーに `break`（委譲境界を越える break は label に戻れない）
+- path 意味論ノード（`path`/`del`/`pick`）が `$var` を参照（値 seed では
+  path provenance #880/#953 が失われ `. as $x | path($x)` が誤エラー化）
+
+**default dispatch は委譲プログラムをコンパイルしない**
+（`is_jit_compilable_with_funcs` が reject）。delegate 支配的な filter は
+whole-filter eval の方が速い（200k NDJSON A/B で委譲側が最大 ~1.1x 劣化、
+per-record の env reset 分）ため。forced knob（`JQJIT_FORCE_CRANELIFT` /
+`JQJIT_FORCE_JITOP_INTERP` / `--force-jit`）は
+`is_jit_compilable_with_delegates` / `compile_jit_with_delegates` 経由で
+委譲込みコンパイルし、backend self-diff がそこをカバーする。
+JIT_CLOSURE_OPS は `Vec<Rc<Expr>>`（per-record の Expr clone を排除、
+既存の closure-op delegate も同恩恵）。
+
 ### テスト出力
 
 `cargo test --release` だけだと regression 通過数が非表示。必ず `--nocapture`:

--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -2978,10 +2978,12 @@ fn real_main() {
     } else if force_cranelift {
         // Self-diff mode (#1059) — pin the Cranelift backend regardless of
         // input-size heuristics; non-flattenable filters fall back to eval.
-        filter.compile_jit();
+        // Delegated programs are accepted here (forced modes carry the
+        // delegation coverage; the default heuristics below do not).
+        filter.compile_jit_with_delegates();
     } else if force_jit {
-        // --force-jit bypasses the heuristics entirely.
-        filter.compile_jit();
+        // --force-jit bypasses the heuristics entirely (delegates included).
+        filter.compile_jit_with_delegates();
     } else if filter.has_loop_constructs() {
         filter.compile_jit();
     } else if null_input {

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -2655,6 +2655,27 @@ impl Filter {
         self.jit_fn.is_some()
     }
 
+    /// Like `compile_jit`, but also accepts programs that lower with
+    /// streaming eval delegation (#1059 Phase 3). Used by the forced-mode
+    /// knobs (`JQJIT_FORCE_CRANELIFT`, `--force-jit`) so the backend
+    /// self-diff covers delegable filters; the default heuristics keep
+    /// them on whole-filter eval, which measures faster when the delegate
+    /// dominates.
+    pub fn compile_jit_with_delegates(&mut self) {
+        if self.jit_fn.is_some() { return; }
+        {
+            let (ref expr, ref funcs) = self.parsed;
+            if crate::jit::is_jit_compilable_with_delegates(expr, funcs) {
+                if let Ok(mut compiler) = crate::jit::JitCompiler::new() {
+                    if let Ok(func) = compiler.compile_with_funcs(expr, funcs) {
+                        self.jit_fn = Some(func);
+                        self._jit_compiler = Some(Box::new(compiler));
+                    }
+                }
+            }
+        }
+    }
+
     /// Build the JitOp program for the direct interpreter backend (#1059).
     /// Mirrors `compile_jit` but stops at the shared lowering — no Cranelift
     /// codegen. No-op if the flattener rejects the filter; execution then
@@ -2662,7 +2683,9 @@ impl Filter {
     pub fn compile_jitop_program(&mut self) {
         if self.jit_program.is_some() { return; }
         let (ref expr, ref funcs) = self.parsed;
-        if crate::jit::is_jit_compilable_with_funcs(expr, funcs) {
+        // Forced-mode knob: accept delegated programs too, mirroring
+        // `compile_jit_with_delegates` on the Cranelift side.
+        if crate::jit::is_jit_compilable_with_delegates(expr, funcs) {
             if let Ok(prog) = crate::jit::JitProgram::compile(expr, funcs) {
                 self.jit_program = Some(prog);
             }

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -29,7 +29,7 @@ thread_local! {
     static JIT_LAST_ERROR: UnsafeCell<Option<JitError>> = const { UnsafeCell::new(None) };
     /// Closure ops captured at compile time; consumed by runtime trampolines
     /// during execution.
-    static JIT_CLOSURE_OPS: UnsafeCell<Vec<Expr>> = const { UnsafeCell::new(Vec::new()) };
+    static JIT_CLOSURE_OPS: UnsafeCell<Vec<Rc<Expr>>> = const { UnsafeCell::new(Vec::new()) };
     /// Pointer to the `JitEnv` currently being driven by `execute_jit*`.
     /// `set_jit_error*` consult this to flip the env's `error_flag` without
     /// plumbing an env pointer through every fallible trampoline signature.
@@ -531,6 +531,18 @@ enum JitOp {
     /// Fused field lookup + yield: borrows the field value from base without cloning.
     /// Replaces IndexField(dst) + Yield(dst) + Drop(dst).
     YieldFieldRef { base: SlotId, field: String },
+    /// Streaming eval delegation (#1059 Phase 3): run the stashed
+    /// closure-op expression `JIT_CLOSURE_OPS[expr_idx]` on the
+    /// tree-walking evaluator with the slot value as input, forwarding
+    /// every yielded value as it is produced — to the generator callback
+    /// when `push` is false, or onto the JitEnv collect stack (the
+    /// CollectPush equivalent) when the emission site sits inside a
+    /// Collect. Unlike the eager collect-then-iterate delegates this
+    /// preserves eval's streaming order and downstream early-stop.
+    /// Returns the early-stop verdict (<= 0) when the callback stops the
+    /// stream; eval errors go through the pending-error flag like
+    /// CallBuiltin (the emitter appends CheckError / JumpIfError).
+    DelegateGen { input: SlotId, expr_idx: usize, push: bool },
 
     // Control flow
     IfTruthy { src: SlotId, then_label: LabelId, else_label: LabelId },
@@ -725,6 +737,10 @@ struct Flattener {
     /// emitting partial code returns the init value instead of the right
     /// answer. (#648)
     has_unresolved_recursion: bool,
+    /// Set by `emit_delegate_gen` when the program contains a streaming
+    /// eval delegation (#1059 Phase 3). The default-dispatch feasibility
+    /// probe rejects such programs (see `is_jit_compilable_with_funcs`).
+    emitted_delegate: bool,
 }
 
 impl Flattener {
@@ -734,7 +750,8 @@ impl Flattener {
                      label_targets: HashMap::new(), funcs: Vec::new(),
                      limit_state: None, closure_ops: Vec::new(),
                      expanding_funcs: HashSet::new(), value_constants: Vec::new(),
-                     is_test: false, has_unresolved_recursion: false }
+                     is_test: false, has_unresolved_recursion: false,
+                     emitted_delegate: false }
     }
 
     /// Materialize a Literal into a heap-allocated Value and return a stable pointer.
@@ -1128,6 +1145,9 @@ impl Flattener {
             JitOp::Negate { .. } | JitOp::CallBuiltin { .. } |
             JitOp::ToF64VarRangeBound { .. } |
             JitOp::ThrowError { .. } |
+            // The eval delegate surfaces eval-side errors through the
+            // pending-error flag after zero or more yields (#1059 Phase 3).
+            JitOp::DelegateGen { .. } |
             // The fused field-op runtimes index `.field` on the base and return
             // GEN_ERROR for a non-object base ("Cannot index <type> with string").
             // Without a CheckError that error is set but never propagated, so the
@@ -1179,6 +1199,47 @@ impl Flattener {
             self.ops.push(JitOp::ReturnError);
             self.ops.push(JitOp::Label { id: ok_label });
         }
+    }
+
+    /// Emit a streaming eval delegation for `expr` (#1059 Phase 3), or
+    /// return false when the context cannot host one:
+    ///
+    /// - anywhere inside `limit(n; …)`: the per-yield counter ops the
+    ///   flattener plants after each yield cannot run inside the helper, so
+    ///   an unbounded delegated stream would ignore the limit — the exact
+    ///   eager-delegate hang of #1085. This blocks even collect contexts
+    ///   nested under the limit: the pipe fallback wraps an unmatched
+    ///   generator left in a CollectBegin, and an infinite delegated stream
+    ///   (`limit(1; path(recurse(.+1)) | .)`) would hang there where eval
+    ///   stops lazily.
+    /// - the subtree contains `break`: a break crossing the delegation
+    ///   boundary would surface as a plain eval error instead of unwinding
+    ///   to its label. The scan is a conservative Debug-format substring
+    ///   probe — a false positive (e.g. a literal string "Break") merely
+    ///   keeps the eval bail of the caller.
+    /// - `path_semantic` nodes (`path(...)`, `del(...)`, `pick(...)`)
+    ///   referencing any `$var`: the env seeding copies plain values, but
+    ///   eval's path provenance (#880/#953) also tracks *where* a variable
+    ///   was bound from — `. as $x | path($x)` is `[]` in eval and an
+    ///   "Invalid path expression" through a value-only seed. Value-semantic
+    ///   delegates (walk/skip/add) are fine with value seeding.
+    fn emit_delegate_gen(&mut self, expr: &Expr, input_slot: SlotId, path_semantic: bool) -> bool {
+        if self.limit_state.is_some() { return false; }
+        if format!("{:?}", expr).contains("Break") { return false; }
+        if path_semantic {
+            let mut vars = Vec::new();
+            Self::collect_loadvar_indices(expr, &mut vars);
+            if !vars.is_empty() { return false; }
+        }
+        let idx = self.closure_ops.len();
+        self.closure_ops.push(expr.clone());
+        self.emitted_delegate = true;
+        self.emit(JitOp::DelegateGen {
+            input: input_slot,
+            expr_idx: idx,
+            push: self.collect_depth > 0,
+        });
+        true
     }
 
     fn emit_yield(&mut self, output: SlotId) {
@@ -3742,14 +3803,19 @@ impl Flattener {
                         }
                     }
                 }
-                // Complex path expressions: bail the whole filter to eval.
-                // The old delegate collected every path into an array up
-                // front, which (a) hangs on infinite streams eval cuts
-                // lazily (`[limit(5; path(recurse(.a)))]`, #1085), and
-                // (b) predates the eval-side provenance fixes (#880/#953),
-                // erroring on rootless anchors like `. as $x | path($x)`.
-                // The flag forces the bail even from emission contexts
-                // that ignore a false return.
+                // Complex path expressions: stream the whole `path(...)`
+                // through the eval delegate (#1059 Phase 3). Unlike the old
+                // eager delegate this preserves laziness (downstream
+                // early-stop flows through the callback) and runs on
+                // today's eval, after the provenance fixes (#880/#953) —
+                // the two reasons the delegate was previously removed.
+                // Contexts the delegate cannot host (inside limit, break in
+                // the subtree) still bail the whole filter to eval; the
+                // flag forces that bail even from emission contexts that
+                // ignore a false return.
+                if self.emit_delegate_gen(expr, input_slot, true) {
+                    return true;
+                }
                 self.has_unresolved_recursion = true;
                 false
             }
@@ -3762,13 +3828,17 @@ impl Flattener {
                 true
             }
 
-            // Filter-argument builtins: delegate to eval (not JIT-compilable)
+            // Filter-argument builtins: stream the whole node through the
+            // eval delegate (#1059 Phase 3) instead of bailing the filter.
+            // `del`/`pick` take path expressions (provenance-sensitive);
+            // `walk`/`skip`/`add` take value filters.
             Expr::CallBuiltin { op, args } if matches!(
                 (op, args.len()),
                 (BuiltinOp::Walk, _) | (BuiltinOp::Pick, _) | (BuiltinOp::Skip, _)
                 | (BuiltinOp::Add, 1) | (BuiltinOp::Del, _)
             ) => {
-                false
+                let path_semantic = matches!(op, BuiltinOp::Del | BuiltinOp::Pick);
+                self.emit_delegate_gen(expr, input_slot, path_semantic)
             }
 
             // CallBuiltin with generator args: rewrite as nested LetBinding
@@ -7135,6 +7205,62 @@ extern "C" fn jit_rt_yield_field_ref(
         }
     }
 }
+/// Streaming eval delegation (#1059 Phase 3). Runs `JIT_CLOSURE_OPS[expr_idx]`
+/// on the tree-walking evaluator with `*input` as input, forwarding each
+/// yielded value as it is produced: `push != 0` pushes onto the JitEnv
+/// collect stack (the CollectPush equivalent for delegates emitted inside a
+/// Collect); otherwise the value goes to the generator callback, whose
+/// verdict <= 0 lazily stops the eval stream. Returns that verdict when
+/// stopped early, GEN_CONTINUE otherwise; eval errors set the pending-error
+/// flag (the flattener emits CheckError / JumpIfError after the op, like
+/// CallBuiltin).
+extern "C" fn jit_rt_delegate_gen(
+    input: *const Value, expr_idx: usize, push: i64,
+    cb: unsafe extern "C" fn(*const Value, *mut u8) -> i64, ctx: *mut u8,
+    env: *mut JitEnv,
+) -> i64 {
+    let expr = JIT_CLOSURE_OPS.with(|cell| unsafe { (&*cell.get()).get(expr_idx).cloned() });
+    let Some(expr) = expr else {
+        set_jit_error(format!("delegate_gen: missing closure op {}", expr_idx));
+        return GEN_CONTINUE;
+    };
+    thread_local! {
+        static DELEGATE_ENV: RefCell<Option<Rc<RefCell<crate::eval::Env>>>> =
+            const { RefCell::new(None) };
+    }
+    let eval_env = DELEGATE_ENV.with(|cell| {
+        let mut opt = cell.borrow_mut();
+        let env = opt
+            .get_or_insert_with(|| Rc::new(RefCell::new(crate::eval::Env::new(vec![]))))
+            .clone();
+        reset_delegated_env(&env, &[&expr]);
+        env
+    });
+    let input_val = unsafe { (*input).clone() };
+    let mut verdict: i64 = GEN_CONTINUE;
+    let result = crate::eval::eval(&expr, input_val, &eval_env, &mut |v| {
+        if push != 0 {
+            jit_rt_collect_push(env, &v as *const Value);
+            Ok(true)
+        } else {
+            let r = unsafe { cb(&v as *const Value, ctx) };
+            if r <= 0 {
+                verdict = r;
+                Ok(false)
+            } else {
+                Ok(true)
+            }
+        }
+    });
+    if let Err(e) = result {
+        // The delegated subtree is break-free by construction (the emitter
+        // skips subtrees containing `break`), so any error here — including
+        // eval's BreakError sentinel, defensively — is a plain jq error.
+        set_jit_error_from(&e);
+    }
+    verdict
+}
+
 extern "C" fn jit_rt_index(dst: *mut Value, base: *const Value, key: *const Value) -> i64 {
     unsafe {
         // Fast path: Array[Num] — most common in loops
@@ -9269,6 +9395,7 @@ fn optimize_clone_yield(mut ops: Vec<JitOp>) -> Vec<JitOp> {
                 *use_count.entry(*key).or_insert(0) += 1;
             }
             JitOp::IndexField { base, .. } | JitOp::FieldBinopField { base, .. } | JitOp::YieldFieldRef { base, .. } => { *use_count.entry(*base).or_insert(0) += 1; }
+            JitOp::DelegateGen { input, .. } => { *use_count.entry(*input).or_insert(0) += 1; }
             JitOp::FieldBinopConst { base, .. } => {
                 *use_count.entry(*base).or_insert(0) += 1;
             }
@@ -9355,6 +9482,7 @@ fn optimize_clone_yield(mut ops: Vec<JitOp>) -> Vec<JitOp> {
                     *use_count.entry(*key).or_insert(0) += 1;
                 }
                 JitOp::IndexField { base, .. } | JitOp::FieldBinopField { base, .. } | JitOp::YieldFieldRef { base, .. } => { *use_count.entry(*base).or_insert(0) += 1; }
+                JitOp::DelegateGen { input, .. } => { *use_count.entry(*input).or_insert(0) += 1; }
             JitOp::FieldBinopConst { base, .. } => {
                 *use_count.entry(*base).or_insert(0) += 1;
             }
@@ -9548,7 +9676,9 @@ fn flatten_filter(expr: &Expr, funcs: &[CompiledFunc]) -> Result<FlattenedFilter
 
     // Store closure ops for runtime access
     if !fl.closure_ops.is_empty() {
-        JIT_CLOSURE_OPS.with(|cell| unsafe { *cell.get() = fl.closure_ops.clone(); });
+        JIT_CLOSURE_OPS.with(|cell| unsafe {
+            *cell.get() = fl.closure_ops.iter().cloned().map(Rc::new).collect();
+        });
     }
 
     Ok(FlattenedFilter {
@@ -9604,6 +9734,7 @@ impl JitCompiler {
             ("jit_rt_index", jit_rt_index as *const u8),
             ("jit_rt_index_field", jit_rt_index_field as *const u8),
             ("jit_rt_yield_field_ref", jit_rt_yield_field_ref as *const u8),
+            ("jit_rt_delegate_gen", jit_rt_delegate_gen as *const u8),
             ("jit_rt_binop", jit_rt_binop as *const u8),
             ("jit_rt_add_move", jit_rt_add_move as *const u8),
             ("jit_rt_unaryop", jit_rt_unaryop as *const u8),
@@ -10338,6 +10469,28 @@ impl JitCompiler {
                         b.switch_to_block(cont_blk);
                         b.seal_block(cont_blk);
                     }
+                    JitOp::DelegateGen { input, expr_idx, push } => {
+                        // Same early-return discipline as YieldFieldRef: a
+                        // verdict <= 0 is the callback's stop signal and
+                        // propagates out of the generator immediately; eval
+                        // errors arrive via the pending-error flag and the
+                        // CheckError / JumpIfError the emitter placed next.
+                        let ia = slot_addr(&mut b, *input);
+                        let idx = b.ins().iconst(ptr_ty, *expr_idx as i64);
+                        let push_v = b.ins().iconst(ptr_ty, *push as i64);
+                        let call = b.ins().call(rt["delegate_gen"], &[ia, idx, push_v, cb_fn, cb_ctx, env_ptr]);
+                        let result = b.inst_results(call)[0];
+                        let zero = b.ins().iconst(ptr_ty, 0);
+                        let stop = b.ins().icmp(cranelift_codegen::ir::condcodes::IntCC::SignedLessThanOrEqual, result, zero);
+                        let stop_blk = b.create_block();
+                        let cont_blk = b.create_block();
+                        b.ins().brif(stop, stop_blk, &[], cont_blk, &[]);
+                        b.switch_to_block(stop_blk);
+                        b.seal_block(stop_blk);
+                        b.ins().return_(&[result]);
+                        b.switch_to_block(cont_blk);
+                        b.seal_block(cont_blk);
+                    }
                     JitOp::IfTruthy { src, then_label, else_label } => {
                         // Inline: null(0) and false(1) are falsy, everything else truthy
                         let sa = slot_addr(&mut b, *src);
@@ -11016,6 +11169,7 @@ fn declare_rt_funcs(module: &mut JITModule, map: &mut HashMap<&'static str, Func
     decl!("index", [p, p, p], [p]);
     decl!("index_field", [p, p, p, p], [p]);
     decl!("yield_field_ref", [p, p, p, p, p], [p]);
+    decl!("delegate_gen", [p, p, p, p, p, p], [p]);  // input, expr_idx, push, cb, ctx, env -> verdict
     decl!("binop", [p, i, p, p], [p]);
     decl!("add_move", [p, p, p], [p]);
     decl!("unaryop", [p, i, p], [p]);
@@ -11086,7 +11240,26 @@ pub fn is_jit_compilable(expr: &Expr) -> bool {
     is_jit_compilable_with_funcs(expr, &[])
 }
 
+/// Default-dispatch feasibility: like the full probe, but rejects programs
+/// that would contain a `DelegateGen` op. Per-record eval delegation
+/// measures up to ~1.1x slower than whole-filter eval when the delegate
+/// dominates the filter (A/B on 200k-record NDJSON, #1059 Phase 3), so the
+/// default heuristics keep those filters on the tree-walking evaluator.
+/// The forced-mode knobs use [`is_jit_compilable_with_delegates`] so the
+/// backend self-diff still covers every delegable filter.
 pub fn is_jit_compilable_with_funcs(expr: &Expr, funcs: &[CompiledFunc]) -> bool {
+    let (ok, emitted_delegate) = jit_feasibility(expr, funcs);
+    ok && !emitted_delegate
+}
+
+/// Forced-mode feasibility: accepts programs that lower with streaming
+/// eval delegation (`DelegateGen`).
+pub fn is_jit_compilable_with_delegates(expr: &Expr, funcs: &[CompiledFunc]) -> bool {
+    jit_feasibility(expr, funcs).0
+}
+
+/// Returns `(flattens, emitted_delegate)`.
+fn jit_feasibility(expr: &Expr, funcs: &[CompiledFunc]) -> (bool, bool) {
     let mut fl = Flattener::new();
     fl.funcs = funcs.to_vec();
     // Mirror `compile_with_funcs`'s inline step so we detect the same
@@ -11096,14 +11269,14 @@ pub fn is_jit_compilable_with_funcs(expr: &Expr, funcs: &[CompiledFunc]) -> bool
     // the eventual `compile_with_funcs` then stack-overflows in
     // `inline_func_calls` (#648).
     let inlined = fl.inline_func_calls(expr);
-    if fl.has_unresolved_recursion { return false; }
+    if fl.has_unresolved_recursion { return (false, false); }
     let input = fl.alloc_slot();
     let ok = fl.flatten_gen(&inlined, input);
     // Subtrees may set `has_unresolved_recursion` mid-flatten to request
     // a JIT bailout (see #683 — Reduce arm in flatten_scalar). Re-check
     // here so the feasibility query agrees with `compile_with_funcs`.
-    if fl.has_unresolved_recursion { return false; }
-    ok
+    if fl.has_unresolved_recursion { return (false, false); }
+    (ok, fl.emitted_delegate)
 }
 
 unsafe extern "C" fn collect_callback(value: *const Value, ctx: *mut u8) -> i64 {
@@ -11355,7 +11528,14 @@ impl JitProgram {
                 }
             }
         }
-        let var_only_loops = Self::loops_are_var_only(&flat.ops, &label_pc);
+        // Delegated programs are excluded from the default sub-threshold
+        // routing (#1059 Phase 3): per-record delegation pays an eval-env
+        // reset that whole-filter eval does not, so until that class is
+        // A/B-measured the status quo (tree-walking eval) keeps those
+        // filters. Forced modes and above-threshold Cranelift still run
+        // them — that is where the delegation coverage pays off.
+        let var_only_loops = !flat.ops.iter().any(|op| matches!(op, JitOp::DelegateGen { .. }))
+            && Self::loops_are_var_only(&flat.ops, &label_pc);
         Ok(JitProgram {
             ops: flat.ops,
             num_slots: flat.num_slots,
@@ -11547,6 +11727,10 @@ impl JitProgram {
                 }
                 JitOp::YieldFieldRef { base, field } => {
                     let r = jit_rt_yield_field_ref(sp(*base), field.as_ptr(), field.len(), cb, ctx);
+                    if r <= 0 { return r; }
+                }
+                JitOp::DelegateGen { input, expr_idx, push } => {
+                    let r = jit_rt_delegate_gen(sp(*input), *expr_idx, *push as i64, cb, ctx, env_ptr);
                     if r <= 0 { return r; }
                 }
                 JitOp::IfTruthy { src, then_label, else_label } => {

--- a/tests/enforce_jit_env_seeding.allowlist
+++ b/tests/enforce_jit_env_seeding.allowlist
@@ -13,13 +13,15 @@
 #
 # Currently allowlisted sites (all in src/jit.rs):
 #
-# - Two `thread_local!` cache `get_or_insert_with` closures that build the
+# - Three `thread_local!` cache `get_or_insert_with` closures that build the
 #   cached `eval::Env` lazily and call `reset_delegated_env` immediately
 #   after to seed it. (Sites: the `PATHS_FILTER_ENV` cache in the
-#   `__paths_filtered__:` handler and the `CLOSURE_OP_ENV` cache in the
-#   `__closure_op__:` handler.) These satisfy the invariant in practice
-#   because the seeding happens inline; the test for closure-op env
-#   seeding (tests/enforce_closure_op_env_seeding.rs) verifies that.
+#   `__paths_filtered__:` handler, the `CLOSURE_OP_ENV` cache in the
+#   `__closure_op__:` handler, and the `DELEGATE_ENV` cache in
+#   `jit_rt_delegate_gen` — the streaming eval delegate of #1059 Phase 3.)
+#   These satisfy the invariant in practice because the seeding happens
+#   inline; the test for closure-op env seeding
+#   (tests/enforce_closure_op_env_seeding.rs) verifies that.
 # - The body of `new_delegated_env` itself, which IS the helper.
 
-src/jit.rs  3
+src/jit.rs  4

--- a/tests/jitop_routing.rs
+++ b/tests/jitop_routing.rs
@@ -90,6 +90,23 @@ fn straight_line_collect_range_routes_to_jitop() {
     assert_eq!(label, "jitop");
 }
 
+/// Programs that lower with a streaming eval delegate (#1059 Phase 3)
+/// stay on whole-filter eval in default dispatch: per-record delegation
+/// measures slower than eval when the delegate dominates. The forced-mode
+/// knobs compile them (tests/selfdiff_jitop_backend.rs covers that side).
+#[test]
+fn delegated_program_stays_on_eval_by_default() {
+    let label = traced_label("[path(.a // .b)]", r#"{"b":1}"#, None);
+    assert_eq!(label, "eval");
+}
+
+/// `--force-jit` accepts delegated programs (debug knob, full coverage).
+#[test]
+fn force_jit_compiles_delegated_program() {
+    let label = traced_label("[path(.a // .b)]", r#"{"b":1}"#, Some("--force-jit"));
+    assert_eq!(label, "jit");
+}
+
 /// `--force-jit` keeps its "Cranelift or eval" debug semantics: the JitOp
 /// routing must not capture it.
 #[test]

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -13612,3 +13612,33 @@ try @csv catch .
 try @tsv catch .
 [[1,2]]
 "array ([1,2]) is not valid in a csv row"
+
+# #1059 Phase 3: complex path() streams through the eval delegate on the JIT backends
+[path(.a // .b)]
+{"b":1}
+[["b"]]
+
+# #1059 Phase 3: del with a generator path argument delegates whole-node
+del(.[] | select(. == 2))
+[1,2,3]
+[1,3]
+
+# #1059 Phase 3: walk delegate sees outer $var bindings via env seeding
+.x as $n | walk(if type == "number" then . + $n else . end) | .v
+{"x":10,"v":[1,2]}
+[11,12]
+
+# #1059 Phase 3: $x-anchored path keeps whole-filter eval (provenance guard)
+. as $x | path($x)
+{"a":1}
+[]
+
+# #1059 Phase 3: delegated path() validation error stays catchable
+5 | [try path(.[0]) catch .]
+null
+["Cannot index number with number"]
+
+# #1059 Phase 3: paths through nested generators via the delegate
+[path(.a[].b)]
+{"a":[{"b":1},{"b":2}]}
+[["a",0,"b"],["a",1,"b"]]


### PR DESCRIPTION
## Summary

Phase 3 of #1059 (first installment): instead of bailing the **whole filter** to the tree-walking evaluator when one subtree cannot be lowered, the flattener now emits `JitOp::DelegateGen` — a **streaming eval delegation** — for that subtree and keeps lowering the rest. Covered nodes: complex `path(...)` forms (43% of the previous bail surface), `del`, `pick`, `walk`, `skip`, `add(gen)`.

The bail surface over the regression + differential corpora drops **366 → 224 filters (-39%)**.

## How the delegate works

- The subtree is stashed as a closure op; `jit_rt_delegate_gen` runs it on eval with the current slot value as input and forwards each yielded value **as it is produced** — to the generator callback at top level (downstream early-stop flows through, so laziness is preserved; no recurrence of the #1085 eager-delegate hang) or onto the JitEnv collect stack inside a Collect.
- Eval errors surface through the pending-error flag like `CallBuiltin` (try/catch works; error wording byte-identical to whole-filter eval).
- Env seeding goes through `reset_delegated_env` (enforce-test allowlist bumped for the new cached-env site, same pattern as `PATHS_FILTER_ENV`).

Delegation is skipped (keeping today's whole-filter bail) when:
- the subtree sits inside `limit(n; …)` — per-yield counters cannot run inside the helper;
- the subtree contains `break` — it cannot unwind across the delegation boundary;
- a path-semantic node (`path`/`del`/`pick`) references `$vars` — value-only seeding loses path provenance (`. as $x | path($x)` must yield `[]`, #880/#953).

## Routing: default dispatch unchanged

Per-record delegation measures up to ~1.1x slower than whole-filter eval when the delegate dominates the filter (200k-record NDJSON A/B), so **default dispatch does not compile delegated programs** — `is_jit_compilable_with_funcs` rejects them and behavior/perf is status quo. The forced-mode knobs (`JQJIT_FORCE_CRANELIFT` / `JQJIT_FORCE_JITOP_INTERP` / `--force-jit`) accept them via the new `*_with_delegates` variants, so the backend self-diff and CI carry the coverage. Flipping profitable classes on by default is follow-up work (needs the remaining per-record delegation overhead tuned; `JIT_CLOSURE_OPS` is now `Vec<Rc<Expr>>`, which already removed the per-record `Expr` clone for all closure-op delegates and cut the gap from 1.3x to ~1.1x).

## Verification

- Full suite green (16 binaries), including 6 new regression cases and 2 new routing-guard tests
- 3-backend sweep (FORCE_CRANELIFT / FORCE_JITOP_INTERP / FORCE_INTERPRETER) over regression + differential corpora, 3737 cases: **zero real divergences** (the only hits are the `env`/`$ENV` knob-reflection artifacts of the sweep itself)
- Spot checks vs real jq 1.8.1 (path/del/walk/pick families, provenance and catchability cases): byte-identical

## Bench

Default routing decisions are unchanged, so `bench/comprehensive.sh` is neutral. Same-machine interleaved A/B on 2M-record NDJSON: `select|field` 1.01x, `.x+.y` 1.02x (noise), `.[]` 0.93x (branch faster), `path(.name,.x)` 1.09x slower — that row's per-record code is untouched by this diff (natively flattened comma path, no delegate, no closure ops), and the simultaneous opposite swing on `.[]` marks both as the known code-layout lottery (docs: p126 precedent), not an algorithmic cost.

## Remaining bail surface (next installments)

sub/gsub with interpolated replacement (27), scan/splits/match/capture generator forms (26), `limit(...)` interplay (22), tostream family (17), recursive defs (17), path/del with `$vars` (17), foreach/while/until edge forms (24), memoize (8), `?//` (4), misc (45).

Refs #1059 (Phase 3, first installment — does not close it)
