### PR TITLE
feat(jit): delegate any non-flattenable generator node to eval (#1059 Phase 3b)

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -181,16 +181,29 @@ gate を通れば tree-walking eval ではなく JitOp interpreter で実行さ�
 
 #### streaming eval delegate（#1059 Phase 3 / `JitOp::DelegateGen`）
 
-flatten 不能だったサブツリー（複雑な `path()`、`del`/`pick`/`walk`/`skip`/
-`add(gen)`）は、ノード単位で eval に **streaming 委譲**して flatten を続行
-できる（`emit_delegate_gen` → `jit_rt_delegate_gen`）。yield は生成順に
-cb / collect stack へ流れるので lazy 性と downstream early-stop が保たれる
-（旧 eager delegate の #1085 hang は再発しない）。委譲しない条件:
+flatten 不能なサブツリーは、ノード単位で eval に **streaming 委譲**して
+flatten を続行できる（`emit_delegate_gen` → `jit_rt_delegate_gen`）。
+`flatten_gen` の最終 fallback が generic に委譲を試みるため、複雑な
+`path()` / `del` / `pick` / `walk` 系に加え、regex 族（scan/match/sub
+補間 replacement）、tostream 族、`?//`、generator subscript なども
+カバーされる。yield は生成順に cb / collect stack へ流れるので lazy 性と
+downstream early-stop が保たれる（旧 eager delegate の #1085 hang は
+再発しない）。委譲しない条件（**拒否時は `has_unresolved_recursion` で
+全体 bail を強制** — ignored-false 文脈で op が落ちる #1093 パターン防止）:
 
 - `limit(n; …)` 内（per-yield counter が helper 内で回せない）
-- サブツリーに `break`（委譲境界を越える break は label に戻れない）
-- path 意味論ノード（`path`/`del`/`pick`）が `$var` を参照（値 seed では
+- サブツリーに `break`（委譲境界を越える break は label に戻れない）、
+  `FuncCall`（委譲 env に関数表が無い）、`memoize`（memo slot 未配線）
+- **push mode（collect 文脈）で無限になり得るサブツリー**
+  （Repeat/While/Until/Recurse）— pipe fallback の collect は eager なので
+  eval が lazy に切る stream が hang する（`first(repeat(7) | .+1)`）。
+  yield mode（tail position）は cb で lazy 停止できるので対象外
+- path 意味論ノード（`path`/`del`/`pick`）が `$var` を参照(値 seed では
   path provenance #880/#953 が失われ `. as $x | path($x)` が誤エラー化）
+
+stream 消費 builtin（`fromstream`/`truncate_stream`）は CallBuiltin の
+generator-arg LetBinding 書き換え（cartesian 意味論）から除外し、原型
+ノードごと委譲する。
 
 **default dispatch は委譲プログラムをコンパイルしない**
 （`is_jit_compilable_with_funcs` が reject）。delegate 支配的な filter は

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -1212,11 +1212,14 @@ impl Flattener {
     ///   generator left in a CollectBegin, and an infinite delegated stream
     ///   (`limit(1; path(recurse(.+1)) | .)`) would hang there where eval
     ///   stops lazily.
-    /// - the subtree contains `break`: a break crossing the delegation
-    ///   boundary would surface as a plain eval error instead of unwinding
-    ///   to its label. The scan is a conservative Debug-format substring
-    ///   probe — a false positive (e.g. a literal string "Break") merely
-    ///   keeps the eval bail of the caller.
+    /// - the subtree contains `break` (cannot unwind across the delegation
+    ///   boundary — it would surface as a plain eval error), an un-inlined
+    ///   `FuncCall` (the delegated env carries no function table; these
+    ///   only survive inlining for recursive defs, which the feasibility
+    ///   probes already reject — belt and suspenders), or `memoize` (the
+    ///   delegated env has no memo slots wired). The scan is a conservative
+    ///   Debug-format substring probe — a false positive (e.g. a literal
+    ///   string "Break") merely keeps the eval bail of the caller.
     /// - `path_semantic` nodes (`path(...)`, `del(...)`, `pick(...)`)
     ///   referencing any `$var`: the env seeding copies plain values, but
     ///   eval's path provenance (#880/#953) also tracks *where* a variable
@@ -1224,12 +1227,38 @@ impl Flattener {
     ///   "Invalid path expression" through a value-only seed. Value-semantic
     ///   delegates (walk/skip/add) are fine with value seeding.
     fn emit_delegate_gen(&mut self, expr: &Expr, input_slot: SlotId, path_semantic: bool) -> bool {
-        if self.limit_state.is_some() { return false; }
-        if format!("{:?}", expr).contains("Break") { return false; }
-        if path_semantic {
+        // Every rejection below also raises `has_unresolved_recursion`:
+        // callers in ignored-false emission contexts would otherwise drop
+        // the subtree's ops silently and ship a program with a hole
+        // (`first(repeat(7) | .+1)` returned nothing instead of bailing) —
+        // the flag forces the whole-filter bail that `flatten_filter` and
+        // the feasibility probes check after flattening. Same pattern as
+        // the PathExpr arm / #683.
+        let mut rejected = self.limit_state.is_some();
+        if !rejected {
+            let dbg = format!("{:?}", expr);
+            rejected = dbg.contains("Break") || dbg.contains("FuncCall") || dbg.contains("Memoize");
+            // Push mode is eager: the delegate fills a collect stack the
+            // lowering materialized (pipe fallback, explicit collect), so a
+            // potentially-infinite delegated stream would hang where eval
+            // cuts it lazily downstream (`first(repeat(7) | . + 1)`).
+            // Native lowering upholds the same invariant by never
+            // flattening unbounded generators; mirror it for delegates.
+            // Yield-mode (tail-position) delegates stay lazy through the
+            // callback and are exempt.
+            rejected = rejected
+                || (self.collect_depth > 0
+                    && (dbg.contains("Repeat") || dbg.contains("While")
+                        || dbg.contains("Until") || dbg.contains("Recurse")));
+        }
+        if !rejected && path_semantic {
             let mut vars = Vec::new();
             Self::collect_loadvar_indices(expr, &mut vars);
-            if !vars.is_empty() { return false; }
+            rejected = !vars.is_empty();
+        }
+        if rejected {
+            self.has_unresolved_recursion = true;
+            return false;
         }
         let idx = self.closure_ops.len();
         self.closure_ops.push(expr.clone());
@@ -3843,7 +3872,18 @@ impl Flattener {
 
             // CallBuiltin with generator args: rewrite as nested LetBinding
             // e.g., join(",","/") → (",","/") as $__arg | join($__arg)
-            Expr::CallBuiltin { op, args } if !args.is_empty() && args.iter().any(|a| !is_scalar(a)) => {
+            //
+            // The rewrite encodes *cartesian* argument semantics (the builtin
+            // runs once per argument combination). Stream-consuming builtins
+            // (`fromstream`, `truncate_stream`) read the whole event stream
+            // statefully instead, so they must skip the rewrite and fall
+            // through to the generic eval delegate below, which runs the
+            // original node wholesale (#1059 Phase 3). Before the delegate
+            // existed the rewritten body failed to flatten and the filter
+            // bailed — the rewrite's wrong shape was never executed.
+            Expr::CallBuiltin { op, args } if !args.is_empty()
+                && args.iter().any(|a| !is_scalar(a))
+                && !matches!(op, BuiltinOp::FromStream | BuiltinOp::TruncateStream) => {
                 // Each generator arg gets bound to a temp var
                 let base_var = VarIdx(10200);
                 let mut var_args = Vec::new();
@@ -3966,11 +4006,18 @@ impl Flattener {
                     self.emit(JitOp::Drop { slot: out });
                     true
                 } else {
-                    false
+                    self.emit_delegate_gen(expr, input_slot, false)
                 }
             }
 
-            _ => false,
+            // Last resort (#1059 Phase 3): any generator-position node with
+            // no native lowering streams through the eval delegate instead
+            // of bailing the whole filter — value semantics only (path
+            // computation never flows through `flatten_gen`; `path(...)`
+            // has its own provenance-guarded arm above). The delegate's own
+            // guards (limit context, `break` / `FuncCall` / `Memoize` in
+            // the subtree) keep the bail where delegation would be wrong.
+            _ => self.emit_delegate_gen(expr, input_slot, false),
         }
     }
 

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -13642,3 +13642,48 @@ null
 [path(.a[].b)]
 {"a":[{"b":1},{"b":2}]}
 [["a",0,"b"],["a",1,"b"]]
+
+# #1059 Phase 3b: gsub with interpolated replacement delegates whole-node
+gsub("(?<x>.)"; "\(.x|ascii_upcase)")
+"hello"
+"HELLO"
+
+# #1059 Phase 3b: scan generator form
+[ "abcabc" | scan("a*") ] | length
+null
+7
+
+# #1059 Phase 3b: tostream delegates as a stream
+[tostream]
+{"a":[1,2]}
+[[["a",0],1],[["a",1],2],[["a",1]],[["a"]]]
+
+# #1059 Phase 3b: fromstream skips the cartesian gen-arg rewrite (stream semantics)
+[tostream] | fromstream(.[])
+{"a":[1,2]}
+{"a":[1,2]}
+
+# #1059 Phase 3b: combinations delegates (was a phantom-builtin bail, #1082)
+[combinations]
+[[1,2],[3,4]]
+[[1,3],[1,4],[2,3],[2,4]]
+
+# #1059 Phase 3b: ?// destructuring alternative delegates
+. as [$a] ?// $a | $a
+7
+7
+
+# #1059 Phase 3b: setpath with generator arguments keeps cartesian semantics
+[setpath((["a"],["b"]); (1,2))]
+{}
+[{"a":1},{"b":1},{"a":2},{"b":2}]
+
+# #1059 Phase 3b: nested generator subscripts via the delegate
+[.[0,1][0,1]]
+[[1,2],[3,4]]
+[1,3,2,4]
+
+# #1059 Phase 3b: multi-generator string interpolation
+["\(1,2)\(3,4)"]
+null
+["13","23","14","24"]


### PR DESCRIPTION
## Summary

Phase 3 of #1059, second installment: the streaming eval delegate (#1101) becomes the **generic last-resort fallback** of `flatten_gen` — any generator-position node without a native lowering streams through `DelegateGen` instead of bailing the whole filter to eval.

Newly covered: the regex family (`scan`/`match`/`capture`/`splits`, `sub`/`gsub` with interpolated replacements), the `tostream` family, `?//` destructuring, `combinations`/`modf` (the #1082 phantom-builtin bail), generator subscripts (`.[0,1][0,1]`), multi-generator string interpolation in collect position, `setpath`/`getpath` generator forms, `input`/`inputs`.

**Bail surface: 224 → 131 filters** over the regression + differential corpora (366 before #1101; **-64% cumulative**).

## Correctness guards added while widening the surface

- **Flag-forced bail on rejection**: guard rejections now raise `has_unresolved_recursion` instead of returning a plain false — callers in ignored-false emission contexts dropped the subtree's ops silently and shipped a program with a hole (`first(repeat(7) | .+1)` returned nothing instead of bailing). Same pattern as #683/#1093.
- **No potentially-infinite delegates in push mode**: a delegate emitted inside a materialized collect (pipe fallback, explicit `[...]`) fills eagerly, so `Repeat`/`While`/`Until`/`Recurse` subtrees are rejected there — eval cuts those streams lazily downstream and an eager fill would hang. Yield-mode (tail-position) delegates stop lazily through the callback and are exempt. This preserves the invariant native lowering upholds by never flattening unbounded generators.
- **`FuncCall` / `memoize` rejected**: the delegated env carries no function table and no memo slots.
- **Stream-consuming builtins skip the cartesian rewrite**: `fromstream`/`truncate_stream` consume the whole event stream statefully, so the generator-arg LetBinding rewrite (per-combination semantics) is wrong for them — they now delegate the original node wholesale (`[tostream] | fromstream(.[])` returned `null` through the rewritten shape).

## Routing

Unchanged from Phase 3a: default dispatch does not compile delegated programs (per-record delegation loses to whole-filter eval when the delegate dominates); the forced-mode knobs carry the coverage and the backend self-diff exercises it in CI.

## Verification

- Full suite green; 9 new regression cases appended
- 3-backend sweep (FORCE_CRANELIFT / FORCE_JITOP_INTERP / FORCE_INTERPRETER) over both corpora, 3743 cases: zero real divergences
- Spot checks vs real jq 1.8.1 across all newly delegated families: byte-identical
- `bench/comprehensive.sh`: same profile as #1101's run (the `path(.name,.x)` history delta is the known per-row layout lottery documented there; this PR adds no per-record code to default dispatch)

Note: forced-mode Cranelift hangs on `isempty(repeat(1))`-class shapes **predate** this change (reproduced on e60269b — native Repeat lowering × limit interplay) and are out of scope.

## Remaining bail surface (131)

limit interplay (22), path/del with `$vars` (21, provenance), recursive defs (17), foreach multi-output forms (14), recurse filtered forms (13), while/until/repeat edge forms (9), memoize (8), reduce edge forms (~8), misc (19).

Refs #1059 (Phase 3, second installment — does not close it)
