### PR TITLE
feat(jit): wire funcs and memoize into the eval delegate (#1059 Phase 3c)

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -192,14 +192,37 @@ downstream early-stop が保たれる（旧 eager delegate の #1085 hang は
 全体 bail を強制** — ignored-false 文脈で op が落ちる #1093 パターン防止）:
 
 - `limit(n; …)` 内（per-yield counter が helper 内で回せない）
-- サブツリーに `break`（委譲境界を越える break は label に戻れない）、
-  `FuncCall`（委譲 env に関数表が無い）、`memoize`（memo slot 未配線）
+- サブツリーに `break`（委譲境界を越える break は label に戻れない）
 - **push mode（collect 文脈）で無限になり得るサブツリー**
-  （Repeat/While/Until/Recurse）— pipe fallback の collect は eager なので
-  eval が lazy に切る stream が hang する（`first(repeat(7) | .+1)`）。
-  yield mode（tail position）は cb で lazy 停止できるので対象外
+  （Repeat/While/Until/Recurse、および再帰 def の `FuncCall`）— pipe
+  fallback の collect は eager なので eval が lazy に切る stream が hang
+  する（`first(repeat(7) | .+1)`）。yield mode（tail position）は cb で
+  lazy 停止できるので対象外
 - path 意味論ノード（`path`/`del`/`pick`）が `$var` を参照(値 seed では
   path provenance #880/#953 が失われ `. as $x | path($x)` が誤エラー化）
+- `FuncCall` を含む委譲で、**いずれかの関数 body** に `break` / path
+  意味論ノードがある場合（委譲は raw body を eval で実行するため、
+  emit 時の Debug probe では body 内が見えない →
+  `funcs_bodies_block_delegation` が関数表ごと probe する）
+
+**funcs / memoize は委譲 env に配線済み（#1059 Phase 3c）**。再帰 def は
+インライン免除（`inline_with_recursion_exemption` が検出 → `FuncCall`
+ノードのまま残す）され、`flatten_gen` の専用 arm が呼び出しごと委譲する。
+`flatten_filter` が `DelegateCfg`（関数表 + body 参照 $var + memo slot 数）
+を thread-local publish し、`reset_delegated_env` / `new_delegated_env` が
+generation 比較で遅延インストールする — sortby key / assign / paths など
+**既存の全 dispatcher にも同時に配線される**（`sort_by(memoize(.a))` が
+"memoize slot 0 not allocated" でエラーになる live bug もこれで解消）。
+memo slot 数は parse 時情報なので `Filter::compile_*`（interpreter.rs）が
+`publish_delegate_memo_config` で別途 publish する。
+
+**probe と実 emission の collect_depth ずれに注意**: 委譲ガードは
+collect_depth 依存（push mode 拒否）なので、「probe は depth 0 で受理 →
+実 emission は collect fallback の depth 1 で拒否」という #683 型の
+すれ違いが起こり得る。`flatten_gen_with_each_output` の generic fallback は
+実 flatten 失敗時に `has_unresolved_recursion` を立てて全体 bail を強制する
+（reduce 系 dispatch は戻り値を無視するため、plain false だとループ本体が
+落ちて init 値が返る — `reduce (range as $m | rec_f) …` で実際に踏んだ）。
 
 stream 消費 builtin（`fromstream`/`truncate_stream`）は CallBuiltin の
 generator-arg LetBinding 書き換え（cartesian 意味論）から除外し、原型

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -223,6 +223,12 @@ pub struct Env {
     /// `memoize(...)` so the Env stays small. Lifetime is the whole program
     /// execution (persists across NDJSON inputs).
     pub memo: Option<Box<MemoState>>,
+    /// Identity of the JIT delegate configuration (funcs table + memoize
+    /// slots) installed into this Env by the delegation helpers in
+    /// `src/jit.rs` (#1059). 0 = nothing installed. Lets a cached delegated
+    /// Env skip per-record reinstallation while still detecting a recompile
+    /// (which bumps the published generation).
+    delegate_cfg_gen: u64,
 }
 
 const DEFAULT_MEMO_MAX_ENTRIES: usize = 1_000_000;
@@ -237,10 +243,28 @@ fn fresh_memo_slots(n: u32) -> Vec<MemoSlot> {
 
 impl Env {
     pub fn new(funcs: Vec<CompiledFunc>) -> Self {
-        Env { vars: vec![Value::Null; 65536], funcs: funcs.into_iter().map(Rc::new).collect(), next_label: 0, next_var: 256, lib_dirs: Vec::new(), closures: Vec::new(), recursive_cache: Vec::new(), subst_cache: Vec::new(), subst_ptr_cache: Vec::new(), memo: None }
+        Env { vars: vec![Value::Null; 65536], funcs: funcs.into_iter().map(Rc::new).collect(), next_label: 0, next_var: 256, lib_dirs: Vec::new(), closures: Vec::new(), recursive_cache: Vec::new(), subst_cache: Vec::new(), subst_ptr_cache: Vec::new(), memo: None, delegate_cfg_gen: 0 }
     }
     pub fn with_lib_dirs(funcs: Vec<CompiledFunc>, lib_dirs: Vec<String>) -> Self {
-        Env { vars: vec![Value::Null; 65536], funcs: funcs.into_iter().map(Rc::new).collect(), next_label: 0, next_var: 256, lib_dirs, closures: Vec::new(), recursive_cache: Vec::new(), subst_cache: Vec::new(), subst_ptr_cache: Vec::new(), memo: None }
+        Env { vars: vec![Value::Null; 65536], funcs: funcs.into_iter().map(Rc::new).collect(), next_label: 0, next_var: 256, lib_dirs, closures: Vec::new(), recursive_cache: Vec::new(), subst_cache: Vec::new(), subst_ptr_cache: Vec::new(), memo: None, delegate_cfg_gen: 0 }
+    }
+    /// Replace the function table. Used by the JIT delegation helpers
+    /// (#1059) to wire the program's `CompiledFunc`s into a cached delegated
+    /// Env so streamed `FuncCall` / `memoize` subtrees resolve. Clears the
+    /// per-func caches — they are keyed by `FuncId` / body pointers and
+    /// would alias across function tables.
+    pub fn set_funcs(&mut self, funcs: Vec<Rc<CompiledFunc>>) {
+        self.funcs = funcs;
+        self.recursive_cache.clear();
+        self.subst_cache.clear();
+        self.subst_ptr_cache.clear();
+    }
+    /// See `delegate_cfg_gen` field doc.
+    pub fn delegate_cfg_gen(&self) -> u64 {
+        self.delegate_cfg_gen
+    }
+    pub fn set_delegate_cfg_gen(&mut self, g: u64) {
+        self.delegate_cfg_gen = g;
     }
     /// Allocate `n` memo cache slots. Called once per program after parsing,
     /// using `ParseResult::memo_slots`. No-op when `n == 0` so non-memoize

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -2644,6 +2644,10 @@ impl Filter {
                     if let Ok(func) = compiler.compile_with_funcs(expr, funcs) {
                         self.jit_fn = Some(func);
                         self._jit_compiler = Some(Box::new(compiler));
+                        // Wire the parse-time memoize slot count into the
+                        // delegated-eval config (#1059 Phase 3c).
+                        crate::jit::publish_delegate_memo_config(
+                            self.memo_slots, self.memo_max_entries);
                     }
                 }
             }
@@ -2670,6 +2674,10 @@ impl Filter {
                     if let Ok(func) = compiler.compile_with_funcs(expr, funcs) {
                         self.jit_fn = Some(func);
                         self._jit_compiler = Some(Box::new(compiler));
+                        // Wire the parse-time memoize slot count into the
+                        // delegated-eval config (#1059 Phase 3c).
+                        crate::jit::publish_delegate_memo_config(
+                            self.memo_slots, self.memo_max_entries);
                     }
                 }
             }
@@ -2688,6 +2696,8 @@ impl Filter {
         if crate::jit::is_jit_compilable_with_delegates(expr, funcs) {
             if let Ok(prog) = crate::jit::JitProgram::compile(expr, funcs) {
                 self.jit_program = Some(prog);
+                crate::jit::publish_delegate_memo_config(
+                    self.memo_slots, self.memo_max_entries);
             }
         }
     }
@@ -2710,6 +2720,8 @@ impl Filter {
             if let Ok(prog) = crate::jit::JitProgram::compile(expr, funcs) {
                 if prog.eligible_for_default_routing() {
                     self.jit_program = Some(prog);
+                    crate::jit::publish_delegate_memo_config(
+                        self.memo_slots, self.memo_max_entries);
                 }
             }
         }

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -30,6 +30,16 @@ thread_local! {
     /// Closure ops captured at compile time; consumed by runtime trampolines
     /// during execution.
     static JIT_CLOSURE_OPS: UnsafeCell<Vec<Rc<Expr>>> = const { UnsafeCell::new(Vec::new()) };
+    /// Delegate configuration captured at compile time (#1059 Phase 3c):
+    /// the program's funcs table, the $vars its bodies reference, and the
+    /// memoize slot setup. Installed into cached delegated eval Envs by
+    /// `reset_delegated_env` / `new_delegated_env`; the generation counter
+    /// lets a cached Env skip reinstallation until the next compile.
+    static JIT_DELEGATE_CFG: RefCell<Rc<DelegateCfg>> = RefCell::new(Rc::new(DelegateCfg::default()));
+    /// Monotonic source for `DelegateCfg::gen`. Starts at 1 so the default
+    /// config (gen 0) matches a fresh Env's `delegate_cfg_gen()` of 0 and
+    /// installs nothing.
+    static JIT_DELEGATE_CFG_GEN: Cell<u64> = const { Cell::new(1) };
     /// Pointer to the `JitEnv` currently being driven by `execute_jit*`.
     /// `set_jit_error*` consult this to flip the env's `error_flag` without
     /// plumbing an env pointer through every fallible trampoline signature.
@@ -741,6 +751,19 @@ struct Flattener {
     /// eval delegation (#1059 Phase 3). The default-dispatch feasibility
     /// probe rejects such programs (see `is_jit_compilable_with_funcs`).
     emitted_delegate: bool,
+    /// Function ids exempt from inlining: recursive defs discovered by
+    /// `inline_with_recursion_exemption`. Calls to these stay as `FuncCall`
+    /// nodes in the inlined tree so `flatten_gen` can stream the whole call
+    /// through the eval delegate — eval owns recursion via
+    /// `stacker::maybe_grow`, the JIT has no recursion-safe lowering (#648).
+    inline_exempt: HashSet<crate::ir::FuncId>,
+    /// Recursive func ids hit during the current `inline_func_calls` pass;
+    /// drained into `inline_exempt` by the retry loop in
+    /// `inline_with_recursion_exemption`.
+    recursion_detected: HashSet<crate::ir::FuncId>,
+    /// Cached verdict of `funcs_bodies_block_delegation` (the function
+    /// table is fixed for the lifetime of a Flattener).
+    funcs_body_block: Option<bool>,
 }
 
 impl Flattener {
@@ -751,7 +774,8 @@ impl Flattener {
                      limit_state: None, closure_ops: Vec::new(),
                      expanding_funcs: HashSet::new(), value_constants: Vec::new(),
                      is_test: false, has_unresolved_recursion: false,
-                     emitted_delegate: false }
+                     emitted_delegate: false, inline_exempt: HashSet::new(),
+                     recursion_detected: HashSet::new(), funcs_body_block: None }
     }
 
     /// Materialize a Literal into a heap-allocated Value and return a stable pointer.
@@ -788,7 +812,35 @@ impl Flattener {
         t.expanding_funcs = self.expanding_funcs.clone();
         t.is_test = true;
         t.has_unresolved_recursion = self.has_unresolved_recursion;
+        t.inline_exempt = self.inline_exempt.clone();
+        t.funcs_body_block = self.funcs_body_block;
         t
+    }
+
+    /// Inline function calls, exempting recursive defs (#1059 Phase 3c).
+    ///
+    /// `inline_func_calls` discovers recursion only mid-expansion (the inner
+    /// call's id is already in `expanding_funcs`), at which point the outer
+    /// call's body is partially inlined. Restart the pass with the detected
+    /// ids exempted so the *outer* call survives as a clean `FuncCall` node
+    /// — that is the shape `flatten_gen` can hand to the eval delegate
+    /// whole. Each retry exempts at least one more func, so the loop runs
+    /// at most `funcs.len() + 1` times (in practice: twice, and only for
+    /// filters that use recursive defs).
+    fn inline_with_recursion_exemption(&mut self, expr: &Expr) -> Expr {
+        loop {
+            let result = self.inline_func_calls(expr);
+            if self.recursion_detected.is_empty() {
+                return result;
+            }
+            let detected = std::mem::take(&mut self.recursion_detected);
+            self.inline_exempt.extend(detected);
+            // The flag and the expansion stack are inline-pass state here
+            // (inline_func_calls is the only inline-time setter); clear them
+            // for the retry. Flatten-time setters run after inlining.
+            self.has_unresolved_recursion = false;
+            self.expanding_funcs.clear();
+        }
     }
 
     /// Inline FuncCall nodes by substituting function bodies.
@@ -805,7 +857,17 @@ impl Flattener {
         match expr {
             Expr::FuncCall { func_id, args } => {
                 if func_id.idx() >= self.funcs.len() { return expr.clone(); }
+                if self.inline_exempt.contains(func_id) {
+                    // Recursive def: keep the call un-inlined so flatten_gen
+                    // can stream the whole call through the eval delegate
+                    // (#1059 Phase 3c). Args still get inlined — they may
+                    // reference non-recursive defs.
+                    let new_args: Vec<Expr> =
+                        args.iter().map(|a| self.inline_func_calls(a)).collect();
+                    return Expr::FuncCall { func_id: *func_id, args: new_args };
+                }
                 if self.expanding_funcs.contains(func_id) {
+                    self.recursion_detected.insert(*func_id);
                     self.has_unresolved_recursion = true;
                     return expr.clone();
                 }
@@ -1201,6 +1263,25 @@ impl Flattener {
         }
     }
 
+    /// True when some function body contains a construct that cannot cross
+    /// the eval-delegation boundary. Delegated `FuncCall`s execute raw
+    /// bodies from the funcs table wired into the delegated env, so the
+    /// emit-time Debug probe on the delegated expression cannot see into
+    /// them; probe the whole table once instead (user defs only — builtins
+    /// are native ops, so the table is small). "Del" / "Pick" / "Paths"
+    /// match the path-semantic builtin-op and Expr variant names; the odd
+    /// substring false positive only costs a bail.
+    fn funcs_bodies_block_delegation(&mut self) -> bool {
+        if let Some(b) = self.funcs_body_block { return b; }
+        let b = self.funcs.iter().any(|f| {
+            let d = format!("{:?}", f.body);
+            d.contains("Break") || d.contains("PathExpr")
+                || d.contains("Del") || d.contains("Pick") || d.contains("Paths")
+        });
+        self.funcs_body_block = Some(b);
+        b
+    }
+
     /// Emit a streaming eval delegation for `expr` (#1059 Phase 3), or
     /// return false when the context cannot host one:
     ///
@@ -1213,13 +1294,15 @@ impl Flattener {
     ///   (`limit(1; path(recurse(.+1)) | .)`) would hang there where eval
     ///   stops lazily.
     /// - the subtree contains `break` (cannot unwind across the delegation
-    ///   boundary — it would surface as a plain eval error), an un-inlined
-    ///   `FuncCall` (the delegated env carries no function table; these
-    ///   only survive inlining for recursive defs, which the feasibility
-    ///   probes already reject — belt and suspenders), or `memoize` (the
-    ///   delegated env has no memo slots wired). The scan is a conservative
-    ///   Debug-format substring probe — a false positive (e.g. a literal
-    ///   string "Break") merely keeps the eval bail of the caller.
+    ///   boundary — it would surface as a plain eval error). The scan is a
+    ///   conservative Debug-format substring probe — a false positive
+    ///   (e.g. a literal string "Break") merely keeps the eval bail of the
+    ///   caller. `FuncCall` / `memoize` are no longer blanket-rejected:
+    ///   the delegated env carries the funcs table and memo slots (#1059
+    ///   Phase 3c). A delegated `FuncCall` is still rejected in push mode
+    ///   (a recursive def can be an unbounded generator) and when any
+    ///   function body contains `break` / path-semantic nodes (see
+    ///   `funcs_bodies_block_delegation`).
     /// - `path_semantic` nodes (`path(...)`, `del(...)`, `pick(...)`)
     ///   referencing any `$var`: the env seeding copies plain values, but
     ///   eval's path provenance (#880/#953) also tracks *where* a variable
@@ -1237,7 +1320,7 @@ impl Flattener {
         let mut rejected = self.limit_state.is_some();
         if !rejected {
             let dbg = format!("{:?}", expr);
-            rejected = dbg.contains("Break") || dbg.contains("FuncCall") || dbg.contains("Memoize");
+            rejected = dbg.contains("Break");
             // Push mode is eager: the delegate fills a collect stack the
             // lowering materialized (pipe fallback, explicit collect), so a
             // potentially-infinite delegated stream would hang where eval
@@ -1250,6 +1333,18 @@ impl Flattener {
                 || (self.collect_depth > 0
                     && (dbg.contains("Repeat") || dbg.contains("While")
                         || dbg.contains("Until") || dbg.contains("Recurse")));
+            if !rejected && dbg.contains("FuncCall") {
+                // The delegate executes raw `CompiledFunc` bodies in eval
+                // (the funcs table is wired into the delegated env, #1059
+                // Phase 3c), and the Debug probe above cannot see into
+                // them. Apply the boundary guards to the bodies too:
+                // - push mode: a recursive def can be an unbounded
+                //   generator (`def f: ., f;`) — same hazard as Repeat
+                // - a `break` inside a body cannot jump back across the
+                //   delegation boundary to a JIT label; path-semantic
+                //   nodes inside a body would lose $var provenance (#880)
+                rejected = self.collect_depth > 0 || self.funcs_bodies_block_delegation();
+            }
         }
         if !rejected && path_semantic {
             let mut vars = Vec::new();
@@ -2479,7 +2574,19 @@ impl Flattener {
                 self.emit(JitOp::Label { id: end_lbl });
                 out
             }
-            Expr::FuncCall { func_id, args } if func_id.idx() < self.funcs.len() && !self.expanding_funcs.contains(func_id) => {
+            // Call to a recursive def (inline-exempt, #1059 Phase 3c) in
+            // scalar position: no delegation here yet (scalar contexts
+            // expect exactly one value; that's a later installment). Force
+            // the whole-filter bail — falling through to the default Null
+            // emit would silently fabricate a value (#1093 pattern).
+            Expr::FuncCall { func_id, .. } if self.inline_exempt.contains(func_id) => {
+                self.has_unresolved_recursion = true;
+                let out = self.alloc_slot();
+                self.emit(JitOp::Null { dst: out });
+                out
+            }
+            Expr::FuncCall { func_id, args } if func_id.idx() < self.funcs.len()
+                && !self.expanding_funcs.contains(func_id) => {
                 self.expanding_funcs.insert(*func_id);
                 let func = &self.funcs[func_id.idx()].clone();
                 let body = if !func.param_vars.is_empty() && !args.is_empty() {
@@ -3297,8 +3404,14 @@ impl Flattener {
                     });
                     return ok;
                 }
-                // Complex path: delegate to runtime (only safe without FuncCall refs)
+                // Complex path: delegate to runtime. Calls to recursive
+                // defs (inline-exempt FuncCall nodes, #1059 Phase 3c) can
+                // reach here now — the assign delegate's path machinery is
+                // not validated for them, so force the whole-filter bail
+                // (plain `false` risks an op hole in ignored-false
+                // contexts, #1093 pattern).
                 if contains_func_call(path_expr) || contains_func_call(value_expr) {
+                    self.has_unresolved_recursion = true;
                     return false;
                 }
                 let idx = self.closure_ops.len();
@@ -3501,8 +3614,10 @@ impl Flattener {
                     self.emit(JitOp::Drop { slot: path_arr });
                     return ok;
                 }
-                // Complex path: delegate to runtime (only safe without FuncCall refs)
+                // Complex path: delegate to runtime. Same recursive-def
+                // guard as the Assign arm above (#1059 Phase 3c / #1093).
                 if contains_func_call(path_expr) || contains_func_call(update_expr) {
+                    self.has_unresolved_recursion = true;
                     return false;
                 }
                 let idx = self.closure_ops.len();
@@ -3697,6 +3812,15 @@ impl Flattener {
                 });
                 self.emit(JitOp::Drop { slot: arr });
                 true
+            }
+
+            // Call to a recursive def (inline-exempt, #1059 Phase 3c):
+            // stream the whole call through the eval delegate. Eval owns
+            // recursion via `stacker::maybe_grow`; the delegate guards
+            // (push-mode rejection, func-body probe) live in
+            // `emit_delegate_gen`.
+            Expr::FuncCall { func_id, .. } if self.inline_exempt.contains(func_id) => {
+                self.emit_delegate_gen(expr, input_slot, false)
             }
 
             Expr::FuncCall { func_id, args } => {
@@ -4176,7 +4300,17 @@ impl Flattener {
                 self.collect_depth += 1;
                 let ok = self.flatten_gen(gen_expr, input_slot);
                 self.collect_depth -= 1;
-                if !ok { return false; }
+                if !ok {
+                    // The pre-check above ran at the caller's collect depth;
+                    // the real flatten runs one deeper, where depth-sensitive
+                    // delegate guards (push-mode rejections, #1059) can fail
+                    // after the probe passed. Several dispatch sites (the
+                    // scalar Reduce family, #683) ignore our return value, so
+                    // a plain false here would ship a loop with no body —
+                    // force the whole-filter bail instead (#1093 pattern).
+                    self.has_unresolved_recursion = true;
+                    return false;
+                }
                 let arr = self.alloc_slot();
                 self.emit(JitOp::CollectFinish { dst: arr });
                 // Iterate the collected array
@@ -9697,12 +9831,11 @@ fn flatten_filter(expr: &Expr, funcs: &[CompiledFunc]) -> Result<FlattenedFilter
     fl.funcs = funcs.to_vec();
     // Pre-inline function calls and apply semantic optimizations.
     // Always run to catch to_entries|from_entries and similar rewrites.
-    let inlined = fl.inline_func_calls(expr);
-    // Recursive def left an un-inlined FuncCall in the tree. The JIT
-    // can't safely emit a recursive call (no host-stack management),
-    // and pressing on would produce a partial code path that returns
-    // garbage. Bail so the binary falls back to eval, which already
-    // handles recursion via `stacker::maybe_grow` (#648).
+    // Calls to recursive defs survive as `FuncCall` nodes (inline-exempt,
+    // #1059 Phase 3c); flatten_gen streams them through the eval delegate
+    // or bails — the JIT has no recursion-safe lowering of its own (#648).
+    let inlined = fl.inline_with_recursion_exemption(expr);
+    // Backstop: the exemption loop should leave no unresolved recursion.
     if fl.has_unresolved_recursion {
         bail!("Expression not JIT-compilable: contains recursive function call");
     }
@@ -9727,6 +9860,26 @@ fn flatten_filter(expr: &Expr, funcs: &[CompiledFunc]) -> Result<FlattenedFilter
             *cell.get() = fl.closure_ops.iter().cloned().map(Rc::new).collect();
         });
     }
+
+    // Publish the delegate funcs config (#1059 Phase 3c). Always overwrite
+    // so a previous compile's table can't leak into this filter's
+    // delegates; the table is only populated when some closure op actually
+    // calls a function (delegated recursive defs, closure-op keys).
+    let needs_funcs = !fl.funcs.is_empty()
+        && fl.closure_ops.iter().any(|e| format!("{:?}", e).contains("FuncCall"));
+    let (cfg_funcs, cfg_body_vars) = if needs_funcs {
+        let mut vars: Vec<VarIdx> = Vec::new();
+        for f in &fl.funcs {
+            Flattener::collect_loadvar_indices(&f.body, &mut vars);
+        }
+        (fl.funcs.iter().cloned().map(Rc::new).collect(), vars)
+    } else {
+        (Vec::new(), Vec::new())
+    };
+    publish_delegate_cfg(move |c| {
+        c.funcs = cfg_funcs;
+        c.func_body_vars = cfg_body_vars;
+    });
 
     Ok(FlattenedFilter {
         ops: optimize_clone_yield(fl.ops),
@@ -11309,13 +11462,11 @@ pub fn is_jit_compilable_with_delegates(expr: &Expr, funcs: &[CompiledFunc]) -> 
 fn jit_feasibility(expr: &Expr, funcs: &[CompiledFunc]) -> (bool, bool) {
     let mut fl = Flattener::new();
     fl.funcs = funcs.to_vec();
-    // Mirror `compile_with_funcs`'s inline step so we detect the same
-    // "recursive def in expr" shape it would reject. Without this, the
-    // Reduce scalar fast path in `flatten_gen` (line 2062) silently returns
-    // true even when the source generator references a recursive def — and
-    // the eventual `compile_with_funcs` then stack-overflows in
-    // `inline_func_calls` (#648).
-    let inlined = fl.inline_func_calls(expr);
+    // Mirror `compile_with_funcs`'s inline step (including the recursion
+    // exemption) so the feasibility verdict agrees with what the real
+    // compile would produce. Diverging here is the #648 failure mode: the
+    // probe accepts a shape the compile then chokes on.
+    let inlined = fl.inline_with_recursion_exemption(expr);
     if fl.has_unresolved_recursion { return (false, false); }
     let input = fl.alloc_slot();
     let ok = fl.flatten_gen(&inlined, input);
@@ -11354,6 +11505,13 @@ fn seed_eval_env_from_jit(env: &Rc<RefCell<crate::eval::Env>>, exprs: &[&Expr]) 
     for e in exprs {
         Flattener::collect_loadvar_indices(e, &mut indices);
     }
+    seed_var_indices(env, &indices);
+}
+
+/// Copy the given JIT-env var slots into the eval Env (the seed loop shared
+/// by the expression walk above and the func-body var list in the delegate
+/// config).
+fn seed_var_indices(env: &Rc<RefCell<crate::eval::Env>>, indices: &[VarIdx]) {
     if indices.is_empty() { return; }
     REUSABLE_ENV.with(|cell| {
         let jit_env_opt = unsafe { &*cell.get() };
@@ -11362,10 +11520,82 @@ fn seed_eval_env_from_jit(env: &Rc<RefCell<crate::eval::Env>>, exprs: &[&Expr]) 
         for idx in indices {
             let i = idx.idx();
             if i < jit_env.vars.len() {
-                env_mut.seed_var(idx, jit_env.vars[i].clone());
+                env_mut.seed_var(*idx, jit_env.vars[i].clone());
             }
         }
     });
+}
+
+/// Compile-time delegate configuration (#1059 Phase 3c). `flatten_filter`
+/// publishes the funcs side; `publish_delegate_memo_config` (called from
+/// `Filter::compile_*`, which owns the parse-time slot count) publishes the
+/// memoize side. Each publish bumps `gen`, so cached delegated Envs
+/// reinstall lazily on their next use after a compile.
+#[derive(Default)]
+struct DelegateCfg {
+    gen: u64,
+    /// The program's function table — populated only when some closure op
+    /// references a `FuncCall`, so func-less programs (the common case)
+    /// install nothing.
+    funcs: Vec<Rc<CompiledFunc>>,
+    /// $vars referenced by any function body. A delegated call can reach a
+    /// body that closes over an outer JIT-bound $var, and the per-record
+    /// seed walk only sees the delegated expression — so these are seeded
+    /// whenever the table is non-empty. Over-seeding is harmless: eval
+    /// rebinds anything bound inside the delegate before reading it.
+    func_body_vars: Vec<VarIdx>,
+    memo_slots: u32,
+    memo_max_entries: usize,
+}
+
+/// Replace the published delegate config, carrying over fields the caller
+/// doesn't touch and stamping a fresh generation.
+fn publish_delegate_cfg(update: impl FnOnce(&mut DelegateCfg)) {
+    JIT_DELEGATE_CFG.with(|cell| {
+        let mut slot = cell.borrow_mut();
+        let mut cfg = DelegateCfg {
+            gen: JIT_DELEGATE_CFG_GEN.with(|g| {
+                let v = g.get();
+                g.set(v + 1);
+                v
+            }),
+            funcs: slot.funcs.clone(),
+            func_body_vars: slot.func_body_vars.clone(),
+            memo_slots: slot.memo_slots,
+            memo_max_entries: slot.memo_max_entries,
+        };
+        update(&mut cfg);
+        *slot = Rc::new(cfg);
+    });
+}
+
+/// Wire the program's memoize slot setup into future delegated Envs. The
+/// slot count is parse-time state on the `Filter`, invisible to the
+/// flattener — `Filter::compile_*` calls this after a successful compile.
+pub fn publish_delegate_memo_config(memo_slots: u32, memo_max_entries: usize) {
+    publish_delegate_cfg(|c| {
+        c.memo_slots = memo_slots;
+        c.memo_max_entries = memo_max_entries;
+    });
+}
+
+/// Install the published delegate config (funcs table + memoize slots) into
+/// a delegated Env unless it already carries the current generation.
+/// Returns the config so callers can seed `func_body_vars`.
+fn install_delegate_cfg(env: &Rc<RefCell<crate::eval::Env>>) -> Rc<DelegateCfg> {
+    let cfg = JIT_DELEGATE_CFG.with(|cell| cell.borrow().clone());
+    {
+        let mut e = env.borrow_mut();
+        if e.delegate_cfg_gen() != cfg.gen {
+            e.set_funcs(cfg.funcs.clone());
+            if cfg.memo_slots > 0 {
+                e.set_memo_slots(cfg.memo_slots);
+                e.set_memo_max_entries(cfg.memo_max_entries);
+            }
+            e.set_delegate_cfg_gen(cfg.gen);
+        }
+    }
+    cfg
 }
 
 /// Build a fresh `eval::Env` for a JIT→eval closure-op delegation, auto-seeded
@@ -11373,7 +11603,11 @@ fn seed_eval_env_from_jit(env: &Rc<RefCell<crate::eval::Env>>, exprs: &[&Expr]) 
 /// `Rc::new(RefCell::new(Env::new(vec![])))` from inside an `__xxx__:` dispatcher.
 fn new_delegated_env(exprs: &[&Expr]) -> Rc<RefCell<crate::eval::Env>> {
     let env = Rc::new(RefCell::new(crate::eval::Env::new(vec![])));
+    let cfg = install_delegate_cfg(&env);
     seed_eval_env_from_jit(&env, exprs);
+    if !cfg.funcs.is_empty() {
+        seed_var_indices(&env, &cfg.func_body_vars);
+    }
     env
 }
 
@@ -11383,7 +11617,11 @@ fn new_delegated_env(exprs: &[&Expr]) -> Rc<RefCell<crate::eval::Env>> {
 /// thread-local to amortize allocation.
 fn reset_delegated_env(env: &Rc<RefCell<crate::eval::Env>>, exprs: &[&Expr]) {
     env.borrow_mut().reset();
+    let cfg = install_delegate_cfg(env);
     seed_eval_env_from_jit(env, exprs);
+    if !cfg.funcs.is_empty() {
+        seed_var_indices(env, &cfg.func_body_vars);
+    }
 }
 
 fn with_jit_env<R>(f: impl FnOnce(&mut JitEnv) -> R) -> R {

--- a/tests/jitop_routing.rs
+++ b/tests/jitop_routing.rs
@@ -118,3 +118,28 @@ fn force_jit_pins_cranelift() {
     );
     assert_eq!(label, "jit");
 }
+
+/// A recursive def now lowers via the eval delegate (#1059 Phase 3c), but
+/// delegated programs stay off the default dispatch — whole-filter eval
+/// measures faster when the delegate dominates.
+#[test]
+fn recursive_def_stays_on_eval_by_default() {
+    let label = traced_label(
+        "def f: if . >= 5 then . else . + 1 | f end; . | f",
+        "0",
+        None,
+    );
+    assert_eq!(label, "eval");
+}
+
+/// `--force-jit` compiles the delegated recursive def (debug knob, full
+/// coverage for the backend self-diff).
+#[test]
+fn force_jit_compiles_recursive_def_delegate() {
+    let label = traced_label(
+        "def f: if . >= 5 then . else . + 1 | f end; . | f",
+        "0",
+        Some("--force-jit"),
+    );
+    assert_eq!(label, "jit");
+}

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -13687,3 +13687,73 @@ null
 ["\(1,2)\(3,4)"]
 null
 ["13","23","14","24"]
+
+# #1059 Phase 3c: recursive def delegated whole to eval (tail position)
+def f: . as $x | if . == 0 then null else (. - 1 | f) as $r | [$x, $r] end; 3 | f
+0
+[3,[2,[1,null]]]
+
+# #1059 Phase 3c: branching recursion (fib) via the delegate
+def fib: . as $n | if $n < 2 then $n else ($n - 1 | fib) + ($n - 2 | fib) end; 10 | fib
+0
+55
+
+# #1059 Phase 3c: recursive def + memoize with wired memo slots
+def fib: memoize(if . < 2 then . else ((. - 1) | fib) + ((. - 2) | fib) end); 30 | fib
+0
+832040
+
+# #1059 Phase 3c: inlined 0-arity memoize body delegated in push mode
+def sq: memoize(. * .); [1, 2, 3, 2, 1] | map(sq)
+null
+[1,4,9,4,1]
+
+# #1059 Phase 3c: multi-output memoize body re-yields the cached stream
+def two: memoize(., . + 1); [1, 1, 2] | map([two]) | add
+null
+[1,2,1,2,2,3]
+
+# #1059 Phase 3c: param-blind memoize caching matches eval (cache key is the input)
+def f($x): memoize(. + $x); 10 | [f(1), f(2)]
+null
+[11,11]
+
+# #1059 Phase 3c: 2-arg memoize key expression through the closure-op delegate
+def by_id: memoize(.value * 2; .id); map(by_id)
+[{"id":1,"value":10},{"id":2,"value":20},{"id":1,"value":999}]
+[20,40,20]
+
+# #1059 Phase 3c: memoize inside sort_by errored "memoize slot 0 not allocated" before memo wiring
+sort_by(memoize(.a))
+[{"a":2},{"a":1}]
+[{"a":1},{"a":2}]
+
+# #1059 Phase 3c: recursive def body closing over an outer JIT-bound $var (func_body_vars seeding)
+5 as $k | def f: if . <= 0 then $k else . - 1 | f end; 10 | f
+null
+5
+
+# #1059 Phase 3c: recursive sort_by key resolves through the wired funcs table
+def d: if type == "array" then (.[0] | d) else . end; sort_by(d)
+[[5],[2],[9]]
+[[2],[5],[9]]
+
+# #1059 Phase 3c: recursive generator in collect context is push-rejected (bails to eval)
+def countdown: if . <= 0 then empty else ., (. - 1 | countdown) end; [3 | countdown]
+null
+[3,2,1]
+
+# #1059 Phase 3c: depth-shifted delegate rejection in a reduce source must bail, not drop the loop body
+def gcd($a;$b): if $b == 0 then $a else gcd($b; $a % $b) end; reduce (range(2;4) as $m | gcd($m;2)) as $g (0; . + $g)
+null
+3
+
+# #1059 Phase 3c: infinite recursive generator under a label stays lazy or bails (must not hang)
+[label $out | (def f: ., f; f) | ., break $out]
+1
+[1]
+
+# #1059 Phase 3c: self-recursive stream in tail position delegates lazily
+def t: if . < 4 then ., (. + 1 | t) else . end; [1 | t]
+null
+[1,2,3,4]


### PR DESCRIPTION
## Summary

Third Phase 3 installment for #1059: recursive defs and `memoize()` no longer force a whole-filter bail — the streaming eval delegate (`JitOp::DelegateGen`) now runs them with a properly wired delegated Env.

- **Recursion exemption**: `inline_with_recursion_exemption` detects recursive defs via an inline retry loop and leaves their calls as `FuncCall` nodes; a dedicated `flatten_gen` arm streams the whole call through the eval delegate (eval owns recursion via `stacker::maybe_grow`). Push mode stays rejected — a recursive def can be an unbounded generator (`def f: ., f;`), the same hazard class as `Repeat`. Delegation is also refused when any function body contains `break` or path-semantic nodes (`funcs_bodies_block_delegation`), since the emit-time probe cannot see into bodies.
- **Delegate config wiring**: `flatten_filter` publishes a `DelegateCfg` (funcs table, body-referenced `$vars`, memoize slots); `reset_delegated_env` / `new_delegated_env` install it generation-lazily into every cached delegated Env. This wires the closure-op dispatchers (`sort_by` keys, `paths`, assign/update) at the same time, so recursive sort keys etc. work too. The parse-time memoize slot count is published from `Filter::compile_*`.
- **Live bug fix**: `sort_by(memoize(.a))` errored `memoize slot 0 not allocated` on the default dispatch while eval sorted fine — fixed by the memo wiring (regression test added).
- **Op-hole fix**: the each-output generic fallback probes at the caller's collect depth but flattens one deeper, where depth-sensitive delegate guards can reject after the probe passed; the reduce-family dispatch ignores the return value, so the loop body silently vanished (`reduce (range(2;4) as $m | rec_f) as $g (0; . + $g)` returned the init value). The fallback now raises `has_unresolved_recursion` to force the whole-filter bail (#1093 pattern).

Default dispatch still rejects delegated programs (`is_jit_compilable_with_funcs`), so default-mode behavior changes only where bugs are fixed.

## Verification

- `cargo build --release`: zero warnings; `cargo test --release`: all green (72 targets)
- 3-backend sweep (FORCE_CRANELIFT / FORCE_JITOP_INTERP / FORCE_INTERPRETER over regression + differential corpora, 3766 cases): no real divergence (only the 2 known env/$ENV knob-reflection artifacts)
- Forced-mode bail count: **131 → 113** (recursive defs −12, memoize −6 of the prior classification)
- Real jq 1.8.1 spot checks: 12/12 match on the newly covered recursion shapes
- `bench/comprehensive.sh`: all 220 rows within ±5% of the v1.8.3 history column

Part of #1059.

🤖 Generated with [Claude Code](https://claude.com/claude-code)