### PR TITLE
feat(jit): fall through to the eval delegate when loop arms reject pre-emission (#1059 PR-C)

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -237,6 +237,16 @@ stream 消費 builtin（`fromstream`/`truncate_stream`）は CallBuiltin の
 generator-arg LetBinding 書き換え（cartesian 意味論）から除外し、原型
 ノードごと委譲する。
 
+**失敗 arm の fall-through 委譲（#1059 PR-C）**: Reduce / Foreach / While /
+Repeat / Recurse の native arm が **op 未 emit の地点**（is_scalar pre-check
+や extract probe の失敗）で `return false` していた箇所は、whole-node の
+`emit_delegate_gen` に fall-through する。partial emission 後の false は
+対象外（ops 汚染、#1093）。また `is_scalar(Reduce)` が真でも source が
+flatten 不能なら flatten_scalar 内で flag が立つため、`flatten_gen` の
+scalar dispatch は Reduce だけ probe してから委譲に切り替える（再帰 def を
+reduce source に含む形がここに落ちる）。委譲可否は emit_delegate_gen の
+ガード（push-mode 無限 / limit budget / break / provenance）がそのまま裁く。
+
 **default dispatch は委譲プログラムをコンパイルしない**
 （`is_jit_compilable_with_funcs` が reject）。delegate 支配的な filter は
 whole-filter eval の方が速い（200k NDJSON A/B で委譲側が最大 ~1.1x 劣化、

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -2748,6 +2748,23 @@ impl Flattener {
     fn flatten_gen(&mut self, expr: &Expr, input_slot: SlotId) -> bool {
         // If scalar, just compute and yield once
         if is_scalar(expr) {
+            // A scalar-classified Reduce can still fail inside
+            // flatten_scalar (source not flattenable — the #683 pre-check
+            // raises the bail flag after the Null emit). In generator
+            // position the single-output contract is just emit_yield, so
+            // probe first and stream the whole node through the eval
+            // delegate instead of bailing the filter (#1059 PR-C; the
+            // recursive-def-in-reduce-source class). Probes skip this —
+            // the outer probe already covers the subtree (#641).
+            if matches!(expr, Expr::Reduce { .. }) && !self.is_test {
+                let mut test = self.test_flattener();
+                test.has_unresolved_recursion = false;
+                let t_in = test.alloc_slot();
+                let _ = test.flatten_scalar(expr, t_in);
+                if test.has_unresolved_recursion {
+                    return self.emit_delegate_gen(expr, input_slot, false);
+                }
+            }
             let out = self.flatten_scalar(expr, input_slot);
             self.emit_yield(out);
             self.emit(JitOp::Drop { slot: out });
@@ -3102,7 +3119,7 @@ impl Flattener {
             }
 
             Expr::Reduce { source, init, var_index, acc_index, update } => {
-                if !is_scalar(init) || !is_scalar(update) { return false; }
+                if !is_scalar(init) || !is_scalar(update) { return self.emit_delegate_gen(expr, input_slot, false); }
                 let acc_val = self.flatten_scalar(init, input_slot);
                 let old_acc = self.alloc_slot();
                 self.emit(JitOp::GetVar { dst: old_acc, var_index: *acc_index });
@@ -3171,7 +3188,7 @@ impl Flattener {
             }
 
             Expr::While { cond, update } => {
-                if !is_scalar(cond) || !is_scalar(update) { return false; }
+                if !is_scalar(cond) || !is_scalar(update) { return self.emit_delegate_gen(expr, input_slot, false); }
                 let current = self.alloc_slot();
                 self.emit(JitOp::Clone { dst: current, src: input_slot });
                 let head = self.alloc_label();
@@ -3195,7 +3212,7 @@ impl Flattener {
             }
 
             Expr::Repeat { update } => {
-                if !is_scalar(update) { return false; }
+                if !is_scalar(update) { return self.emit_delegate_gen(expr, input_slot, false); }
                 // repeat(f) = def _repeat: f, _repeat; _repeat;
                 // Each iteration applies f to the SAME input (comma semantics),
                 // not chaining outputs.
@@ -3353,11 +3370,11 @@ impl Flattener {
 
             Expr::Foreach { source, init, var_index, acc_index, update, extract } if !is_scalar(init) => {
                 // Generator init: rewrite as init as $tmp | foreach source as $var ($tmp; update; extract)
-                if !is_scalar(update) { return false; }
+                if !is_scalar(update) { return self.emit_delegate_gen(expr, input_slot, false); }
                 if let Some(ext) = extract.as_ref() {
                     let mut test = self.test_flattener();
                     let t_in = test.alloc_slot();
-                    if !test.flatten_gen(ext, t_in) { return false; }
+                    if !test.flatten_gen(ext, t_in) { return self.emit_delegate_gen(expr, input_slot, false); }
                 }
                 let init_var = VarIdx(10500);
                 let rewritten = Expr::LetBinding {
@@ -3376,12 +3393,12 @@ impl Flattener {
             }
 
             Expr::Foreach { source, init, var_index, acc_index, update, extract } => {
-                if !is_scalar(update) { return false; }
+                if !is_scalar(update) { return self.emit_delegate_gen(expr, input_slot, false); }
                 // Pre-check: if extract exists, it must be compilable as a generator
                 if let Some(ext) = extract.as_ref() {
                     let mut test = self.test_flattener();
                     let t_in = test.alloc_slot();
-                    if !test.flatten_gen(ext, t_in) { return false; }
+                    if !test.flatten_gen(ext, t_in) { return self.emit_delegate_gen(expr, input_slot, false); }
                 }
 
                 // Evaluate init → accumulator
@@ -3844,7 +3861,7 @@ impl Flattener {
                     input_expr.as_ref(),
                     Expr::EachOpt { input_expr: inner } if matches!(**inner, Expr::Input)
                 );
-                if !is_default_descent { return false; }
+                if !is_default_descent { return self.emit_delegate_gen(expr, input_slot, false); }
                 // Seed is the pipeline input (jq's `def recurse: ., (.[]? | recurse);`).
                 let val = self.flatten_scalar(&Expr::Input, input_slot);
                 let arr = self.alloc_slot();

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -13802,3 +13802,48 @@ null
 def f($n): if $n >= 3 then [$n] else (range(1;3) as $k | f($n + $k)) end; first(f(0))
 null
 [3]
+
+# #1059 PR-C: 3-arg foreach with non-scalar update/extract via the delegate
+[foreach range(3) as $i (0; ., . + $i; .)]
+null
+[0,0,0,1,1,3]
+
+# #1059 PR-C: multi-output foreach update streams through the delegate
+[foreach range(3) as $i (null; $i, "x")]
+null
+[0,"x",1,"x",2,"x"]
+
+# #1059 PR-C: multi-output reduce init runs the whole reduce per init value
+[reduce (1,2) as $x ((10,20); . + $x)]
+null
+[13,23]
+
+# #1059 PR-C: empty reduce init yields nothing
+[reduce .[] as $x (empty; . + $x)]
+[1,2,3]
+[]
+
+# #1059 PR-C: generator-init foreach (cartesian over init values)
+[foreach (1,2) as $x ([10], [20]; . + [$x])]
+null
+[[10,1],[10,1,2],[20,1],[20,1,2]]
+
+# #1059 PR-C: custom recurse step bounded by the limit budget
+[limit(3; recurse(. + 1))]
+0
+[0,1,2]
+
+# #1059 PR-C: multi-output while update bounded by the limit budget
+[limit(8; while(.<3; .+1, .+2))]
+0
+[0,1,2,2]
+
+# #1059 PR-C: recursive def in a reduce source delegates the whole reduce (yield mode)
+def gcd($a;$b): if $b == 0 then $a else gcd($b; $a % $b) end; reduce (range(2; 50) as $m | range(1; $m) as $n | gcd($m; $n)) as $g (0; . + $g)
+null
+2580
+
+# #1059 PR-C: comma fallback after an empty-yield while under first()
+first(while(true; empty), 88)
+null
+null


### PR DESCRIPTION
## Summary

Fifth Phase 3 installment for #1059: the loop-family arms in `flatten_gen` no longer bail the whole filter when their pre-emission checks reject a shape — they hand the whole node to the streaming eval delegate instead.

- **Fall-through sites** (pre-emission only; failures after partial emission keep the bail per the #1093 op-hole doctrine): `Reduce` (non-scalar init/update), `Foreach` (both arms: non-scalar update, extract probe failure), `While` (non-scalar cond/update), `Repeat` (non-scalar update), `Recurse` (non-default step). `emit_delegate_gen`'s existing guards — push-mode unbounded streams, limit budget coupling (PR #1104), `break`, path provenance — decide per context whether delegation is actually safe; rejection still forces the whole-filter bail.
- **Scalar-Reduce interception**: a scalar-classified `Reduce` whose source cannot flatten fails *inside* `flatten_scalar` (the #683 pre-check raises the bail flag after the Null emit), out of reach of arm-level fall-through. `flatten_gen`'s scalar dispatch now probes `Reduce` nodes first and delegates the whole node in generator position — rescuing the recursive-def-in-reduce-source class (`reduce (range(2;50) as $m | range(1;$m) as $n | gcd($m;$n)) as $g (0; .+$g)`).

Newly delegated shapes include 3-arg/multi-output `foreach`, generator/`empty` reduce inits, custom `recurse` steps and multi-output `while` bodies under a limit budget. Unbounded recurse/while in push mode without a budget, label-crossing `break` forms, and `path(foreach …)` with binding vars stay on eval (PR-D/E scope).

## Verification

- `cargo build --release`: zero warnings; `cargo test --release`: all green (72 targets)
- 3-backend sweep (3784 cases): no real divergence (only the 2 known env/$ENV artifacts)
- Forced-mode bail count: **109 → 84** (−25, zero new bails; cumulative 131 → 84 across PR #1103/#1104/this)
- Real jq 1.8.1 spot checks: 13/13 match
- `bench/comprehensive.sh`: all 220 rows within ±5% of the v1.8.3 history column

Part of #1059.

🤖 Generated with [Claude Code](https://claude.com/claude-code)