### PR TITLE
feat(jit): allow data-bounded recursive descent through the push-mode delegate (#1059 PR-D)

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -206,7 +206,12 @@ downstream early-stop が保たれる（旧 eager delegate の #1085 hang は
   （Repeat/While/Until/Recurse、および再帰 def の `FuncCall`）— pipe
   fallback の collect は eager なので eval が lazy に切る stream が hang
   する（`first(repeat(7) | .+1)`）。yield mode（tail position）は cb で
-  lazy 停止できるので対象外
+  lazy 停止できるので対象外。**例外: data-bounded な recurse**（#1059
+  PR-D）— 委譲ノードが `Recurse` そのもので、step が
+  `Each/EachOpt(navigation chain)` / `empty` /（select フィルタ付き、
+  cond に Recurse を含まない）なら出力は常に入力の真部分木なので有限
+  ドキュメントで必ず停止する（`[recurse(.[]?; cond)]` 級）。`recurse(.a)`
+  の field step は null が無限連鎖するので対象外（limit budget 下のみ可）
 - path 意味論ノード（`path`/`del`/`pick`）が `$var` を参照(値 seed では
   path provenance #880/#953 が失われ `. as $x | path($x)` が誤エラー化）
 - `FuncCall` を含む委譲で、**いずれかの関数 body** に `break` / path

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -1319,6 +1319,49 @@ impl Flattener {
     ///   was bound from — `. as $x | path($x)` is `[]` in eval and an
     ///   "Invalid path expression" through a value-only seed. Value-semantic
     ///   delegates (walk/skip/add) are fine with value seeding.
+    /// True for a recurse step whose every output is a strict subtree of
+    /// its input (possibly select-filtered): iterating such a step
+    /// terminates on any finite JSON document, so a delegated
+    /// `[recurse(step)]` collect is data-bounded even though the generic
+    /// probe treats `Recurse` as potentially infinite (#1059 PR-D). The
+    /// boundedness comes from the trailing Each/EachOpt — iterating a
+    /// scalar yields nothing (or errors). Field steps like `recurse(.a)`
+    /// are NOT bounded: `.a` of null is null, an infinite chain.
+    fn recurse_step_is_data_bounded(step: &Expr) -> bool {
+        fn is_nav(e: &Expr) -> bool {
+            match e {
+                Expr::Input => true,
+                Expr::Index { expr, key } | Expr::IndexOpt { expr, key } => {
+                    is_nav(expr)
+                        && matches!(key.as_ref(), Expr::Literal(_) | Expr::LoadVar { .. })
+                }
+                _ => false,
+            }
+        }
+        match step {
+            Expr::Empty => true,
+            Expr::Each { input_expr } | Expr::EachOpt { input_expr } => is_nav(input_expr),
+            // `recurse(f; cond)` lowers to Pipe{f, IfThenElse{cond, ., empty}}
+            // (parser.rs). The select filter only removes — or, for a
+            // multi-output cond, duplicates — subtree values, so the
+            // boundedness is f's. The cond must not hide an unbounded
+            // generator of its own: Repeat/While/Until in it are caught by
+            // the caller's Debug probe either way, a nested Recurse needs
+            // this explicit check.
+            Expr::Pipe { left, right } => {
+                if let Expr::IfThenElse { cond, then_branch, else_branch } = right.as_ref() {
+                    matches!(then_branch.as_ref(), Expr::Input)
+                        && matches!(else_branch.as_ref(), Expr::Empty)
+                        && !format!("{:?}", cond).contains("Recurse")
+                        && Self::recurse_step_is_data_bounded(left)
+                } else {
+                    false
+                }
+            }
+            _ => false,
+        }
+    }
+
     fn emit_delegate_gen(&mut self, expr: &Expr, input_slot: SlotId, path_semantic: bool) -> bool {
         // Every rejection below also raises `has_unresolved_recursion`:
         // callers in ignored-false emission contexts would otherwise drop
@@ -1362,10 +1405,18 @@ impl Flattener {
             // flattening unbounded generators; mirror it for delegates.
             // Yield-mode (tail-position) delegates stay lazy through the
             // callback and are exempt.
+            // A whole-node recursive descent with a data-bounded step is
+            // finite on any finite document — exempt it from the eager
+            // push-mode rejection (#1059 PR-D). Only the directly-delegated
+            // Recurse node qualifies; a Recurse buried deeper in the
+            // subtree keeps the conservative Debug-probe rejection.
+            let bounded_recurse = matches!(expr, Expr::Recurse { input_expr }
+                if Self::recurse_step_is_data_bounded(input_expr));
             rejected = rejected
                 || (self.collect_depth > 0 && !bounded
                     && (dbg.contains("Repeat") || dbg.contains("While")
-                        || dbg.contains("Until") || dbg.contains("Recurse")));
+                        || dbg.contains("Until")
+                        || (dbg.contains("Recurse") && !bounded_recurse)));
             if !rejected && dbg.contains("FuncCall") {
                 // The delegate executes raw `CompiledFunc` bodies in eval
                 // (the funcs table is wired into the delegated env, #1059

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -13847,3 +13847,28 @@ null
 first(while(true; empty), 88)
 null
 null
+
+# #1059 PR-D: conditional recursive descent is data-bounded, delegated in push mode
+[recurse(.[]?; . != null)]
+[[1],2]
+[[[1],2],[1],1,2]
+
+# #1059 PR-D: navigation-chain recurse step (tree walk by field)
+[recurse(.children[]?; . != null) | .name]
+{"name":"a","children":[{"name":"b","children":[]}]}
+["a","b"]
+
+# #1059 PR-D: recurse(empty) yields just the input
+[recurse(empty)]
+3
+[3]
+
+# #1059 PR-D: multi-output cond duplicates subtree values but stays finite
+[recurse(.[]?; true, . != null)]
+[[1]]
+[[[1]],[1],1,1,[1],1,1]
+
+# #1059 PR-D: field recurse stays unbounded (delegated only under a limit budget)
+[limit(3; recurse(.a))]
+{"a":{"a":1}}
+[{"a":{"a":1}},{"a":1},1]


### PR DESCRIPTION
## Summary

Sixth Phase 3 installment for #1059: a delegated `Recurse` node whose step is **data-bounded** is exempt from the eager push-mode rejection.

A descent step whose every output is a strict subtree of its input terminates on any finite JSON document — the trailing `Each`/`EachOpt` yields nothing (or errors) on scalars, so the walk bottoms out. `recurse_step_is_data_bounded` accepts:

- `Each`/`EachOpt` over a navigation chain (`Input` / `Index` / `IndexOpt` with literal or `$var` keys) — `[recurse(.[]?; cond)]`, `[recurse(.children[]?; …) | .name]`
- `empty` (yields just the input)
- the `recurse(f; cond)` select-filter lowering (`Pipe` into `IfThenElse{cond, ., empty}`) — filtering only removes (or, for a multi-output cond, duplicates) subtree values, so boundedness is `f`'s; a nested `Recurse` hiding inside the cond is rejected explicitly

Field steps like `recurse(.a)` stay rejected (`.a` of `null` is `null` — an infinite chain); they still run delegated under a limit budget (PR #1104). Only a directly-delegated `Recurse` node qualifies; a `Recurse` buried deeper in a delegated subtree keeps the conservative Debug-probe rejection.

## Verification

- `cargo build --release`: zero warnings; `cargo test --release`: all green (72 targets)
- 3-backend sweep (3789 cases): no real divergence (only the 2 known env/$ENV artifacts)
- Forced-mode bail count: **84 → 80** (cumulative 131 → 80 across PR #1103–#1105 and this)
- Real jq 1.8.1 spot checks: 6/6 match (cond filtering, navigation chains, multi-output conds, error parity for non-opt iteration)
- `bench/comprehensive.sh`: all 220 rows within ±5% of the v1.8.3 history column (flattener-only change, no per-record runtime code touched)

Part of #1059.

🤖 Generated with [Claude Code](https://claude.com/claude-code)