### PR TITLE
feat(jit): delegate whole binding scopes for path-provenance vars (#1059 PR-E)

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -212,12 +212,23 @@ downstream early-stop が保たれる（旧 eager delegate の #1085 hang は
   cond に Recurse を含まない）なら出力は常に入力の真部分木なので有限
   ドキュメントで必ず停止する（`[recurse(.[]?; cond)]` 級）。`recurse(.a)`
   の field step は null が無限連鎖するので対象外（limit budget 下のみ可）
-- path 意味論ノード（`path`/`del`/`pick`）が `$var` を参照(値 seed では
-  path provenance #880/#953 が失われ `. as $x | path($x)` が誤エラー化）
+- path 意味論ノード（`path`/`del`/`pick`）が **free な** `$var` を参照
+  （値 seed では path provenance #880/#953 が失われ `. as $x | path($x)` が
+  誤エラー化）。**委譲サブツリー内で束縛される var は対象外**（#1059
+  PR-E）— eval が束縛自体を実行するので provenance が保たれる
+  （`path(. as [$a] | $a)` / `path(foreach .[] as $x …)` 級が委譲で動く）。
+  free 判定は `expr_free_vars`（参照 − binder の集合差。parser の VarIdx は
+  binder ごとに一意なので shadowing も正しく扱える）。外側で束縛された var
+  （`. as $x | path($x)`）は LetBinding arm の probe 截取が**束縛スコープ
+  ごと**委譲する — body だけの委譲は値 seed になるため不可
 - `FuncCall` を含む委譲で、**いずれかの関数 body** に `break` / path
   意味論ノードがある場合（委譲は raw body を eval で実行するため、
   emit 時の Debug probe では body 内が見えない →
-  `funcs_bodies_block_delegation` が関数表ごと probe する）
+  `funcs_bodies_block_delegation` が関数表ごと probe する）。
+  path 意味論の委譲ではさらに、**body が外側 $var を close over する**
+  （body の free var が param 以外にある）場合も拒否
+  （`funcs_bodies_close_over_vars`、#1059 PR-E — 値 seed 経由で
+  `. as $x | def f: …$x…; path(f)` の provenance が落ちる live bug を修正）
 
 **funcs / memoize は委譲 env に配線済み（#1059 Phase 3c）**。再帰 def は
 インライン免除（`inline_with_recursion_exemption` が検出 → `FuncCall`
@@ -251,6 +262,16 @@ flatten 不能なら flatten_scalar 内で flag が立つため、`flatten_gen` 
 scalar dispatch は Reduce だけ probe してから委譲に切り替える（再帰 def を
 reduce source に含む形がここに落ちる）。委譲可否は emit_delegate_gen の
 ガード（push-mode 無限 / limit budget / break / provenance）がそのまま裁く。
+
+**LetBinding の probe 截取（#1059 PR-E）**: `flatten_gen` の LetBinding arm
+は、サブツリーに path 意味論マーカー（Debug に PathExpr/Del/Pick/Paths）が
+ある場合だけ test flattener で whole-node を probe し、native flatten が
+失敗するなら束縛スコープごと `emit_delegate_gen(…, path_semantic=true)` に
+切り替える。native arm は body 失敗時点で既に ops を emit しているため
+probe 先行が必須（scalar-Reduce 截取と同形）。free var が残る場合
+（`. as $y | (. as $x | path($y))` の内側）は free-var チェックが拒否し、
+さらに外側の LetBinding 截取が拾う。`nth(n; g)` / `last(g)` の lowering も
+LetBinding スコープなので、`path(nth(2; .[]))` 級がここで委譲に乗る。
 
 **default dispatch は委譲プログラムをコンパイルしない**
 （`is_jit_compilable_with_funcs` が reject）。delegate 支配的な filter は

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -774,6 +774,9 @@ struct Flattener {
     /// Cached verdict of `funcs_bodies_block_delegation` (the function
     /// table is fixed for the lifetime of a Flattener).
     funcs_body_block: Option<bool>,
+    /// Cached verdict of `funcs_bodies_close_over_vars` (same lifetime
+    /// argument as `funcs_body_block`).
+    funcs_body_closure: Option<bool>,
 }
 
 impl Flattener {
@@ -785,7 +788,8 @@ impl Flattener {
                      expanding_funcs: HashSet::new(), value_constants: Vec::new(),
                      is_test: false, has_unresolved_recursion: false,
                      emitted_delegate: false, inline_exempt: HashSet::new(),
-                     recursion_detected: HashSet::new(), funcs_body_block: None }
+                     recursion_detected: HashSet::new(), funcs_body_block: None,
+                     funcs_body_closure: None }
     }
 
     /// Materialize a Literal into a heap-allocated Value and return a stable pointer.
@@ -824,6 +828,7 @@ impl Flattener {
         t.has_unresolved_recursion = self.has_unresolved_recursion;
         t.inline_exempt = self.inline_exempt.clone();
         t.funcs_body_block = self.funcs_body_block;
+        t.funcs_body_closure = self.funcs_body_closure;
         t
     }
 
@@ -1292,6 +1297,25 @@ impl Flattener {
         b
     }
 
+    /// True when some function body closes over an outer `$var` (a free
+    /// variable that is not one of the function's own params). A delegated
+    /// path-semantic expression reaches such a body through the funcs
+    /// table, where the var arrives as a value-only seed with no path
+    /// provenance — the same hazard the free-var check on the delegated
+    /// expression guards against, invisible to that walk (#1059 PR-E).
+    /// Params are exempt: eval binds them at the call site inside the
+    /// delegate, provenance intact.
+    fn funcs_bodies_close_over_vars(&mut self) -> bool {
+        if let Some(b) = self.funcs_body_closure { return b; }
+        let b = self.funcs.iter().any(|f| {
+            Self::expr_free_vars(&f.body)
+                .iter()
+                .any(|v| !f.param_vars.contains(v))
+        });
+        self.funcs_body_closure = Some(b);
+        b
+    }
+
     /// Emit a streaming eval delegation for `expr` (#1059 Phase 3), or
     /// return false when the context cannot host one:
     ///
@@ -1314,11 +1338,17 @@ impl Flattener {
     ///   function body contains `break` / path-semantic nodes (see
     ///   `funcs_bodies_block_delegation`).
     /// - `path_semantic` nodes (`path(...)`, `del(...)`, `pick(...)`)
-    ///   referencing any `$var`: the env seeding copies plain values, but
-    ///   eval's path provenance (#880/#953) also tracks *where* a variable
-    ///   was bound from — `. as $x | path($x)` is `[]` in eval and an
-    ///   "Invalid path expression" through a value-only seed. Value-semantic
-    ///   delegates (walk/skip/add) are fine with value seeding.
+    ///   referencing a *free* `$var`: the env seeding copies plain values,
+    ///   but eval's path provenance (#880/#953) also tracks *where* a
+    ///   variable was bound from — `. as $x | path($x)` is `[]` in eval and
+    ///   an "Invalid path expression" through a value-only seed. A var
+    ///   bound *inside* the delegated subtree (`path(. as [$a] | $a)`,
+    ///   foreach/reduce element vars) is fine — eval performs the binding
+    ///   itself, provenance intact (#1059 PR-E). Function bodies reached
+    ///   through the funcs table are invisible to the free-var walk, so a
+    ///   body closing over an outer var rejects the whole delegate
+    ///   (`funcs_bodies_close_over_vars`). Value-semantic delegates
+    ///   (walk/skip/add) are fine with value seeding either way.
     /// True for a recurse step whose every output is a strict subtree of
     /// its input (possibly select-filtered): iterating such a step
     /// terminates on any finite JSON document, so a delegated
@@ -1432,9 +1462,9 @@ impl Flattener {
             }
         }
         if !rejected && path_semantic {
-            let mut vars = Vec::new();
-            Self::collect_loadvar_indices(expr, &mut vars);
-            rejected = !vars.is_empty();
+            rejected = !Self::expr_free_vars(expr).is_empty()
+                || (format!("{:?}", expr).contains("FuncCall")
+                    && self.funcs_bodies_close_over_vars());
         }
         if rejected {
             self.has_unresolved_recursion = true;
@@ -3060,6 +3090,34 @@ impl Flattener {
             }
 
             Expr::LetBinding { var_index, value, body } => {
+                // A binding whose body needs eval's path provenance for the
+                // bound var (`. as $x | path($x)`) cannot flatten natively,
+                // and delegating just the *body* would seed `$x` by value,
+                // losing the provenance. Delegating the whole binding scope
+                // lets eval perform the binding itself (#1059 PR-E). Probe
+                // on a discardable test flattener first — the native arm
+                // below has already emitted ops by the time the body fails
+                // (same shape as the scalar-Reduce interception, #683).
+                // Gated on a path-semantic marker so the common binding
+                // skips the probe; `path_semantic: true` engages the
+                // free-var check, which bubbles a still-free outer var
+                // (`. as $y | (. as $x | path($y))`) up to the enclosing
+                // binding's interception.
+                if !self.is_test {
+                    let dbg = format!("{:?}", expr);
+                    if dbg.contains("PathExpr") || dbg.contains("Del")
+                        || dbg.contains("Pick") || dbg.contains("Paths") {
+                        let mut test = self.test_flattener();
+                        test.has_unresolved_recursion = false;
+                        let t_in = test.alloc_slot();
+                        let ok = test.flatten_gen(expr, t_in);
+                        if (!ok || test.has_unresolved_recursion)
+                            && self.emit_delegate_gen(expr, input_slot, true)
+                        {
+                            return true;
+                        }
+                    }
+                }
                 if is_scalar(value) {
                     let val = self.flatten_scalar(value, input_slot);
                     let old = self.alloc_slot();
@@ -5628,157 +5686,185 @@ impl Flattener {
     /// variant here silently loses any `$var` buried inside and degrades the
     /// delegated call to `null`.
     fn collect_loadvar_indices(expr: &Expr, out: &mut Vec<VarIdx>) {
+        let mut binders = Vec::new();
+        Self::collect_vars(expr, out, &mut binders);
+    }
+
+    /// The *free* variables of `expr`: `$var` references whose binder lies
+    /// outside the subtree. The parser allocates a fresh `VarIdx` per
+    /// binder (`next_var` is monotonic), so set difference against the
+    /// binders collected in the same walk is scope-exact — a shadowing
+    /// inner `as $x` has a different index than the outer one (#1059 PR-E).
+    fn expr_free_vars(expr: &Expr) -> Vec<VarIdx> {
+        let mut refs = Vec::new();
+        let mut binders = Vec::new();
+        Self::collect_vars(expr, &mut refs, &mut binders);
+        refs.retain(|v| !binders.contains(v));
+        refs
+    }
+
+    /// Shared walk behind `collect_loadvar_indices` / `expr_free_vars`:
+    /// every `LoadVar` index goes into `refs`, every binder-introduced
+    /// index (`as $x`, reduce/foreach element and accumulator vars) into
+    /// `binders`. Label vars are a separate namespace (`Break` carries the
+    /// label index outside any `LoadVar`) and are not collected.
+    fn collect_vars(expr: &Expr, refs: &mut Vec<VarIdx>, binders: &mut Vec<VarIdx>) {
         use crate::ir::StringPart;
         match expr {
             Expr::LoadVar { var_index } => {
-                if !out.contains(var_index) { out.push(*var_index); }
+                if !refs.contains(var_index) { refs.push(*var_index); }
             }
             Expr::Input | Expr::Empty | Expr::Literal(_) | Expr::Not
             | Expr::Loc { .. } | Expr::Env | Expr::Builtins
             | Expr::ReadInput | Expr::ReadInputs
             | Expr::ModuleMeta | Expr::GenLabel => {}
             Expr::BinOp { lhs, rhs, .. } => {
-                Self::collect_loadvar_indices(lhs, out);
-                Self::collect_loadvar_indices(rhs, out);
+                Self::collect_vars(lhs, refs, binders);
+                Self::collect_vars(rhs, refs, binders);
             }
             Expr::UnaryOp { operand, .. } | Expr::Negate { operand } => {
-                Self::collect_loadvar_indices(operand, out);
+                Self::collect_vars(operand, refs, binders);
             }
             Expr::Index { expr, key } | Expr::IndexOpt { expr, key } => {
-                Self::collect_loadvar_indices(expr, out);
-                Self::collect_loadvar_indices(key, out);
+                Self::collect_vars(expr, refs, binders);
+                Self::collect_vars(key, refs, binders);
             }
             Expr::Pipe { left, right } | Expr::Comma { left, right } => {
-                Self::collect_loadvar_indices(left, out);
-                Self::collect_loadvar_indices(right, out);
+                Self::collect_vars(left, refs, binders);
+                Self::collect_vars(right, refs, binders);
             }
             Expr::IfThenElse { cond, then_branch, else_branch } => {
-                Self::collect_loadvar_indices(cond, out);
-                Self::collect_loadvar_indices(then_branch, out);
-                Self::collect_loadvar_indices(else_branch, out);
+                Self::collect_vars(cond, refs, binders);
+                Self::collect_vars(then_branch, refs, binders);
+                Self::collect_vars(else_branch, refs, binders);
             }
             Expr::TryCatch { try_expr, catch_expr, .. } => {
-                Self::collect_loadvar_indices(try_expr, out);
-                Self::collect_loadvar_indices(catch_expr, out);
+                Self::collect_vars(try_expr, refs, binders);
+                Self::collect_vars(catch_expr, refs, binders);
             }
             Expr::Each { input_expr } | Expr::EachOpt { input_expr }
             | Expr::Recurse { input_expr } => {
-                Self::collect_loadvar_indices(input_expr, out);
+                Self::collect_vars(input_expr, refs, binders);
             }
-            Expr::LetBinding { value, body, .. } => {
-                Self::collect_loadvar_indices(value, out);
-                Self::collect_loadvar_indices(body, out);
+            Expr::LetBinding { var_index, value, body } => {
+                if !binders.contains(var_index) { binders.push(*var_index); }
+                Self::collect_vars(value, refs, binders);
+                Self::collect_vars(body, refs, binders);
             }
-            Expr::Reduce { source, init, update, .. } => {
-                Self::collect_loadvar_indices(source, out);
-                Self::collect_loadvar_indices(init, out);
-                Self::collect_loadvar_indices(update, out);
+            Expr::Reduce { source, init, update, var_index, acc_index } => {
+                if !binders.contains(var_index) { binders.push(*var_index); }
+                if !binders.contains(acc_index) { binders.push(*acc_index); }
+                Self::collect_vars(source, refs, binders);
+                Self::collect_vars(init, refs, binders);
+                Self::collect_vars(update, refs, binders);
             }
-            Expr::Foreach { source, init, update, extract, .. } => {
-                Self::collect_loadvar_indices(source, out);
-                Self::collect_loadvar_indices(init, out);
-                Self::collect_loadvar_indices(update, out);
-                if let Some(e) = extract { Self::collect_loadvar_indices(e, out); }
+            Expr::Foreach { source, init, update, extract, var_index, acc_index } => {
+                if !binders.contains(var_index) { binders.push(*var_index); }
+                if !binders.contains(acc_index) { binders.push(*acc_index); }
+                Self::collect_vars(source, refs, binders);
+                Self::collect_vars(init, refs, binders);
+                Self::collect_vars(update, refs, binders);
+                if let Some(e) = extract { Self::collect_vars(e, refs, binders); }
             }
-            Expr::Collect { generator } => Self::collect_loadvar_indices(generator, out),
+            Expr::Collect { generator } => Self::collect_vars(generator, refs, binders),
             Expr::ObjectConstruct { pairs } => {
                 for (k, v) in pairs {
-                    Self::collect_loadvar_indices(k, out);
-                    Self::collect_loadvar_indices(v, out);
+                    Self::collect_vars(k, refs, binders);
+                    Self::collect_vars(v, refs, binders);
                 }
             }
             Expr::Alternative { primary, fallback } => {
-                Self::collect_loadvar_indices(primary, out);
-                Self::collect_loadvar_indices(fallback, out);
+                Self::collect_vars(primary, refs, binders);
+                Self::collect_vars(fallback, refs, binders);
             }
             Expr::Range { from, to, step } => {
-                Self::collect_loadvar_indices(from, out);
-                Self::collect_loadvar_indices(to, out);
-                if let Some(s) = step { Self::collect_loadvar_indices(s, out); }
+                Self::collect_vars(from, refs, binders);
+                Self::collect_vars(to, refs, binders);
+                if let Some(s) = step { Self::collect_vars(s, refs, binders); }
             }
-            Expr::Label { body, .. } => Self::collect_loadvar_indices(body, out),
-            Expr::Break { value, .. } => Self::collect_loadvar_indices(value, out),
+            Expr::Label { body, .. } => Self::collect_vars(body, refs, binders),
+            Expr::Break { value, .. } => Self::collect_vars(value, refs, binders),
             Expr::Update { path_expr, update_expr } => {
-                Self::collect_loadvar_indices(path_expr, out);
-                Self::collect_loadvar_indices(update_expr, out);
+                Self::collect_vars(path_expr, refs, binders);
+                Self::collect_vars(update_expr, refs, binders);
             }
             Expr::Assign { path_expr, value_expr } => {
-                Self::collect_loadvar_indices(path_expr, out);
-                Self::collect_loadvar_indices(value_expr, out);
+                Self::collect_vars(path_expr, refs, binders);
+                Self::collect_vars(value_expr, refs, binders);
             }
             Expr::Mutate { path_expr, value_expr, .. } => {
-                Self::collect_loadvar_indices(path_expr, out);
-                Self::collect_loadvar_indices(value_expr, out);
+                Self::collect_vars(path_expr, refs, binders);
+                Self::collect_vars(value_expr, refs, binders);
             }
-            Expr::PathExpr { expr } => Self::collect_loadvar_indices(expr, out),
+            Expr::PathExpr { expr } => Self::collect_vars(expr, refs, binders),
             Expr::SetPath { path, value } => {
-                Self::collect_loadvar_indices(path, out);
-                Self::collect_loadvar_indices(value, out);
+                Self::collect_vars(path, refs, binders);
+                Self::collect_vars(value, refs, binders);
             }
-            Expr::GetPath { path } => Self::collect_loadvar_indices(path, out),
-            Expr::DelPaths { paths } => Self::collect_loadvar_indices(paths, out),
+            Expr::GetPath { path } => Self::collect_vars(path, refs, binders),
+            Expr::DelPaths { paths } => Self::collect_vars(paths, refs, binders),
             Expr::FuncCall { args, .. } => {
-                for a in args { Self::collect_loadvar_indices(a, out); }
+                for a in args { Self::collect_vars(a, refs, binders); }
             }
             Expr::StringInterpolation { parts } => {
                 for p in parts {
-                    if let StringPart::Expr(e) = p { Self::collect_loadvar_indices(e, out); }
+                    if let StringPart::Expr(e) = p { Self::collect_vars(e, refs, binders); }
                 }
             }
             Expr::Limit { count, generator } => {
-                Self::collect_loadvar_indices(count, out);
-                Self::collect_loadvar_indices(generator, out);
+                Self::collect_vars(count, refs, binders);
+                Self::collect_vars(generator, refs, binders);
             }
             Expr::While { cond, update } | Expr::Until { cond, update } => {
-                Self::collect_loadvar_indices(cond, out);
-                Self::collect_loadvar_indices(update, out);
+                Self::collect_vars(cond, refs, binders);
+                Self::collect_vars(update, refs, binders);
             }
-            Expr::Repeat { update } => Self::collect_loadvar_indices(update, out),
+            Expr::Repeat { update } => Self::collect_vars(update, refs, binders),
             Expr::AllShort { generator, predicate }
             | Expr::AnyShort { generator, predicate } => {
-                Self::collect_loadvar_indices(generator, out);
-                Self::collect_loadvar_indices(predicate, out);
+                Self::collect_vars(generator, refs, binders);
+                Self::collect_vars(predicate, refs, binders);
             }
             Expr::Error { msg } => {
-                if let Some(m) = msg { Self::collect_loadvar_indices(m, out); }
+                if let Some(m) = msg { Self::collect_vars(m, refs, binders); }
             }
-            Expr::Format { expr, .. } => Self::collect_loadvar_indices(expr, out),
+            Expr::Format { expr, .. } => Self::collect_vars(expr, refs, binders),
             Expr::ClosureOp { input_expr, key_expr, .. } => {
-                Self::collect_loadvar_indices(input_expr, out);
-                Self::collect_loadvar_indices(key_expr, out);
+                Self::collect_vars(input_expr, refs, binders);
+                Self::collect_vars(key_expr, refs, binders);
             }
             Expr::RegexTest { input_expr, re, flags }
             | Expr::RegexMatch { input_expr, re, flags }
             | Expr::RegexCapture { input_expr, re, flags }
             | Expr::RegexScan { input_expr, re, flags } => {
-                Self::collect_loadvar_indices(input_expr, out);
-                Self::collect_loadvar_indices(re, out);
-                Self::collect_loadvar_indices(flags, out);
+                Self::collect_vars(input_expr, refs, binders);
+                Self::collect_vars(re, refs, binders);
+                Self::collect_vars(flags, refs, binders);
             }
             Expr::RegexSub { input_expr, re, tostr, flags }
             | Expr::RegexGsub { input_expr, re, tostr, flags } => {
-                Self::collect_loadvar_indices(input_expr, out);
-                Self::collect_loadvar_indices(re, out);
-                Self::collect_loadvar_indices(tostr, out);
-                Self::collect_loadvar_indices(flags, out);
+                Self::collect_vars(input_expr, refs, binders);
+                Self::collect_vars(re, refs, binders);
+                Self::collect_vars(tostr, refs, binders);
+                Self::collect_vars(flags, refs, binders);
             }
             Expr::AlternativeDestructure { alternatives } => {
-                for a in alternatives { Self::collect_loadvar_indices(a, out); }
+                for a in alternatives { Self::collect_vars(a, refs, binders); }
             }
             Expr::Slice { expr, from, to } => {
-                Self::collect_loadvar_indices(expr, out);
-                if let Some(f) = from { Self::collect_loadvar_indices(f, out); }
-                if let Some(t) = to { Self::collect_loadvar_indices(t, out); }
+                Self::collect_vars(expr, refs, binders);
+                if let Some(f) = from { Self::collect_vars(f, refs, binders); }
+                if let Some(t) = to { Self::collect_vars(t, refs, binders); }
             }
             Expr::Debug { expr } | Expr::Stderr { expr } => {
-                Self::collect_loadvar_indices(expr, out);
+                Self::collect_vars(expr, refs, binders);
             }
             Expr::CallBuiltin { args, .. } => {
-                for a in args { Self::collect_loadvar_indices(a, out); }
+                for a in args { Self::collect_vars(a, refs, binders); }
             }
             Expr::Memoize { key, body, .. } => {
-                if let Some(k) = key { Self::collect_loadvar_indices(k, out); }
-                Self::collect_loadvar_indices(body, out);
+                if let Some(k) = key { Self::collect_vars(k, refs, binders); }
+                Self::collect_vars(body, refs, binders);
             }
         }
     }

--- a/tests/enforce_collect_loadvar_exhaustive.rs
+++ b/tests/enforce_collect_loadvar_exhaustive.rs
@@ -1,5 +1,6 @@
 //! Enforce maintenance.md §3 "JIT → eval 委譲時の env seeding":
-//! `Flattener::collect_loadvar_indices` (in `src/jit.rs`) must mention every
+//! `Flattener::collect_vars` (in `src/jit.rs`, the shared walk behind
+//! `collect_loadvar_indices` / `expr_free_vars`) must mention every
 //! `Expr` variant defined in `src/ir.rs`.
 //!
 //! Every JIT→eval closure-op dispatcher walks the delegated expression with
@@ -9,7 +10,7 @@
 //! arg, ...) and the closure op runs against a `null`-shaped env.
 //!
 //! This test parses the `Expr` enum out of `src/ir.rs` and the body of
-//! `collect_loadvar_indices` out of `src/jit.rs`, then asserts that every
+//! `collect_vars` out of `src/jit.rs`, then asserts that every
 //! variant name appears at least once in the function body — either in an
 //! explicit recurse arm or in a no-children leaf arm. Add a new variant and
 //! forget to extend the walker → this test fails with the missing names.
@@ -102,7 +103,7 @@ fn collect_loadvar_indices_covers_every_expr_variant() {
         variants.len(), variants,
     );
 
-    let body = extract_fn_body(&jit_src, "collect_loadvar_indices");
+    let body = extract_fn_body(&jit_src, "collect_vars");
 
     let mut missing: Vec<&str> = Vec::new();
     for v in &variants {
@@ -113,19 +114,19 @@ fn collect_loadvar_indices_covers_every_expr_variant() {
     }
 
     eprintln!();
-    eprintln!("=== `collect_loadvar_indices` Expr exhaustiveness ===");
+    eprintln!("=== `collect_vars` Expr exhaustiveness ===");
     eprintln!("parsed Expr variants:  {}", variants.len());
     eprintln!("walker mentions:       {}", variants.len() - missing.len());
 
     if !missing.is_empty() {
         eprintln!();
-        eprintln!("=== Expr variants missing from `collect_loadvar_indices` ===");
+        eprintln!("=== Expr variants missing from `collect_vars` ===");
         for v in &missing {
             eprintln!("  Expr::{}", v);
         }
         eprintln!();
         eprintln!("Every variant must appear at least once in");
-        eprintln!("`Flattener::collect_loadvar_indices` (src/jit.rs). For variants");
+        eprintln!("`Flattener::collect_vars` (src/jit.rs). For variants");
         eprintln!("that hold sub-expressions, recurse into each one. For leaf");
         eprintln!("variants without sub-expressions, add them to the no-children");
         eprintln!("arm. Skipping a variant silently drops any `$var` buried inside");
@@ -136,7 +137,7 @@ fn collect_loadvar_indices_covers_every_expr_variant() {
 
     assert!(
         missing.is_empty(),
-        "collect_loadvar_indices missing {} Expr variant(s): {:?}",
+        "collect_vars missing {} Expr variant(s): {:?}",
         missing.len(), missing,
     );
 }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -13872,3 +13872,58 @@ null
 [limit(3; recurse(.a))]
 {"a":{"a":1}}
 [{"a":{"a":1}},{"a":1},1]
+
+# #1059 PR-E: var bound inside a delegated path() keeps eval provenance
+path(. as [$a] | $a)
+[5]
+[0]
+
+# #1059 PR-E: whole-binding delegation when the bound var feeds path()
+. as $x | path($x)
+{"x":{"y":1}}
+[]
+
+# #1059 PR-E: bound var navigated further inside path()
+. as $x | path($x | .a)
+{"a":1}
+["a"]
+
+# #1059 PR-E: shadowing — outer free var bubbles to the enclosing binding's delegation
+. as $y | (. as $x | path($y))
+{"a":1}
+[]
+
+# #1059 PR-E: destructuring chain bound inside del()
+del(. as [$a] | $a)
+[5,6]
+[6]
+
+# #1059 PR-E: nested object destructuring inside path()
+path(. as {x:{y:$a}} | $a)
+{"x":{"y":1}}
+["x","y"]
+
+# #1059 PR-E: ?// alternative destructuring inside path()
+path(. as [$a] ?// $a | .x)
+{"x":1}
+["x"]
+
+# #1059 PR-E: foreach element var inside a collected path()
+[path(foreach .[] as $x (0; .; $x.b))]
+[{"b":1}]
+[[0,"b"]]
+
+# #1059 PR-E: multiple outputs from one delegated binding scope
+[path(. as [$a] | $a, $a)]
+[5]
+[[0],[0]]
+
+# #1059 PR-E: nth lowering (binding scope) inside path()
+path(nth(2; .[]))
+[1,2,3]
+[2]
+
+# #1059 PR-E: recursive def closing over an outer var must not delegate inside path()
+. as $x | def f: if . < 1 then $x else (.-1)|f end; path(f)
+0
+[]


### PR DESCRIPTION
## Summary

Phase 3 delegation, roadmap step PR-E: lift the blanket "$var inside path()/del()/pick() rejects the eval delegate" rule to a **free-variable** rule, and delegate whole **binding scopes** when the bound var needs eval's path provenance.

- **Free-var check** (`expr_free_vars`): `collect_loadvar_indices` is refactored into a shared `collect_vars` walk that also collects binder-introduced indices (`as $x`, reduce/foreach element + accumulator vars). The parser allocates a fresh `VarIdx` per binder, so the set difference is scope-exact (shadowing included). Vars bound *inside* the delegated subtree are now allowed — eval performs the binding itself, provenance intact. Covers `path(. as [$a] | $a)`, `?//` alternatives, nested destructuring, `path(foreach .[] as $x ...)`, `del(. as [$a] | $a)`.
- **LetBinding probe-interception** in `flatten_gen`: when the subtree carries a path-semantic marker and a test-flattener probe shows the native flatten fails, the whole binding scope is delegated (`. as $x | path($x)`). A still-free outer var is rejected by the free-var check and bubbles up to the enclosing binding (`. as $y | (. as $x | path($y))`). `nth`/`last` lowerings are binding scopes too, so `path(nth(2; .[]))` rides the same interception.
- **Func-body closure guard** (`funcs_bodies_close_over_vars`): a delegated function body can close over an outer `$var` invisibly to the free-var walk (it is reached through the funcs table). Path-semantic delegation now rejects that case — fixing a **live divergence** in forced modes where `. as $x | def f: ...$x...; path(f)` returned `Invalid path expression` instead of eval's `[]`.

Forced-jitop bails over the regression + differential corpora: **80 → 51** (−29, no new bails).

## Verification

- `cargo build --release` zero warnings; `cargo test --release` all 72 targets green (the `collect_loadvar_indices` exhaustiveness contract test now scans the shared `collect_vars` walk)
- 3-backend sweep (cranelift / jitop / eval) over `tests/differential/corpus.test` + `tests/regression.test`: no divergence beyond the two known env/`$ENV` knob-reflection cases
- New coverage spot-checked against system jq 1.8.1 (provenance shapes, destructuring, foreach, nth/last, limit interplay, del/pick, error parity)
- 11 regression test groups appended (provenance family + the func-body closure fix)
- Bench: rows beyond ±5% of the v1.8.3 history column re-measured with interleaved same-machine A/B against main — all identical (cross-day noise / timer quantization on sub-3ms rows)

Part of #1059.

🤖 Generated with [Claude Code](https://claude.com/claude-code)