### PR TITLE
fix(jit): stop eagerly collecting potentially-infinite pipe generators (#1059 PR-H)

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -263,6 +263,15 @@ scalar dispatch は Reduce だけ probe してから委譲に切り替える（�
 reduce source に含む形がここに落ちる）。委譲可否は emit_delegate_gen の
 ガード（push-mode 無限 / limit budget / break / provenance）がそのまま裁く。
 
+**unbounded pipe-left の laziness（#1059 PR-H）**: each_output の generic
+fallback は出力を **eager collect** するため、`first(repeat(7) | .+1)`
+（= `limit(1; …)`）の無限 pipe-left が forced 系で hang していた（e60269b
+からの既存バグ）。`gen_may_be_unbounded`（Debug に Repeat/While/Until/Recurse、
+ただし data-bounded recurse は除外 — `.. | f` は native のまま）が真の left は
+flatten_gen_pipe の generic arm が `delegate_pipe` で委譲し、limit 配下なら
+PR-B の yield budget で lazy 停止する。each_output 側にも backstop
+（flag + return false → 無 budget 文脈は eval bail）。
+
 **label-scoped break と Collect/Label 截取（#1059 PR-G、bail 面ゼロ到達）**:
 emit_delegate_gen の break 一律拒否（Debug probe）を `expr_free_breaks`
 （break 対象 − label binder の集合差）に緩和 — label binder が委譲式内に

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -4560,7 +4560,17 @@ impl Flattener {
                 ok
             }
             _ => {
-                // Generic fallback: collect all outputs, then iterate
+                // Generic fallback: collect all outputs, then iterate.
+                // Refuse a potentially-infinite gen_expr — the eager
+                // collect would hang where eval stays lazy (#1059 PR-H).
+                // The flag forces the whole-filter bail even from callers
+                // that ignore the return value (#683 pattern); the pipe
+                // arm delegates before reaching here, so this is the
+                // backstop for the remaining each_output callers.
+                if Self::gen_may_be_unbounded(gen_expr) {
+                    self.has_unresolved_recursion = true;
+                    return false;
+                }
                 // Pre-check: can we compile gen_expr?
                 {
                     let mut test = self.test_flattener();
@@ -4649,6 +4659,24 @@ impl Flattener {
 
         self.emit(JitOp::Label { id: done_label });
         true
+    }
+
+    /// True when a generator may produce unboundedly many outputs:
+    /// carries a loop marker (Repeat/While/Until/Recurse) in its Debug
+    /// form, except a whole-node recursive descent with a data-bounded
+    /// step (finite on any finite document, PR-D). Used to keep
+    /// potentially-infinite generators out of the *eager* collect
+    /// fallbacks — an eager collect of `repeat(7) | …` hangs where eval
+    /// (and jq) stop lazily under `limit`/`first` (#1059 PR-H).
+    fn gen_may_be_unbounded(e: &Expr) -> bool {
+        if let Expr::Recurse { input_expr } = e {
+            if Self::recurse_step_is_data_bounded(input_expr) {
+                return false;
+            }
+        }
+        let dbg = format!("{:?}", e);
+        dbg.contains("Repeat") || dbg.contains("While") || dbg.contains("Until")
+            || dbg.contains("Recurse")
     }
 
     /// Delegate `left | right` wholesale when a pipe arm cannot lower the
@@ -4950,6 +4978,17 @@ impl Flattener {
 
             // Generic fallback: for any generator left, iterate its outputs and apply right
             _ => {
+                // A potentially-infinite left would be eagerly collected by
+                // the each_output fallback below, hanging where eval stops
+                // lazily (`first(repeat(7) | .+1)` = `limit(1; …)` — the
+                // pre-existing forced-mode hang). Delegate the composition
+                // instead: under a limit the delegate carries the yield
+                // budget (PR-B) and stops lazily; in an unbudgeted push
+                // context the delegate guard rejects and the filter bails
+                // to eval (#1059 PR-H).
+                if Self::gen_may_be_unbounded(left) {
+                    return self.delegate_pipe(left, right, input_slot);
+                }
                 // Pre-check: can we compile both left and right? Skipped when
                 // we're already in a probe pass (#641 — see IfThenElse case).
                 if !self.is_test {

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -14057,3 +14057,33 @@ import "issue_638" as M; M::f
 . as $x | def f: if . < 1 then $x else (.-1)|f end; path(f)
 0
 []
+
+# #1059 PR-H: lazy stop over an infinite pipe-left (was a forced-mode hang)
+first(repeat(7) | .+1)
+null
+8
+
+# #1059 PR-H: isempty over an infinite generator stops at the first output
+isempty(repeat(1))
+null
+false
+
+# #1059 PR-H: limit budget over an infinite pipe-left composition
+[limit(3; repeat(5) | .+1)]
+null
+[6,6,6]
+
+# #1059 PR-H: while-driven infinite pipe-left under first
+first(while(true; .+1) | . * 2)
+0
+0
+
+# #1059 PR-H: computational recurse pipe-left under a limit budget
+[limit(2; recurse(.+1) | tostring)]
+0
+["0","1"]
+
+# #1059 PR-H: data-bounded descent pipe keeps the native eager collect
+[.. | numbers]
+{"a":1,"b":[2,3]}
+[1,2,3]


### PR DESCRIPTION
## Summary

Fixes a pre-existing forced-mode hang: the each_output generic fallback eagerly collects all generator outputs, so an unbounded pipe-left — `first(repeat(7) | .+1)`, which lowers to `limit(1; ...)` — hung in both forced JIT modes where eval (and jq) stop lazily. The divergence dates to the native Repeat lowering (e60269b) and was masked in default routing by the eval fallback. It also blocked the #1059 default-routing flip: flipping would have exposed the hang to default mode.

- `gen_may_be_unbounded`: a generator carrying a Repeat/While/Until/Recurse marker is treated as potentially infinite, **except** a whole-node recursive descent with a data-bounded step (PR-D classification) — `.. | f` keeps its native eager collect and routing.
- The `flatten_gen_pipe` generic arm delegates such compositions wholesale: under a limit the delegate carries the yield budget (PR-B) and stops lazily; in an unbudgeted push context the delegate guard rejects and the filter bails to eval (which hangs only where jq itself hangs).
- The each_output generic fallback gets the same check as a backstop for its remaining callers (flag + whole-filter bail, #683 pattern).

`first(repeat(7) | .+1)` => `8`, `isempty(repeat(1))` => `false`, `[limit(3; repeat(5) | .+1)]` => `[6,6,6]`, `first(while(true; .+1) | . * 2)` => `0` — all four engines (eval / jitop / cranelift / system jq 1.8.1) now agree.

## Verification

- `cargo build --release` zero warnings; full suite all 72 targets green (re-run after the test append)
- Zero forced-jitop eval bails preserved over both corpora
- 3-backend sweep: no divergence beyond the two known env/`$ENV` knob cases
- 6 regression groups appended (including the native-path pin for `[.. | numbers]`)
- Bench: noisy rows re-measured with interleaved same-machine A/B against main — identical

Part of #1059; unblocks the default-routing flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)