### PR TITLE
feat(jit): route delegated programs in default dispatch, A/B-gated (#1059 Phase 3.9)

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -312,15 +312,24 @@ probe 先行が必須（scalar-Reduce 截取と同形）。free var が残る場
 さらに外側の LetBinding 截取が拾う。`nth(n; g)` / `last(g)` の lowering も
 LetBinding スコープなので、`path(nth(2; .[]))` 級がここで委譲に乗る。
 
-**default dispatch は委譲プログラムをコンパイルしない**
-（`is_jit_compilable_with_funcs` が reject）。delegate 支配的な filter は
-whole-filter eval の方が速い（200k NDJSON A/B で委譲側が最大 ~1.1x 劣化、
-per-record の env reset 分）ため。forced knob（`JQJIT_FORCE_CRANELIFT` /
-`JQJIT_FORCE_JITOP_INTERP` / `--force-jit`）は
-`is_jit_compilable_with_delegates` / `compile_jit_with_delegates` 経由で
-委譲込みコンパイルし、backend self-diff がそこをカバーする。
-JIT_CLOSURE_OPS は `Vec<Rc<Expr>>`（per-record の Expr clone を排除、
-既存の closure-op delegate も同恩恵）。
+**default dispatch の委譲プログラム routing（#1059 Phase 3.9 で flip）**:
+`is_jit_compilable_with_funcs` は委譲プログラムを受理する。ただし
+2 つのガードが残る:
+1. **delegate-dominant 拒否**: native（非 DelegateGen）op 数が
+   `DELEGATE_DOMINANT_NATIVE_OPS`(=16) 以下のプログラムは eval 維持
+   （2M NDJSON A/B で委譲側 ~1.13x 劣化。mixed プログラムは native 部が
+   JIT 速度で走り最大 25% 勝ち、毎レコード委譲発火でも ~1.02x）
+2. **interleaved IO 拒否**: ReadInput 系が 2 回以上、または ReadInput 系 +
+   input_line_number/input_filename の組合せは eval 維持 — JIT の `inputs`
+   lowering は eager 収集なので `[inputs as $x | input_line_number]` が
+   [3,3,3] になる（eval/jq は [1,2,3]）。**この eager 乖離は forced 系では
+   従来から存在する未修正バグ**（flip が default に露出させかけた）
+委譲境界コストは 2 段で削減済み: `Env::reset` の Null-skip（eval 全経路にも
+~30% 効く）と、seed var list の per-compile memoize（`seed_eval_env_from_jit`、
+free var のみ seed — 委譲式内で束縛される var は eval が再束縛するので不要）。
+forced knob は従来どおり `is_jit_compilable_with_delegates` /
+`compile_jit_with_delegates` 経由（ガードなし全コンパイル）。
+JIT_CLOSURE_OPS は `Vec<Rc<Expr>>`（per-record の Expr clone を排除）。
 
 ### テスト出力
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -283,10 +283,17 @@ impl Env {
     /// Reset env state for reuse across multiple inputs.
     /// Keeps allocated buffers (vars, caches) but resets mutable state.
     pub fn reset(&mut self) {
-        // Only reset vars that were actually used (0..next_var), not all 65536
+        // Only reset vars that were actually used (0..next_var), not all
+        // 65536 — and skip slots that are already Null: per-record
+        // delegated-env resets (#1059) walk this every input, and the
+        // unconditional store paid a drop-check + cache-line dirty per
+        // slot for a region that is almost entirely Null after the first
+        // reset.
         let used = self.next_var as usize;
         for v in self.vars[..used].iter_mut() {
-            *v = Value::Null;
+            if !matches!(*v, Value::Null) {
+                *v = Value::Null;
+            }
         }
         self.next_label = 0;
         self.next_var = 256;

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -2659,12 +2659,12 @@ impl Filter {
         self.jit_fn.is_some()
     }
 
-    /// Like `compile_jit`, but also accepts programs that lower with
-    /// streaming eval delegation (#1059 Phase 3). Used by the forced-mode
-    /// knobs (`JQJIT_FORCE_CRANELIFT`, `--force-jit`) so the backend
-    /// self-diff covers delegable filters; the default heuristics keep
-    /// them on whole-filter eval, which measures faster when the delegate
-    /// dominates.
+    /// Like `compile_jit`, but skips the default-routing heuristics
+    /// entirely. Used by the forced-mode knobs (`JQJIT_FORCE_CRANELIFT`,
+    /// `--force-jit`) so the backend self-diff covers every delegable
+    /// filter. Since #1059 Phase 3.9 the default gate also accepts
+    /// delegated programs, so the remaining difference is historical
+    /// naming plus future heuristic divergence.
     pub fn compile_jit_with_delegates(&mut self) {
         if self.jit_fn.is_some() { return; }
         {

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -771,7 +771,8 @@ struct Flattener {
     has_unresolved_recursion: bool,
     /// Set by `emit_delegate_gen` when the program contains a streaming
     /// eval delegation (#1059 Phase 3). The default-dispatch feasibility
-    /// probe rejects such programs (see `is_jit_compilable_with_funcs`).
+    /// historically gated default routing (the gate accepts delegated
+    /// programs since #1059 Phase 3.9; forced knobs never gated on it).
     emitted_delegate: bool,
     /// Function ids exempt from inlining: recursive defs discovered by
     /// `inline_with_recursion_exemption`. Calls to these stay as `FuncCall`
@@ -11914,17 +11915,45 @@ pub fn is_jit_compilable(expr: &Expr) -> bool {
     is_jit_compilable_with_funcs(expr, &[])
 }
 
-/// Default-dispatch feasibility: like the full probe, but rejects programs
-/// that would contain a `DelegateGen` op. Per-record eval delegation
-/// measures up to ~1.1x slower than whole-filter eval when the delegate
-/// dominates the filter (A/B on 200k-record NDJSON, #1059 Phase 3), so the
-/// default heuristics keep those filters on the tree-walking evaluator.
-/// The forced-mode knobs use [`is_jit_compilable_with_delegates`] so the
-/// backend self-diff still covers every delegable filter.
+/// Default-dispatch feasibility. Since #1059 Phase 3.9 this accepts
+/// programs that lower with streaming eval delegation (`DelegateGen`) —
+/// the same verdict as [`is_jit_compilable_with_delegates`]. The flip is
+/// safe because the remaining default-routing guards still apply: the
+/// interpreter fast paths are tried first (e.g. `del(.y)` / `walk(...)`
+/// stay on their dedicated routines), and the JitOp-interp tier requires
+/// `eligible_for_default_routing` (a delegate inside a loop body
+/// disqualifies the span). For the straight-line delegated class the
+/// A/B against whole-filter eval measures at parity (the per-record
+/// seed-list walk is memoized per compile generation, see
+/// `seed_eval_env_from_jit`).
 pub fn is_jit_compilable_with_funcs(expr: &Expr, funcs: &[CompiledFunc]) -> bool {
-    let (ok, emitted_delegate) = jit_feasibility(expr, funcs);
-    ok && !emitted_delegate
+    let (ok, emitted_delegate, native_ops) = jit_feasibility(expr, funcs);
+    if std::env::var_os("JQJIT_DEBUG_FEASIBILITY").is_some() {
+        eprintln!("[feasibility] ok={} delegate={} native_ops={}", ok, emitted_delegate, native_ops);
+    }
+    // The JIT lowering of `inputs` collects the stream eagerly, so a
+    // program that *observes* per-read input state (input_line_number /
+    // input_filename) or mixes several readers sees post-consumption
+    // state where eval interleaves lazily — `[inputs as $x |
+    // input_line_number]` is [1,2,3] in eval/jq and [3,3,3] eagerly.
+    // Keep such programs on eval in default routing (the forced knobs
+    // still compile them; the eager divergence predates the flip).
+    let dbg = format!("{:?}", expr);
+    let readers = dbg.matches("ReadInput").count();
+    let interleaved_io = readers >= 2
+        || (readers >= 1
+            && (dbg.contains("InputLineNumber") || dbg.contains("InputFilename")));
+    ok && !interleaved_io
+        && (!emitted_delegate || native_ops > DELEGATE_DOMINANT_NATIVE_OPS)
 }
+
+/// A delegated program with at most this many native (non-DelegateGen)
+/// ops is "delegate-dominant": nearly all per-record work happens inside
+/// eval anyway, and the delegation boundary (env reset + seeding + FFI)
+/// measures ~1.1x over whole-filter eval on 2M-record NDJSON. Such
+/// programs keep the eval route; mixed programs (real native work plus a
+/// delegated subtree) route to the JIT where the native part wins.
+const DELEGATE_DOMINANT_NATIVE_OPS: usize = 16;
 
 /// Forced-mode feasibility: accepts programs that lower with streaming
 /// eval delegation (`DelegateGen`).
@@ -11932,8 +11961,11 @@ pub fn is_jit_compilable_with_delegates(expr: &Expr, funcs: &[CompiledFunc]) -> 
     jit_feasibility(expr, funcs).0
 }
 
-/// Returns `(flattens, emitted_delegate)`.
-fn jit_feasibility(expr: &Expr, funcs: &[CompiledFunc]) -> (bool, bool) {
+/// Returns `(flattens, emitted_delegate, native_op_count)` where
+/// `native_op_count` is the number of lowered ops that are not
+/// `DelegateGen` — the default-routing gate uses it to spot
+/// delegate-dominant programs (#1059 Phase 3.9).
+fn jit_feasibility(expr: &Expr, funcs: &[CompiledFunc]) -> (bool, bool, usize) {
     let mut fl = Flattener::new();
     fl.funcs = funcs.to_vec();
     // Mirror `compile_with_funcs`'s inline step (including the recursion
@@ -11941,14 +11973,17 @@ fn jit_feasibility(expr: &Expr, funcs: &[CompiledFunc]) -> (bool, bool) {
     // compile would produce. Diverging here is the #648 failure mode: the
     // probe accepts a shape the compile then chokes on.
     let inlined = fl.inline_with_recursion_exemption(expr);
-    if fl.has_unresolved_recursion { return (false, false); }
+    if fl.has_unresolved_recursion { return (false, false, 0); }
     let input = fl.alloc_slot();
     let ok = fl.flatten_gen(&inlined, input);
     // Subtrees may set `has_unresolved_recursion` mid-flatten to request
     // a JIT bailout (see #683 — Reduce arm in flatten_scalar). Re-check
     // here so the feasibility query agrees with `compile_with_funcs`.
-    if fl.has_unresolved_recursion { return (false, false); }
-    (ok, fl.emitted_delegate)
+    if fl.has_unresolved_recursion { return (false, false, 0); }
+    let native_ops = fl.ops.iter()
+        .filter(|op| !matches!(op, JitOp::DelegateGen { .. }))
+        .count();
+    (ok, fl.emitted_delegate, native_ops)
 }
 
 unsafe extern "C" fn collect_callback(value: *const Value, ctx: *mut u8) -> i64 {
@@ -11975,11 +12010,41 @@ thread_local! {
 /// `Env::new` directly — they guarantee the JIT-set let-bindings are seeded so
 /// new closure ops can't silently regress.
 fn seed_eval_env_from_jit(env: &Rc<RefCell<crate::eval::Env>>, exprs: &[&Expr]) {
-    let mut indices: Vec<VarIdx> = Vec::new();
-    for e in exprs {
-        Flattener::collect_loadvar_indices(e, &mut indices);
+    // The walk over the delegated expression is compile-shaped work that
+    // used to run per record; memoize the per-expr seed list keyed by the
+    // expression's address (the closure-op table holds the Rc alive, so
+    // the pointer is stable) and the delegate-config generation (bumped on
+    // every compile, so republished tables can't alias stale entries).
+    // #1059 Phase 3.9. The size cap is a defensive bound in case a future
+    // dispatcher passes per-record temporaries.
+    thread_local! {
+        static SEED_VAR_CACHE: RefCell<(u64, std::collections::HashMap<usize, Rc<Vec<VarIdx>>>)> =
+            RefCell::new((0, std::collections::HashMap::new()));
     }
-    seed_var_indices(env, &indices);
+    let gen = JIT_DELEGATE_CFG.with(|cell| cell.borrow().gen);
+    for e in exprs {
+        let key = (*e) as *const Expr as usize;
+        let list = SEED_VAR_CACHE.with(|cell| {
+            let mut c = cell.borrow_mut();
+            if c.0 != gen {
+                c.0 = gen;
+                c.1.clear();
+            }
+            if let Some(l) = c.1.get(&key) {
+                return l.clone();
+            }
+            // Only *free* vars need seeding: a var bound inside the
+            // delegated expression is rebound by eval before any read
+            // (parser indices are unique per binder), so copying the JIT
+            // slot for it is dead work (#1059 Phase 3.9).
+            let l = Rc::new(Flattener::expr_free_vars(e));
+            if c.1.len() < 4096 {
+                c.1.insert(key, l.clone());
+            }
+            l
+        });
+        seed_var_indices(env, &list);
+    }
 }
 
 /// Copy the given JIT-env var slots into the eval Env (the seed loop shared
@@ -12288,14 +12353,13 @@ impl JitProgram {
                 }
             }
         }
-        // Delegated programs are excluded from the default sub-threshold
-        // routing (#1059 Phase 3): per-record delegation pays an eval-env
-        // reset that whole-filter eval does not, so until that class is
-        // A/B-measured the status quo (tree-walking eval) keeps those
-        // filters. Forced modes and above-threshold Cranelift still run
-        // them — that is where the delegation coverage pays off.
-        let var_only_loops = !flat.ops.iter().any(|op| matches!(op, JitOp::DelegateGen { .. }))
-            && Self::loops_are_var_only(&flat.ops, &label_pc);
+        // Delegated programs are routable since the #1059 Phase 3.9 flip
+        // (A/B-measured; the delegate-dominant class is filtered upstream
+        // in `is_jit_compilable_with_funcs`). A DelegateGen *inside a loop
+        // body* still disqualifies the span — it is not in the var-only
+        // allowlist below — so per-iteration delegation boundaries keep
+        // the eval route.
+        let var_only_loops = Self::loops_are_var_only(&flat.ops, &label_pc);
         Ok(JitProgram {
             ops: flat.ops,
             num_slots: flat.num_slots,

--- a/tests/jitop_routing.rs
+++ b/tests/jitop_routing.rs
@@ -91,12 +91,37 @@ fn straight_line_collect_range_routes_to_jitop() {
 }
 
 /// Programs that lower with a streaming eval delegate (#1059 Phase 3)
-/// stay on whole-filter eval in default dispatch: per-record delegation
-/// measures slower than eval when the delegate dominates. The forced-mode
-/// knobs compile them (tests/selfdiff_jitop_backend.rs covers that side).
+/// stay on whole-filter eval in default dispatch when the delegate
+/// *dominates* the program (few native ops — per-record delegation
+/// measures ~1.1x over eval, #1059 Phase 3.9). The forced-mode knobs
+/// compile them (tests/selfdiff_jitop_backend.rs covers that side).
 #[test]
 fn delegated_program_stays_on_eval_by_default() {
     let label = traced_label("[path(.a // .b)]", r#"{"b":1}"#, None);
+    assert_eq!(label, "eval");
+}
+
+/// A *mixed* program (real native work plus a delegated subtree) routes
+/// to the shared lowering by default since the #1059 Phase 3.9 flip —
+/// the native part runs at JIT speed and measures faster than
+/// whole-filter eval.
+#[test]
+fn mixed_delegated_program_routes_by_default() {
+    let label = traced_label(
+        "select(.x > 100) | path(. as [$a] | $a)",
+        r#"{"x":500}"#,
+        None,
+    );
+    assert_eq!(label, "jitop");
+}
+
+/// Programs observing per-read input state must keep eval's lazy
+/// interleaving: the JIT lowering collects `inputs` eagerly, so
+/// `[inputs as $x | input_line_number]` would report post-consumption
+/// line numbers. The routing gate keeps them on eval.
+#[test]
+fn interleaved_input_state_stays_on_eval() {
+    let label = traced_label("[inputs as $x | input_line_number]", "1", None);
     assert_eq!(label, "eval");
 }
 
@@ -119,9 +144,9 @@ fn force_jit_pins_cranelift() {
     assert_eq!(label, "jit");
 }
 
-/// A recursive def now lowers via the eval delegate (#1059 Phase 3c), but
-/// delegated programs stay off the default dispatch — whole-filter eval
-/// measures faster when the delegate dominates.
+/// A recursive def now lowers via the eval delegate (#1059 Phase 3c).
+/// This one is delegate-dominant (the call IS the program), so default
+/// dispatch keeps whole-filter eval, which measures faster.
 #[test]
 fn recursive_def_stays_on_eval_by_default() {
     let label = traced_label(


### PR DESCRIPTION
## Summary

Phase 3.9 of #1059: default dispatch now accepts programs that lower with streaming eval delegation (`DelegateGen`), with three data-driven guards from interleaved same-machine A/B on 2M-record NDJSON:

| class | routing | A/B |
|---|---|---|
| delegate-dominant (≤16 native ops) | stays on eval | jit+delegate ~1.13x slower — eval does all the work anyway |
| mixed (native work + delegated subtree) | routes to JIT | up to 25% faster (native part at JIT speed); ~1.02x worst case when the delegate fires per record |
| interleaved input state (`input_line_number`/`input_filename` + reader, or multiple readers) | stays on eval | correctness: JIT collects `inputs` eagerly — `[inputs as $x | input_line_number]` reports `[3,3,3]` vs eval/jq `[1,2,3]` |

The eager-`inputs` divergence predates the flip and remains reachable in forced modes (pre-existing; to be fixed separately). The blanket JitProgram-level `DelegateGen` exclusion is removed — a delegate inside a loop body still disqualifies JitOp-interp routing via the existing var-only-loops gate.

Boundary-cost reductions that make the flip viable:
- **`Env::reset` Null-skip**: stop unconditionally storing 256+ `Value::Null`s per record (drop-check + dirty cache line per slot). Also speeds the whole-filter eval route by ~30% on small-filter NDJSON workloads.
- **Seed-list memoization + free-var seeding**: `seed_eval_env_from_jit` caches the per-expression seed list per delegate-config generation (the expr walk was per-record work) and seeds only *free* vars — a var bound inside the delegated expression is rebound by eval before any read.

## Verification

- `cargo build --release` zero warnings; all 72 test targets green
- 3 new routing tests (mixed routes / dominant stays / interleaved IO stays); existing dominant-stays tests still pass under the new gate
- 3-backend sweep over both corpora: no divergence beyond the two known env/`$ENV` knob cases
- Forced-mode bail count unaffected (still zero eval bails)
- Bench: rows beyond ±5% of the v1.8.3 history re-measured with interleaved same-machine A/B against main (`.[]`, `to_entries`, `path(.name,.x)`, p150 mutate, etc.) — all identical

Part of #1059.

🤖 Generated with [Claude Code](https://claude.com/claude-code)