### PR TITLE
docs: record the #1059 endgame execution model and close out Phase 4

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -179,6 +179,28 @@ gate を通れば tree-walking eval ではなく JitOp interpreter で実行さ�
 `JQJIT_TRACE=1` の generic fallback ラベルは `jit` / `jitop` / `eval` の
 3 値（`tests/jitop_routing.rs` がルーティング決定をガードする）。
 
+#### #1059 endgame: 実行モデルの最終地図（2026-06 完了）
+
+#1059（共有 lowering への実行統一）は次の状態で完了:
+
+1. **カバレッジ**: regression + differential corpora の全 filter が共有
+   lowering（flatten）でコンパイル可能。forced-jitop の eval-bail は
+   **131 → 0**（PR #1103-#1110）。exotic ノードは `DelegateGen` で eval に
+   streaming 委譲される
+2. **default routing**: fast path 群 → JIT（cranelift / jitop-interp）→ eval
+   の優先順。委譲込みプログラムも routing 対象（PR #1111 の flip）。ただし
+   delegate-dominant（native ops ≤16）/ interleaved-IO / loop 内 delegate は
+   A/B・正しさの根拠で eval 維持
+3. **eval の役割**: 「独立した第二実装」から「委譲先エンジン + A/B で勝つ
+   class の routing 先」へ縮小。semantics の正本は flatten 側にあり、
+   eval との一致は selfdiff（default vs eval）+ 3-backend sweep が常時検証
+4. **self-diff の主役**: `tests/selfdiff_jitop_backend.rs`（jitop-interp vs
+   cranelift — 同一 op 列の真の backend diff）。`selfdiff_jit_interp.rs`
+   （default vs eval）は委譲経路と routing 境界の検証として存続
+5. **既知の残骸**: forced 系の eager `inputs` 収集による
+   `[inputs as $x | input_line_number]` 乖離（default は routing guard で
+   回避、forced のみ残存・未修正）
+
 #### streaming eval delegate（#1059 Phase 3 / `JitOp::DelegateGen`）
 
 flatten 不能なサブツリーは、ノード単位で eval に **streaming 委譲**して
@@ -201,7 +223,9 @@ downstream early-stop が保たれる（旧 eager delegate の #1085 hang は
   collect 深度**（limit 配下の合成 collect 内）は budget が数えられないので
   従来どおり bail。Limit arm の pre-check は placeholder limit_state を
   立てて probe する（probe/real の文脈ずれ防止）
-- サブツリーに `break`（委譲境界を越える break は label に戻れない）
+- サブツリーに **free な** `break`（対象 label が委譲境界の外 — JIT label に
+  戻れない）。label binder が委譲式内にある break は eval 内で完結するので
+  委譲可（#1059 PR-G、`expr_free_breaks`）
 - **push mode（collect 文脈）で無限になり得るサブツリー**
   （Repeat/While/Until/Recurse、および再帰 def の `FuncCall`）— pipe
   fallback の collect は eager なので eval が lazy に切る stream が hang

--- a/tests/selfdiff_jit_interp.rs
+++ b/tests/selfdiff_jit_interp.rs
@@ -7,6 +7,13 @@
 //! the JIT path and the interpreter path inside jq-jit drifting apart on the
 //! same filter — without depending on an external `jq` binary.
 //!
+//! Post-#1059 role: the shared JitOp lowering covers the full corpus and
+//! `tests/selfdiff_jitop_backend.rs` is the primary backend diff
+//! (jitop-interp vs Cranelift over identical op sequences). Eval survives
+//! as the delegated-op engine and as the A/B-preferred route for
+//! delegate-dominant / interleaved-IO programs — this harness pins those
+//! delegation and routing boundaries against eval semantics.
+//!
 //! The runtime knob is `JQJIT_FORCE_INTERPRETER=1`: the binary then disables
 //! all raw-byte fast paths, skips JIT compilation, and routes
 //! `Filter::execute` / `Filter::execute_cb` through the generic interpreter


### PR DESCRIPTION
## Summary

Final closeout for #1059. Documentation-only: records the endgame execution model in `docs/maintenance.md` (the five-point map: full-corpus lowering coverage with bail 131→0, the A/B-gated default routing flip, eval's reduced role as the delegated-op engine, the backend self-diff as the primary harness, and the known forced-mode eager-`inputs` residue), refreshes the stale break-rejection bullet to the free-break scoping shipped in PR #1109, and documents `selfdiff_jit_interp.rs`'s post-#1059 role in its header.

The sequence that completes the issue:

| PR | step | bails |
|---|---|---|
| #1103 | funcs/memoize wiring into delegated envs | 131→113 |
| #1104 | limit budget coupling | →109 |
| #1105 | loop-arm fall-through delegation | →84 |
| #1106 | data-bounded recurse in push mode | →80 |
| #1107 | binding-scope delegation (path provenance) | →51 |
| #1108 | generator-arm fall-through batch 2 | →23 |
| #1109 | label-scoped break + collect/label scopes | **→0** |
| #1110 | unbounded pipe-left laziness fix | 0 (fixes pre-existing forced hang) |
| #1111 | default routing flip, A/B-gated | — |

Correctness gates held throughout: all 72 test targets green per PR, 3-backend sweeps (Cranelift / JitOp interpreter / eval) clean over both corpora beyond the two known env knob cases, spot checks against system jq 1.8.1, and same-machine interleaved A/B on every bench row beyond ±5% of the v1.8.3 history.

Closes #1059

🤖 Generated with [Claude Code](https://claude.com/claude-code)