### PR TITLE
fix(jit): preserve lazy input-state interleaving via whole-program delegation

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -197,9 +197,15 @@ gate を通れば tree-walking eval ではなく JitOp interpreter で実行さ�
 4. **self-diff の主役**: `tests/selfdiff_jitop_backend.rs`（jitop-interp vs
    cranelift — 同一 op 列の真の backend diff）。`selfdiff_jit_interp.rs`
    （default vs eval）は委譲経路と routing 境界の検証として存続
-5. **既知の残骸**: forced 系の eager `inputs` 収集による
-   `[inputs as $x | input_line_number]` 乖離（default は routing guard で
-   回避、forced のみ残存・未修正）
+5. **interleaved input-state は丸ごと委譲**: `input_line_number` /
+   `input_filename` を読者と組み合わせる（or 複数読者の）プログラムは、
+   `flatten_filter` 入口の `observes_interleaved_input_state` 判定で
+   **プログラム全体を 1 個の pull-mode `DelegateGen`** に lower する。
+   generic fallback（let-binding 値 / pipe left）の eager collect が
+   `inputs` を本体実行前に全消費し `[inputs as $x | input_line_number]` が
+   [3,3,3] になる乖離（#1059 完了時の既知残骸）はこれで forced 系も解消。
+   default routing は delegate-dominant guard により従来どおり eval 行き
+   （明示の interleaved-IO チェックは冗長になり撤去）
 
 #### streaming eval delegate（#1059 Phase 3 / `JitOp::DelegateGen`）
 
@@ -337,17 +343,19 @@ probe 先行が必須（scalar-Reduce 截取と同形）。free var が残る場
 LetBinding スコープなので、`path(nth(2; .[]))` 級がここで委譲に乗る。
 
 **default dispatch の委譲プログラム routing（#1059 Phase 3.9 で flip）**:
-`is_jit_compilable_with_funcs` は委譲プログラムを受理する。ただし
-2 つのガードが残る:
-1. **delegate-dominant 拒否**: native（非 DelegateGen）op 数が
-   `DELEGATE_DOMINANT_NATIVE_OPS`(=16) 以下のプログラムは eval 維持
-   （2M NDJSON A/B で委譲側 ~1.13x 劣化。mixed プログラムは native 部が
-   JIT 速度で走り最大 25% 勝ち、毎レコード委譲発火でも ~1.02x）
-2. **interleaved IO 拒否**: ReadInput 系が 2 回以上、または ReadInput 系 +
-   input_line_number/input_filename の組合せは eval 維持 — JIT の `inputs`
-   lowering は eager 収集なので `[inputs as $x | input_line_number]` が
-   [3,3,3] になる（eval/jq は [1,2,3]）。**この eager 乖離は forced 系では
-   従来から存在する未修正バグ**（flip が default に露出させかけた）
+`is_jit_compilable_with_funcs` は委譲プログラムを受理する。残るガードは
+**delegate-dominant 拒否**: native（非 DelegateGen）op 数が
+`DELEGATE_DOMINANT_NATIVE_OPS`(=16) 以下のプログラムは eval 維持
+（2M NDJSON A/B で委譲側 ~1.13x 劣化。mixed プログラムは native 部が
+JIT 速度で走り最大 25% 勝ち、毎レコード委譲発火でも ~1.02x）。
+interleaved input-state プログラム（ReadInput 系 2 回以上、または
+ReadInput 系 + input_line_number/input_filename）は flip 当初は明示拒否
+していたが、現在は `flatten_filter` 入口で**プログラム全体が 1 個の
+pull-mode DelegateGen に lower される**（forced 系の eager 収集乖離の
+修正、上記 endgame 地図 5 点目）ため delegate-dominant 拒否に包摂され、
+明示チェックは撤去した（routing 検証は
+tests/jitop_routing.rs の interleaved_input_state_stays_on_eval /
+forced_modes_interleave_input_state_lazily）。
 委譲境界コストは 2 段で削減済み: `Env::reset` の Null-skip（eval 全経路にも
 ~30% 効く）と、seed var list の per-compile memoize（`seed_eval_env_from_jit`、
 free var のみ seed — 委譲式内で束縛される var は eval が再束縛するので不要）。

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -10254,6 +10254,24 @@ struct FlattenedFilter {
     value_constants: Vec<Box<Value>>,
 }
 
+/// A program that *observes* per-read input state (`input_line_number` /
+/// `input_filename`) or mixes several readers needs eval's lazy
+/// interleaving end to end: the flattener's generic generator fallbacks
+/// (let-binding values, pipe lefts) collect their stream eagerly, so a
+/// native lowering of `[inputs as $x | input_line_number]` reads all
+/// inputs before the body runs — [3,3,3] where eval/jq stream [1,2,3].
+/// Such programs lower as a single whole-program `DelegateGen` instead
+/// (the pull-mode delegate streams through the output callback, so
+/// laziness is preserved); a lone reader without state observation keeps
+/// the native lowering, where eager collection is unobservable.
+fn observes_interleaved_input_state(expr: &Expr) -> bool {
+    let dbg = format!("{:?}", expr);
+    let readers = dbg.matches("ReadInput").count();
+    readers >= 2
+        || (readers >= 1
+            && (dbg.contains("InputLineNumber") || dbg.contains("InputFilename")))
+}
+
 /// Shared lowering for both execution backends (Cranelift codegen and the
 /// direct JitOp interpreter, #1059): inline function calls, flatten to the
 /// linear JitOp sequence, publish closure ops for runtime delegation, and
@@ -10274,7 +10292,15 @@ fn flatten_filter(expr: &Expr, funcs: &[CompiledFunc]) -> Result<FlattenedFilter
     let input_slot = fl.alloc_slot(); // slot 0 = input ptr (read-only, owned by caller)
     // Use input_slot directly — flatten_gen only reads it, never writes/drops it.
     // Both backends handle Drop{slot:0} as a no-op.
-    if !fl.flatten_gen(&inlined, input_slot) {
+    if observes_interleaved_input_state(&inlined) {
+        // Whole-program delegation preserves the input-state interleaving
+        // that the native generic fallbacks' eager collects would break;
+        // a guard rejection here must bail to whole-filter eval, never
+        // fall through to the (incorrect) native lowering.
+        if !fl.emit_delegate_gen(&inlined, input_slot, false) {
+            bail!("Expression not JIT-compilable: interleaved input state");
+        }
+    } else if !fl.flatten_gen(&inlined, input_slot) {
         bail!("Expression not JIT-compilable");
     }
     // Sub-trees can request a JIT bailout mid-flatten (e.g. a reduce
@@ -11931,20 +11957,12 @@ pub fn is_jit_compilable_with_funcs(expr: &Expr, funcs: &[CompiledFunc]) -> bool
     if std::env::var_os("JQJIT_DEBUG_FEASIBILITY").is_some() {
         eprintln!("[feasibility] ok={} delegate={} native_ops={}", ok, emitted_delegate, native_ops);
     }
-    // The JIT lowering of `inputs` collects the stream eagerly, so a
-    // program that *observes* per-read input state (input_line_number /
-    // input_filename) or mixes several readers sees post-consumption
-    // state where eval interleaves lazily — `[inputs as $x |
-    // input_line_number]` is [1,2,3] in eval/jq and [3,3,3] eagerly.
-    // Keep such programs on eval in default routing (the forced knobs
-    // still compile them; the eager divergence predates the flip).
-    let dbg = format!("{:?}", expr);
-    let readers = dbg.matches("ReadInput").count();
-    let interleaved_io = readers >= 2
-        || (readers >= 1
-            && (dbg.contains("InputLineNumber") || dbg.contains("InputFilename")));
-    ok && !interleaved_io
-        && (!emitted_delegate || native_ops > DELEGATE_DOMINANT_NATIVE_OPS)
+    // Programs observing per-read input state lower as a whole-program
+    // eval delegate (see `observes_interleaved_input_state`), which makes
+    // them delegate-dominant by construction — the guard below keeps them
+    // on whole-filter eval in default routing, same verdict as the
+    // pre-fix explicit check.
+    ok && (!emitted_delegate || native_ops > DELEGATE_DOMINANT_NATIVE_OPS)
 }
 
 /// A delegated program with at most this many native (non-DelegateGen)
@@ -11975,7 +11993,14 @@ fn jit_feasibility(expr: &Expr, funcs: &[CompiledFunc]) -> (bool, bool, usize) {
     let inlined = fl.inline_with_recursion_exemption(expr);
     if fl.has_unresolved_recursion { return (false, false, 0); }
     let input = fl.alloc_slot();
-    let ok = fl.flatten_gen(&inlined, input);
+    // Mirror `flatten_filter`'s whole-program delegation of interleaved
+    // input-state programs so the feasibility verdict agrees with the
+    // real compile (#648 failure mode otherwise).
+    let ok = if observes_interleaved_input_state(&inlined) {
+        fl.emit_delegate_gen(&inlined, input, false)
+    } else {
+        fl.flatten_gen(&inlined, input)
+    };
     // Subtrees may set `has_unresolved_recursion` mid-flatten to request
     // a JIT bailout (see #683 — Reduce arm in flatten_scalar). Re-check
     // here so the feasibility query agrees with `compile_with_funcs`.

--- a/tests/jitop_routing.rs
+++ b/tests/jitop_routing.rs
@@ -115,14 +115,53 @@ fn mixed_delegated_program_routes_by_default() {
     assert_eq!(label, "jitop");
 }
 
-/// Programs observing per-read input state must keep eval's lazy
-/// interleaving: the JIT lowering collects `inputs` eagerly, so
-/// `[inputs as $x | input_line_number]` would report post-consumption
-/// line numbers. The routing gate keeps them on eval.
+/// Programs observing per-read input state lower as a whole-program
+/// eval delegate (see `observes_interleaved_input_state` in src/jit.rs),
+/// which makes them delegate-dominant — default routing keeps them on
+/// whole-filter eval.
 #[test]
 fn interleaved_input_state_stays_on_eval() {
     let label = traced_label("[inputs as $x | input_line_number]", "1", None);
     assert_eq!(label, "eval");
+}
+
+/// Run the binary under one forced-backend env knob with `-n -c` and
+/// multi-line stdin, returning stdout.
+fn forced_output(knob: &str, filter: &str, stdin_data: &str) -> String {
+    let bin = env!("CARGO_BIN_EXE_jq-jit");
+    let mut cmd = Command::new(bin);
+    cmd.arg("-n").arg("-c").arg(filter);
+    cmd.env(knob, "1");
+    cmd.stdin(std::process::Stdio::piped());
+    cmd.stdout(std::process::Stdio::piped());
+    cmd.stderr(std::process::Stdio::piped());
+    let mut child = cmd.spawn().expect("spawn jq-jit");
+    {
+        use std::io::Write;
+        let mut stdin = child.stdin.take().expect("stdin");
+        let _ = stdin.write_all(stdin_data.as_bytes());
+    }
+    let out = child.wait_with_output().expect("wait jq-jit");
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+/// Forced-mode correctness for interleaved input state: such programs
+/// lower as a single whole-program `DelegateGen`, preserving eval's lazy
+/// read interleaving. The eager native lowering used to consume the
+/// whole stream before the binding body ran, reporting post-consumption
+/// line numbers ([3,3,3] instead of [1,2,3]).
+#[test]
+fn forced_modes_interleave_input_state_lazily() {
+    for knob in ["JQJIT_FORCE_JITOP_INTERP", "JQJIT_FORCE_CRANELIFT"] {
+        let out = forced_output(knob, "[inputs as $x | input_line_number]", "1\n2\n3\n");
+        assert_eq!(out, "[1,2,3]", "{knob}");
+        let out = forced_output(
+            knob,
+            "[input, input_line_number, input, input_line_number]",
+            "10\n20\n30\n",
+        );
+        assert_eq!(out, "[10,1,20,2]", "{knob}");
+    }
 }
 
 /// `--force-jit` accepts delegated programs (debug knob, full coverage).


### PR DESCRIPTION
## Summary

Fixes the last documented residue of the #1059 endgame: in the forced backend modes (`JQJIT_FORCE_CRANELIFT` / `JQJIT_FORCE_JITOP_INTERP`), programs observing per-read input state diverged from eval/jq because the flattener's generic generator fallbacks (let-binding values, pipe lefts) collect their stream eagerly:

```
$ printf '1\n2\n3\n' | jq-jit -nc '[inputs as $x | input_line_number]'   # forced modes
[3,3,3]    # eval / jq 1.8.1: [1,2,3]
```

All inputs were consumed before the binding body ran, so `input_line_number` reported post-consumption state.

## Fix

`flatten_filter` (the shared lowering entry for both backends) now detects interleaved input-state programs — `ReadInput`/`ReadInputs` combined with `input_line_number`/`input_filename`, or multiple readers — and lowers them as a **single whole-program pull-mode `DelegateGen`**. The pull-mode delegate streams every yield through the output callback, so eval's lazy read interleaving is preserved end to end, with one chokepoint instead of patching every eager-collect site. The feasibility probe mirrors the interception so its verdict agrees with the real compile.

The explicit interleaved-IO check in the default routing gate (added with the #1059 Phase 3.9 flip as a correctness guard) is now redundant: a whole-program delegate is delegate-dominant by construction, so the existing guard keeps these programs on whole-filter eval with the same verdict. Removed.

## Verification

- `cargo build --release` zero warnings; `cargo test --release` all green (685 passed), including new `forced_modes_interleave_input_state_lazily` covering `[inputs as $x | input_line_number]` → `[1,2,3]` and `[input, input_line_number, input, input_line_number]` → `[10,1,20,2]` under both forced knobs
- Forced-mode bail count over regression + differential corpora stays **0**
- 3-backend sweep (cranelift / jitop-interp / eval) clean — only the 4 known env/`$ENV` knob diffs
- Spot parity vs system jq 1.8.1 for `inputs`/`input` interleaving shapes, including the unaffected lone-reader case `[., inputs]`
- No per-record code touched (the predicate runs once per compile), so the benchmark gate does not apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)