### PR TITLE
refactor(eval): unify error(value) raises on the typed ErrorValue channel

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -2555,17 +2555,14 @@ pub fn eval(
                         let v = take_error_payload(ev);
                         return eval(catch_expr, v, env, cb);
                     }
-                    let msg = format!("{}", e);
                     // halt / halt_error are non-recoverable: jq lets them
                     // propagate past `try ... catch` so the process exits with
                     // the requested code (#182).
                     if e.downcast_ref::<crate::signal::HaltSignal>().is_some() { return Err(e); }
-                    let catch_val = if let Some(json) = msg.strip_prefix("__jqerror__:") {
-                        crate::value::json_to_value(json).unwrap_or(Value::from_str(&msg))
-                    } else {
-                        Value::from_str(&msg)
-                    };
-                    eval(catch_expr, catch_val, env, cb)
+                    // Every `error(value)` raise is a typed `ErrorValue`
+                    // (downcast above), so what remains here is a plain
+                    // message error — bind its text directly (#1034).
+                    eval(catch_expr, Value::from_str(&format!("{}", e)), env, cb)
                 }
             }
         }
@@ -3525,7 +3522,7 @@ pub fn eval(
                         // true for NaN and it takes the negative-count error
                         // path rather than acting as an unbounded count (#813).
                         if n < 0.0 || n.is_nan() {
-                            bail!("__jqerror__:\"limit doesn't support negative count\"");
+                            return Err(ErrorValue::raise(Value::from_str("limit doesn't support negative count")));
                         }
                         if n == 0.0 { return Ok(true); } // 0.0 and -0.0 → empty
                         let mut emitted: i64 = 0;
@@ -3552,7 +3549,7 @@ pub fn eval(
                     // so `$n < 0` is true for these and they take jq's
                     // "negative count" branch (#539).
                     Value::Null | Value::True | Value::False => {
-                        bail!("__jqerror__:\"limit doesn't support negative count\"");
+                        return Err(ErrorValue::raise(Value::from_str("limit doesn't support negative count")));
                     }
                     // String / array / object surface jq's `$n - 1`
                     // arithmetic error from the limit reduce. jq computes that
@@ -3564,17 +3561,14 @@ pub fn eval(
                             "{} and number (1) cannot be subtracted",
                             crate::runtime::errdesc_pub(other),
                         );
-                        let err = format!(
-                            "__jqerror__:{}",
-                            crate::value::value_to_json_precise(&Value::from_string(msg)),
-                        );
+                        let err_val = Value::from_string(msg);
                         let mut yielded = false;
                         eval(generator, input.clone(), env, &mut |_val| {
                             yielded = true;
                             Ok(false)
                         })?;
                         if yielded {
-                            bail!("{}", err);
+                            return Err(ErrorValue::raise(err_val));
                         }
                         Ok(true)
                     }
@@ -5997,7 +5991,6 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
             match result {
                 Ok(cont) => Ok(cont),
                 Err(e) => {
-                    let msg = format!("{}", e);
                     // halt / halt_error are non-recoverable: jq lets them
                     // propagate past `try ... catch` so the process exits with
                     // the requested code (#182).
@@ -6026,12 +6019,10 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
                         let v = take_error_payload(ev);
                         return eval_path_catch(catch_expr, v, &input, env, cb);
                     }
-                    let catch_val = if let Some(json) = msg.strip_prefix("__jqerror__:") {
-                        crate::value::json_to_value(json).unwrap_or(Value::from_str(&msg))
-                    } else {
-                        Value::from_str(&msg)
-                    };
-                    eval_path_catch(catch_expr, catch_val, &input, env, cb)
+                    // Every `error(value)` raise is a typed `ErrorValue`
+                    // (downcast above), so what remains here is a plain
+                    // message error — bind its text directly (#1034).
+                    eval_path_catch(catch_expr, Value::from_str(&format!("{}", e)), &input, env, cb)
                 }
             }
         }
@@ -6146,7 +6137,7 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
                 let n = match &cv {
                     Value::Num(n, _) => *n,
                     Value::Null | Value::True | Value::False => {
-                        bail!("__jqerror__:\"limit doesn't support negative count\"");
+                        return Err(ErrorValue::raise(Value::from_str("limit doesn't support negative count")));
                     }
                     // A string/array/object count surfaces jq's `$n - 1`
                     // arithmetic error lazily — only when the generator yields
@@ -6157,23 +6148,20 @@ fn eval_path(expr: &Expr, input: Value, env: &EnvRef, cb: &mut dyn FnMut(Value) 
                             "{} and number (1) cannot be subtracted",
                             crate::runtime::errdesc_pub(other),
                         );
-                        let err = format!(
-                            "__jqerror__:{}",
-                            crate::value::value_to_json_precise(&Value::from_string(msg)),
-                        );
+                        let err_val = Value::from_string(msg);
                         let mut yielded = false;
                         eval_path(generator, input.clone(), env, &mut |_p| {
                             yielded = true;
                             Ok(false)
                         })?;
                         if yielded {
-                            bail!("{}", err);
+                            return Err(ErrorValue::raise(err_val));
                         }
                         return Ok(true);
                     }
                 };
                 if n < 0.0 || n.is_nan() {
-                    bail!("__jqerror__:\"limit doesn't support negative count\"");
+                    return Err(ErrorValue::raise(Value::from_str("limit doesn't support negative count")));
                 }
                 if n == 0.0 { return Ok(true); }
                 let mut emitted: i64 = 0;
@@ -7847,11 +7835,11 @@ fn eval_skip(exp: &Expr, nval: &Value, input: Value, env: &EnvRef, cb: &mut dyn 
         Value::Num(n, _) => {
             let n = *n as i64;
             if n < 0 {
-                return Err(anyhow::anyhow!("__jqerror__:\"skip doesn't support negative count\""));
+                return Err(ErrorValue::raise(Value::from_str("skip doesn't support negative count")));
             }
             n
         }
-        _ => return Err(anyhow::anyhow!("__jqerror__:\"skip count must be a number\"")),
+        _ => return Err(ErrorValue::raise(Value::from_str("skip count must be a number"))),
     };
     let mut count = 0i64;
     eval(exp, input, env, &mut |val| {
@@ -8303,12 +8291,14 @@ pub fn execute_ir_with_libs(expr: &Expr, input: Value, funcs: Vec<CompiledFunc>,
             if e.downcast_ref::<BreakError>().is_some() {
                 Ok(outputs)
             } else {
-                let msg = format!("{}", e);
-                // Report error to stderr but still return collected outputs
-                if let Some(json) = msg.strip_prefix("__jqerror__:") {
-                    eprintln!("jq: error: {}", json);
+                // Report error to stderr but still return collected
+                // outputs. A typed `error(value)` payload prints as its
+                // JSON (byte-identical to the legacy sentinel text, #1034).
+                if let Some(ev) = e.downcast_ref::<ErrorValue>() {
+                    let v = take_error_payload(ev);
+                    eprintln!("jq: error: {}", crate::value::value_to_json_precise(&v));
                 } else {
-                    eprintln!("jq: error: {}", msg);
+                    eprintln!("jq: error: {}", e);
                 }
                 Ok(outputs)
             }

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -128,19 +128,9 @@ fn jit_error_from_anyhow(e: &anyhow::Error) -> JitError {
     if let Some(b) = e.downcast_ref::<crate::signal::BreakError>() {
         return JitError::Break(b.0);
     }
-    let msg = format!("{}", e);
-    // Some eval paths still raise the legacy string encoding of an error
-    // *value* (`bail!("__jqerror__:{json}")` — e.g. limit's count type
-    // errors). Eval's own catch strips the prefix (see Expr::TryCatch in
-    // eval.rs); errors crossing the delegation boundary into a JIT catch
-    // must be lifted the same way or the catch body sees the raw wrapper
-    // (#1059 PR-F).
-    if let Some(json) = msg.strip_prefix("__jqerror__:") {
-        if let Ok(v) = crate::value::json_to_value(json) {
-            return JitError::Raise(v);
-        }
-    }
-    JitError::Msg(msg)
+    // Every `error(value)` raise in eval is a typed `ErrorValue` (#1034),
+    // so anything else is a plain message error — no sentinel parsing.
+    JitError::Msg(format!("{}", e))
 }
 
 fn set_jit_error(msg: String) {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -536,10 +536,9 @@ pub fn call_builtin_op(op: RtBuiltin, args: &[Value]) -> Result<Value> {
             match &args[0] {
                 Value::Str(s) if s.as_str() == "match failed" => Ok(Value::Null),
                 Value::Str(s) => bail!("{}", s.as_str()),
-                other => bail!(
-                    "__jqerror__:{}",
-                    crate::value::value_to_json_precise(other),
-                ),
+                // Non-string payloads rethrow as a typed `error(value)` so
+                // a downstream catch recovers the value losslessly (#1034).
+                other => Err(crate::signal::ErrorValue::raise(other.clone())),
             }
         }
         RtBuiltin::First | RtBuiltin::Last | RtBuiltin::Nth | RtBuiltin::Range | RtBuiltin::While | RtBuiltin::Until | RtBuiltin::Repeat | RtBuiltin::Recurse

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -14087,3 +14087,8 @@ first(while(true; .+1) | . * 2)
 [.. | numbers]
 {"a":1,"b":[2,3]}
 [1,2,3]
+
+# #1034: typed error(value) channel — skip count errors bind losslessly in catch
+[try (skip(-1; 1)) catch ., try (skip("x"; 1)) catch .]
+null
+["skip doesn't support negative count","skip count must be a number"]


### PR DESCRIPTION
## Summary

Part of #1034 — continues the typed-signal series (HaltSignal #1042, PathResultSignal #1044, signal.rs #1045, JitError #1046).

Converts the last raise sites that encoded an error **value** into the legacy `__jqerror__:<json>` display string to `ErrorValue::raise`, which carries the payload losslessly and keeps the uncaught Display text byte-identical:

- `limit` count errors (value and path mode, including the deferred non-number form, #806/#813)
- `skip` count errors
- the JIT regex rethrow helper's non-string payload (`RethrowUnlessNoMatch`)

With every producer typed, the string-parse fallbacks are dead and removed:

- both `TryCatch` catch arms in eval (value and path mode)
- the `eval_to_values` stderr report site
- the delegation-boundary lift in `jit_error_from_anyhow` (the band-aid added in the #1059 endgame)

**No `__jqerror__` / `__halt__` / `__break__` sentinel parsing remains in eval.rs / jit.rs / runtime.rs / interpreter.rs.** jit.rs retains only the `legacy_string()` *producers* feeding the `Value::Error` channel — that is the remaining #1034 audit item, planned as the follow-up PR (together with the bin-side display parses it gates).

## Verification

- Zero-warning `cargo build --release`; full suite green (685), including a new regression group pinning skip count errors through catch
- 3-backend sweep (cranelift / jitop-interp / eval) clean — only the 4 known env/`$ENV` knob diffs
- Spot parity vs system jq 1.8.1 across all four execution modes for limit/skip count errors, catch payload binding (`try error({a:1}) catch .`), deferred empty-generator forms (`[limit({}; empty)]` → `[]`), and match type errors
- Error paths are cold; no per-record hot path touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)