### PR TITLE
refactor(value): retire the Value::Error variant, type the CLI error report

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -257,52 +257,6 @@ fn jqjit_trace_fast_path(name: &str, filter_text: &str) {
     }
 }
 
-/// Decode a JSON-quoted string back to its raw character form, e.g.
-/// `"\"foo\\n\""` -> `foo\n`. Used when an `error(val)` sentinel carries
-/// a `JV_KIND_STRING`-shaped payload so we can strip the JSON quoting
-/// the way jq does. Returns None if the JSON is malformed.
-fn decode_json_string_literal(s: &str) -> Option<String> {
-    let b = s.as_bytes();
-    if b.len() < 2 || b[0] != b'"' || b[b.len()-1] != b'"' { return None; }
-    let inner = &b[1..b.len()-1];
-    let mut out = String::with_capacity(inner.len());
-    let mut i = 0;
-    while i < inner.len() {
-        let c = inner[i];
-        if c != b'\\' { out.push(c as char); i += 1; continue; }
-        if i + 1 >= inner.len() { return None; }
-        match inner[i+1] {
-            b'"' => out.push('"'),
-            b'\\' => out.push('\\'),
-            b'/' => out.push('/'),
-            b'b' => out.push('\u{08}'),
-            b'f' => out.push('\u{0C}'),
-            b'n' => out.push('\n'),
-            b'r' => out.push('\r'),
-            b't' => out.push('\t'),
-            b'u' => {
-                if i + 6 > inner.len() { return None; }
-                let hex = std::str::from_utf8(&inner[i+2..i+6]).ok()?;
-                let cp = u32::from_str_radix(hex, 16).ok()?;
-                out.push(char::from_u32(cp).unwrap_or('\u{FFFD}'));
-                i += 6;
-                continue;
-            }
-            _ => return None,
-        }
-        i += 2;
-    }
-    Some(out)
-}
-
-/// Emit a jq-style error line, matching jq 1.8.1's format:
-///   jq: error (at <stdin>:N)[ (not a string)]: <body>
-///
-/// `msg` is the raw error body we got from the anyhow chain. Strings
-/// produced by `error(val)` arrive prefixed with `__jqerror__:<JSON>`;
-/// the JSON form carries the type info jq normally reads from the
-/// original jv, so we use it to decide between the unquoted string
-/// branch and the ` (not a string)` branch.
 /// Validate a jq variable name from `--arg` / `--argjson`. Per jq, the binding
 /// must look like `[A-Za-z_][A-Za-z0-9_]*`; numeric or symbolic names are
 /// rejected at the CLI parser so the resulting `$<name>` reference doesn't
@@ -323,16 +277,26 @@ const RAW_OUTPUT0_NUL_ERR: &str =
 
 fn print_jq_error(msg: &str) {
     let line = jq_jit::eval::get_input_line_number();
-    if let Some(jq_msg) = msg.strip_prefix("__jqerror__:") {
-        if jq_msg.starts_with('"') && jq_msg.ends_with('"') {
-            if let Some(unwrapped) = decode_json_string_literal(jq_msg) {
-                eprintln!("jq: error (at <stdin>:{}): {}", line, unwrapped);
-                return;
-            }
+    eprintln!("jq: error (at <stdin>:{}): {}", line, msg);
+}
+
+/// Print a terminal filter error. An `error(value)` payload arrives as a
+/// typed [`jq_jit::signal::ErrorValue`] from every engine (#1034): strings
+/// print bare, any other payload gets jq's "(not a string)" marker with its
+/// JSON. Plain message errors print their display text as-is.
+fn print_jq_error_typed(e: &anyhow::Error) {
+    if let Some(ev) = e.downcast_ref::<jq_jit::signal::ErrorValue>() {
+        let line = jq_jit::eval::get_input_line_number();
+        match jq_jit::signal::take_error_payload(ev) {
+            Value::Str(s) => eprintln!("jq: error (at <stdin>:{}): {}", line, s.as_str()),
+            other => eprintln!(
+                "jq: error (at <stdin>:{}) (not a string): {}",
+                line,
+                jq_jit::value::value_to_json_precise(&other),
+            ),
         }
-        eprintln!("jq: error (at <stdin>:{}) (not a string): {}", line, jq_msg);
     } else {
-        eprintln!("jq: error (at <stdin>:{}): {}", line, msg);
+        print_jq_error(&format!("{}", e));
     }
 }
 
@@ -3746,11 +3710,6 @@ fn real_main() {
     let mut compact_buf: Vec<u8> = if use_compact_buf || use_pretty_buf || raw_csv_fields.is_some() { Vec::with_capacity(1 << 17) } else { Vec::new() };
     let process_input = |input: &Value, raw_bytes: Option<&[u8]>, out: &mut io::BufWriter<io::StdoutLock>, cbuf: &mut Vec<u8>, any_false: &mut bool, had_error: &mut bool| {
         let result = filter.execute_cb(input, &mut |result| {
-            if let Value::Error(e) = result {
-                print_jq_error(e.as_str());
-                *had_error = true;
-                return Ok(true);
-            }
             if exit_status {
                 if !result.is_true() {
                     *any_false = true;
@@ -3870,16 +3829,14 @@ fn real_main() {
             let _ = out.flush();
         }
         if let Err(e) = result {
-            let msg = format!("{}", e);
             // halt / halt_error: drain any buffered output, release our
             // hold on stdout, then terminate with the requested exit
             // status. Stderr (halt_error's message) was already written
-            // directly in eval.rs at raise time. The string form is the
-            // fallback for halts that crossed the JIT FFI boundary, where
-            // only the Display text survives (see src/signal.rs).
+            // directly in eval.rs at raise time. The signal arrives typed
+            // from every engine — the JIT boundary rebuilds it in
+            // JitError::into_anyhow (#1034).
             let halt_code = e.downcast_ref::<jq_jit::signal::HaltSignal>()
-                .map(|h| h.code)
-                .or_else(|| msg.strip_prefix("__halt__:").map(|c| c.parse().unwrap_or(0)));
+                .map(|h| h.code);
             if let Some(code) = halt_code {
                 if !cbuf.is_empty() {
                     let _ = out.write_all(cbuf);
@@ -3888,7 +3845,7 @@ fn real_main() {
                 let _ = out.flush();
                 std::process::exit(code);
             }
-            print_jq_error(&msg);
+            print_jq_error_typed(&e);
             *had_error = true;
         }
     };

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -2524,18 +2524,11 @@ pub fn eval(
         Expr::TryCatch { try_expr, catch_expr, .. } => {
             let cb_error = std::cell::Cell::new(false);
             let result = eval(try_expr, input.clone(), env, &mut |val| {
-                match &val {
-                    Value::Error(msg) => {
-                        eval(catch_expr, Value::from_str(msg.as_str()), env, cb)
-                    }
-                    _ => {
-                        let r = cb(val);
-                        if r.is_err() {
-                            cb_error.set(true);
-                        }
-                        r
-                    }
+                let r = cb(val);
+                if r.is_err() {
+                    cb_error.set(true);
                 }
+                r
             });
             match result {
                 Ok(cont) => Ok(cont),
@@ -4539,7 +4532,6 @@ pub fn eval_format(kind: &FormatKind, val: &Value) -> Result<String> {
                         v.type_name(),
                         crate::value::value_to_json(v),
                     ),
-                    _ => buf.push_str(&crate::value::value_to_json(v)),
                 }
             }
             return Ok(buf);
@@ -4573,7 +4565,6 @@ pub fn eval_format(kind: &FormatKind, val: &Value) -> Result<String> {
                         v.type_name(),
                         crate::value::value_to_json(v),
                     ),
-                    _ => buf.push_str(&crate::value::value_to_json(v)),
                 }
             }
             return Ok(buf);
@@ -7321,7 +7312,7 @@ fn input_length_is_zero(v: &Value) -> bool {
         Value::Obj(o) => o.is_empty(),
         Value::Str(s) => s.as_str().is_empty(),
         Value::Num(n, _) => *n == 0.0,
-        Value::True | Value::False | Value::Error(_) => false,
+        Value::True | Value::False => false,
     }
 }
 
@@ -7430,7 +7421,6 @@ fn stream_first_length(v: &Value) -> Result<i64> {
         Value::Arr(a) => a.len() as i64,
         Value::Obj(ObjInner(o)) => o.len() as i64,
         Value::True | Value::False => bail!("boolean ({}) has no length", crate::value::value_to_json(v)),
-        Value::Error(_) => bail!("error has no length"),
     })
 }
 
@@ -7916,7 +7906,6 @@ fn value_type_name(v: &Value) -> &'static str {
         Value::Str(..) => "string",
         Value::Arr(..) => "array",
         Value::Obj(..) => "object",
-        Value::Error(..) => "error",
     }
 }
 
@@ -8282,7 +8271,7 @@ pub fn execute_ir_with_libs(expr: &Expr, input: Value, funcs: Vec<CompiledFunc>,
     let env = Rc::new(RefCell::new(Env::with_lib_dirs(funcs, lib_dirs)));
     let mut outputs = Vec::new();
     let result = eval(expr, input, &env, &mut |val| {
-        match &val { Value::Error(e) => { eprintln!("jq: error: {}", e); }, _ => { outputs.push(val); } }
+        outputs.push(val);
         Ok(true)
     });
     match result {

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -11725,7 +11725,7 @@ impl Filter {
         };
         let mut outputs = Vec::new();
         crate::eval::execute_ir_with_env_cb(expr, input.clone(), &env, &mut |v| {
-            match &v { Value::Error(e) => { eprintln!("jq: error: {}", e); }, _ => { outputs.push(v); } }
+            outputs.push(v);
             Ok(true)
         })?;
         Ok(outputs)
@@ -11781,13 +11781,7 @@ impl Filter {
         };
         crate::eval::execute_ir_with_env_cb(
             expr, input.clone(), &env,
-            &mut |val| {
-                if let Value::Error(e) = &val {
-                    eprintln!("jq: error: {}", e.as_str());
-                    return Ok(true);
-                }
-                cb(&val)
-            },
+            &mut |val| cb(&val),
         )
     }
 

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -80,18 +80,6 @@ pub(crate) enum JitError {
 }
 
 impl JitError {
-    /// The legacy string form — what the channel carried before it was
-    /// typed. Used where the consumer is still string-shaped: `Value::Error`
-    /// results from `execute_jit` and catch values for halt/break (#1043).
-    fn legacy_string(&self) -> String {
-        match self {
-            JitError::Msg(s) => s.clone(),
-            JitError::Raise(v) => format!("__jqerror__:{}", crate::value::value_to_json(v)),
-            JitError::Halt(c) => format!("__halt__:{}", c),
-            JitError::Break(id) => format!("__break__:{}:", id),
-        }
-    }
-
     /// Rebuild the typed anyhow signal at the JIT→caller boundary so
     /// downstream downcasts (try/catch in eval, the CLI halt handler) see
     /// the same types the eval engine raises.
@@ -111,7 +99,12 @@ impl JitError {
     fn into_catch_value(self) -> Value {
         match self {
             JitError::Raise(v) => v,
-            other => Value::from_str(&other.legacy_string()),
+            JitError::Msg(s) => Value::from_string(s),
+            // Halt and Break keep their historical sentinel-text shape
+            // (#1043 bug-compat; a pending Halt is normally refused by
+            // `jit_rt_get_error` and never lands here).
+            JitError::Halt(c) => Value::from_string(format!("__halt__:{}", c)),
+            JitError::Break(id) => Value::from_string(format!("__break__:{}:", id)),
         }
     }
 }
@@ -8048,7 +8041,6 @@ extern "C" fn jit_rt_unaryop(dst: *mut Value, op: i32, input: *const Value) -> i
                 }
                 Value::Arr(a) => Value::number(a.len() as f64),
                 Value::Obj(ObjInner(o)) => Value::number(o.len() as f64),
-                Value::Error(_) => Value::number(0.0),
             };
             std::ptr::write(dst, v);
             return 0;
@@ -8062,7 +8054,6 @@ extern "C" fn jit_rt_unaryop(dst: *mut Value, op: i32, input: *const Value) -> i
                 Value::Str(_) => "string",
                 Value::Arr(_) => "array",
                 Value::Obj(_) => "object",
-                Value::Error(_) => "error",
             };
             std::ptr::write(dst, Value::from_str(s));
             return 0;
@@ -8582,7 +8573,7 @@ extern "C" fn jit_rt_not(dst: *mut Value, input: *const Value) -> i64 {
 extern "C" fn jit_rt_kind(v: *const Value) -> i64 {
     unsafe {
         match &*v { Value::Null => 0, Value::False => 1, Value::True => 2, Value::Num(..) => 3,
-            Value::Str(_) => 4, Value::Arr(_) => 5, Value::Obj(_) => 6, Value::Error(_) => 7 }
+            Value::Str(_) => 4, Value::Arr(_) => 5, Value::Obj(_) => 6 }
     }
 }
 extern "C" fn jit_rt_len(v: *const Value) -> i64 {
@@ -9303,7 +9294,7 @@ extern "C" fn jit_rt_call_builtin(dst: *mut Value, builtin: *const JitBuiltin,
         if rt == Some(crate::runtime::RtBuiltin::Join) && args.len() == 2 {
             if let (Value::Arr(a), Value::Str(sep)) = (&args[0], &args[1]) {
                 // Check all elements are scalar (not arr/obj) — otherwise fall through to runtime for error
-                let all_scalar = a.iter().all(|v| !matches!(v, Value::Arr(_) | Value::Obj(_) | Value::Error(_)));
+                let all_scalar = a.iter().all(|v| !matches!(v, Value::Arr(_) | Value::Obj(_)));
                 if all_scalar {
                     let cap = a.len() * (8 + sep.len());
                     let mut buf: Vec<u8> = Vec::with_capacity(cap);
@@ -9533,7 +9524,6 @@ extern "C" fn jit_rt_call_builtin(dst: *mut Value, builtin: *const JitBuiltin,
                                 std::ptr::write(dst, Value::Null);
                                 return GEN_ERROR;
                             }
-                            _ => buf.extend_from_slice(crate::value::value_to_json(v).as_bytes()),
                         }
                     }
                     std::ptr::write(dst, Value::from_string(String::from_utf8_unchecked(buf)));
@@ -9582,7 +9572,6 @@ extern "C" fn jit_rt_call_builtin(dst: *mut Value, builtin: *const JitBuiltin,
                                 std::ptr::write(dst, Value::Null);
                                 return GEN_ERROR;
                             }
-                            _ => buf.extend_from_slice(crate::value::value_to_json(v).as_bytes()),
                         }
                     }
                     std::ptr::write(dst, Value::from_string(String::from_utf8_unchecked(buf)));
@@ -12213,13 +12202,12 @@ fn execute_collect(run: impl FnOnce(&mut JitEnv, RawYieldCb, *mut u8) -> i64) ->
         let ctx = &mut results as *mut Vec<Value> as *mut u8;
         let result = run(env, collect_callback, ctx);
         if result == GEN_ERROR {
-            // This non-streaming entry returns errors as Value::Error, a
-            // string-shaped channel — keep the legacy text until the
-            // Value::Error variant itself is retired (#1034).
-            let err_msg = env.error.take()
-                .map(|e| e.legacy_string())
-                .unwrap_or_else(|| "JIT execution error".to_string());
-            results.push(Value::Error(Rc::new(err_msg)));
+            // Surface the terminal error as the typed anyhow signal, same
+            // as the streaming driver — outputs collected before the error
+            // are dropped, matching the whole-filter eval engine (#1034).
+            return Err(env.error.take()
+                .map(JitError::into_anyhow)
+                .unwrap_or_else(|| anyhow::anyhow!("JIT execution error")));
         }
         Ok(results)
     })

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1463,7 +1463,6 @@ pub fn compare_values(a: &Value, b: &Value) -> std::cmp::Ordering {
             Value::Str(_) => 4,
             Value::Arr(_) => 5,
             Value::Obj(_) => 6,
-            Value::Error(_) => 7,
         }
     };
 
@@ -1641,7 +1640,6 @@ fn rt_reverse(v: &Value) -> Result<Value> {
         Value::Num(_, _) => bail!("Cannot index number with number"),
         // errdesc keeps repr/truncation consistent across error sites (#580).
         Value::True | Value::False => bail!("{} has no length", errdesc(v)),
-        _ => bail!("{} cannot be reversed", v.type_name()),
     }
 }
 
@@ -2325,7 +2323,6 @@ fn jq_kind_tag(v: &Value) -> u8 {
         Value::Str(_) => 4,
         Value::Arr(_) => 5,
         Value::Obj(_) => 6,
-        Value::Error(_) => 7,
     }
 }
 
@@ -2854,7 +2851,6 @@ pub fn index_err_desc(key: &Value) -> String {
         Value::True | Value::False => "boolean".to_string(),
         Value::Arr(_) => "array".to_string(),
         Value::Obj(_) => "object".to_string(),
-        Value::Error(_) => "error".to_string(),
     }
 }
 

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -76,7 +76,7 @@ thread_local! {
 /// [`ERROR_PAYLOAD`] instead; `Display` still emits the `__jqerror__:<JSON>`
 /// form so uncaught errors print exactly as before.
 #[derive(Debug)]
-pub(crate) struct ErrorValue {
+pub struct ErrorValue {
     display: String,
 }
 impl ErrorValue {
@@ -100,7 +100,7 @@ impl std::error::Error for ErrorValue {}
 
 /// Take the payload stashed by the most recent `error(value)`. Falls back to
 /// re-parsing the marker's `display` JSON if the slot is somehow empty.
-pub(crate) fn take_error_payload(ev: &ErrorValue) -> crate::value::Value {
+pub fn take_error_payload(ev: &ErrorValue) -> crate::value::Value {
     if let Some(v) = ERROR_PAYLOAD.with(|slot| slot.borrow_mut().take()) {
         return v;
     }

--- a/src/value.rs
+++ b/src/value.rs
@@ -433,7 +433,6 @@ pub enum Value {
     Str(KeyStr),
     Arr(Rc<Vec<Value>>),
     Obj(ObjInner),
-    Error(Rc<String>),
 }
 
 impl Clone for Value {
@@ -446,7 +445,6 @@ impl Clone for Value {
             Value::Str(s) => Value::Str(s.clone()),
             Value::Arr(a) => Value::Arr(Rc::clone(a)),
             Value::Obj(ObjInner(o)) => Value::Obj(ObjInner(Rc::clone(o))),
-            Value::Error(e) => Value::Error(Rc::clone(e)),
         }
     }
 }
@@ -506,7 +504,6 @@ impl ValueKey {
                         y.get(k.as_str()).is_some_and(|yv| Self::key_eq(v, yv))
                     })
             }
-            (Value::Error(x), Value::Error(y)) => x == y,
             _ => false,
         }
     }
@@ -549,10 +546,6 @@ impl ValueKey {
                     combined ^= h.finish();
                 }
                 combined.hash(state);
-            }
-            Value::Error(e) => {
-                7u8.hash(state);
-                e.as_str().hash(state);
             }
         }
     }
@@ -746,7 +739,6 @@ impl Value {
             Value::Str(_) => "string",
             Value::Arr(_) => "array",
             Value::Obj(_) => "object",
-            Value::Error(_) => "error",
         }
     }
 
@@ -780,7 +772,6 @@ impl Value {
             }
             Value::Arr(a) => Ok(Value::number(a.len() as f64)),
             Value::Obj(ObjInner(o)) => Ok(Value::number(o.len() as f64)),
-            Value::Error(_) => bail!("error has no length"),
         }
     }
 }
@@ -805,7 +796,6 @@ impl fmt::Debug for Value {
             Value::Str(s) => write!(f, "Str({:?})", s.as_str()),
             Value::Arr(a) => write!(f, "Arr({:?})", a.as_ref()),
             Value::Obj(ObjInner(o)) => write!(f, "Obj({:?})", o.as_ref()),
-            Value::Error(e) => write!(f, "Error({:?})", e.as_str()),
         }
     }
 }
@@ -6555,7 +6545,6 @@ fn push_value_tojson(v: &Value, out: &mut String, depth: usize) {
             }
             out.push('}');
         }
-        Value::Error(e) => push_json_string(out, e),
     }
 }
 
@@ -6649,11 +6638,6 @@ fn value_to_json_depth(v: &Value, depth: usize, precise: bool) -> String {
                 out.push_str(&value_to_json_depth(v, depth + 1, precise));
             }
             out.push('}');
-            out
-        }
-        Value::Error(e) => {
-            let mut out = String::with_capacity(e.len() + 2);
-            push_json_string(&mut out, e);
             out
         }
     }
@@ -6829,7 +6813,6 @@ fn write_pretty_to_string_impl<const COLOR: bool>(out: &mut String, v: &Value, d
             c!(COLOR_RESET);
         }
         Value::Str(s) => { c!(p.string.as_str()); push_json_string(out, s); c!(COLOR_RESET); }
-        Value::Error(e) => push_json_string(out, e),
         Value::Arr(a) if a.is_empty() => { c!(p.arr.as_str()); out.push_str("[]"); c!(COLOR_RESET); }
         Value::Obj(ObjInner(o)) if o.is_empty() => { c!(p.obj.as_str()); out.push_str("{}"); c!(COLOR_RESET); }
         Value::Arr(a) => {
@@ -6982,7 +6965,7 @@ pub fn write_value_pretty_line(w: &mut dyn io::Write, v: &Value, indent: usize, 
 pub fn write_value_pretty_line_color(w: &mut dyn io::Write, v: &Value, indent: usize, use_tab: bool, sort_keys: bool, color: bool) -> io::Result<()> {
     if !color {
         match v {
-            Value::Null | Value::True | Value::False | Value::Num(..) | Value::Str(_) | Value::Error(_) => {
+            Value::Null | Value::True | Value::False | Value::Num(..) | Value::Str(_) => {
                 // Scalar values: pretty == compact
                 let mut buf = [0u8; 512];
                 if let Some(n) = write_compact_to_buf(v, &mut buf) {
@@ -7093,7 +7076,6 @@ fn push_compact_value_color(buf: &mut Vec<u8>, v: &Value) {
             }
             c!(p.obj.as_str()); buf.push(b'}'); c!(COLOR_RESET);
         }
-        Value::Error(e) => push_json_string_to_vec(buf, e.as_str()),
     }
 }
 
@@ -7130,7 +7112,6 @@ fn push_pretty_value_impl<const COLOR: bool>(buf: &mut Vec<u8>, v: &Value, depth
             c!(COLOR_RESET);
         }
         Value::Str(s) => { c!(p.string.as_str()); push_json_string_to_vec(buf, s.as_str()); c!(COLOR_RESET); }
-        Value::Error(e) => push_json_string_to_vec(buf, e.as_str()),
         Value::Arr(a) if a.is_empty() => { c!(p.arr.as_str()); buf.extend_from_slice(b"[]"); c!(COLOR_RESET); }
         Value::Obj(ObjInner(o)) if o.is_empty() => { c!(p.obj.as_str()); buf.extend_from_slice(b"{}"); c!(COLOR_RESET); }
         Value::Arr(a) => {
@@ -7256,9 +7237,6 @@ fn push_compact_value(buf: &mut Vec<u8>, v: &Value) {
                 push_compact_value(buf, val);
             }
             buf.push(b'}');
-        }
-        Value::Error(e) => {
-            push_json_string_to_vec(buf, e.as_str());
         }
     }
 }
@@ -7443,16 +7421,6 @@ fn write_compact_buf_inner(v: &Value, buf: &mut [u8], pos: &mut usize) -> bool {
             }
             push!(b"}");
         }
-        Value::Error(e) => {
-            let bytes = e.as_bytes();
-            if *pos + bytes.len() + 2 > buf.len() { return false; }
-            buf[*pos] = b'"';
-            *pos += 1;
-            buf[*pos..*pos + bytes.len()].copy_from_slice(bytes);
-            *pos += bytes.len();
-            buf[*pos] = b'"';
-            *pos += 1;
-        }
     }
     true
 }
@@ -7499,6 +7467,5 @@ fn write_value_compact_ext_inner(w: &mut dyn io::Write, v: &Value, sort_keys: bo
             }
             w.write_all(b"}")
         }
-        Value::Error(e) => write_json_string(w, e),
     }
 }

--- a/tests/cli_error_format.rs
+++ b/tests/cli_error_format.rs
@@ -1,0 +1,97 @@
+//! #1034: the CLI's uncaught-error report is built from the typed
+//! `ErrorValue` signal (no sentinel-string parsing). Pin jq 1.8.1's format:
+//! a string payload prints bare, any other payload gets the
+//! ` (not a string)` marker with its JSON form, and a plain message error
+//! prints its display text — identically across every execution backend.
+//!
+//! `regression.test` / `corpus.test` can't cover this: both harnesses
+//! compare stdout, while the error report goes to stderr. Shell out and
+//! inspect the raw stderr line instead.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+const KNOBS: [&[(&str, &str)]; 4] = [
+    &[],
+    &[("JQJIT_FORCE_INTERPRETER", "1")],
+    &[("JQJIT_FORCE_JITOP_INTERP", "1")],
+    &[("JQJIT_FORCE_CRANELIFT", "1")],
+];
+
+fn first_stderr_line(filter: &str, input: &str, envs: &[(&str, &str)]) -> String {
+    let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
+    let mut cmd = Command::new(jq_jit);
+    cmd.arg("-c").arg(filter);
+    for (k, v) in envs {
+        cmd.env(k, v);
+    }
+    let mut child = cmd
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn jq-jit");
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(input.as_bytes())
+        .unwrap();
+    let out = child.wait_with_output().expect("wait failed");
+    String::from_utf8_lossy(&out.stderr)
+        .lines()
+        .next()
+        .unwrap_or_default()
+        .to_string()
+}
+
+fn assert_all_backends(filter: &str, input: &str, expected: &str) {
+    for envs in KNOBS {
+        assert_eq!(
+            first_stderr_line(filter, input, envs),
+            expected,
+            "filter={filter:?} envs={envs:?}"
+        );
+    }
+}
+
+#[test]
+fn string_payload_prints_bare() {
+    assert_all_backends(
+        r#"error("boom")"#,
+        "1\n",
+        "jq: error (at <stdin>:1): boom",
+    );
+}
+
+#[test]
+fn non_string_payload_gets_marker_with_json() {
+    assert_all_backends(
+        r#"error({"a":1})"#,
+        "1\n",
+        r#"jq: error (at <stdin>:1) (not a string): {"a":1}"#,
+    );
+    assert_all_backends(
+        "error(null)",
+        "1\n",
+        "jq: error (at <stdin>:1) (not a string): null",
+    );
+}
+
+#[test]
+fn bare_error_rethrows_the_input() {
+    assert_all_backends(
+        "error",
+        "{\"x\":1}\n",
+        r#"jq: error (at <stdin>:1) (not a string): {"x":1}"#,
+    );
+}
+
+#[test]
+fn plain_message_error_prints_display_text() {
+    assert_all_backends(
+        r#"1 + "x""#,
+        "1\n",
+        r#"jq: error (at <stdin>:1): number (1) and string ("x") cannot be added"#,
+    );
+}


### PR DESCRIPTION
## Summary

Part of #1034 — the `Value::Error(Rc<String>)` audit. The audit's conclusion: the variant had exactly **one producer** left (`execute_collect`, the non-streaming JIT driver, wrapping its terminal error in legacy sentinel text) and zero reachable consumers — the streaming driver has carried typed anyhow errors since the JitError conversion (#1046), and eval never constructs error-as-value. So the variant retires entirely instead of being routed through `Raise`.

- `execute_collect` surfaces its terminal error as the typed anyhow signal via `JitError::into_anyhow`, aligning `Filter::execute`'s error contract with the eval engine.
- The `Value::Error` variant and all ~30 dead consumer arms are removed (serializers, type ordinals, hash/eq/debug, csv-tsv catch-alls that became unreachable, the TryCatch stream arm, stderr-print arms in eval/interpreter/bin).
- The CLI builds the uncaught-error report from the typed `ErrorValue` payload: strings print bare, other payloads get jq's `(not a string)` marker with their JSON — byte-identical to the previous prefix-parsed output. The dead `__halt__` string fallback and the JSON-literal decoder go with it.
- `JitError::legacy_string` is inlined into `into_catch_value`; halt/break catch values keep their historical sentinel-text shape (#1043 bug-compat) and are now the only sentinel *producers* left in jit.rs.

With this, **no `__jqerror__` / `__halt__` / `__break__` sentinel parsing remains anywhere in the codebase** outside signal.rs's internal defensive fallbacks — the headline acceptance criterion of #1034.

## Verification

- Zero-warning `cargo build --release`; full suite green (689), including the new `tests/cli_error_format.rs` shell-out test pinning the stderr report format (string / non-string / bare `error` / plain message) across all four execution modes
- 3-backend sweep clean (4 known env knob diffs); forced-mode bail count stays 0
- Spot parity vs system jq 1.8.1: uncaught `error(value)` formats (including the no-trailing-newline `<stdin>:0` case), `halt` / `halt_error` exit codes and stderr payloads, `try halt catch .` propagation
- No per-record semantics change — the serializer edits only delete unreachable match arms

🤖 Generated with [Claude Code](https://claude.com/claude-code)