### PR TITLE
refactor(runtime): fail loudly on non-value-dispatchable builtin placeholders

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -392,8 +392,11 @@ pub fn call_builtin_op(op: RtBuiltin, args: &[Value]) -> Result<Value> {
             Ok(v.clone())
         }),
         RtBuiltin::Input | RtBuiltin::Inputs => {
-            // These need special handling with the input source
-            Ok(Value::Null)
+            // Wired to the input source in the engines (Expr::ReadInput /
+            // Expr::ReadInputs); reaching the value dispatcher means a
+            // lowering routed them here by mistake. Fail loudly instead of
+            // yielding a silent null (#1034 placeholder audit).
+            bail!("{} is not value-dispatchable (input source required)", op.name())
         }
         RtBuiltin::Now => Ok(Value::number(std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -515,10 +518,13 @@ pub fn call_builtin_op(op: RtBuiltin, args: &[Value]) -> Result<Value> {
                 bail!("{} requires 3 arguments", op.name());
             }
         }
-        RtBuiltin::Limit => binary_arg(args, |_a, _b| {
-            // limit needs special handling as a generator
-            Ok(Value::Null)
-        }),
+        RtBuiltin::Limit => {
+            // A generator builtin: the engines lower `limit` structurally
+            // (Expr::Limit). Reaching the value dispatcher means a lowering
+            // routed it here by mistake — fail loudly instead of yielding a
+            // silent null (#1034 placeholder audit).
+            bail!("{} is not value-dispatchable (generator)", op.name())
+        }
         RtBuiltin::RangeBoundsGuard => {
             // JIT-only (#1084): the range loops run on unboxed f64 counters
             // that silently coerce non-numbers, so validate the bounds with
@@ -554,15 +560,20 @@ pub fn call_builtin_op(op: RtBuiltin, args: &[Value]) -> Result<Value> {
                     }
                 }
                 RtBuiltin::Delpaths => binary_arg(args, rt_delpaths),
-                _ => Ok(Value::Null),
+                // Generator builtins (first/last/nth/range/while/until/
+                // repeat/recurse) are lowered structurally by the engines;
+                // see the Limit arm (#1034 placeholder audit).
+                _ => bail!("{} is not value-dispatchable (generator)", op.name()),
             }
         }
-        RtBuiltin::SortBy | RtBuiltin::GroupBy | RtBuiltin::UniqueBy | RtBuiltin::MinBy | RtBuiltin::MaxBy => {
-            // Closure-based operations need special handling
-            Ok(args.first().cloned().unwrap_or(Value::Null))
-        }
-        RtBuiltin::Map | RtBuiltin::Select | RtBuiltin::MapValues | RtBuiltin::WithEntries => {
-            Ok(args.first().cloned().unwrap_or(Value::Null))
+        RtBuiltin::SortBy | RtBuiltin::GroupBy | RtBuiltin::UniqueBy | RtBuiltin::MinBy | RtBuiltin::MaxBy
+        | RtBuiltin::Map | RtBuiltin::Select | RtBuiltin::MapValues | RtBuiltin::WithEntries => {
+            // Closure-taking builtins run through their dedicated
+            // dispatchers (__sortby__-style closure ops / structural
+            // lowering). The old placeholder returned the input unchanged —
+            // a silent wrong answer if ever reached. Fail loudly (#1034
+            // placeholder audit).
+            bail!("{} is not value-dispatchable (closure argument)", op.name())
         }
         // flatten with depth already handled above
         RtBuiltin::Pow => ternary_arg(args, rt_pow),
@@ -997,6 +1008,9 @@ pub fn errdesc_pub(v: &Value) -> String { errdesc(v) }
 /// error (e.g. `1 + "a"`) returns `None` so the runtime error surfaces
 /// normally. Returns the folded value, or `None` when the expression is not a
 /// compile-time constant under jq's rules.
+///
+/// Audited for #1034: `None` is genuine absence ("not a constant"), not a
+/// swallowed error — fold-rejected expressions evaluate normally at runtime.
 pub fn const_fold(expr: &crate::ir::Expr) -> Option<Value> {
     use crate::ir::{BinOp, Expr, Literal};
     use std::cmp::Ordering;
@@ -4187,6 +4201,9 @@ fn time_arr_to_broken(a: &[Value]) -> Result<BrokenTime> {
 /// matching libc's `timegm` calendar walk: `mday=0` rolls back a day,
 /// `mon=12` rolls forward a year, and so on. Returns `None` if year/mon
 /// land outside chrono's representable range.
+///
+/// Audited for #1034: `None` is genuine absence (unrepresentable datetime),
+/// not a swallowed error — the caller attaches jq's canonical message.
 fn mktime_normalize(t: &BrokenTime) -> Option<chrono::NaiveDateTime> {
     use chrono::{Duration, NaiveDate};
     let mut year = t.year;
@@ -4500,6 +4517,9 @@ fn rt_strptime(v: &Value, fmt: &Value) -> Result<Value> {
 /// conflict. Returns `None` if any item fails to match, an out-of-range field
 /// is seen, or input is left over (trailing garbage) — all of which jq treats
 /// as an error.
+///
+/// Audited for #1034: every `None` cause maps to the single canonical
+/// "does not match format" error at the caller — nothing is swallowed.
 fn strptime_last_wins(s: &str, f: &str) -> Option<BrokenTime> {
     use chrono::format::{parse_and_remainder, Parsed, StrftimeItems};
     // Each item parses against the remaining input with its own `Parsed`, so a


### PR DESCRIPTION
## Summary

Final piece of #1034 — closes out the typed-signal series (Phase 1).

### Placeholder guards

The value dispatcher (`call_builtin_op`) kept placeholder arms for builtins the engines handle structurally:

| Arm | Old behavior if reached |
|---|---|
| `input` / `inputs` | silent `null` |
| `limit`, generator family (`first`/`last`/`nth`/`range`/`while`/`until`/`repeat`/`recurse`) | silent `null` |
| closure-taking family (`sort_by`/`group_by`/`unique_by`/`min_by`/`max_by`/`map`/`select`/`map_values`/`with_entries`) | input returned unchanged — a silent **wrong answer** |

The #1043 halt bug was exactly this dispatch class (an eval-only builtin misrouted to the runtime dispatcher). All placeholders now `bail!` with an explicit "not value-dispatchable" message, so a misrouted lowering surfaces immediately instead of corrupting output.

### Option-sentinel audit (issue's remaining bullet)

The issue flagged `const_fold` / `mktime_normalize` / `strptime_last_wins` (and the `Option<Value>` / `Ok(Value::Null)` class) for `Result` normalization. Audit conclusion, now recorded in their doc comments: each `None` is genuine absence ("not a constant" / unrepresentable datetime / format mismatch) with the caller attaching jq's canonical error message at a single point — nothing is swallowed, so `Option` is the right type and they stay. The remaining `Ok(Value::Null)` sites in the dispatcher are jq semantics (null propagation, `index` misses, string-repeat by negative counts), not failure sentinels.

### #1034 acceptance criteria status

- ✅ No `strip_prefix("__...")` sentinel parsing in eval/jit (PR #1114 removed the raise-side strings, PR #1115 the last consumers; only signal.rs's internal defensive fallbacks and the #1043 bug-compat halt/break catch *texts* remain, both documented)
- ✅ `error(value)` payloads ride as `Value` end to end — no JSON round-trip, NaN/Inf survive (`ErrorValue` + payload slot)
- ✅ `Value::Error(Rc<String>)` audited and retired entirely (PR #1115)
- ✅ Halt converts to anyhow once and is consumed typed at the binary boundary
- ✅ Zero warnings, full suite green

Closes #1034

## Verification

- Zero-warning `cargo build --release`; full suite green (689)
- 3-backend sweep clean (4 known env knob diffs); forced-mode bail count 0 — confirming the placeholder arms were unreachable across both corpora
- CLI spot checks of every guarded builtin family across all four execution modes against jq 1.8.1 (all byte-identical), plus `input`/`inputs` smoke tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)