### PR TITLE
test: key selfdiff KNOWN_DIVERGENCES by case content instead of line numbers

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -127,9 +127,12 @@ JIT_INTERP_DIFF_LIMIT=200 cargo test --release --test selfdiff_jit_interp -- --n
 新しい fast path を足した直後 / 既存の fast path を弄った直後はこれが落ちる
 ことがある。落ちたら基本的に「fast path 側が正しい」（差分テストで jq と
 照合済み）／「interpreter 側が drift してる」のどちらか。両側を直すか、
-どうしても今すぐ直せない invariant 違反は `KNOWN_DIVERGENCES` に line 番号と
-理由を書いて allowlist する。allowlist は audit trail なので、ケースを直したら
-必ずエントリも消す（ハーネスは「known なのに今 pass した」も検知して落ちる）。
+どうしても今すぐ直せない invariant 違反は `KNOWN_DIVERGENCES` に
+`(filter, input)` の content key と理由を書いて allowlist する（#1026 で
+line 番号 key から移行済み — regression.test はどこに挿入してもよい）。
+allowlist は audit trail なので、ケースを直したら必ずエントリも消す
+（ハーネスは「known なのに今 pass した」と「どのケースにもマッチしない
+エントリ」の両方を検知して落ちる）。
 
 ### JitOp backend self-diff（`tests/selfdiff_jitop_backend.rs` / #1059）
 

--- a/tests/selfdiff_jit_interp.rs
+++ b/tests/selfdiff_jit_interp.rs
@@ -147,7 +147,12 @@ fn normalize(output: &str) -> String {
 }
 
 /// Cases the harness flags but does not fail on. Each entry pins a specific
-/// regression-test line to the underlying-divergence note that explains it.
+/// case to the underlying-divergence note that explains it. Entries are
+/// keyed by `(filter, input)` content — not `tests/regression.test` line
+/// numbers — so the corpus can be edited anywhere without renumbering the
+/// allowlist (#1026). A content key matches every corpus case with that
+/// exact filter and input line (behaviour is deterministic per content, so
+/// duplicates share one verdict).
 /// New divergences are NOT silently allowed — they have to be added here with
 /// rationale, which is the point: the allowlist is the audit trail of "we
 /// know about this, here's why we haven't fixed it yet."
@@ -162,13 +167,26 @@ fn normalize(output: &str) -> String {
 ///   without also flipping `have_decnum` to `true` breaks the upstream
 ///   `tests/official/jq.test` decnum consistency check (#443). Tracked
 ///   in #415.
-const KNOWN_DIVERGENCES: &[usize] = &[2230, 2235, 2240, 2366, 2371];
+const KNOWN_DIVERGENCES: &[(&str, &str)] = &[
+    ("tojson", "1e1000"),
+    ("tojson", "[1.5e-10, 1e1000, 17.5]"),
+    ("tojson", r#"{"a": 1.5e-10, "b": 1e1000}"#),
+    ("tojson", "-1e1000"),
+];
+
+/// Index of the allowlist entry matching this case's content, if any.
+fn known_divergence_idx(case: &Case) -> Option<usize> {
+    KNOWN_DIVERGENCES
+        .iter()
+        .position(|&(f, i)| f == case.filter && i == case.input)
+}
 
 /// Per-case verdict, produced in parallel and folded sequentially so the
 /// counters and reporting stay identical to the original serial loop.
 enum Outcome {
-    /// Agreed (jit == interp). `Some(line)` if the case is on the allowlist
-    /// yet agreed anyway — counts as a pass *and* flags a stale entry.
+    /// Agreed (jit == interp). `Some(idx)` if the case matches allowlist
+    /// entry `idx` yet agreed anyway — counts as a pass *and* flags a stale
+    /// entry.
     Pass(Option<usize>),
     KnownDiverged,
     SpawnFail(String),
@@ -185,10 +203,27 @@ fn jit_vs_interpreter_self_diff() {
     let mut cases = parse_corpus(&content);
     assert!(!cases.is_empty(), "regression corpus is empty");
 
+    let mut limited = false;
     if let Ok(limit) = std::env::var("JIT_INTERP_DIFF_LIMIT") {
         if let Ok(n) = limit.parse::<usize>() {
             cases.truncate(n);
+            limited = true;
         }
+    }
+
+    // Every allowlist entry must match at least one corpus case, or it is
+    // dead weight (e.g. the case was rewritten without updating the entry).
+    // Skipped under JIT_INTERP_DIFF_LIMIT — truncation drops cases.
+    if !limited {
+        let dangling: Vec<&(&str, &str)> = KNOWN_DIVERGENCES
+            .iter()
+            .filter(|(f, i)| !cases.iter().any(|c| c.filter == *f && c.input == *i))
+            .collect();
+        assert!(
+            dangling.is_empty(),
+            "KNOWN_DIVERGENCES entries match no corpus case (filter, input): {:?}",
+            dangling
+        );
     }
 
     let mut pass = 0usize;
@@ -202,7 +237,7 @@ fn jit_vs_interpreter_self_diff() {
     // interpreter); no shared in-process state, so fan out across cores and
     // fold the verdicts back in input order.
     let outcomes = common::parallel::par_map(&cases, |case| {
-        let known = KNOWN_DIVERGENCES.contains(&case.line);
+        let known = known_divergence_idx(case);
         let jit = run_once(jq_jit, &case.filter, &case.input, false);
         let interp = run_once(jq_jit, &case.filter, &case.input, true);
 
@@ -214,10 +249,10 @@ fn jit_vs_interpreter_self_diff() {
         };
 
         if jit.is_error && interp.is_error {
-            return Outcome::Pass(known.then_some(case.line));
+            return Outcome::Pass(known);
         }
         if jit.is_error != interp.is_error {
-            if known {
+            if known.is_some() {
                 return Outcome::KnownDiverged;
             }
             return Outcome::Fail(format!(
@@ -230,8 +265,8 @@ fn jit_vs_interpreter_self_diff() {
         let jit_norm = normalize(&jit.stdout);
         let interp_norm = normalize(&interp.stdout);
         if jit_norm == interp_norm {
-            Outcome::Pass(known.then_some(case.line))
-        } else if known {
+            Outcome::Pass(known)
+        } else if known.is_some() {
             Outcome::KnownDiverged
         } else {
             Outcome::Fail(format!(
@@ -243,10 +278,10 @@ fn jit_vs_interpreter_self_diff() {
 
     for outcome in outcomes {
         match outcome {
-            Outcome::Pass(maybe_line) => {
+            Outcome::Pass(maybe_idx) => {
                 pass += 1;
-                if let Some(line) = maybe_line {
-                    unexpected_pass.push(line);
+                if let Some(idx) = maybe_idx {
+                    unexpected_pass.push(idx);
                 }
             }
             Outcome::KnownDiverged => known_diverged += 1,
@@ -287,9 +322,15 @@ fn jit_vs_interpreter_self_diff() {
 
     // If a previously-known-divergent case now agrees, the allowlist entry is
     // stale: shrinking the list is the goal, so flag it loudly.
+    unexpected_pass.sort_unstable();
+    unexpected_pass.dedup();
+    let stale: Vec<&(&str, &str)> = unexpected_pass
+        .iter()
+        .map(|&idx| &KNOWN_DIVERGENCES[idx])
+        .collect();
     assert!(
-        unexpected_pass.is_empty(),
-        "KNOWN_DIVERGENCES is stale — these line(s) now agree and should be removed: {:?}",
-        unexpected_pass
+        stale.is_empty(),
+        "KNOWN_DIVERGENCES is stale — these entries now agree and should be removed (filter, input): {:?}",
+        stale
     );
 }

--- a/tests/selfdiff_layers.rs
+++ b/tests/selfdiff_layers.rs
@@ -215,13 +215,30 @@ fn normalize(output: &str) -> String {
 /// (`tests/selfdiff_jit_interp.rs`). The 4-way harness inherits these so
 /// known upstream-tracked divergences do not double-fail. Keep in sync
 /// with `selfdiff_jit_interp.rs::KNOWN_DIVERGENCES`.
-const KNOWN_DIVERGENCES: &[usize] = &[2230, 2235, 2240, 2366, 2371];
+///
+/// Entries are keyed by `(filter, input)` content — not
+/// `tests/regression.test` line numbers — so the corpus can be edited
+/// anywhere without renumbering the allowlist (#1026).
+const KNOWN_DIVERGENCES: &[(&str, &str)] = &[
+    ("tojson", "1e1000"),
+    ("tojson", "[1.5e-10, 1e1000, 17.5]"),
+    ("tojson", r#"{"a": 1.5e-10, "b": 1e1000}"#),
+    ("tojson", "-1e1000"),
+];
+
+/// Index of the allowlist entry matching this case's content, if any.
+fn known_divergence_idx(case: &Case) -> Option<usize> {
+    KNOWN_DIVERGENCES
+        .iter()
+        .position(|&(f, i)| f == case.filter && i == case.input)
+}
 
 /// Per-case verdict, produced in parallel and folded sequentially so the
 /// counters and reporting stay identical to the original serial loop.
 enum Outcome {
-    /// Agreed across all configs. `Some(line)` if the case is on the allowlist
-    /// yet agreed anyway — counts as a pass *and* flags a stale entry.
+    /// Agreed across all configs. `Some(idx)` if the case matches allowlist
+    /// entry `idx` yet agreed anyway — counts as a pass *and* flags a stale
+    /// entry.
     Pass(Option<usize>),
     KnownDiverged,
     SpawnFail(String),
@@ -238,10 +255,27 @@ fn layer_pinned_self_diff() {
     let mut cases = parse_corpus(&content);
     assert!(!cases.is_empty(), "regression corpus is empty");
 
+    let mut limited = false;
     if let Ok(limit) = std::env::var("JIT_INTERP_DIFF_LIMIT") {
         if let Ok(n) = limit.parse::<usize>() {
             cases.truncate(n);
+            limited = true;
         }
+    }
+
+    // Every allowlist entry must match at least one corpus case, or it is
+    // dead weight (e.g. the case was rewritten without updating the entry).
+    // Skipped under JIT_INTERP_DIFF_LIMIT — truncation drops cases.
+    if !limited {
+        let dangling: Vec<&(&str, &str)> = KNOWN_DIVERGENCES
+            .iter()
+            .filter(|(f, i)| !cases.iter().any(|c| c.filter == *f && c.input == *i))
+            .collect();
+        assert!(
+            dangling.is_empty(),
+            "KNOWN_DIVERGENCES entries match no corpus case (filter, input): {:?}",
+            dangling
+        );
     }
 
     let mut pass = 0usize;
@@ -255,7 +289,7 @@ fn layer_pinned_self_diff() {
     // config); no shared in-process state, so fan out across cores and fold
     // the verdicts back in input order.
     let outcomes = common::parallel::par_map(&cases, |case| {
-        let known = KNOWN_DIVERGENCES.contains(&case.line);
+        let known = known_divergence_idx(case);
 
         // Run all four configs. Baseline is the oracle every other config
         // is compared against.
@@ -291,9 +325,9 @@ fn layer_pinned_self_diff() {
         }
 
         if disagreeing.is_empty() {
-            return Outcome::Pass(known.then_some(case.line));
+            return Outcome::Pass(known);
         }
-        if known {
+        if known.is_some() {
             return Outcome::KnownDiverged;
         }
 
@@ -331,10 +365,10 @@ fn layer_pinned_self_diff() {
 
     for outcome in outcomes {
         match outcome {
-            Outcome::Pass(maybe_line) => {
+            Outcome::Pass(maybe_idx) => {
                 pass += 1;
-                if let Some(line) = maybe_line {
-                    unexpected_pass.push(line);
+                if let Some(idx) = maybe_idx {
+                    unexpected_pass.push(idx);
                 }
             }
             Outcome::KnownDiverged => known_diverged += 1,
@@ -374,9 +408,15 @@ fn layer_pinned_self_diff() {
         cases.len(),
     );
 
+    unexpected_pass.sort_unstable();
+    unexpected_pass.dedup();
+    let stale: Vec<&(&str, &str)> = unexpected_pass
+        .iter()
+        .map(|&idx| &KNOWN_DIVERGENCES[idx])
+        .collect();
     assert!(
-        unexpected_pass.is_empty(),
-        "KNOWN_DIVERGENCES is stale — these line(s) now agree across all four configs and should be removed (also check `selfdiff_jit_interp.rs::KNOWN_DIVERGENCES`): {:?}",
-        unexpected_pass,
+        stale.is_empty(),
+        "KNOWN_DIVERGENCES is stale — these entries now agree across all four configs and should be removed (also check `selfdiff_jit_interp.rs::KNOWN_DIVERGENCES`, filter, input): {:?}",
+        stale,
     );
 }


### PR DESCRIPTION
## Summary

`tests/selfdiff_jit_interp.rs` and `tests/selfdiff_layers.rs` shared a `KNOWN_DIVERGENCES: &[usize]` allowlist of hardcoded `tests/regression.test` line numbers (2230, 2235, 2240, 2366, 2371). Mid-file insertion shifted every allowlisted line and broke both suites, forcing an append-only convention on the corpus and a synchronized two-file renumbering chore on rebases.

This PR keys the allowlist by `(filter, input)` content:

```rust
const KNOWN_DIVERGENCES: &[(&str, &str)] = &[
    ("tojson", "1e1000"),
    ("tojson", "[1.5e-10, 1e1000, 17.5]"),
    ("tojson", r#"{"a": 1.5e-10, "b": 1e1000}"#),
    ("tojson", "-1e1000"),
];
```

The five line numbers collapse to four content entries — two corpus cases share the same `tojson` / `1e1000` content; behavior is deterministic per content, so duplicates share one verdict.

## Detection logic preserved and strengthened

- **Stale entries** (the existing check): an allowlisted entry whose matching cases now agree fails the suite, reported by content instead of line number.
- **Dangling entries** (new): an entry that matches no corpus case at all fails the suite — catches a case being rewritten without updating the allowlist, which the line-number scheme could never detect. Skipped under `JIT_INTERP_DIFF_LIMIT` truncation.

Both failure modes verified locally by temporarily injecting a bogus entry (dangling fired) and an agreeing entry (stale fired).

## Benefit

The append-only constraint on `tests/regression.test` is gone — cases can be inserted, reordered, or rewritten anywhere without touching either selfdiff suite. `docs/maintenance.md` allowlist guidance updated.

## Verification

- `cargo build --release` — zero warnings
- `cargo test --release` — 689 passed, 0 failed (both selfdiff suites still report the four entries as KNOWN-DIV)

Closes #1026

🤖 Generated with [Claude Code](https://claude.com/claude-code)