### PR TITLE
release v1.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jq-jit"
-version = "1.9.0"
+version = "1.9.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jq-jit"
-version = "1.9.0"
+version = "1.9.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A JIT-compiling implementation of jq using Cranelift"

--- a/docs/benchmark-history.md
+++ b/docs/benchmark-history.md
@@ -6,268 +6,268 @@ Recent slice (last 5 columns). Full history lives in
 
 ```text
 --- NDJSON workloads (2M objects) ---
-  Benchmark                    v1.8.0  v1.8.1  v1.8.2  v1.8.3  v1.9.0
+  Benchmark                    v1.8.1  v1.8.2  v1.8.3  v1.9.0  v1.9.1
   ---                          ------  ------  ------  ------  ------
-  empty                        0.017s  0.017s  0.017s  0.017s  0.018s
-  identity -c                  0.084s  0.083s  0.085s  0.085s  0.088s
-  identity (pretty)            0.099s  0.103s  0.110s  0.106s  0.109s
-  field access .name           0.089s  0.103s  0.110s  0.114s  0.084s
-  nested .x,.y,.name           0.149s  0.171s  0.184s  0.200s  0.119s
-  arithmetic .x + .y           0.079s  0.083s  0.087s  0.084s  0.088s
-  select .x > 1500000          0.077s  0.082s  0.086s  0.081s  0.083s
-  string concat                0.088s  0.090s  0.096s  0.093s  0.092s
-  object construct             0.109s  0.124s  0.135s  0.137s  0.118s
-  array construct              0.100s  0.123s  0.135s  0.136s  0.108s
-  .[]                          0.098s  0.111s  0.117s  0.116s  0.120s
-  to_entries                   0.150s  0.169s  0.149s  0.148s  0.155s
-  keys                         0.098s  0.101s  0.104s  0.103s  0.107s
-  keys_unsorted                0.090s  0.094s  0.100s  0.099s  0.101s
-  length                       0.084s  0.086s  0.086s  0.084s  0.090s
-  has("x")                     0.035s  0.038s  0.037s  0.039s  0.040s
-  type                         0.021s  0.022s  0.020s  0.020s  0.021s
-  del(.name)                   0.098s  0.113s  0.115s  0.113s  0.117s
-  @csv                         0.119s  0.125s  0.119s  0.118s  0.123s
-  split/join                   0.086s  0.089s  0.089s  0.088s  0.090s
-  select|field                 0.093s  0.098s  0.100s  0.097s  0.097s
-  select|remap                 0.093s  0.097s  0.101s  0.102s  0.100s
-  computed remap               0.186s  0.206s  0.222s  0.224s  0.206s
-  [.x,.y]|add                  0.081s  0.082s  0.086s  0.084s  0.090s
-  [.x,.y]|avg                  0.105s  0.105s  0.111s  0.112s  0.112s
-  map(*2)|add                  0.099s  0.104s  0.106s  0.102s  0.108s
-  keys|length                  0.249s  0.252s  0.263s  0.253s  0.263s
-  .+{z=0}                      0.142s  0.147s  0.154s  0.150s  0.150s
-  split|first                  0.086s  0.087s  0.086s  0.086s  0.088s
-  slice[0..5]                  0.088s  0.091s  0.093s  0.091s  0.091s
-  dynkey {(.name)}             0.100s  0.114s  0.113s  0.117s  0.115s
-  .x += 1                      0.124s  0.127s  0.128s  0.128s  0.133s
-  {a}+{b} merge                0.128s  0.148s  0.161s  0.166s  0.132s
-  .x*2+1                       0.057s  0.059s  0.061s  0.062s  0.062s
-  .x+.y*2                      0.094s  0.095s  0.100s  0.100s  0.100s
-  .x > .y                      0.074s  0.078s  0.081s  0.078s  0.080s
-  to_entries|len               0.389s  0.393s  0.387s  0.387s  0.392s
-  .x|.+1 (pipe)                0.055s  0.057s  0.058s  0.058s  0.058s
-  .x|.*2|.+1                   0.056s  0.059s  0.061s  0.061s  0.062s
-  .name|.+"_x"                 0.088s  0.092s  0.095s  0.093s  0.093s
-  .x>N | not                   0.047s  0.050s  0.049s  0.051s  0.052s
-  and (2 cmp)                  0.078s  0.081s  0.084s  0.085s  0.085s
-  if-then-else                 0.049s  0.052s  0.053s  0.053s  0.054s
-  sel(and)|field               0.073s  0.077s  0.080s  0.079s  0.080s
-  sel(and)|remap               0.074s  0.078s  0.080s  0.080s  0.083s
-  arith|cmp                    0.051s  0.053s  0.055s  0.054s  0.057s
-  if cmp .field                0.108s  0.113s  0.119s  0.122s  0.115s
-  split|length                 0.085s  0.087s  0.089s  0.086s  0.090s
-  [x,y]|min                    0.087s  0.090s  0.095s  0.093s  0.098s
-  [x,y]|max                    0.090s  0.094s  0.100s  0.097s  0.099s
-  [x,y]|sort|.[0]              0.085s  0.089s  0.095s  0.093s  0.099s
-  .name|len>5                  0.088s  0.091s  0.087s  0.085s  0.088s
-  sel(len>5)|.x                0.105s  0.106s  0.110s  0.108s  0.112s
-  if .x>.y .name               0.088s  0.089s  0.092s  0.092s  0.094s
-  sel(.x>.y)|.name             0.067s  0.071s  0.075s  0.071s  0.076s
-  .x*2|tostring                0.053s  0.056s  0.059s  0.057s  0.057s
-  .x*.x+1                      0.063s  0.066s  0.068s  0.067s  0.067s
-  {k=.name,v=tostr}            0.138s  0.157s  0.167s  0.170s  0.144s
-  str add chain                0.372s  0.380s  0.396s  0.385s  0.403s
-  if>.y .name|empty            0.070s  0.073s  0.075s  0.074s  0.078s
-  if .x%2==0                   0.052s  0.054s  0.055s  0.054s  0.057s
-  if .x*2+1>1M                 0.052s  0.054s  0.056s  0.057s  0.057s
-  sel(.x%2==0)|.name           0.080s  0.084s  0.083s  0.084s  0.084s
-  sel(.x*2+1>1M)               0.151s  0.157s  0.156s  0.153s  0.161s
-  .x|@json                     0.046s  0.048s  0.051s  0.060s  0.061s
-  .x|@text                     0.045s  0.048s  0.050s  0.060s  0.062s
-  .name|@json                  0.099s  0.102s  0.107s  0.104s  0.105s
-  sel|[arr]                    0.140s  0.160s  0.172s  0.180s  0.184s
-  sel(and)|[arr]               0.076s  0.079s  0.081s  0.080s  0.084s
-  if>.y [arr]                  0.178s  0.198s  0.205s  0.217s  0.221s
-  if sw then .f                0.132s  0.139s  0.147s  0.142s  0.144s
-  dynkey {(.n)=.x*2}           0.111s  0.116s  0.118s  0.119s  0.117s
-  sel(and)|.x*.y               0.074s  0.079s  0.080s  0.079s  0.082s
-  sel>N|str chain              0.151s  0.153s  0.157s  0.166s  0.167s
-  .f+"_"+arith_ts              0.130s  0.133s  0.133s  0.137s  0.137s
-  sel(sw)|str ch               0.301s  0.303s  0.312s  0.309s  0.317s
-  split|rev|join               0.111s  0.112s  0.114s  0.116s  0.115s
-  dynkey+static                0.332s  0.339s  0.340s  0.351s  0.343s
-  if>.y str chain              0.167s  0.170s  0.171s  0.173s  0.171s
-  remap+str chain              0.145s  0.160s  0.162s  0.178s  0.165s
-  sel(len>8)                   0.154s  0.159s  0.161s  0.161s  0.163s
-  up|split|join                0.095s  0.096s  0.097s  0.096s  0.097s
-  .name|index                  0.114s  0.121s  0.120s  0.118s  0.119s
-  .name|index+1                0.117s  0.122s  0.126s  0.121s  0.128s
-  .name|rindex                 0.122s  0.124s  0.129s  0.129s  0.127s
-  .name|indices                0.145s  0.159s  0.150s  0.147s  0.151s
-  [x,y]|sort                   0.152s  0.168s  0.175s  0.178s  0.178s
-  .name|scan                   0.208s  0.206s  0.205s  0.204s  0.204s
-  .name|gsub                   0.162s  0.168s  0.167s  0.164s  0.168s
-  walk(if num .+1)             0.136s  0.137s  0.141s  0.142s  0.141s
-  tojson                       0.100s  0.107s  0.115s  0.117s  0.119s
-  {name,x}                     0.123s  0.150s  0.154s  0.166s  0.127s
-  .z//.name                    0.146s  0.164s  0.175s  0.174s  0.177s
-  .x|=test(re)                 0.165s  0.170s  0.172s  0.174s  0.173s
-  ./sep|first                  0.173s  0.179s  0.186s  0.180s  0.185s
-  .y=(.x*2)                    0.172s  0.176s  0.179s  0.179s  0.183s
-  .y=(.x+.y)                   0.224s  0.232s  0.235s  0.237s  0.234s
-  objects                      0.130s  0.125s  0.137s  0.146s  0.150s
-  .tag|=if..then N             0.590s  0.607s  0.635s  0.624s  0.613s
-  .x=(.x+1)                    0.123s  0.128s  0.131s  0.127s  0.133s
-  sel>N|.y+=1                  0.119s  0.122s  0.124s  0.125s  0.127s
-  sel(and)|.x+=1               0.106s  0.106s  0.108s  0.108s  0.109s
-  sel(sw)|.x+=1                0.156s  0.164s  0.169s  0.165s  0.169s
-  match(re)                    0.355s  0.363s  0.379s  0.372s  0.382s
-  capture(re)                  0.294s  0.299s  0.306s  0.303s  0.301s
-  first(.name,.x)              0.092s  0.106s  0.109s  0.116s  0.083s
-  if .x==null                  0.045s  0.047s  0.047s  0.048s  0.049s
-  we(sw(.key))                 0.104s  0.109s  0.118s  0.117s  0.118s
-  sel(sw or ew)                0.198s  0.206s  0.205s  0.199s  0.208s
-  path(.name,.x)               0.264s  0.273s  0.320s  0.300s  0.308s
-  sel(str+num+num)             0.145s  0.150s  0.151s  0.154s  0.155s
-  nested if|field              0.074s  0.078s  0.083s  0.079s  0.084s
-  .f|floor|.*2                 0.058s  0.062s  0.062s  0.062s  0.062s
-  split|len>1                  0.110s  0.117s  0.114s  0.110s  0.110s
-  .name|len|.*2                0.097s  0.101s  0.102s  0.102s  0.104s
-  if len>5 .x .y               0.110s  0.112s  0.115s  0.114s  0.114s
-  sel(len>5)|remap             0.198s  0.199s  0.209s  0.203s  0.204s
-  .x|tostr|len                 0.057s  0.060s  0.061s  0.059s  0.061s
-  if .x>.y .x .y               0.091s  0.093s  0.099s  0.096s  0.097s
-  split|last|tonum             0.092s  0.097s  0.095s  0.094s  0.096s
-  split|rev|.[0]               0.089s  0.092s  0.091s  0.091s  0.094s
-  split|.[0]+.[1]              0.109s  0.112s  0.114s  0.111s  0.112s
-  .[]|strings                  0.106s  0.108s  0.108s  0.105s  0.110s
-  .[]|numbers                  0.125s  0.126s  0.125s  0.124s  0.127s
-  [x,y]|any(>1M)               0.079s  0.082s  0.086s  0.084s  0.087s
-  sel(dc|sw)                   0.094s  0.099s  0.098s  0.095s  0.095s
-  [[x,y],[n]]|flat             0.450s  0.459s  0.520s  0.488s  0.460s
-  .x|floor|.*2                 0.059s  0.062s  0.060s  0.062s  0.064s
-  tojson|fromjson              0.080s  0.086s  0.086s  0.084s  0.085s
-  [.x]|add                     0.057s  0.064s  0.066s  0.071s  0.048s
-  if>N {o}+.                   0.127s  0.137s  0.135s  0.137s  0.137s
-  if>N .+{o}                   0.131s  0.132s  0.134s  0.133s  0.132s
-  if .n=="s" .+{o}             0.154s  0.162s  0.162s  0.159s  0.160s
-  sel(.n>"s")                  0.085s  0.088s  0.092s  0.088s  0.089s
-  [x,y,z]|min                  0.305s  0.313s  0.311s  0.313s  0.315s
-  if .n|len>5 l s              0.095s  0.100s  0.101s  0.101s  0.101s
-  if .x|flr>N b s              0.053s  0.055s  0.055s  0.056s  0.056s
-  if .n|test l e               0.102s  0.109s  0.103s  0.104s  0.105s
-  if .n|sw l e                 0.080s  0.085s  0.086s  0.083s  0.086s
-  if .n|ew l e                 0.080s  0.084s  0.083s  0.084s  0.086s
-  .n|len|tostr                 0.085s  0.090s  0.089s  0.089s  0.092s
+  empty                        0.017s  0.017s  0.017s  0.018s  0.018s
+  identity -c                  0.083s  0.085s  0.085s  0.088s  0.085s
+  identity (pretty)            0.103s  0.110s  0.106s  0.109s  0.112s
+  field access .name           0.103s  0.110s  0.114s  0.084s  0.081s
+  nested .x,.y,.name           0.171s  0.184s  0.200s  0.119s  0.123s
+  arithmetic .x + .y           0.083s  0.087s  0.084s  0.088s  0.090s
+  select .x > 1500000          0.082s  0.086s  0.081s  0.083s  0.083s
+  string concat                0.090s  0.096s  0.093s  0.092s  0.094s
+  object construct             0.124s  0.135s  0.137s  0.118s  0.120s
+  array construct              0.123s  0.135s  0.136s  0.108s  0.105s
+  .[]                          0.111s  0.117s  0.116s  0.120s  0.120s
+  to_entries                   0.169s  0.149s  0.148s  0.155s  0.151s
+  keys                         0.101s  0.104s  0.103s  0.107s  0.104s
+  keys_unsorted                0.094s  0.100s  0.099s  0.101s  0.102s
+  length                       0.086s  0.086s  0.084s  0.090s  0.087s
+  has("x")                     0.038s  0.037s  0.039s  0.040s  0.039s
+  type                         0.022s  0.020s  0.020s  0.021s  0.020s
+  del(.name)                   0.113s  0.115s  0.113s  0.117s  0.115s
+  @csv                         0.125s  0.119s  0.118s  0.123s  0.117s
+  split/join                   0.089s  0.089s  0.088s  0.090s  0.088s
+  select|field                 0.098s  0.100s  0.097s  0.097s  0.098s
+  select|remap                 0.097s  0.101s  0.102s  0.100s  0.101s
+  computed remap               0.206s  0.222s  0.224s  0.206s  0.205s
+  [.x,.y]|add                  0.082s  0.086s  0.084s  0.090s  0.091s
+  [.x,.y]|avg                  0.105s  0.111s  0.112s  0.112s  0.114s
+  map(*2)|add                  0.104s  0.106s  0.102s  0.108s  0.108s
+  keys|length                  0.252s  0.263s  0.253s  0.263s  0.260s
+  .+{z=0}                      0.147s  0.154s  0.150s  0.150s  0.152s
+  split|first                  0.087s  0.086s  0.086s  0.088s  0.090s
+  slice[0..5]                  0.091s  0.093s  0.091s  0.091s  0.093s
+  dynkey {(.name)}             0.114s  0.113s  0.117s  0.115s  0.115s
+  .x += 1                      0.127s  0.128s  0.128s  0.133s  0.135s
+  {a}+{b} merge                0.148s  0.161s  0.166s  0.132s  0.131s
+  .x*2+1                       0.059s  0.061s  0.062s  0.062s  0.062s
+  .x+.y*2                      0.095s  0.100s  0.100s  0.100s  0.101s
+  .x > .y                      0.078s  0.081s  0.078s  0.080s  0.082s
+  to_entries|len               0.393s  0.387s  0.387s  0.392s  0.388s
+  .x|.+1 (pipe)                0.057s  0.058s  0.058s  0.058s  0.058s
+  .x|.*2|.+1                   0.059s  0.061s  0.061s  0.062s  0.062s
+  .name|.+"_x"                 0.092s  0.095s  0.093s  0.093s  0.095s
+  .x>N | not                   0.050s  0.049s  0.051s  0.052s  0.051s
+  and (2 cmp)                  0.081s  0.084s  0.085s  0.085s  0.087s
+  if-then-else                 0.052s  0.053s  0.053s  0.054s  0.053s
+  sel(and)|field               0.077s  0.080s  0.079s  0.080s  0.083s
+  sel(and)|remap               0.078s  0.080s  0.080s  0.083s  0.085s
+  arith|cmp                    0.053s  0.055s  0.054s  0.057s  0.055s
+  if cmp .field                0.113s  0.119s  0.122s  0.115s  0.116s
+  split|length                 0.087s  0.089s  0.086s  0.090s  0.087s
+  [x,y]|min                    0.090s  0.095s  0.093s  0.098s  0.098s
+  [x,y]|max                    0.094s  0.100s  0.097s  0.099s  0.102s
+  [x,y]|sort|.[0]              0.089s  0.095s  0.093s  0.099s  0.097s
+  .name|len>5                  0.091s  0.087s  0.085s  0.088s  0.087s
+  sel(len>5)|.x                0.106s  0.110s  0.108s  0.112s  0.109s
+  if .x>.y .name               0.089s  0.092s  0.092s  0.094s  0.098s
+  sel(.x>.y)|.name             0.071s  0.075s  0.071s  0.076s  0.076s
+  .x*2|tostring                0.056s  0.059s  0.057s  0.057s  0.060s
+  .x*.x+1                      0.066s  0.068s  0.067s  0.067s  0.068s
+  {k=.name,v=tostr}            0.157s  0.167s  0.170s  0.144s  0.143s
+  str add chain                0.380s  0.396s  0.385s  0.403s  0.396s
+  if>.y .name|empty            0.073s  0.075s  0.074s  0.078s  0.078s
+  if .x%2==0                   0.054s  0.055s  0.054s  0.057s  0.055s
+  if .x*2+1>1M                 0.054s  0.056s  0.057s  0.057s  0.057s
+  sel(.x%2==0)|.name           0.084s  0.083s  0.084s  0.084s  0.086s
+  sel(.x*2+1>1M)               0.157s  0.156s  0.153s  0.161s  0.160s
+  .x|@json                     0.048s  0.051s  0.060s  0.061s  0.062s
+  .x|@text                     0.048s  0.050s  0.060s  0.062s  0.059s
+  .name|@json                  0.102s  0.107s  0.104s  0.105s  0.100s
+  sel|[arr]                    0.160s  0.172s  0.180s  0.184s  0.173s
+  sel(and)|[arr]               0.079s  0.081s  0.080s  0.084s  0.080s
+  if>.y [arr]                  0.198s  0.205s  0.217s  0.221s  0.216s
+  if sw then .f                0.139s  0.147s  0.142s  0.144s  0.141s
+  dynkey {(.n)=.x*2}           0.116s  0.118s  0.119s  0.117s  0.113s
+  sel(and)|.x*.y               0.079s  0.080s  0.079s  0.082s  0.084s
+  sel>N|str chain              0.153s  0.157s  0.166s  0.167s  0.161s
+  .f+"_"+arith_ts              0.133s  0.133s  0.137s  0.137s  0.135s
+  sel(sw)|str ch               0.303s  0.312s  0.309s  0.317s  0.309s
+  split|rev|join               0.112s  0.114s  0.116s  0.115s  0.117s
+  dynkey+static                0.339s  0.340s  0.351s  0.343s  0.348s
+  if>.y str chain              0.170s  0.171s  0.173s  0.171s  0.173s
+  remap+str chain              0.160s  0.162s  0.178s  0.165s  0.167s
+  sel(len>8)                   0.159s  0.161s  0.161s  0.163s  0.159s
+  up|split|join                0.096s  0.097s  0.096s  0.097s  0.097s
+  .name|index                  0.121s  0.120s  0.118s  0.119s  0.121s
+  .name|index+1                0.122s  0.126s  0.121s  0.128s  0.127s
+  .name|rindex                 0.124s  0.129s  0.129s  0.127s  0.128s
+  .name|indices                0.159s  0.150s  0.147s  0.151s  0.148s
+  [x,y]|sort                   0.168s  0.175s  0.178s  0.178s  0.179s
+  .name|scan                   0.206s  0.205s  0.204s  0.204s  0.203s
+  .name|gsub                   0.168s  0.167s  0.164s  0.168s  0.166s
+  walk(if num .+1)             0.137s  0.141s  0.142s  0.141s  0.142s
+  tojson                       0.107s  0.115s  0.117s  0.119s  0.118s
+  {name,x}                     0.150s  0.154s  0.166s  0.127s  0.135s
+  .z//.name                    0.164s  0.175s  0.174s  0.177s  0.175s
+  .x|=test(re)                 0.170s  0.172s  0.174s  0.173s  0.171s
+  ./sep|first                  0.179s  0.186s  0.180s  0.185s  0.189s
+  .y=(.x*2)                    0.176s  0.179s  0.179s  0.183s  0.180s
+  .y=(.x+.y)                   0.232s  0.235s  0.237s  0.234s  0.235s
+  objects                      0.125s  0.137s  0.146s  0.150s  0.145s
+  .tag|=if..then N             0.607s  0.635s  0.624s  0.613s  0.615s
+  .x=(.x+1)                    0.128s  0.131s  0.127s  0.133s  0.131s
+  sel>N|.y+=1                  0.122s  0.124s  0.125s  0.127s  0.127s
+  sel(and)|.x+=1               0.106s  0.108s  0.108s  0.109s  0.107s
+  sel(sw)|.x+=1                0.164s  0.169s  0.165s  0.169s  0.165s
+  match(re)                    0.363s  0.379s  0.372s  0.382s  0.369s
+  capture(re)                  0.299s  0.306s  0.303s  0.301s  0.294s
+  first(.name,.x)              0.106s  0.109s  0.116s  0.083s  0.082s
+  if .x==null                  0.047s  0.047s  0.048s  0.049s  0.050s
+  we(sw(.key))                 0.109s  0.118s  0.117s  0.118s  0.120s
+  sel(sw or ew)                0.206s  0.205s  0.199s  0.208s  0.203s
+  path(.name,.x)               0.273s  0.320s  0.300s  0.308s  0.311s
+  sel(str+num+num)             0.150s  0.151s  0.154s  0.155s  0.154s
+  nested if|field              0.078s  0.083s  0.079s  0.084s  0.083s
+  .f|floor|.*2                 0.062s  0.062s  0.062s  0.062s  0.063s
+  split|len>1                  0.117s  0.114s  0.110s  0.110s  0.111s
+  .name|len|.*2                0.101s  0.102s  0.102s  0.104s  0.100s
+  if len>5 .x .y               0.112s  0.115s  0.114s  0.114s  0.113s
+  sel(len>5)|remap             0.199s  0.209s  0.203s  0.204s  0.205s
+  .x|tostr|len                 0.060s  0.061s  0.059s  0.061s  0.061s
+  if .x>.y .x .y               0.093s  0.099s  0.096s  0.097s  0.104s
+  split|last|tonum             0.097s  0.095s  0.094s  0.096s  0.095s
+  split|rev|.[0]               0.092s  0.091s  0.091s  0.094s  0.089s
+  split|.[0]+.[1]              0.112s  0.114s  0.111s  0.112s  0.113s
+  .[]|strings                  0.108s  0.108s  0.105s  0.110s  0.103s
+  .[]|numbers                  0.126s  0.125s  0.124s  0.127s  0.125s
+  [x,y]|any(>1M)               0.082s  0.086s  0.084s  0.087s  0.088s
+  sel(dc|sw)                   0.099s  0.098s  0.095s  0.095s  0.097s
+  [[x,y],[n]]|flat             0.459s  0.520s  0.488s  0.460s  0.460s
+  .x|floor|.*2                 0.062s  0.060s  0.062s  0.064s  0.063s
+  tojson|fromjson              0.086s  0.086s  0.084s  0.085s  0.087s
+  [.x]|add                     0.064s  0.066s  0.071s  0.048s  0.049s
+  if>N {o}+.                   0.137s  0.135s  0.137s  0.137s  0.136s
+  if>N .+{o}                   0.132s  0.134s  0.133s  0.132s  0.137s
+  if .n=="s" .+{o}             0.162s  0.162s  0.159s  0.160s  0.158s
+  sel(.n>"s")                  0.088s  0.092s  0.088s  0.089s  0.087s
+  [x,y,z]|min                  0.313s  0.311s  0.313s  0.315s  0.318s
+  if .n|len>5 l s              0.100s  0.101s  0.101s  0.101s  0.100s
+  if .x|flr>N b s              0.055s  0.055s  0.056s  0.056s  0.056s
+  if .n|test l e               0.109s  0.103s  0.104s  0.105s  0.106s
+  if .n|sw l e                 0.085s  0.086s  0.083s  0.086s  0.086s
+  if .n|ew l e                 0.084s  0.083s  0.084s  0.086s  0.084s
+  .n|len|tostr                 0.090s  0.089s  0.089s  0.092s  0.091s
 
 --- String operations (2M objects) ---
-  Benchmark                    v1.8.0  v1.8.1  v1.8.2  v1.8.3  v1.9.0
+  Benchmark                    v1.8.1  v1.8.2  v1.8.3  v1.9.0  v1.9.1
   ---                          ------  ------  ------  ------  ------
-  ascii_downcase               0.100s  0.104s  0.095s  0.092s  0.095s
-  ascii_upcase                 0.099s  0.101s  0.094s  0.094s  0.094s
-  ltrimstr                     0.093s  0.096s  0.097s  0.095s  0.095s
-  rtrimstr                     0.095s  0.099s  0.095s  0.097s  0.094s
-  split                        0.156s  0.166s  0.158s  0.157s  0.159s
-  case+split                   0.113s  0.117s  0.116s  0.116s  0.114s
-  join                         0.091s  0.092s  0.094s  0.096s  0.092s
-  startswith                   0.090s  0.096s  0.090s  0.090s  0.090s
-  endswith                     0.091s  0.096s  0.090s  0.088s  0.093s
-  tostring                     0.060s  0.073s  0.068s  0.064s  0.065s
-  tonumber                     0.108s  0.108s  0.110s  0.108s  0.113s
-  string interpolation         0.114s  0.120s  0.115s  0.127s  0.126s
+  ascii_downcase               0.104s  0.095s  0.092s  0.095s  0.094s
+  ascii_upcase                 0.101s  0.094s  0.094s  0.094s  0.096s
+  ltrimstr                     0.096s  0.097s  0.095s  0.095s  0.098s
+  rtrimstr                     0.099s  0.095s  0.097s  0.094s  0.098s
+  split                        0.166s  0.158s  0.157s  0.159s  0.162s
+  case+split                   0.117s  0.116s  0.116s  0.114s  0.117s
+  join                         0.092s  0.094s  0.096s  0.092s  0.097s
+  startswith                   0.096s  0.090s  0.090s  0.090s  0.091s
+  endswith                     0.096s  0.090s  0.088s  0.093s  0.091s
+  tostring                     0.073s  0.068s  0.064s  0.065s  0.066s
+  tonumber                     0.108s  0.110s  0.108s  0.113s  0.111s
+  string interpolation         0.120s  0.115s  0.127s  0.126s  0.124s
 
 --- String ops (200K objects) ---
-  Benchmark                    v1.8.0  v1.8.1  v1.8.2  v1.8.3  v1.9.0
+  Benchmark                    v1.8.1  v1.8.2  v1.8.3  v1.9.0  v1.9.1
   ---                          ------  ------  ------  ------  ------
-  test (regex)                 0.014s  0.014s  0.015s  0.014s  0.015s
-  match (regex)                0.033s  0.032s  0.033s  0.033s  0.033s
-  @base64                      0.011s  0.012s  0.012s  0.011s  0.012s
-  @uri                         0.011s  0.012s  0.013s  0.011s  0.013s
-  @html                        0.011s  0.012s  0.013s  0.012s  0.013s
-  @csv (array)                 0.015s  0.016s  0.015s  0.016s  0.016s
-  @tsv (array)                 0.014s  0.015s  0.015s  0.015s  0.016s
-  gsub                         0.018s  0.019s  0.018s  0.018s  0.019s
-  case+gsub                    0.177s  0.182s  0.179s  0.181s  0.178s
-  case+test                    0.114s  0.122s  0.117s  0.118s  0.119s
-  ltrim+tonum+arith            0.107s  0.111s  0.110s  0.110s  0.116s
+  test (regex)                 0.014s  0.015s  0.014s  0.015s  0.015s
+  match (regex)                0.032s  0.033s  0.033s  0.033s  0.033s
+  @base64                      0.012s  0.012s  0.011s  0.012s  0.012s
+  @uri                         0.012s  0.013s  0.011s  0.013s  0.012s
+  @html                        0.012s  0.013s  0.012s  0.013s  0.012s
+  @csv (array)                 0.016s  0.015s  0.016s  0.016s  0.016s
+  @tsv (array)                 0.015s  0.015s  0.015s  0.016s  0.017s
+  gsub                         0.019s  0.018s  0.018s  0.019s  0.019s
+  case+gsub                    0.182s  0.179s  0.181s  0.178s  0.181s
+  case+test                    0.122s  0.117s  0.118s  0.119s  0.117s
+  ltrim+tonum+arith            0.111s  0.110s  0.110s  0.116s  0.112s
 
 --- Numeric & math (2M objects) ---
-  Benchmark                    v1.8.0  v1.8.1  v1.8.2  v1.8.3  v1.9.0
+  Benchmark                    v1.8.1  v1.8.2  v1.8.3  v1.9.0  v1.9.1
   ---                          ------  ------  ------  ------  ------
-  floor                        0.054s  0.057s  0.056s  0.058s  0.058s
-  sqrt                         0.077s  0.080s  0.081s  0.079s  0.081s
-  modulo                       0.055s  0.059s  0.058s  0.059s  0.059s
-  if-elif-else                 0.123s  0.126s  0.130s  0.131s  0.127s
-  select|del                   0.087s  0.097s  0.097s  0.096s  0.100s
-  select|merge                 0.114s  0.119s  0.123s  0.121s  0.121s
-  select(test)|merge           0.020s  0.022s  0.021s  0.021s  0.023s
+  floor                        0.057s  0.056s  0.058s  0.058s  0.060s
+  sqrt                         0.080s  0.081s  0.079s  0.081s  0.080s
+  modulo                       0.059s  0.058s  0.059s  0.059s  0.060s
+  if-elif-else                 0.126s  0.130s  0.131s  0.127s  0.127s
+  select|del                   0.097s  0.097s  0.096s  0.100s  0.099s
+  select|merge                 0.119s  0.123s  0.121s  0.121s  0.121s
+  select(test)|merge           0.022s  0.021s  0.021s  0.023s  0.022s
 
 --- Array generators ---
-  Benchmark                    v1.8.0  v1.8.1  v1.8.2  v1.8.3  v1.9.0
+  Benchmark                    v1.8.1  v1.8.2  v1.8.3  v1.9.0  v1.9.1
   ---                          ------  ------  ------  ------  ------
-  range(2M) | length           0.011s  0.012s  0.012s  0.011s  0.009s
-  reverse(2M)                  0.017s  0.018s  0.018s  0.018s  0.016s
-  sort(2M)                     0.022s  0.024s  0.023s  0.024s  0.025s
-  unique(1M)                   0.029s  0.031s  0.033s  0.033s  0.034s
-  flatten(500K)                0.010s  0.011s  0.011s  0.010s  0.010s
-  min, max(2M)                 0.017s  0.020s  0.021s  0.020s  0.016s
-  add numbers(2M)              0.012s  0.013s  0.013s  0.013s  0.011s
-  any/all(2M)                  0.028s  0.028s  0.029s  0.028s  0.031s
-  limit(10; range(10M))        0.002s  0.002s  0.002s  0.002s  0.003s
-  first(range(10M))            0.002s  0.002s  0.002s  0.002s  0.003s
-  last(range(2M))              0.002s  0.002s  0.002s  0.002s  0.003s
-  indices(1M)                  0.016s  0.016s  0.017s  0.017s  0.018s
+  range(2M) | length           0.012s  0.012s  0.011s  0.009s  0.009s
+  reverse(2M)                  0.018s  0.018s  0.018s  0.016s  0.016s
+  sort(2M)                     0.024s  0.023s  0.024s  0.025s  0.026s
+  unique(1M)                   0.031s  0.033s  0.033s  0.034s  0.034s
+  flatten(500K)                0.011s  0.011s  0.010s  0.010s  0.010s
+  min, max(2M)                 0.020s  0.021s  0.020s  0.016s  0.017s
+  add numbers(2M)              0.013s  0.013s  0.013s  0.011s  0.011s
+  any/all(2M)                  0.028s  0.029s  0.028s  0.031s  0.032s
+  limit(10; range(10M))        0.002s  0.002s  0.002s  0.003s  0.003s
+  first(range(10M))            0.002s  0.002s  0.002s  0.003s  0.002s
+  last(range(2M))              0.002s  0.002s  0.002s  0.003s  0.002s
+  indices(1M)                  0.016s  0.017s  0.017s  0.018s  0.017s
 
 --- Reduce & foreach ---
-  Benchmark                    v1.8.0  v1.8.1  v1.8.2  v1.8.3  v1.9.0
+  Benchmark                    v1.8.1  v1.8.2  v1.8.3  v1.9.0  v1.9.1
   ---                          ------  ------  ------  ------  ------
-  reduce (sum)                 0.009s  0.009s  0.009s  0.009s  0.010s
-  reduce (array build)         0.004s  0.004s  0.004s  0.004s  0.005s
-  reduce (obj build)           0.009s  0.010s  0.009s  0.010s  0.010s
-  reduce (setpath)             0.016s  0.017s  0.016s  0.016s  0.018s
-  foreach (running sum)        0.009s  0.010s  0.010s  0.010s  0.011s
-  foreach + emit               0.010s  0.010s  0.010s  0.010s  0.011s
-  reduce (sum-of-squares)      0.032s  0.033s  0.033s  0.033s  0.036s
-  reduce (conditional)         0.033s  0.035s  0.036s  0.035s  0.037s
-  reduce (product)             0.035s  0.034s  0.035s  0.034s  0.036s
-  foreach (conditional)        0.010s  0.010s  0.011s  0.010s  0.011s
-  until (100M)                 0.301s  0.301s  0.308s  0.312s  0.322s
-  reduce (harmonic)            0.032s  0.032s  0.033s  0.035s  0.036s
-  reduce (floor pipe)          0.032s  0.033s  0.033s  0.033s  0.035s
-  reduce (sqrt pipe)           0.032s  0.033s  0.033s  0.034s  0.035s
-  reduce (sin+cos)             0.051s  0.052s  0.052s  0.052s  0.053s
+  reduce (sum)                 0.009s  0.009s  0.009s  0.010s  0.010s
+  reduce (array build)         0.004s  0.004s  0.004s  0.005s  0.005s
+  reduce (obj build)           0.010s  0.009s  0.010s  0.010s  0.010s
+  reduce (setpath)             0.017s  0.016s  0.016s  0.018s  0.017s
+  foreach (running sum)        0.010s  0.010s  0.010s  0.011s  0.011s
+  foreach + emit               0.010s  0.010s  0.010s  0.011s  0.011s
+  reduce (sum-of-squares)      0.033s  0.033s  0.033s  0.036s  0.034s
+  reduce (conditional)         0.035s  0.036s  0.035s  0.037s  0.037s
+  reduce (product)             0.034s  0.035s  0.034s  0.036s  0.035s
+  foreach (conditional)        0.010s  0.011s  0.010s  0.011s  0.011s
+  until (100M)                 0.301s  0.308s  0.312s  0.322s  0.325s
+  reduce (harmonic)            0.032s  0.033s  0.035s  0.036s  0.035s
+  reduce (floor pipe)          0.033s  0.033s  0.033s  0.035s  0.034s
+  reduce (sqrt pipe)           0.033s  0.033s  0.034s  0.035s  0.035s
+  reduce (sin+cos)             0.052s  0.052s  0.052s  0.053s  0.053s
 
 --- Object operations ---
-  Benchmark                    v1.8.0  v1.8.1  v1.8.2  v1.8.3  v1.9.0
+  Benchmark                    v1.8.1  v1.8.2  v1.8.3  v1.9.0  v1.9.1
   ---                          ------  ------  ------  ------  ------
   large obj construct          0.004s  0.004s  0.004s  0.004s  0.004s
   large obj keys               0.011s  0.011s  0.011s  0.011s  0.011s
   large obj to_entries         0.012s  0.012s  0.012s  0.012s  0.012s
-  with_entries                 0.008s  0.009s  0.009s  0.009s  0.009s
+  with_entries                 0.009s  0.009s  0.009s  0.009s  0.010s
 
 --- Assignment operators ---
-  Benchmark                    v1.8.0  v1.8.1  v1.8.2  v1.8.3  v1.9.0
+  Benchmark                    v1.8.1  v1.8.2  v1.8.3  v1.9.0  v1.9.1
   ---                          ------  ------  ------  ------  ------
-  .[] |= f (100K)              0.005s  0.005s  0.005s  0.005s  0.005s
-  .[] += 1 (100K)              0.005s  0.005s  0.005s  0.005s  0.006s
-  .[k] = v reduce(50K)         0.008s  0.008s  0.008s  0.008s  0.009s
-  p126-shape nested reduce     0.103s  0.110s  0.120s  0.121s  0.118s
-  p126-shape w/ mutate         0.105s  0.112s  0.129s  0.124s  0.124s
-  p150-shape serial mutate     0.010s  0.012s  0.011s  0.012s  0.013s
+  .[] |= f (100K)              0.005s  0.005s  0.005s  0.005s  0.006s
+  .[] += 1 (100K)              0.005s  0.005s  0.005s  0.006s  0.006s
+  .[k] = v reduce(50K)         0.008s  0.008s  0.008s  0.009s  0.009s
+  p126-shape nested reduce     0.110s  0.120s  0.121s  0.118s  0.120s
+  p126-shape w/ mutate         0.112s  0.129s  0.124s  0.124s  0.120s
+  p150-shape serial mutate     0.012s  0.011s  0.012s  0.013s  0.012s
 
 --- String-heavy generators ---
-  Benchmark                    v1.8.0  v1.8.1  v1.8.2  v1.8.3  v1.9.0
+  Benchmark                    v1.8.1  v1.8.2  v1.8.3  v1.9.0  v1.9.1
   ---                          ------  ------  ------  ------  ------
-  gsub(100K)                   0.026s  0.027s  0.029s  0.028s  0.029s
-  join large(100K)             0.005s  0.006s  0.006s  0.006s  0.006s
-  explode/implode(100K)        0.027s  0.028s  0.028s  0.027s  0.029s
-  reduce str concat(100K)      0.007s  0.008s  0.008s  0.008s  0.008s
+  gsub(100K)                   0.027s  0.029s  0.028s  0.029s  0.029s
+  join large(100K)             0.006s  0.006s  0.006s  0.006s  0.006s
+  explode/implode(100K)        0.028s  0.028s  0.027s  0.029s  0.028s
+  reduce str concat(100K)      0.008s  0.008s  0.008s  0.008s  0.008s
 
 --- Try-catch & alternative ---
-  Benchmark                    v1.8.0  v1.8.1  v1.8.2  v1.8.3  v1.9.0
+  Benchmark                    v1.8.1  v1.8.2  v1.8.3  v1.9.0  v1.9.1
   ---                          ------  ------  ------  ------  ------
-  alternative //               0.034s  0.035s  0.032s  0.033s  0.034s
-  try-catch                    0.023s  0.023s  0.024s  0.024s  0.024s
+  alternative //               0.035s  0.032s  0.033s  0.034s  0.034s
+  try-catch                    0.023s  0.024s  0.024s  0.024s  0.024s
   label-break                  0.004s  0.004s  0.004s  0.004s  0.004s
 
 --- Type conversion ---
-  Benchmark                    v1.8.0  v1.8.1  v1.8.2  v1.8.3  v1.9.0
+  Benchmark                    v1.8.1  v1.8.2  v1.8.3  v1.9.0  v1.9.1
   ---                          ------  ------  ------  ------  ------
-  tojson/fromjson(100K)        0.022s  0.022s  0.022s  0.022s  0.022s
-  null propagation(2M)         0.090s  0.092s  0.092s  0.090s  0.091s
+  tojson/fromjson(100K)        0.022s  0.022s  0.022s  0.022s  0.023s
+  null propagation(2M)         0.092s  0.092s  0.090s  0.091s  0.090s
 
 --- jaq-derived ---
-  Benchmark                    v1.8.0  v1.8.1  v1.8.2  v1.8.3  v1.9.0
+  Benchmark                    v1.8.1  v1.8.2  v1.8.3  v1.9.0  v1.9.1
   ---                          ------  ------  ------  ------  ------
   jaq: reverse                 -       -       -       -       -
   jaq: sort                    -       -       -       -       -
@@ -294,9 +294,9 @@ Recent slice (last 5 columns). Full history lives in
   jaq: str-slice               -       -       -       -       -
 
 --- Memoization (jqx) ---
-  Benchmark                    v1.8.0  v1.8.1  v1.8.2  v1.8.3  v1.9.0
+  Benchmark                    v1.8.1  v1.8.2  v1.8.3  v1.9.0  v1.9.1
   ---                          ------  ------  ------  ------  ------
   memo fib (1K)                0.003s  0.003s  0.003s  0.003s  0.003s
-  memo collatz sum (10K)       0.016s  0.017s  0.016s  0.014s  0.015s
-  memo by .id (100K, 1K keys)  0.020s  0.020s  0.020s  0.020s  0.020s
+  memo collatz sum (10K)       0.017s  0.016s  0.014s  0.015s  0.015s
+  memo by .id (100K, 1K keys)  0.020s  0.020s  0.020s  0.020s  0.021s
 ```

--- a/docs/benchmark-history.tsv
+++ b/docs/benchmark-history.tsv
@@ -6014,3 +6014,223 @@ Type conversion	null propagation(2M)	v1.9.0	0.091
 Memoization (jqx)	memo fib (1K)	v1.9.0	0.003
 Memoization (jqx)	memo collatz sum (10K)	v1.9.0	0.015
 Memoization (jqx)	memo by .id (100K, 1K keys)	v1.9.0	0.020
+NDJSON workloads (2M objects)	empty	v1.9.1	0.018
+NDJSON workloads (2M objects)	identity -c	v1.9.1	0.085
+NDJSON workloads (2M objects)	identity (pretty)	v1.9.1	0.112
+NDJSON workloads (2M objects)	field access .name	v1.9.1	0.081
+NDJSON workloads (2M objects)	nested .x,.y,.name	v1.9.1	0.123
+NDJSON workloads (2M objects)	arithmetic .x + .y	v1.9.1	0.090
+NDJSON workloads (2M objects)	select .x > 1500000	v1.9.1	0.083
+NDJSON workloads (2M objects)	string concat	v1.9.1	0.094
+NDJSON workloads (2M objects)	object construct	v1.9.1	0.120
+NDJSON workloads (2M objects)	array construct	v1.9.1	0.105
+NDJSON workloads (2M objects)	.[]	v1.9.1	0.120
+NDJSON workloads (2M objects)	to_entries	v1.9.1	0.151
+NDJSON workloads (2M objects)	keys	v1.9.1	0.104
+NDJSON workloads (2M objects)	keys_unsorted	v1.9.1	0.102
+NDJSON workloads (2M objects)	length	v1.9.1	0.087
+NDJSON workloads (2M objects)	has("x")	v1.9.1	0.039
+NDJSON workloads (2M objects)	type	v1.9.1	0.020
+NDJSON workloads (2M objects)	del(.name)	v1.9.1	0.115
+NDJSON workloads (2M objects)	@csv	v1.9.1	0.117
+NDJSON workloads (2M objects)	split/join	v1.9.1	0.088
+NDJSON workloads (2M objects)	select|field	v1.9.1	0.098
+NDJSON workloads (2M objects)	select|remap	v1.9.1	0.101
+NDJSON workloads (2M objects)	computed remap	v1.9.1	0.205
+NDJSON workloads (2M objects)	[.x,.y]|add	v1.9.1	0.091
+NDJSON workloads (2M objects)	[.x,.y]|avg	v1.9.1	0.114
+NDJSON workloads (2M objects)	map(*2)|add	v1.9.1	0.108
+NDJSON workloads (2M objects)	keys|length	v1.9.1	0.260
+NDJSON workloads (2M objects)	.+{z=0}	v1.9.1	0.152
+NDJSON workloads (2M objects)	split|first	v1.9.1	0.090
+NDJSON workloads (2M objects)	slice[0..5]	v1.9.1	0.093
+NDJSON workloads (2M objects)	dynkey {(.name)}	v1.9.1	0.115
+NDJSON workloads (2M objects)	.x += 1	v1.9.1	0.135
+NDJSON workloads (2M objects)	{a}+{b} merge	v1.9.1	0.131
+NDJSON workloads (2M objects)	.x*2+1	v1.9.1	0.062
+NDJSON workloads (2M objects)	.x+.y*2	v1.9.1	0.101
+NDJSON workloads (2M objects)	.x > .y	v1.9.1	0.082
+NDJSON workloads (2M objects)	to_entries|len	v1.9.1	0.388
+NDJSON workloads (2M objects)	.x|.+1 (pipe)	v1.9.1	0.058
+NDJSON workloads (2M objects)	.x|.*2|.+1	v1.9.1	0.062
+NDJSON workloads (2M objects)	.name|.+"_x"	v1.9.1	0.095
+NDJSON workloads (2M objects)	.x>N | not	v1.9.1	0.051
+NDJSON workloads (2M objects)	and (2 cmp)	v1.9.1	0.087
+NDJSON workloads (2M objects)	if-then-else	v1.9.1	0.053
+NDJSON workloads (2M objects)	sel(and)|field	v1.9.1	0.083
+NDJSON workloads (2M objects)	sel(and)|remap	v1.9.1	0.085
+NDJSON workloads (2M objects)	arith|cmp	v1.9.1	0.055
+NDJSON workloads (2M objects)	if cmp .field	v1.9.1	0.116
+NDJSON workloads (2M objects)	split|length	v1.9.1	0.087
+NDJSON workloads (2M objects)	[x,y]|min	v1.9.1	0.098
+NDJSON workloads (2M objects)	[x,y]|max	v1.9.1	0.102
+NDJSON workloads (2M objects)	[x,y]|sort|.[0]	v1.9.1	0.097
+NDJSON workloads (2M objects)	.name|len>5	v1.9.1	0.087
+NDJSON workloads (2M objects)	sel(len>5)|.x	v1.9.1	0.109
+NDJSON workloads (2M objects)	if .x>.y .name	v1.9.1	0.098
+NDJSON workloads (2M objects)	sel(.x>.y)|.name	v1.9.1	0.076
+NDJSON workloads (2M objects)	.x*2|tostring	v1.9.1	0.060
+NDJSON workloads (2M objects)	.x*.x+1	v1.9.1	0.068
+NDJSON workloads (2M objects)	{k=.name,v=tostr}	v1.9.1	0.143
+NDJSON workloads (2M objects)	str add chain	v1.9.1	0.396
+NDJSON workloads (2M objects)	if>.y .name|empty	v1.9.1	0.078
+NDJSON workloads (2M objects)	if .x%2==0	v1.9.1	0.055
+NDJSON workloads (2M objects)	if .x*2+1>1M	v1.9.1	0.057
+NDJSON workloads (2M objects)	sel(.x%2==0)|.name	v1.9.1	0.086
+NDJSON workloads (2M objects)	sel(.x*2+1>1M)	v1.9.1	0.160
+NDJSON workloads (2M objects)	.x|@json	v1.9.1	0.062
+NDJSON workloads (2M objects)	.x|@text	v1.9.1	0.059
+NDJSON workloads (2M objects)	.name|@json	v1.9.1	0.100
+NDJSON workloads (2M objects)	sel|[arr]	v1.9.1	0.173
+NDJSON workloads (2M objects)	sel(and)|[arr]	v1.9.1	0.080
+NDJSON workloads (2M objects)	if>.y [arr]	v1.9.1	0.216
+NDJSON workloads (2M objects)	if sw then .f	v1.9.1	0.141
+NDJSON workloads (2M objects)	dynkey {(.n)=.x*2}	v1.9.1	0.113
+NDJSON workloads (2M objects)	sel(and)|.x*.y	v1.9.1	0.084
+NDJSON workloads (2M objects)	sel>N|str chain	v1.9.1	0.161
+NDJSON workloads (2M objects)	.f+"_"+arith_ts	v1.9.1	0.135
+NDJSON workloads (2M objects)	sel(sw)|str ch	v1.9.1	0.309
+NDJSON workloads (2M objects)	split|rev|join	v1.9.1	0.117
+NDJSON workloads (2M objects)	dynkey+static	v1.9.1	0.348
+NDJSON workloads (2M objects)	if>.y str chain	v1.9.1	0.173
+NDJSON workloads (2M objects)	remap+str chain	v1.9.1	0.167
+NDJSON workloads (2M objects)	sel(len>8)	v1.9.1	0.159
+NDJSON workloads (2M objects)	up|split|join	v1.9.1	0.097
+NDJSON workloads (2M objects)	.name|index	v1.9.1	0.121
+NDJSON workloads (2M objects)	.name|index+1	v1.9.1	0.127
+NDJSON workloads (2M objects)	.name|rindex	v1.9.1	0.128
+NDJSON workloads (2M objects)	.name|indices	v1.9.1	0.148
+NDJSON workloads (2M objects)	[x,y]|sort	v1.9.1	0.179
+NDJSON workloads (2M objects)	.name|scan	v1.9.1	0.203
+NDJSON workloads (2M objects)	.name|gsub	v1.9.1	0.166
+NDJSON workloads (2M objects)	walk(if num .+1)	v1.9.1	0.142
+NDJSON workloads (2M objects)	tojson	v1.9.1	0.118
+NDJSON workloads (2M objects)	{name,x}	v1.9.1	0.135
+NDJSON workloads (2M objects)	.z//.name	v1.9.1	0.175
+NDJSON workloads (2M objects)	.x|=test(re)	v1.9.1	0.171
+NDJSON workloads (2M objects)	./sep|first	v1.9.1	0.189
+NDJSON workloads (2M objects)	.y=(.x*2)	v1.9.1	0.180
+NDJSON workloads (2M objects)	.y=(.x+.y)	v1.9.1	0.235
+NDJSON workloads (2M objects)	objects	v1.9.1	0.145
+NDJSON workloads (2M objects)	.tag|=if..then N	v1.9.1	0.615
+NDJSON workloads (2M objects)	.x=(.x+1)	v1.9.1	0.131
+NDJSON workloads (2M objects)	sel>N|.y+=1	v1.9.1	0.127
+NDJSON workloads (2M objects)	sel(and)|.x+=1	v1.9.1	0.107
+NDJSON workloads (2M objects)	sel(sw)|.x+=1	v1.9.1	0.165
+NDJSON workloads (2M objects)	match(re)	v1.9.1	0.369
+NDJSON workloads (2M objects)	capture(re)	v1.9.1	0.294
+NDJSON workloads (2M objects)	first(.name,.x)	v1.9.1	0.082
+NDJSON workloads (2M objects)	if .x==null	v1.9.1	0.050
+NDJSON workloads (2M objects)	we(sw(.key))	v1.9.1	0.120
+NDJSON workloads (2M objects)	sel(sw or ew)	v1.9.1	0.203
+NDJSON workloads (2M objects)	path(.name,.x)	v1.9.1	0.311
+NDJSON workloads (2M objects)	sel(str+num+num)	v1.9.1	0.154
+NDJSON workloads (2M objects)	nested if|field	v1.9.1	0.083
+NDJSON workloads (2M objects)	.f|floor|.*2	v1.9.1	0.063
+NDJSON workloads (2M objects)	split|len>1	v1.9.1	0.111
+NDJSON workloads (2M objects)	.name|len|.*2	v1.9.1	0.100
+NDJSON workloads (2M objects)	if len>5 .x .y	v1.9.1	0.113
+NDJSON workloads (2M objects)	sel(len>5)|remap	v1.9.1	0.205
+NDJSON workloads (2M objects)	.x|tostr|len	v1.9.1	0.061
+NDJSON workloads (2M objects)	if .x>.y .x .y	v1.9.1	0.104
+NDJSON workloads (2M objects)	split|last|tonum	v1.9.1	0.095
+NDJSON workloads (2M objects)	split|rev|.[0]	v1.9.1	0.089
+NDJSON workloads (2M objects)	split|.[0]+.[1]	v1.9.1	0.113
+NDJSON workloads (2M objects)	.[]|strings	v1.9.1	0.103
+NDJSON workloads (2M objects)	.[]|numbers	v1.9.1	0.125
+NDJSON workloads (2M objects)	[x,y]|any(>1M)	v1.9.1	0.088
+NDJSON workloads (2M objects)	sel(dc|sw)	v1.9.1	0.097
+NDJSON workloads (2M objects)	[[x,y],[n]]|flat	v1.9.1	0.460
+NDJSON workloads (2M objects)	.x|floor|.*2	v1.9.1	0.063
+NDJSON workloads (2M objects)	tojson|fromjson	v1.9.1	0.087
+NDJSON workloads (2M objects)	[.x]|add	v1.9.1	0.049
+NDJSON workloads (2M objects)	if>N {o}+.	v1.9.1	0.136
+NDJSON workloads (2M objects)	if>N .+{o}	v1.9.1	0.137
+NDJSON workloads (2M objects)	if .n=="s" .+{o}	v1.9.1	0.158
+NDJSON workloads (2M objects)	sel(.n>"s")	v1.9.1	0.087
+NDJSON workloads (2M objects)	[x,y,z]|min	v1.9.1	0.318
+NDJSON workloads (2M objects)	if .n|len>5 l s	v1.9.1	0.100
+NDJSON workloads (2M objects)	if .x|flr>N b s	v1.9.1	0.056
+NDJSON workloads (2M objects)	if .n|test l e	v1.9.1	0.106
+NDJSON workloads (2M objects)	if .n|sw l e	v1.9.1	0.086
+NDJSON workloads (2M objects)	if .n|ew l e	v1.9.1	0.084
+NDJSON workloads (2M objects)	.n|len|tostr	v1.9.1	0.091
+String operations (2M objects)	ascii_downcase	v1.9.1	0.094
+String operations (2M objects)	ascii_upcase	v1.9.1	0.096
+String operations (2M objects)	ltrimstr	v1.9.1	0.098
+String operations (2M objects)	rtrimstr	v1.9.1	0.098
+String operations (2M objects)	split	v1.9.1	0.162
+String operations (2M objects)	case+split	v1.9.1	0.117
+String operations (2M objects)	join	v1.9.1	0.097
+String operations (2M objects)	startswith	v1.9.1	0.091
+String operations (2M objects)	endswith	v1.9.1	0.091
+String operations (2M objects)	tostring	v1.9.1	0.066
+String operations (2M objects)	tonumber	v1.9.1	0.111
+String operations (2M objects)	string interpolation	v1.9.1	0.124
+String ops (200K objects)	test (regex)	v1.9.1	0.015
+String ops (200K objects)	match (regex)	v1.9.1	0.033
+String ops (200K objects)	@base64	v1.9.1	0.012
+String ops (200K objects)	@uri	v1.9.1	0.012
+String ops (200K objects)	@html	v1.9.1	0.012
+String ops (200K objects)	@csv (array)	v1.9.1	0.016
+String ops (200K objects)	@tsv (array)	v1.9.1	0.017
+String ops (200K objects)	gsub	v1.9.1	0.019
+String ops (200K objects)	case+gsub	v1.9.1	0.181
+String ops (200K objects)	case+test	v1.9.1	0.117
+String ops (200K objects)	ltrim+tonum+arith	v1.9.1	0.112
+Numeric & math (2M objects)	floor	v1.9.1	0.060
+Numeric & math (2M objects)	sqrt	v1.9.1	0.080
+Numeric & math (2M objects)	modulo	v1.9.1	0.060
+Numeric & math (2M objects)	if-elif-else	v1.9.1	0.127
+Numeric & math (2M objects)	select|del	v1.9.1	0.099
+Numeric & math (2M objects)	select|merge	v1.9.1	0.121
+Numeric & math (2M objects)	select(test)|merge	v1.9.1	0.022
+Array generators	range(2M) | length	v1.9.1	0.009
+Array generators	reverse(2M)	v1.9.1	0.016
+Array generators	sort(2M)	v1.9.1	0.026
+Array generators	unique(1M)	v1.9.1	0.034
+Array generators	flatten(500K)	v1.9.1	0.010
+Array generators	min, max(2M)	v1.9.1	0.017
+Array generators	add numbers(2M)	v1.9.1	0.011
+Array generators	any/all(2M)	v1.9.1	0.032
+Array generators	limit(10; range(10M))	v1.9.1	0.003
+Array generators	first(range(10M))	v1.9.1	0.002
+Array generators	last(range(2M))	v1.9.1	0.002
+Array generators	indices(1M)	v1.9.1	0.017
+Reduce & foreach	reduce (sum)	v1.9.1	0.010
+Reduce & foreach	reduce (array build)	v1.9.1	0.005
+Reduce & foreach	reduce (obj build)	v1.9.1	0.010
+Reduce & foreach	reduce (setpath)	v1.9.1	0.017
+Reduce & foreach	foreach (running sum)	v1.9.1	0.011
+Reduce & foreach	foreach + emit	v1.9.1	0.011
+Reduce & foreach	reduce (sum-of-squares)	v1.9.1	0.034
+Reduce & foreach	reduce (conditional)	v1.9.1	0.037
+Reduce & foreach	reduce (product)	v1.9.1	0.035
+Reduce & foreach	foreach (conditional)	v1.9.1	0.011
+Reduce & foreach	until (100M)	v1.9.1	0.325
+Reduce & foreach	reduce (harmonic)	v1.9.1	0.035
+Reduce & foreach	reduce (floor pipe)	v1.9.1	0.034
+Reduce & foreach	reduce (sqrt pipe)	v1.9.1	0.035
+Reduce & foreach	reduce (sin+cos)	v1.9.1	0.053
+Object operations	large obj construct	v1.9.1	0.004
+Object operations	large obj keys	v1.9.1	0.011
+Object operations	large obj to_entries	v1.9.1	0.012
+Object operations	with_entries	v1.9.1	0.010
+Assignment operators	.[] |= f (100K)	v1.9.1	0.006
+Assignment operators	.[] += 1 (100K)	v1.9.1	0.006
+Assignment operators	.[k] = v reduce(50K)	v1.9.1	0.009
+Assignment operators	p126-shape nested reduce	v1.9.1	0.120
+Assignment operators	p126-shape w/ mutate	v1.9.1	0.120
+Assignment operators	p150-shape serial mutate	v1.9.1	0.012
+String-heavy generators	gsub(100K)	v1.9.1	0.029
+String-heavy generators	join large(100K)	v1.9.1	0.006
+String-heavy generators	explode/implode(100K)	v1.9.1	0.028
+String-heavy generators	reduce str concat(100K)	v1.9.1	0.008
+Try-catch & alternative	alternative //	v1.9.1	0.034
+Try-catch & alternative	try-catch	v1.9.1	0.024
+Try-catch & alternative	label-break	v1.9.1	0.004
+Type conversion	tojson/fromjson(100K)	v1.9.1	0.023
+Type conversion	null propagation(2M)	v1.9.1	0.090
+Memoization (jqx)	memo fib (1K)	v1.9.1	0.003
+Memoization (jqx)	memo collatz sum (10K)	v1.9.1	0.015
+Memoization (jqx)	memo by .id (100K, 1K keys)	v1.9.1	0.021


### PR DESCRIPTION
## Summary

Release v1.9.1 — re-delivery release. The v1.8.3 and v1.9.0 release workflows both failed at the Windows test step on a test-side JSON-escaping bug in `tests/loc_module_file.rs` (fixed in #1122; only release.yml runs tests on Windows, so PR CI never caught it). Neither version shipped a GitHub Release, binaries, or a Homebrew bump, so this patch release delivers everything since v1.8.2 — most notably the #1059 JIT delegation series, the #1032–#1037 type-safety series, the #1028 number-formatter unification, and the `JitOp::PathProbe` perf fix from the v1.9.0 gate.

## Benchmarks

220 matched benchmarks vs v1.9.0 (binary-identical build — the only diff is the test fix): geomean 0.994, worst 1.07 on millisecond-scale entries; pure run-to-run noise, no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)