### PR TITLE
fix(test): JSON-escape the canonical -L path in module_search_path

### DIFF
--- a/tests/module_search_path.rs
+++ b/tests/module_search_path.rs
@@ -11,6 +11,16 @@
 use std::io::Write;
 use std::process::{Command, Stdio};
 
+/// JSON-escape a filesystem path for embedding in an expected output
+/// string. Windows canonical paths (`\\?\C:\...`) contain backslashes,
+/// which `get_search_list` renders as `\\` — embedding the raw path made
+/// the assertion a Windows-only failure (caught by release.yml / the
+/// scheduled full-matrix CI, the only workflows that test on Windows).
+/// Same fix as tests/loc_module_file.rs.
+fn json_escaped(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
 fn run(args: &[&str]) -> (String, bool) {
     let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
     let mut child = Command::new(jq_jit)
@@ -58,7 +68,7 @@ fn get_search_list_reflects_dash_l() {
     let dir_s = dir.to_str().unwrap();
     // jq canonicalises a resolvable -L dir via realpath; mirror that here.
     let canon = std::fs::canonicalize(&dir).unwrap();
-    let canon_s = canon.to_str().unwrap();
+    let canon_s = json_escaped(canon.to_str().unwrap());
 
     let (out, ok) = run(&["-L", dir_s, "-c", "get_search_list"]);
     assert!(ok);


### PR DESCRIPTION
## Summary

Same Windows-only failure class as #1122: `get_search_list_reflects_dash_l` embeds the canonicalized temp dir into the expected JSON verbatim, so on Windows the UNC path's backslashes (`\\?\C:\...`) leave the expected string one escaping level short of the actual `get_search_list` output. This was the next test in line once #1122 unblocked the v1.9.1 release run's Windows job (cargo test is fail-fast per binary, so it hid behind `loc_module_file`).

Audited the remaining suite for the pattern: every other `temp_dir`/`canonicalize` use either keeps paths out of expected output entirely (`cli_attached_library_path`, `data_module_multivalue`) or embeds them via `{:?}` (`input_filename`), which Debug-escapes correctly.

Before tagging the re-delivery release, the full 3-OS matrix will be verified via a manual `ci.yml` dispatch instead of burning another tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)