### PR TITLE
release v1.9.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jq-jit"
-version = "1.9.1"
+version = "1.9.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jq-jit"
-version = "1.9.1"
+version = "1.9.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A JIT-compiling implementation of jq using Cranelift"

--- a/docs/benchmark-history.md
+++ b/docs/benchmark-history.md
@@ -6,268 +6,268 @@ Recent slice (last 5 columns). Full history lives in
 
 ```text
 --- NDJSON workloads (2M objects) ---
-  Benchmark                    v1.8.1  v1.8.2  v1.8.3  v1.9.0  v1.9.1
+  Benchmark                    v1.8.2  v1.8.3  v1.9.0  v1.9.1  v1.9.2
   ---                          ------  ------  ------  ------  ------
-  empty                        0.017s  0.017s  0.017s  0.018s  0.018s
-  identity -c                  0.083s  0.085s  0.085s  0.088s  0.085s
-  identity (pretty)            0.103s  0.110s  0.106s  0.109s  0.112s
-  field access .name           0.103s  0.110s  0.114s  0.084s  0.081s
-  nested .x,.y,.name           0.171s  0.184s  0.200s  0.119s  0.123s
-  arithmetic .x + .y           0.083s  0.087s  0.084s  0.088s  0.090s
-  select .x > 1500000          0.082s  0.086s  0.081s  0.083s  0.083s
-  string concat                0.090s  0.096s  0.093s  0.092s  0.094s
-  object construct             0.124s  0.135s  0.137s  0.118s  0.120s
-  array construct              0.123s  0.135s  0.136s  0.108s  0.105s
-  .[]                          0.111s  0.117s  0.116s  0.120s  0.120s
-  to_entries                   0.169s  0.149s  0.148s  0.155s  0.151s
-  keys                         0.101s  0.104s  0.103s  0.107s  0.104s
-  keys_unsorted                0.094s  0.100s  0.099s  0.101s  0.102s
-  length                       0.086s  0.086s  0.084s  0.090s  0.087s
-  has("x")                     0.038s  0.037s  0.039s  0.040s  0.039s
-  type                         0.022s  0.020s  0.020s  0.021s  0.020s
-  del(.name)                   0.113s  0.115s  0.113s  0.117s  0.115s
-  @csv                         0.125s  0.119s  0.118s  0.123s  0.117s
-  split/join                   0.089s  0.089s  0.088s  0.090s  0.088s
-  select|field                 0.098s  0.100s  0.097s  0.097s  0.098s
-  select|remap                 0.097s  0.101s  0.102s  0.100s  0.101s
-  computed remap               0.206s  0.222s  0.224s  0.206s  0.205s
-  [.x,.y]|add                  0.082s  0.086s  0.084s  0.090s  0.091s
-  [.x,.y]|avg                  0.105s  0.111s  0.112s  0.112s  0.114s
-  map(*2)|add                  0.104s  0.106s  0.102s  0.108s  0.108s
-  keys|length                  0.252s  0.263s  0.253s  0.263s  0.260s
-  .+{z=0}                      0.147s  0.154s  0.150s  0.150s  0.152s
-  split|first                  0.087s  0.086s  0.086s  0.088s  0.090s
-  slice[0..5]                  0.091s  0.093s  0.091s  0.091s  0.093s
-  dynkey {(.name)}             0.114s  0.113s  0.117s  0.115s  0.115s
-  .x += 1                      0.127s  0.128s  0.128s  0.133s  0.135s
-  {a}+{b} merge                0.148s  0.161s  0.166s  0.132s  0.131s
-  .x*2+1                       0.059s  0.061s  0.062s  0.062s  0.062s
-  .x+.y*2                      0.095s  0.100s  0.100s  0.100s  0.101s
-  .x > .y                      0.078s  0.081s  0.078s  0.080s  0.082s
-  to_entries|len               0.393s  0.387s  0.387s  0.392s  0.388s
-  .x|.+1 (pipe)                0.057s  0.058s  0.058s  0.058s  0.058s
-  .x|.*2|.+1                   0.059s  0.061s  0.061s  0.062s  0.062s
-  .name|.+"_x"                 0.092s  0.095s  0.093s  0.093s  0.095s
-  .x>N | not                   0.050s  0.049s  0.051s  0.052s  0.051s
-  and (2 cmp)                  0.081s  0.084s  0.085s  0.085s  0.087s
-  if-then-else                 0.052s  0.053s  0.053s  0.054s  0.053s
-  sel(and)|field               0.077s  0.080s  0.079s  0.080s  0.083s
-  sel(and)|remap               0.078s  0.080s  0.080s  0.083s  0.085s
-  arith|cmp                    0.053s  0.055s  0.054s  0.057s  0.055s
-  if cmp .field                0.113s  0.119s  0.122s  0.115s  0.116s
-  split|length                 0.087s  0.089s  0.086s  0.090s  0.087s
-  [x,y]|min                    0.090s  0.095s  0.093s  0.098s  0.098s
-  [x,y]|max                    0.094s  0.100s  0.097s  0.099s  0.102s
-  [x,y]|sort|.[0]              0.089s  0.095s  0.093s  0.099s  0.097s
-  .name|len>5                  0.091s  0.087s  0.085s  0.088s  0.087s
-  sel(len>5)|.x                0.106s  0.110s  0.108s  0.112s  0.109s
-  if .x>.y .name               0.089s  0.092s  0.092s  0.094s  0.098s
-  sel(.x>.y)|.name             0.071s  0.075s  0.071s  0.076s  0.076s
-  .x*2|tostring                0.056s  0.059s  0.057s  0.057s  0.060s
-  .x*.x+1                      0.066s  0.068s  0.067s  0.067s  0.068s
-  {k=.name,v=tostr}            0.157s  0.167s  0.170s  0.144s  0.143s
-  str add chain                0.380s  0.396s  0.385s  0.403s  0.396s
-  if>.y .name|empty            0.073s  0.075s  0.074s  0.078s  0.078s
-  if .x%2==0                   0.054s  0.055s  0.054s  0.057s  0.055s
-  if .x*2+1>1M                 0.054s  0.056s  0.057s  0.057s  0.057s
-  sel(.x%2==0)|.name           0.084s  0.083s  0.084s  0.084s  0.086s
-  sel(.x*2+1>1M)               0.157s  0.156s  0.153s  0.161s  0.160s
-  .x|@json                     0.048s  0.051s  0.060s  0.061s  0.062s
-  .x|@text                     0.048s  0.050s  0.060s  0.062s  0.059s
-  .name|@json                  0.102s  0.107s  0.104s  0.105s  0.100s
-  sel|[arr]                    0.160s  0.172s  0.180s  0.184s  0.173s
-  sel(and)|[arr]               0.079s  0.081s  0.080s  0.084s  0.080s
-  if>.y [arr]                  0.198s  0.205s  0.217s  0.221s  0.216s
-  if sw then .f                0.139s  0.147s  0.142s  0.144s  0.141s
-  dynkey {(.n)=.x*2}           0.116s  0.118s  0.119s  0.117s  0.113s
-  sel(and)|.x*.y               0.079s  0.080s  0.079s  0.082s  0.084s
-  sel>N|str chain              0.153s  0.157s  0.166s  0.167s  0.161s
-  .f+"_"+arith_ts              0.133s  0.133s  0.137s  0.137s  0.135s
-  sel(sw)|str ch               0.303s  0.312s  0.309s  0.317s  0.309s
-  split|rev|join               0.112s  0.114s  0.116s  0.115s  0.117s
-  dynkey+static                0.339s  0.340s  0.351s  0.343s  0.348s
-  if>.y str chain              0.170s  0.171s  0.173s  0.171s  0.173s
-  remap+str chain              0.160s  0.162s  0.178s  0.165s  0.167s
-  sel(len>8)                   0.159s  0.161s  0.161s  0.163s  0.159s
-  up|split|join                0.096s  0.097s  0.096s  0.097s  0.097s
-  .name|index                  0.121s  0.120s  0.118s  0.119s  0.121s
-  .name|index+1                0.122s  0.126s  0.121s  0.128s  0.127s
-  .name|rindex                 0.124s  0.129s  0.129s  0.127s  0.128s
-  .name|indices                0.159s  0.150s  0.147s  0.151s  0.148s
-  [x,y]|sort                   0.168s  0.175s  0.178s  0.178s  0.179s
-  .name|scan                   0.206s  0.205s  0.204s  0.204s  0.203s
-  .name|gsub                   0.168s  0.167s  0.164s  0.168s  0.166s
-  walk(if num .+1)             0.137s  0.141s  0.142s  0.141s  0.142s
-  tojson                       0.107s  0.115s  0.117s  0.119s  0.118s
-  {name,x}                     0.150s  0.154s  0.166s  0.127s  0.135s
-  .z//.name                    0.164s  0.175s  0.174s  0.177s  0.175s
-  .x|=test(re)                 0.170s  0.172s  0.174s  0.173s  0.171s
-  ./sep|first                  0.179s  0.186s  0.180s  0.185s  0.189s
-  .y=(.x*2)                    0.176s  0.179s  0.179s  0.183s  0.180s
-  .y=(.x+.y)                   0.232s  0.235s  0.237s  0.234s  0.235s
-  objects                      0.125s  0.137s  0.146s  0.150s  0.145s
-  .tag|=if..then N             0.607s  0.635s  0.624s  0.613s  0.615s
-  .x=(.x+1)                    0.128s  0.131s  0.127s  0.133s  0.131s
-  sel>N|.y+=1                  0.122s  0.124s  0.125s  0.127s  0.127s
-  sel(and)|.x+=1               0.106s  0.108s  0.108s  0.109s  0.107s
-  sel(sw)|.x+=1                0.164s  0.169s  0.165s  0.169s  0.165s
-  match(re)                    0.363s  0.379s  0.372s  0.382s  0.369s
-  capture(re)                  0.299s  0.306s  0.303s  0.301s  0.294s
-  first(.name,.x)              0.106s  0.109s  0.116s  0.083s  0.082s
-  if .x==null                  0.047s  0.047s  0.048s  0.049s  0.050s
-  we(sw(.key))                 0.109s  0.118s  0.117s  0.118s  0.120s
-  sel(sw or ew)                0.206s  0.205s  0.199s  0.208s  0.203s
-  path(.name,.x)               0.273s  0.320s  0.300s  0.308s  0.311s
-  sel(str+num+num)             0.150s  0.151s  0.154s  0.155s  0.154s
-  nested if|field              0.078s  0.083s  0.079s  0.084s  0.083s
-  .f|floor|.*2                 0.062s  0.062s  0.062s  0.062s  0.063s
-  split|len>1                  0.117s  0.114s  0.110s  0.110s  0.111s
-  .name|len|.*2                0.101s  0.102s  0.102s  0.104s  0.100s
-  if len>5 .x .y               0.112s  0.115s  0.114s  0.114s  0.113s
-  sel(len>5)|remap             0.199s  0.209s  0.203s  0.204s  0.205s
-  .x|tostr|len                 0.060s  0.061s  0.059s  0.061s  0.061s
-  if .x>.y .x .y               0.093s  0.099s  0.096s  0.097s  0.104s
-  split|last|tonum             0.097s  0.095s  0.094s  0.096s  0.095s
-  split|rev|.[0]               0.092s  0.091s  0.091s  0.094s  0.089s
-  split|.[0]+.[1]              0.112s  0.114s  0.111s  0.112s  0.113s
-  .[]|strings                  0.108s  0.108s  0.105s  0.110s  0.103s
-  .[]|numbers                  0.126s  0.125s  0.124s  0.127s  0.125s
-  [x,y]|any(>1M)               0.082s  0.086s  0.084s  0.087s  0.088s
-  sel(dc|sw)                   0.099s  0.098s  0.095s  0.095s  0.097s
-  [[x,y],[n]]|flat             0.459s  0.520s  0.488s  0.460s  0.460s
-  .x|floor|.*2                 0.062s  0.060s  0.062s  0.064s  0.063s
-  tojson|fromjson              0.086s  0.086s  0.084s  0.085s  0.087s
-  [.x]|add                     0.064s  0.066s  0.071s  0.048s  0.049s
-  if>N {o}+.                   0.137s  0.135s  0.137s  0.137s  0.136s
-  if>N .+{o}                   0.132s  0.134s  0.133s  0.132s  0.137s
-  if .n=="s" .+{o}             0.162s  0.162s  0.159s  0.160s  0.158s
-  sel(.n>"s")                  0.088s  0.092s  0.088s  0.089s  0.087s
-  [x,y,z]|min                  0.313s  0.311s  0.313s  0.315s  0.318s
-  if .n|len>5 l s              0.100s  0.101s  0.101s  0.101s  0.100s
-  if .x|flr>N b s              0.055s  0.055s  0.056s  0.056s  0.056s
-  if .n|test l e               0.109s  0.103s  0.104s  0.105s  0.106s
-  if .n|sw l e                 0.085s  0.086s  0.083s  0.086s  0.086s
-  if .n|ew l e                 0.084s  0.083s  0.084s  0.086s  0.084s
-  .n|len|tostr                 0.090s  0.089s  0.089s  0.092s  0.091s
+  empty                        0.017s  0.017s  0.018s  0.018s  0.019s
+  identity -c                  0.085s  0.085s  0.088s  0.085s  0.087s
+  identity (pretty)            0.110s  0.106s  0.109s  0.112s  0.111s
+  field access .name           0.110s  0.114s  0.084s  0.081s  0.084s
+  nested .x,.y,.name           0.184s  0.200s  0.119s  0.123s  0.121s
+  arithmetic .x + .y           0.087s  0.084s  0.088s  0.090s  0.088s
+  select .x > 1500000          0.086s  0.081s  0.083s  0.083s  0.084s
+  string concat                0.096s  0.093s  0.092s  0.094s  0.096s
+  object construct             0.135s  0.137s  0.118s  0.120s  0.121s
+  array construct              0.135s  0.136s  0.108s  0.105s  0.106s
+  .[]                          0.117s  0.116s  0.120s  0.120s  0.120s
+  to_entries                   0.149s  0.148s  0.155s  0.151s  0.150s
+  keys                         0.104s  0.103s  0.107s  0.104s  0.104s
+  keys_unsorted                0.100s  0.099s  0.101s  0.102s  0.103s
+  length                       0.086s  0.084s  0.090s  0.087s  0.092s
+  has("x")                     0.037s  0.039s  0.040s  0.039s  0.040s
+  type                         0.020s  0.020s  0.021s  0.020s  0.020s
+  del(.name)                   0.115s  0.113s  0.117s  0.115s  0.114s
+  @csv                         0.119s  0.118s  0.123s  0.117s  0.122s
+  split/join                   0.089s  0.088s  0.090s  0.088s  0.089s
+  select|field                 0.100s  0.097s  0.097s  0.098s  0.097s
+  select|remap                 0.101s  0.102s  0.100s  0.101s  0.099s
+  computed remap               0.222s  0.224s  0.206s  0.205s  0.201s
+  [.x,.y]|add                  0.086s  0.084s  0.090s  0.091s  0.089s
+  [.x,.y]|avg                  0.111s  0.112s  0.112s  0.114s  0.113s
+  map(*2)|add                  0.106s  0.102s  0.108s  0.108s  0.108s
+  keys|length                  0.263s  0.253s  0.263s  0.260s  0.261s
+  .+{z=0}                      0.154s  0.150s  0.150s  0.152s  0.158s
+  split|first                  0.086s  0.086s  0.088s  0.090s  0.088s
+  slice[0..5]                  0.093s  0.091s  0.091s  0.093s  0.095s
+  dynkey {(.name)}             0.113s  0.117s  0.115s  0.115s  0.115s
+  .x += 1                      0.128s  0.128s  0.133s  0.135s  0.133s
+  {a}+{b} merge                0.161s  0.166s  0.132s  0.131s  0.137s
+  .x*2+1                       0.061s  0.062s  0.062s  0.062s  0.062s
+  .x+.y*2                      0.100s  0.100s  0.100s  0.101s  0.101s
+  .x > .y                      0.081s  0.078s  0.080s  0.082s  0.082s
+  to_entries|len               0.387s  0.387s  0.392s  0.388s  0.389s
+  .x|.+1 (pipe)                0.058s  0.058s  0.058s  0.058s  0.058s
+  .x|.*2|.+1                   0.061s  0.061s  0.062s  0.062s  0.062s
+  .name|.+"_x"                 0.095s  0.093s  0.093s  0.095s  0.094s
+  .x>N | not                   0.049s  0.051s  0.052s  0.051s  0.052s
+  and (2 cmp)                  0.084s  0.085s  0.085s  0.087s  0.084s
+  if-then-else                 0.053s  0.053s  0.054s  0.053s  0.052s
+  sel(and)|field               0.080s  0.079s  0.080s  0.083s  0.086s
+  sel(and)|remap               0.080s  0.080s  0.083s  0.085s  0.084s
+  arith|cmp                    0.055s  0.054s  0.057s  0.055s  0.056s
+  if cmp .field                0.119s  0.122s  0.115s  0.116s  0.113s
+  split|length                 0.089s  0.086s  0.090s  0.087s  0.089s
+  [x,y]|min                    0.095s  0.093s  0.098s  0.098s  0.096s
+  [x,y]|max                    0.100s  0.097s  0.099s  0.102s  0.099s
+  [x,y]|sort|.[0]              0.095s  0.093s  0.099s  0.097s  0.094s
+  .name|len>5                  0.087s  0.085s  0.088s  0.087s  0.086s
+  sel(len>5)|.x                0.110s  0.108s  0.112s  0.109s  0.113s
+  if .x>.y .name               0.092s  0.092s  0.094s  0.098s  0.092s
+  sel(.x>.y)|.name             0.075s  0.071s  0.076s  0.076s  0.077s
+  .x*2|tostring                0.059s  0.057s  0.057s  0.060s  0.058s
+  .x*.x+1                      0.068s  0.067s  0.067s  0.068s  0.069s
+  {k=.name,v=tostr}            0.167s  0.170s  0.144s  0.143s  0.145s
+  str add chain                0.396s  0.385s  0.403s  0.396s  0.395s
+  if>.y .name|empty            0.075s  0.074s  0.078s  0.078s  0.077s
+  if .x%2==0                   0.055s  0.054s  0.057s  0.055s  0.055s
+  if .x*2+1>1M                 0.056s  0.057s  0.057s  0.057s  0.056s
+  sel(.x%2==0)|.name           0.083s  0.084s  0.084s  0.086s  0.085s
+  sel(.x*2+1>1M)               0.156s  0.153s  0.161s  0.160s  0.162s
+  .x|@json                     0.051s  0.060s  0.061s  0.062s  0.061s
+  .x|@text                     0.050s  0.060s  0.062s  0.059s  0.062s
+  .name|@json                  0.107s  0.104s  0.105s  0.100s  0.103s
+  sel|[arr]                    0.172s  0.180s  0.184s  0.173s  0.175s
+  sel(and)|[arr]               0.081s  0.080s  0.084s  0.080s  0.080s
+  if>.y [arr]                  0.205s  0.217s  0.221s  0.216s  0.214s
+  if sw then .f                0.147s  0.142s  0.144s  0.141s  0.143s
+  dynkey {(.n)=.x*2}           0.118s  0.119s  0.117s  0.113s  0.117s
+  sel(and)|.x*.y               0.080s  0.079s  0.082s  0.084s  0.080s
+  sel>N|str chain              0.157s  0.166s  0.167s  0.161s  0.166s
+  .f+"_"+arith_ts              0.133s  0.137s  0.137s  0.135s  0.140s
+  sel(sw)|str ch               0.312s  0.309s  0.317s  0.309s  0.320s
+  split|rev|join               0.114s  0.116s  0.115s  0.117s  0.118s
+  dynkey+static                0.340s  0.351s  0.343s  0.348s  0.344s
+  if>.y str chain              0.171s  0.173s  0.171s  0.173s  0.172s
+  remap+str chain              0.162s  0.178s  0.165s  0.167s  0.163s
+  sel(len>8)                   0.161s  0.161s  0.163s  0.159s  0.163s
+  up|split|join                0.097s  0.096s  0.097s  0.097s  0.098s
+  .name|index                  0.120s  0.118s  0.119s  0.121s  0.121s
+  .name|index+1                0.126s  0.121s  0.128s  0.127s  0.127s
+  .name|rindex                 0.129s  0.129s  0.127s  0.128s  0.130s
+  .name|indices                0.150s  0.147s  0.151s  0.148s  0.151s
+  [x,y]|sort                   0.175s  0.178s  0.178s  0.179s  0.183s
+  .name|scan                   0.205s  0.204s  0.204s  0.203s  0.210s
+  .name|gsub                   0.167s  0.164s  0.168s  0.166s  0.166s
+  walk(if num .+1)             0.141s  0.142s  0.141s  0.142s  0.143s
+  tojson                       0.115s  0.117s  0.119s  0.118s  0.119s
+  {name,x}                     0.154s  0.166s  0.127s  0.135s  0.131s
+  .z//.name                    0.175s  0.174s  0.177s  0.175s  0.179s
+  .x|=test(re)                 0.172s  0.174s  0.173s  0.171s  0.174s
+  ./sep|first                  0.186s  0.180s  0.185s  0.189s  0.188s
+  .y=(.x*2)                    0.179s  0.179s  0.183s  0.180s  0.184s
+  .y=(.x+.y)                   0.235s  0.237s  0.234s  0.235s  0.238s
+  objects                      0.137s  0.146s  0.150s  0.145s  0.140s
+  .tag|=if..then N             0.635s  0.624s  0.613s  0.615s  0.612s
+  .x=(.x+1)                    0.131s  0.127s  0.133s  0.131s  0.138s
+  sel>N|.y+=1                  0.124s  0.125s  0.127s  0.127s  0.129s
+  sel(and)|.x+=1               0.108s  0.108s  0.109s  0.107s  0.108s
+  sel(sw)|.x+=1                0.169s  0.165s  0.169s  0.165s  0.166s
+  match(re)                    0.379s  0.372s  0.382s  0.369s  0.376s
+  capture(re)                  0.306s  0.303s  0.301s  0.294s  0.305s
+  first(.name,.x)              0.109s  0.116s  0.083s  0.082s  0.081s
+  if .x==null                  0.047s  0.048s  0.049s  0.050s  0.048s
+  we(sw(.key))                 0.118s  0.117s  0.118s  0.120s  0.120s
+  sel(sw or ew)                0.205s  0.199s  0.208s  0.203s  0.210s
+  path(.name,.x)               0.320s  0.300s  0.308s  0.311s  0.307s
+  sel(str+num+num)             0.151s  0.154s  0.155s  0.154s  0.152s
+  nested if|field              0.083s  0.079s  0.084s  0.083s  0.082s
+  .f|floor|.*2                 0.062s  0.062s  0.062s  0.063s  0.063s
+  split|len>1                  0.114s  0.110s  0.110s  0.111s  0.113s
+  .name|len|.*2                0.102s  0.102s  0.104s  0.100s  0.103s
+  if len>5 .x .y               0.115s  0.114s  0.114s  0.113s  0.112s
+  sel(len>5)|remap             0.209s  0.203s  0.204s  0.205s  0.206s
+  .x|tostr|len                 0.061s  0.059s  0.061s  0.061s  0.061s
+  if .x>.y .x .y               0.099s  0.096s  0.097s  0.104s  0.099s
+  split|last|tonum             0.095s  0.094s  0.096s  0.095s  0.093s
+  split|rev|.[0]               0.091s  0.091s  0.094s  0.089s  0.092s
+  split|.[0]+.[1]              0.114s  0.111s  0.112s  0.113s  0.113s
+  .[]|strings                  0.108s  0.105s  0.110s  0.103s  0.106s
+  .[]|numbers                  0.125s  0.124s  0.127s  0.125s  0.127s
+  [x,y]|any(>1M)               0.086s  0.084s  0.087s  0.088s  0.088s
+  sel(dc|sw)                   0.098s  0.095s  0.095s  0.097s  0.097s
+  [[x,y],[n]]|flat             0.520s  0.488s  0.460s  0.460s  0.459s
+  .x|floor|.*2                 0.060s  0.062s  0.064s  0.063s  0.062s
+  tojson|fromjson              0.086s  0.084s  0.085s  0.087s  0.089s
+  [.x]|add                     0.066s  0.071s  0.048s  0.049s  0.050s
+  if>N {o}+.                   0.135s  0.137s  0.137s  0.136s  0.138s
+  if>N .+{o}                   0.134s  0.133s  0.132s  0.137s  0.142s
+  if .n=="s" .+{o}             0.162s  0.159s  0.160s  0.158s  0.157s
+  sel(.n>"s")                  0.092s  0.088s  0.089s  0.087s  0.087s
+  [x,y,z]|min                  0.311s  0.313s  0.315s  0.318s  0.316s
+  if .n|len>5 l s              0.101s  0.101s  0.101s  0.100s  0.100s
+  if .x|flr>N b s              0.055s  0.056s  0.056s  0.056s  0.056s
+  if .n|test l e               0.103s  0.104s  0.105s  0.106s  0.101s
+  if .n|sw l e                 0.086s  0.083s  0.086s  0.086s  0.083s
+  if .n|ew l e                 0.083s  0.084s  0.086s  0.084s  0.085s
+  .n|len|tostr                 0.089s  0.089s  0.092s  0.091s  0.092s
 
 --- String operations (2M objects) ---
-  Benchmark                    v1.8.1  v1.8.2  v1.8.3  v1.9.0  v1.9.1
+  Benchmark                    v1.8.2  v1.8.3  v1.9.0  v1.9.1  v1.9.2
   ---                          ------  ------  ------  ------  ------
-  ascii_downcase               0.104s  0.095s  0.092s  0.095s  0.094s
-  ascii_upcase                 0.101s  0.094s  0.094s  0.094s  0.096s
-  ltrimstr                     0.096s  0.097s  0.095s  0.095s  0.098s
-  rtrimstr                     0.099s  0.095s  0.097s  0.094s  0.098s
-  split                        0.166s  0.158s  0.157s  0.159s  0.162s
-  case+split                   0.117s  0.116s  0.116s  0.114s  0.117s
-  join                         0.092s  0.094s  0.096s  0.092s  0.097s
-  startswith                   0.096s  0.090s  0.090s  0.090s  0.091s
-  endswith                     0.096s  0.090s  0.088s  0.093s  0.091s
-  tostring                     0.073s  0.068s  0.064s  0.065s  0.066s
-  tonumber                     0.108s  0.110s  0.108s  0.113s  0.111s
-  string interpolation         0.120s  0.115s  0.127s  0.126s  0.124s
+  ascii_downcase               0.095s  0.092s  0.095s  0.094s  0.095s
+  ascii_upcase                 0.094s  0.094s  0.094s  0.096s  0.095s
+  ltrimstr                     0.097s  0.095s  0.095s  0.098s  0.095s
+  rtrimstr                     0.095s  0.097s  0.094s  0.098s  0.096s
+  split                        0.158s  0.157s  0.159s  0.162s  0.164s
+  case+split                   0.116s  0.116s  0.114s  0.117s  0.120s
+  join                         0.094s  0.096s  0.092s  0.097s  0.096s
+  startswith                   0.090s  0.090s  0.090s  0.091s  0.090s
+  endswith                     0.090s  0.088s  0.093s  0.091s  0.089s
+  tostring                     0.068s  0.064s  0.065s  0.066s  0.065s
+  tonumber                     0.110s  0.108s  0.113s  0.111s  0.113s
+  string interpolation         0.115s  0.127s  0.126s  0.124s  0.128s
 
 --- String ops (200K objects) ---
-  Benchmark                    v1.8.1  v1.8.2  v1.8.3  v1.9.0  v1.9.1
+  Benchmark                    v1.8.2  v1.8.3  v1.9.0  v1.9.1  v1.9.2
   ---                          ------  ------  ------  ------  ------
-  test (regex)                 0.014s  0.015s  0.014s  0.015s  0.015s
-  match (regex)                0.032s  0.033s  0.033s  0.033s  0.033s
-  @base64                      0.012s  0.012s  0.011s  0.012s  0.012s
-  @uri                         0.012s  0.013s  0.011s  0.013s  0.012s
-  @html                        0.012s  0.013s  0.012s  0.013s  0.012s
-  @csv (array)                 0.016s  0.015s  0.016s  0.016s  0.016s
-  @tsv (array)                 0.015s  0.015s  0.015s  0.016s  0.017s
-  gsub                         0.019s  0.018s  0.018s  0.019s  0.019s
-  case+gsub                    0.182s  0.179s  0.181s  0.178s  0.181s
-  case+test                    0.122s  0.117s  0.118s  0.119s  0.117s
-  ltrim+tonum+arith            0.111s  0.110s  0.110s  0.116s  0.112s
+  test (regex)                 0.015s  0.014s  0.015s  0.015s  0.015s
+  match (regex)                0.033s  0.033s  0.033s  0.033s  0.033s
+  @base64                      0.012s  0.011s  0.012s  0.012s  0.012s
+  @uri                         0.013s  0.011s  0.013s  0.012s  0.012s
+  @html                        0.013s  0.012s  0.013s  0.012s  0.012s
+  @csv (array)                 0.015s  0.016s  0.016s  0.016s  0.016s
+  @tsv (array)                 0.015s  0.015s  0.016s  0.017s  0.017s
+  gsub                         0.018s  0.018s  0.019s  0.019s  0.019s
+  case+gsub                    0.179s  0.181s  0.178s  0.181s  0.180s
+  case+test                    0.117s  0.118s  0.119s  0.117s  0.119s
+  ltrim+tonum+arith            0.110s  0.110s  0.116s  0.112s  0.111s
 
 --- Numeric & math (2M objects) ---
-  Benchmark                    v1.8.1  v1.8.2  v1.8.3  v1.9.0  v1.9.1
+  Benchmark                    v1.8.2  v1.8.3  v1.9.0  v1.9.1  v1.9.2
   ---                          ------  ------  ------  ------  ------
-  floor                        0.057s  0.056s  0.058s  0.058s  0.060s
-  sqrt                         0.080s  0.081s  0.079s  0.081s  0.080s
-  modulo                       0.059s  0.058s  0.059s  0.059s  0.060s
-  if-elif-else                 0.126s  0.130s  0.131s  0.127s  0.127s
-  select|del                   0.097s  0.097s  0.096s  0.100s  0.099s
-  select|merge                 0.119s  0.123s  0.121s  0.121s  0.121s
-  select(test)|merge           0.022s  0.021s  0.021s  0.023s  0.022s
+  floor                        0.056s  0.058s  0.058s  0.060s  0.059s
+  sqrt                         0.081s  0.079s  0.081s  0.080s  0.079s
+  modulo                       0.058s  0.059s  0.059s  0.060s  0.059s
+  if-elif-else                 0.130s  0.131s  0.127s  0.127s  0.130s
+  select|del                   0.097s  0.096s  0.100s  0.099s  0.098s
+  select|merge                 0.123s  0.121s  0.121s  0.121s  0.123s
+  select(test)|merge           0.021s  0.021s  0.023s  0.022s  0.022s
 
 --- Array generators ---
-  Benchmark                    v1.8.1  v1.8.2  v1.8.3  v1.9.0  v1.9.1
+  Benchmark                    v1.8.2  v1.8.3  v1.9.0  v1.9.1  v1.9.2
   ---                          ------  ------  ------  ------  ------
-  range(2M) | length           0.012s  0.012s  0.011s  0.009s  0.009s
-  reverse(2M)                  0.018s  0.018s  0.018s  0.016s  0.016s
-  sort(2M)                     0.024s  0.023s  0.024s  0.025s  0.026s
-  unique(1M)                   0.031s  0.033s  0.033s  0.034s  0.034s
-  flatten(500K)                0.011s  0.011s  0.010s  0.010s  0.010s
-  min, max(2M)                 0.020s  0.021s  0.020s  0.016s  0.017s
-  add numbers(2M)              0.013s  0.013s  0.013s  0.011s  0.011s
-  any/all(2M)                  0.028s  0.029s  0.028s  0.031s  0.032s
-  limit(10; range(10M))        0.002s  0.002s  0.002s  0.003s  0.003s
-  first(range(10M))            0.002s  0.002s  0.002s  0.003s  0.002s
-  last(range(2M))              0.002s  0.002s  0.002s  0.003s  0.002s
-  indices(1M)                  0.016s  0.017s  0.017s  0.018s  0.017s
+  range(2M) | length           0.012s  0.011s  0.009s  0.009s  0.009s
+  reverse(2M)                  0.018s  0.018s  0.016s  0.016s  0.018s
+  sort(2M)                     0.023s  0.024s  0.025s  0.026s  0.027s
+  unique(1M)                   0.033s  0.033s  0.034s  0.034s  0.035s
+  flatten(500K)                0.011s  0.010s  0.010s  0.010s  0.010s
+  min, max(2M)                 0.021s  0.020s  0.016s  0.017s  0.017s
+  add numbers(2M)              0.013s  0.013s  0.011s  0.011s  0.010s
+  any/all(2M)                  0.029s  0.028s  0.031s  0.032s  0.031s
+  limit(10; range(10M))        0.002s  0.002s  0.003s  0.003s  0.003s
+  first(range(10M))            0.002s  0.002s  0.003s  0.002s  0.003s
+  last(range(2M))              0.002s  0.002s  0.003s  0.002s  0.003s
+  indices(1M)                  0.017s  0.017s  0.018s  0.017s  0.018s
 
 --- Reduce & foreach ---
-  Benchmark                    v1.8.1  v1.8.2  v1.8.3  v1.9.0  v1.9.1
+  Benchmark                    v1.8.2  v1.8.3  v1.9.0  v1.9.1  v1.9.2
   ---                          ------  ------  ------  ------  ------
-  reduce (sum)                 0.009s  0.009s  0.009s  0.010s  0.010s
-  reduce (array build)         0.004s  0.004s  0.004s  0.005s  0.005s
-  reduce (obj build)           0.010s  0.009s  0.010s  0.010s  0.010s
-  reduce (setpath)             0.017s  0.016s  0.016s  0.018s  0.017s
-  foreach (running sum)        0.010s  0.010s  0.010s  0.011s  0.011s
-  foreach + emit               0.010s  0.010s  0.010s  0.011s  0.011s
-  reduce (sum-of-squares)      0.033s  0.033s  0.033s  0.036s  0.034s
-  reduce (conditional)         0.035s  0.036s  0.035s  0.037s  0.037s
-  reduce (product)             0.034s  0.035s  0.034s  0.036s  0.035s
-  foreach (conditional)        0.010s  0.011s  0.010s  0.011s  0.011s
-  until (100M)                 0.301s  0.308s  0.312s  0.322s  0.325s
-  reduce (harmonic)            0.032s  0.033s  0.035s  0.036s  0.035s
-  reduce (floor pipe)          0.033s  0.033s  0.033s  0.035s  0.034s
-  reduce (sqrt pipe)           0.033s  0.033s  0.034s  0.035s  0.035s
-  reduce (sin+cos)             0.052s  0.052s  0.052s  0.053s  0.053s
+  reduce (sum)                 0.009s  0.009s  0.010s  0.010s  0.010s
+  reduce (array build)         0.004s  0.004s  0.005s  0.005s  0.005s
+  reduce (obj build)           0.009s  0.010s  0.010s  0.010s  0.010s
+  reduce (setpath)             0.016s  0.016s  0.018s  0.017s  0.017s
+  foreach (running sum)        0.010s  0.010s  0.011s  0.011s  0.011s
+  foreach + emit               0.010s  0.010s  0.011s  0.011s  0.011s
+  reduce (sum-of-squares)      0.033s  0.033s  0.036s  0.034s  0.036s
+  reduce (conditional)         0.036s  0.035s  0.037s  0.037s  0.037s
+  reduce (product)             0.035s  0.034s  0.036s  0.035s  0.036s
+  foreach (conditional)        0.011s  0.010s  0.011s  0.011s  0.011s
+  until (100M)                 0.308s  0.312s  0.322s  0.325s  0.324s
+  reduce (harmonic)            0.033s  0.035s  0.036s  0.035s  0.035s
+  reduce (floor pipe)          0.033s  0.033s  0.035s  0.034s  0.035s
+  reduce (sqrt pipe)           0.033s  0.034s  0.035s  0.035s  0.035s
+  reduce (sin+cos)             0.052s  0.052s  0.053s  0.053s  0.052s
 
 --- Object operations ---
-  Benchmark                    v1.8.1  v1.8.2  v1.8.3  v1.9.0  v1.9.1
+  Benchmark                    v1.8.2  v1.8.3  v1.9.0  v1.9.1  v1.9.2
   ---                          ------  ------  ------  ------  ------
   large obj construct          0.004s  0.004s  0.004s  0.004s  0.004s
   large obj keys               0.011s  0.011s  0.011s  0.011s  0.011s
-  large obj to_entries         0.012s  0.012s  0.012s  0.012s  0.012s
-  with_entries                 0.009s  0.009s  0.009s  0.009s  0.010s
+  large obj to_entries         0.012s  0.012s  0.012s  0.012s  0.013s
+  with_entries                 0.009s  0.009s  0.009s  0.010s  0.010s
 
 --- Assignment operators ---
-  Benchmark                    v1.8.1  v1.8.2  v1.8.3  v1.9.0  v1.9.1
+  Benchmark                    v1.8.2  v1.8.3  v1.9.0  v1.9.1  v1.9.2
   ---                          ------  ------  ------  ------  ------
-  .[] |= f (100K)              0.005s  0.005s  0.005s  0.005s  0.006s
-  .[] += 1 (100K)              0.005s  0.005s  0.005s  0.006s  0.006s
-  .[k] = v reduce(50K)         0.008s  0.008s  0.008s  0.009s  0.009s
-  p126-shape nested reduce     0.110s  0.120s  0.121s  0.118s  0.120s
-  p126-shape w/ mutate         0.112s  0.129s  0.124s  0.124s  0.120s
-  p150-shape serial mutate     0.012s  0.011s  0.012s  0.013s  0.012s
+  .[] |= f (100K)              0.005s  0.005s  0.005s  0.006s  0.005s
+  .[] += 1 (100K)              0.005s  0.005s  0.006s  0.006s  0.006s
+  .[k] = v reduce(50K)         0.008s  0.008s  0.009s  0.009s  0.009s
+  p126-shape nested reduce     0.120s  0.121s  0.118s  0.120s  0.119s
+  p126-shape w/ mutate         0.129s  0.124s  0.124s  0.120s  0.132s
+  p150-shape serial mutate     0.011s  0.012s  0.013s  0.012s  0.013s
 
 --- String-heavy generators ---
-  Benchmark                    v1.8.1  v1.8.2  v1.8.3  v1.9.0  v1.9.1
+  Benchmark                    v1.8.2  v1.8.3  v1.9.0  v1.9.1  v1.9.2
   ---                          ------  ------  ------  ------  ------
-  gsub(100K)                   0.027s  0.029s  0.028s  0.029s  0.029s
+  gsub(100K)                   0.029s  0.028s  0.029s  0.029s  0.029s
   join large(100K)             0.006s  0.006s  0.006s  0.006s  0.006s
-  explode/implode(100K)        0.028s  0.028s  0.027s  0.029s  0.028s
+  explode/implode(100K)        0.028s  0.027s  0.029s  0.028s  0.028s
   reduce str concat(100K)      0.008s  0.008s  0.008s  0.008s  0.008s
 
 --- Try-catch & alternative ---
-  Benchmark                    v1.8.1  v1.8.2  v1.8.3  v1.9.0  v1.9.1
+  Benchmark                    v1.8.2  v1.8.3  v1.9.0  v1.9.1  v1.9.2
   ---                          ------  ------  ------  ------  ------
-  alternative //               0.035s  0.032s  0.033s  0.034s  0.034s
-  try-catch                    0.023s  0.024s  0.024s  0.024s  0.024s
+  alternative //               0.032s  0.033s  0.034s  0.034s  0.034s
+  try-catch                    0.024s  0.024s  0.024s  0.024s  0.025s
   label-break                  0.004s  0.004s  0.004s  0.004s  0.004s
 
 --- Type conversion ---
-  Benchmark                    v1.8.1  v1.8.2  v1.8.3  v1.9.0  v1.9.1
+  Benchmark                    v1.8.2  v1.8.3  v1.9.0  v1.9.1  v1.9.2
   ---                          ------  ------  ------  ------  ------
-  tojson/fromjson(100K)        0.022s  0.022s  0.022s  0.022s  0.023s
-  null propagation(2M)         0.092s  0.092s  0.090s  0.091s  0.090s
+  tojson/fromjson(100K)        0.022s  0.022s  0.022s  0.023s  0.022s
+  null propagation(2M)         0.092s  0.090s  0.091s  0.090s  0.090s
 
 --- jaq-derived ---
-  Benchmark                    v1.8.1  v1.8.2  v1.8.3  v1.9.0  v1.9.1
+  Benchmark                    v1.8.2  v1.8.3  v1.9.0  v1.9.1  v1.9.2
   ---                          ------  ------  ------  ------  ------
   jaq: reverse                 -       -       -       -       -
   jaq: sort                    -       -       -       -       -
@@ -294,9 +294,9 @@ Recent slice (last 5 columns). Full history lives in
   jaq: str-slice               -       -       -       -       -
 
 --- Memoization (jqx) ---
-  Benchmark                    v1.8.1  v1.8.2  v1.8.3  v1.9.0  v1.9.1
+  Benchmark                    v1.8.2  v1.8.3  v1.9.0  v1.9.1  v1.9.2
   ---                          ------  ------  ------  ------  ------
   memo fib (1K)                0.003s  0.003s  0.003s  0.003s  0.003s
-  memo collatz sum (10K)       0.017s  0.016s  0.014s  0.015s  0.015s
-  memo by .id (100K, 1K keys)  0.020s  0.020s  0.020s  0.020s  0.021s
+  memo collatz sum (10K)       0.016s  0.014s  0.015s  0.015s  0.015s
+  memo by .id (100K, 1K keys)  0.020s  0.020s  0.020s  0.021s  0.021s
 ```

--- a/docs/benchmark-history.tsv
+++ b/docs/benchmark-history.tsv
@@ -6234,3 +6234,223 @@ Type conversion	null propagation(2M)	v1.9.1	0.090
 Memoization (jqx)	memo fib (1K)	v1.9.1	0.003
 Memoization (jqx)	memo collatz sum (10K)	v1.9.1	0.015
 Memoization (jqx)	memo by .id (100K, 1K keys)	v1.9.1	0.021
+NDJSON workloads (2M objects)	empty	v1.9.2	0.019
+NDJSON workloads (2M objects)	identity -c	v1.9.2	0.087
+NDJSON workloads (2M objects)	identity (pretty)	v1.9.2	0.111
+NDJSON workloads (2M objects)	field access .name	v1.9.2	0.084
+NDJSON workloads (2M objects)	nested .x,.y,.name	v1.9.2	0.121
+NDJSON workloads (2M objects)	arithmetic .x + .y	v1.9.2	0.088
+NDJSON workloads (2M objects)	select .x > 1500000	v1.9.2	0.084
+NDJSON workloads (2M objects)	string concat	v1.9.2	0.096
+NDJSON workloads (2M objects)	object construct	v1.9.2	0.121
+NDJSON workloads (2M objects)	array construct	v1.9.2	0.106
+NDJSON workloads (2M objects)	.[]	v1.9.2	0.120
+NDJSON workloads (2M objects)	to_entries	v1.9.2	0.150
+NDJSON workloads (2M objects)	keys	v1.9.2	0.104
+NDJSON workloads (2M objects)	keys_unsorted	v1.9.2	0.103
+NDJSON workloads (2M objects)	length	v1.9.2	0.092
+NDJSON workloads (2M objects)	has("x")	v1.9.2	0.040
+NDJSON workloads (2M objects)	type	v1.9.2	0.020
+NDJSON workloads (2M objects)	del(.name)	v1.9.2	0.114
+NDJSON workloads (2M objects)	@csv	v1.9.2	0.122
+NDJSON workloads (2M objects)	split/join	v1.9.2	0.089
+NDJSON workloads (2M objects)	select|field	v1.9.2	0.097
+NDJSON workloads (2M objects)	select|remap	v1.9.2	0.099
+NDJSON workloads (2M objects)	computed remap	v1.9.2	0.201
+NDJSON workloads (2M objects)	[.x,.y]|add	v1.9.2	0.089
+NDJSON workloads (2M objects)	[.x,.y]|avg	v1.9.2	0.113
+NDJSON workloads (2M objects)	map(*2)|add	v1.9.2	0.108
+NDJSON workloads (2M objects)	keys|length	v1.9.2	0.261
+NDJSON workloads (2M objects)	.+{z=0}	v1.9.2	0.158
+NDJSON workloads (2M objects)	split|first	v1.9.2	0.088
+NDJSON workloads (2M objects)	slice[0..5]	v1.9.2	0.095
+NDJSON workloads (2M objects)	dynkey {(.name)}	v1.9.2	0.115
+NDJSON workloads (2M objects)	.x += 1	v1.9.2	0.133
+NDJSON workloads (2M objects)	{a}+{b} merge	v1.9.2	0.137
+NDJSON workloads (2M objects)	.x*2+1	v1.9.2	0.062
+NDJSON workloads (2M objects)	.x+.y*2	v1.9.2	0.101
+NDJSON workloads (2M objects)	.x > .y	v1.9.2	0.082
+NDJSON workloads (2M objects)	to_entries|len	v1.9.2	0.389
+NDJSON workloads (2M objects)	.x|.+1 (pipe)	v1.9.2	0.058
+NDJSON workloads (2M objects)	.x|.*2|.+1	v1.9.2	0.062
+NDJSON workloads (2M objects)	.name|.+"_x"	v1.9.2	0.094
+NDJSON workloads (2M objects)	.x>N | not	v1.9.2	0.052
+NDJSON workloads (2M objects)	and (2 cmp)	v1.9.2	0.084
+NDJSON workloads (2M objects)	if-then-else	v1.9.2	0.052
+NDJSON workloads (2M objects)	sel(and)|field	v1.9.2	0.086
+NDJSON workloads (2M objects)	sel(and)|remap	v1.9.2	0.084
+NDJSON workloads (2M objects)	arith|cmp	v1.9.2	0.056
+NDJSON workloads (2M objects)	if cmp .field	v1.9.2	0.113
+NDJSON workloads (2M objects)	split|length	v1.9.2	0.089
+NDJSON workloads (2M objects)	[x,y]|min	v1.9.2	0.096
+NDJSON workloads (2M objects)	[x,y]|max	v1.9.2	0.099
+NDJSON workloads (2M objects)	[x,y]|sort|.[0]	v1.9.2	0.094
+NDJSON workloads (2M objects)	.name|len>5	v1.9.2	0.086
+NDJSON workloads (2M objects)	sel(len>5)|.x	v1.9.2	0.113
+NDJSON workloads (2M objects)	if .x>.y .name	v1.9.2	0.092
+NDJSON workloads (2M objects)	sel(.x>.y)|.name	v1.9.2	0.077
+NDJSON workloads (2M objects)	.x*2|tostring	v1.9.2	0.058
+NDJSON workloads (2M objects)	.x*.x+1	v1.9.2	0.069
+NDJSON workloads (2M objects)	{k=.name,v=tostr}	v1.9.2	0.145
+NDJSON workloads (2M objects)	str add chain	v1.9.2	0.395
+NDJSON workloads (2M objects)	if>.y .name|empty	v1.9.2	0.077
+NDJSON workloads (2M objects)	if .x%2==0	v1.9.2	0.055
+NDJSON workloads (2M objects)	if .x*2+1>1M	v1.9.2	0.056
+NDJSON workloads (2M objects)	sel(.x%2==0)|.name	v1.9.2	0.085
+NDJSON workloads (2M objects)	sel(.x*2+1>1M)	v1.9.2	0.162
+NDJSON workloads (2M objects)	.x|@json	v1.9.2	0.061
+NDJSON workloads (2M objects)	.x|@text	v1.9.2	0.062
+NDJSON workloads (2M objects)	.name|@json	v1.9.2	0.103
+NDJSON workloads (2M objects)	sel|[arr]	v1.9.2	0.175
+NDJSON workloads (2M objects)	sel(and)|[arr]	v1.9.2	0.080
+NDJSON workloads (2M objects)	if>.y [arr]	v1.9.2	0.214
+NDJSON workloads (2M objects)	if sw then .f	v1.9.2	0.143
+NDJSON workloads (2M objects)	dynkey {(.n)=.x*2}	v1.9.2	0.117
+NDJSON workloads (2M objects)	sel(and)|.x*.y	v1.9.2	0.080
+NDJSON workloads (2M objects)	sel>N|str chain	v1.9.2	0.166
+NDJSON workloads (2M objects)	.f+"_"+arith_ts	v1.9.2	0.140
+NDJSON workloads (2M objects)	sel(sw)|str ch	v1.9.2	0.320
+NDJSON workloads (2M objects)	split|rev|join	v1.9.2	0.118
+NDJSON workloads (2M objects)	dynkey+static	v1.9.2	0.344
+NDJSON workloads (2M objects)	if>.y str chain	v1.9.2	0.172
+NDJSON workloads (2M objects)	remap+str chain	v1.9.2	0.163
+NDJSON workloads (2M objects)	sel(len>8)	v1.9.2	0.163
+NDJSON workloads (2M objects)	up|split|join	v1.9.2	0.098
+NDJSON workloads (2M objects)	.name|index	v1.9.2	0.121
+NDJSON workloads (2M objects)	.name|index+1	v1.9.2	0.127
+NDJSON workloads (2M objects)	.name|rindex	v1.9.2	0.130
+NDJSON workloads (2M objects)	.name|indices	v1.9.2	0.151
+NDJSON workloads (2M objects)	[x,y]|sort	v1.9.2	0.183
+NDJSON workloads (2M objects)	.name|scan	v1.9.2	0.210
+NDJSON workloads (2M objects)	.name|gsub	v1.9.2	0.166
+NDJSON workloads (2M objects)	walk(if num .+1)	v1.9.2	0.143
+NDJSON workloads (2M objects)	tojson	v1.9.2	0.119
+NDJSON workloads (2M objects)	{name,x}	v1.9.2	0.131
+NDJSON workloads (2M objects)	.z//.name	v1.9.2	0.179
+NDJSON workloads (2M objects)	.x|=test(re)	v1.9.2	0.174
+NDJSON workloads (2M objects)	./sep|first	v1.9.2	0.188
+NDJSON workloads (2M objects)	.y=(.x*2)	v1.9.2	0.184
+NDJSON workloads (2M objects)	.y=(.x+.y)	v1.9.2	0.238
+NDJSON workloads (2M objects)	objects	v1.9.2	0.140
+NDJSON workloads (2M objects)	.tag|=if..then N	v1.9.2	0.612
+NDJSON workloads (2M objects)	.x=(.x+1)	v1.9.2	0.138
+NDJSON workloads (2M objects)	sel>N|.y+=1	v1.9.2	0.129
+NDJSON workloads (2M objects)	sel(and)|.x+=1	v1.9.2	0.108
+NDJSON workloads (2M objects)	sel(sw)|.x+=1	v1.9.2	0.166
+NDJSON workloads (2M objects)	match(re)	v1.9.2	0.376
+NDJSON workloads (2M objects)	capture(re)	v1.9.2	0.305
+NDJSON workloads (2M objects)	first(.name,.x)	v1.9.2	0.081
+NDJSON workloads (2M objects)	if .x==null	v1.9.2	0.048
+NDJSON workloads (2M objects)	we(sw(.key))	v1.9.2	0.120
+NDJSON workloads (2M objects)	sel(sw or ew)	v1.9.2	0.210
+NDJSON workloads (2M objects)	path(.name,.x)	v1.9.2	0.307
+NDJSON workloads (2M objects)	sel(str+num+num)	v1.9.2	0.152
+NDJSON workloads (2M objects)	nested if|field	v1.9.2	0.082
+NDJSON workloads (2M objects)	.f|floor|.*2	v1.9.2	0.063
+NDJSON workloads (2M objects)	split|len>1	v1.9.2	0.113
+NDJSON workloads (2M objects)	.name|len|.*2	v1.9.2	0.103
+NDJSON workloads (2M objects)	if len>5 .x .y	v1.9.2	0.112
+NDJSON workloads (2M objects)	sel(len>5)|remap	v1.9.2	0.206
+NDJSON workloads (2M objects)	.x|tostr|len	v1.9.2	0.061
+NDJSON workloads (2M objects)	if .x>.y .x .y	v1.9.2	0.099
+NDJSON workloads (2M objects)	split|last|tonum	v1.9.2	0.093
+NDJSON workloads (2M objects)	split|rev|.[0]	v1.9.2	0.092
+NDJSON workloads (2M objects)	split|.[0]+.[1]	v1.9.2	0.113
+NDJSON workloads (2M objects)	.[]|strings	v1.9.2	0.106
+NDJSON workloads (2M objects)	.[]|numbers	v1.9.2	0.127
+NDJSON workloads (2M objects)	[x,y]|any(>1M)	v1.9.2	0.088
+NDJSON workloads (2M objects)	sel(dc|sw)	v1.9.2	0.097
+NDJSON workloads (2M objects)	[[x,y],[n]]|flat	v1.9.2	0.459
+NDJSON workloads (2M objects)	.x|floor|.*2	v1.9.2	0.062
+NDJSON workloads (2M objects)	tojson|fromjson	v1.9.2	0.089
+NDJSON workloads (2M objects)	[.x]|add	v1.9.2	0.050
+NDJSON workloads (2M objects)	if>N {o}+.	v1.9.2	0.138
+NDJSON workloads (2M objects)	if>N .+{o}	v1.9.2	0.142
+NDJSON workloads (2M objects)	if .n=="s" .+{o}	v1.9.2	0.157
+NDJSON workloads (2M objects)	sel(.n>"s")	v1.9.2	0.087
+NDJSON workloads (2M objects)	[x,y,z]|min	v1.9.2	0.316
+NDJSON workloads (2M objects)	if .n|len>5 l s	v1.9.2	0.100
+NDJSON workloads (2M objects)	if .x|flr>N b s	v1.9.2	0.056
+NDJSON workloads (2M objects)	if .n|test l e	v1.9.2	0.101
+NDJSON workloads (2M objects)	if .n|sw l e	v1.9.2	0.083
+NDJSON workloads (2M objects)	if .n|ew l e	v1.9.2	0.085
+NDJSON workloads (2M objects)	.n|len|tostr	v1.9.2	0.092
+String operations (2M objects)	ascii_downcase	v1.9.2	0.095
+String operations (2M objects)	ascii_upcase	v1.9.2	0.095
+String operations (2M objects)	ltrimstr	v1.9.2	0.095
+String operations (2M objects)	rtrimstr	v1.9.2	0.096
+String operations (2M objects)	split	v1.9.2	0.164
+String operations (2M objects)	case+split	v1.9.2	0.120
+String operations (2M objects)	join	v1.9.2	0.096
+String operations (2M objects)	startswith	v1.9.2	0.090
+String operations (2M objects)	endswith	v1.9.2	0.089
+String operations (2M objects)	tostring	v1.9.2	0.065
+String operations (2M objects)	tonumber	v1.9.2	0.113
+String operations (2M objects)	string interpolation	v1.9.2	0.128
+String ops (200K objects)	test (regex)	v1.9.2	0.015
+String ops (200K objects)	match (regex)	v1.9.2	0.033
+String ops (200K objects)	@base64	v1.9.2	0.012
+String ops (200K objects)	@uri	v1.9.2	0.012
+String ops (200K objects)	@html	v1.9.2	0.012
+String ops (200K objects)	@csv (array)	v1.9.2	0.016
+String ops (200K objects)	@tsv (array)	v1.9.2	0.017
+String ops (200K objects)	gsub	v1.9.2	0.019
+String ops (200K objects)	case+gsub	v1.9.2	0.180
+String ops (200K objects)	case+test	v1.9.2	0.119
+String ops (200K objects)	ltrim+tonum+arith	v1.9.2	0.111
+Numeric & math (2M objects)	floor	v1.9.2	0.059
+Numeric & math (2M objects)	sqrt	v1.9.2	0.079
+Numeric & math (2M objects)	modulo	v1.9.2	0.059
+Numeric & math (2M objects)	if-elif-else	v1.9.2	0.130
+Numeric & math (2M objects)	select|del	v1.9.2	0.098
+Numeric & math (2M objects)	select|merge	v1.9.2	0.123
+Numeric & math (2M objects)	select(test)|merge	v1.9.2	0.022
+Array generators	range(2M) | length	v1.9.2	0.009
+Array generators	reverse(2M)	v1.9.2	0.018
+Array generators	sort(2M)	v1.9.2	0.027
+Array generators	unique(1M)	v1.9.2	0.035
+Array generators	flatten(500K)	v1.9.2	0.010
+Array generators	min, max(2M)	v1.9.2	0.017
+Array generators	add numbers(2M)	v1.9.2	0.010
+Array generators	any/all(2M)	v1.9.2	0.031
+Array generators	limit(10; range(10M))	v1.9.2	0.003
+Array generators	first(range(10M))	v1.9.2	0.003
+Array generators	last(range(2M))	v1.9.2	0.003
+Array generators	indices(1M)	v1.9.2	0.018
+Reduce & foreach	reduce (sum)	v1.9.2	0.010
+Reduce & foreach	reduce (array build)	v1.9.2	0.005
+Reduce & foreach	reduce (obj build)	v1.9.2	0.010
+Reduce & foreach	reduce (setpath)	v1.9.2	0.017
+Reduce & foreach	foreach (running sum)	v1.9.2	0.011
+Reduce & foreach	foreach + emit	v1.9.2	0.011
+Reduce & foreach	reduce (sum-of-squares)	v1.9.2	0.036
+Reduce & foreach	reduce (conditional)	v1.9.2	0.037
+Reduce & foreach	reduce (product)	v1.9.2	0.036
+Reduce & foreach	foreach (conditional)	v1.9.2	0.011
+Reduce & foreach	until (100M)	v1.9.2	0.324
+Reduce & foreach	reduce (harmonic)	v1.9.2	0.035
+Reduce & foreach	reduce (floor pipe)	v1.9.2	0.035
+Reduce & foreach	reduce (sqrt pipe)	v1.9.2	0.035
+Reduce & foreach	reduce (sin+cos)	v1.9.2	0.052
+Object operations	large obj construct	v1.9.2	0.004
+Object operations	large obj keys	v1.9.2	0.011
+Object operations	large obj to_entries	v1.9.2	0.013
+Object operations	with_entries	v1.9.2	0.010
+Assignment operators	.[] |= f (100K)	v1.9.2	0.005
+Assignment operators	.[] += 1 (100K)	v1.9.2	0.006
+Assignment operators	.[k] = v reduce(50K)	v1.9.2	0.009
+Assignment operators	p126-shape nested reduce	v1.9.2	0.119
+Assignment operators	p126-shape w/ mutate	v1.9.2	0.132
+Assignment operators	p150-shape serial mutate	v1.9.2	0.013
+String-heavy generators	gsub(100K)	v1.9.2	0.029
+String-heavy generators	join large(100K)	v1.9.2	0.006
+String-heavy generators	explode/implode(100K)	v1.9.2	0.028
+String-heavy generators	reduce str concat(100K)	v1.9.2	0.008
+Try-catch & alternative	alternative //	v1.9.2	0.034
+Try-catch & alternative	try-catch	v1.9.2	0.025
+Try-catch & alternative	label-break	v1.9.2	0.004
+Type conversion	tojson/fromjson(100K)	v1.9.2	0.022
+Type conversion	null propagation(2M)	v1.9.2	0.090
+Memoization (jqx)	memo fib (1K)	v1.9.2	0.003
+Memoization (jqx)	memo collatz sum (10K)	v1.9.2	0.015
+Memoization (jqx)	memo by .id (100K, 1K keys)	v1.9.2	0.021


### PR DESCRIPTION
## Summary

Release v1.9.2 — re-delivery release. The v1.9.1 release run was blocked by the second Windows-only test-escaping bug (`module_search_path`, fixed in #1124, same class as #1122); v1.8.3/v1.9.0/v1.9.1 never shipped binaries. This time the full 3-OS matrix was verified green via a manual ci.yml dispatch (run 27391491709, Windows included) before tagging.

Ships everything since v1.8.2: the #1059 JIT delegation series, the #1032–#1037 type-safety series, the #1028 number-formatter unification, the `JitOp::PathProbe` perf fix from the v1.9.0 gate, and the two Windows test fixes.

## Benchmarks

220 matched benchmarks vs v1.9.1 (binary-identical build): geomean 1.007, worst real entry 1.10 on the documented p126 layout-lottery benchmark — pure run-to-run noise, no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)