### PR TITLE
perf(serialization): cut per-emit canonicalization scans on @text/@json/interpolation hot paths

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -921,6 +921,20 @@ fn push_interp_num_canon(buf: &mut Vec<u8>, val: &[u8]) {
     buf.extend_from_slice(val);
 }
 
+/// Variant of [`emit_interp_field_raw`] for fields the extraction walk
+/// classified clean (`json_object_get_fields_raw_buf_classified`): the
+/// lexeme is a canonical scalar with no re-encodable escape (composites
+/// always classify dirty), so strings copy their inner content and every
+/// other value copies verbatim — zero per-field scans (#1077).
+#[inline]
+fn emit_interp_field_verbatim(buf: &mut Vec<u8>, val: &[u8]) {
+    if val.first() == Some(&b'"') && val.len() >= 2 {
+        buf.extend_from_slice(&val[1..val.len() - 1]);
+    } else {
+        buf.extend_from_slice(val);
+    }
+}
+
 /// Variant of [`emit_interp_field_raw`] for records pre-checked to contain
 /// no `\` / DEL byte anywhere (one per-record `memchr2` amortizes the
 /// per-field escape scans on the interpolation hot paths): string content
@@ -7617,11 +7631,13 @@ fn real_main() {
                     // .field | @text / @json / @base64 / @uri / @html — raw byte format
                     json_stream_raw(&input_str, |start, end| {
                         let raw = &input_bytes[start..end];
-                        let outcome = apply_field_format_raw(raw, ff_field, |val, content| {
+                        let outcome = apply_field_format_raw(raw, ff_field, |val, content, clean| {
                             match (ff_format.as_str(), content) {
                                 ("text", Some(_)) => {
-                                    // @text on string: identity — output the JSON string as-is
-                                    if raw_contains_noncanon_escape(val) { push_raw_canon_escapes(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
+                                    // @text on string: identity — output the JSON string
+                                    // as-is. A clean value can't carry a re-encodable
+                                    // escape, so the scan is skipped (#1077).
+                                    if !clean && raw_contains_noncanon_escape(val) { push_raw_canon_escapes(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
                                     compact_buf.push(b'\n');
                                     RawApplyOutcome::Emit
                                 }
@@ -7644,10 +7660,18 @@ fn real_main() {
                                 }
                                 ("json" | "text", None) => {
                                     // @json/@text on non-string scalars: wrap raw bytes in
-                                    // quotes. A composite needs its inner quotes escaped, and
-                                    // a NaN/Infinity or non-canonical number lexeme must be
-                                    // normalised, not echoed (#1021) — both defer to the
-                                    // typed path.
+                                    // quotes. A clean value is a canonical scalar lexeme
+                                    // (composites always classify dirty) — emit verbatim
+                                    // with no per-value scan (#1077). Otherwise a composite
+                                    // needs its inner quotes escaped, and a NaN/Infinity or
+                                    // non-canonical number lexeme must be normalised, not
+                                    // echoed (#1021) — both defer to the typed path.
+                                    if clean {
+                                        compact_buf.push(b'"');
+                                        compact_buf.extend_from_slice(val);
+                                        compact_buf.extend_from_slice(b"\"\n");
+                                        return RawApplyOutcome::Emit;
+                                    }
                                     if matches!(val.first(), Some(b'{') | Some(b'['))
                                         || raw_contains_non_canonical_number(val)
                                     {
@@ -7867,12 +7891,16 @@ fn real_main() {
                             process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                             return Ok(());
                         }
-                        // Extract all needed fields
-                        if json_object_get_fields_raw_buf(raw, 0, &field_names, &mut ranges_buf) {
+                        // Extract all needed fields, classifying their
+                        // verbatim-safety in the same walk (#1077).
+                        if let Some(all_clean) = jq_jit::value::json_object_get_fields_raw_buf_classified(raw, 0, &field_names, &mut ranges_buf) {
                             // One scan amortizes the per-field escape checks:
                             // a record with no backslash/DEL anywhere cannot
                             // need string re-encoding (#1027 cost control).
-                            let strings_clean = memchr::memchr2(b'\\', 0x7F, raw).is_none();
+                            // Skipped when every extracted field already
+                            // classified clean — those emit verbatim.
+                            let strings_clean = !all_clean
+                                && memchr::memchr2(b'\\', 0x7F, raw).is_none();
                             compact_buf.push(b'"');
                             let mut field_idx = 0;
                             for (i, (is_lit, _)) in interp_parts.iter().enumerate() {
@@ -7887,7 +7915,9 @@ fn real_main() {
                                     // keep canonical lexemes and re-render
                                     // NaN/Infinity/non-canonical ones (#1021);
                                     // composites re-escape for embedding.
-                                    if strings_clean {
+                                    if all_clean {
+                                        emit_interp_field_verbatim(&mut compact_buf, val);
+                                    } else if strings_clean {
                                         emit_interp_field_raw_clean(&mut compact_buf, val);
                                     } else {
                                         emit_interp_field_raw(&mut compact_buf, val);
@@ -20257,10 +20287,11 @@ fn real_main() {
                 let content_bytes = content.as_bytes();
                 json_stream_raw(content, |start, end| {
                     let raw = &content_bytes[start..end];
-                    let outcome = apply_field_format_raw(raw, ff_field, |val, content_no_quotes| {
+                    let outcome = apply_field_format_raw(raw, ff_field, |val, content_no_quotes, clean| {
                         match (ff_format.as_str(), content_no_quotes) {
                             ("text", Some(_)) => {
-                                if raw_contains_noncanon_escape(val) { push_raw_canon_escapes(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
+                                // Clean values can't carry a re-encodable escape (#1077).
+                                if !clean && raw_contains_noncanon_escape(val) { push_raw_canon_escapes(&mut compact_buf, val); } else { compact_buf.extend_from_slice(val); }
                                 compact_buf.push(b'\n');
                                 RawApplyOutcome::Emit
                             }
@@ -20281,6 +20312,13 @@ fn real_main() {
                                 RawApplyOutcome::Emit
                             }
                             ("json" | "text", None) => {
+                                // Clean scalar lexeme: verbatim, no per-value scan (#1077).
+                                if clean {
+                                    compact_buf.push(b'"');
+                                    compact_buf.extend_from_slice(val);
+                                    compact_buf.extend_from_slice(b"\"\n");
+                                    return RawApplyOutcome::Emit;
+                                }
                                 // Composite / non-canonical number lexeme: defer to the
                                 // typed path (inner-quote escaping, NaN -> null; #1021).
                                 if matches!(val.first(), Some(b'{') | Some(b'['))
@@ -20502,9 +20540,11 @@ fn real_main() {
                         process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
                         return Ok(());
                     }
-                    if json_object_get_fields_raw_buf(raw, 0, &field_names, &mut ranges_buf) {
-                        // See the NDJSON twin: per-record escape gate (#1027).
-                        let strings_clean = memchr::memchr2(b'\\', 0x7F, raw).is_none();
+                    if let Some(all_clean) = jq_jit::value::json_object_get_fields_raw_buf_classified(raw, 0, &field_names, &mut ranges_buf) {
+                        // See the NDJSON twin: per-record escape gate (#1027),
+                        // skipped when every extracted field classified clean (#1077).
+                        let strings_clean = !all_clean
+                            && memchr::memchr2(b'\\', 0x7F, raw).is_none();
                         compact_buf.push(b'"');
                         let mut field_idx = 0;
                         for (i, (is_lit, _)) in interp_parts.iter().enumerate() {
@@ -20516,7 +20556,9 @@ fn real_main() {
                                 let val = &raw[vs..ve];
                                 // Shared emitter (see the NDJSON twin): #1027 /
                                 // #1021 canonicalisation in one place.
-                                if strings_clean {
+                                if all_clean {
+                                    emit_interp_field_verbatim(&mut compact_buf, val);
+                                } else if strings_clean {
                                     emit_interp_field_raw_clean(&mut compact_buf, val);
                                 } else {
                                     emit_interp_field_raw(&mut compact_buf, val);

--- a/src/fast_path.rs
+++ b/src/fast_path.rs
@@ -69,7 +69,8 @@ use crate::value::{
     KeyStr, Value, ObjInner, json_each_value_cb, json_object_assign_field_arith,
     json_object_assign_two_fields_arith, json_object_del_field, json_object_del_fields,
     json_object_filter_by_key_str, json_object_filter_by_value_type,
-    json_object_get_field_raw, json_object_get_fields_raw_buf, json_object_merge_literal,
+    json_object_get_field_raw, json_object_get_field_raw_classified,
+    json_object_get_fields_raw_buf, json_object_merge_literal,
     json_object_values_tostring, json_with_entries_select_value_cmp, push_tojson_raw,
     raw_contains_non_canonical_number,
     json_object_get_nested_field_raw, json_object_get_num, json_object_get_two_nums,
@@ -632,39 +633,44 @@ where
 /// returned [`RawApplyOutcome`].
 ///
 /// * Object input, field present, value is a quoted string with no `\`
-///   escapes — invokes `on_value(val_with_quotes, Some(content))`.
+///   escapes — invokes `on_value(val_with_quotes, Some(content), clean)`.
 /// * Object input, field present, value is a non-string scalar
 ///   (number / bool / null / array / object literal) — invokes
-///   `on_value(val_bytes, None)`. The closure decides whether to emit
-///   or to return [`RawApplyOutcome::Bail`] (e.g. `@base64` returns
+///   `on_value(val_bytes, None, clean)`. The closure decides whether to
+///   emit or to return [`RawApplyOutcome::Bail`] (e.g. `@base64` returns
 ///   Bail, `@json` returns Emit after wrapping the raw bytes).
 /// * Field absent, or value is a quoted string with at least one `\`
 ///   escape — returns [`RawApplyOutcome::Bail`] without invoking the
 ///   closure (the generic path decodes the escape / raises the error).
 /// * Non-object input — returns [`RawApplyOutcome::Bail`] (the field
 ///   fetch fails).
+///
+/// `clean` is the extraction walk's verbatim-safety verdict for the value
+/// (see `skip_json_value_classify`): when true, the lexeme carries no
+/// non-canonical number shape, no escape jq would re-encode, and no DEL
+/// byte, so the apply site can emit it without any per-value scan (#1077).
 pub fn apply_field_format_raw<F>(
     raw: &[u8],
     field: &str,
     on_value: F,
 ) -> RawApplyOutcome
 where
-    F: FnOnce(&[u8], Option<&[u8]>) -> RawApplyOutcome,
+    F: FnOnce(&[u8], Option<&[u8]>, bool) -> RawApplyOutcome,
 {
-    let (vs, ve) = match json_object_get_field_raw(raw, 0, field) {
+    let (vs, ve, clean) = match json_object_get_field_raw_classified(raw, 0, field) {
         Some(r) => r,
         None => return RawApplyOutcome::Bail,
     };
     let val = &raw[vs..ve];
     let content = if val.len() >= 2 && val[0] == b'"' && val[val.len() - 1] == b'"' {
-        if val[1..val.len() - 1].contains(&b'\\') {
+        if !clean && val[1..val.len() - 1].contains(&b'\\') {
             return RawApplyOutcome::Bail;
         }
         Some(&val[1..val.len() - 1])
     } else {
         None
     };
-    on_value(val, content)
+    on_value(val, content, clean)
 }
 
 /// Apply the `.field | ltrimstr("prefix") | tonumber [ | <arith> ]*`

--- a/src/value.rs
+++ b/src/value.rs
@@ -5995,6 +5995,16 @@ pub fn push_jq_number_str(buf: &mut String, n: f64) {
 ///   but the canonical literal still round-trips through f64 — e.g.
 ///   DBL_MAX `1.7976931348623157e308` and the smallest subnormal `5e-324`.
 fn num_repr_text<'a>(n: f64, repr: Option<&'a Rc<str>>) -> Option<std::borrow::Cow<'a, str>> {
+    // One-pass fast path for the dominant lexeme shape in number-heavy hot
+    // loops (#1077): a plain short decimal is simultaneously a valid JSON
+    // number, exact for its paired f64, and already canonical, so the three
+    // full scans below (validity / exactness / normalization) can be
+    // skipped. Rejection is never wrong — it just falls through.
+    if let Some(r) = repr {
+        if n.is_finite() && repr_is_short_canonical_plain(r) {
+            return Some(std::borrow::Cow::Borrowed(&**r));
+        }
+    }
     if let Some(r) = repr.filter(|r| is_valid_json_number(r) && repr_is_exact_for_f64(r, n)) {
         return Some(match normalize_jq_repr(r) {
             Some(canonical) => std::borrow::Cow::Owned(canonical),
@@ -6005,6 +6015,47 @@ fn num_repr_text<'a>(n: f64, repr: Option<&'a Rc<str>>) -> Option<std::borrow::C
         .and_then(|r| normalize_jq_repr(r))
         .filter(|c| c.as_str().parse::<f64>().ok() == Some(n))
         .map(std::borrow::Cow::Owned)
+}
+
+/// One-pass test for a plain decimal lexeme (optional `-`, integer part
+/// without leading zeros, optional non-empty fraction, no exponent) of at
+/// most 15 total digits whose fraction does not open with six zeros.
+/// Such a lexeme passes all three of `num_repr_text`'s checks verbatim:
+/// it is a valid JSON number by shape, exact for its paired f64
+/// (`repr_is_exact_for_f64` accepts any ≤15-sig-digit finite lexeme, and
+/// total digits bound sig digits), and `normalize_jq_repr` returns `None`
+/// for every plain decimal whose effective exponent stays in the
+/// canonical window — which the ≤15-digit and no-`.000000` constraints
+/// guarantee. Conservative by construction: any rejected lexeme simply
+/// takes the full checks.
+#[inline]
+fn repr_is_short_canonical_plain(repr: &str) -> bool {
+    let b = repr.as_bytes();
+    let mut i = usize::from(b.first() == Some(&b'-'));
+    let int_start = i;
+    while i < b.len() && b[i].is_ascii_digit() { i += 1; }
+    let int_len = i - int_start;
+    if int_len == 0 || (int_len > 1 && b[int_start] == b'0') {
+        return false;
+    }
+    let mut digits = int_len;
+    if i < b.len() {
+        if b[i] != b'.' {
+            return false;
+        }
+        // `0.000000x` normalizes to scientific form (#611) — defer.
+        if b.get(i + 1..i + 7) == Some(&[b'0'; 6][..]) {
+            return false;
+        }
+        i += 1;
+        let frac_start = i;
+        while i < b.len() && b[i].is_ascii_digit() { i += 1; }
+        if i != b.len() || i == frac_start {
+            return false;
+        }
+        digits += i - frac_start;
+    }
+    digits <= 15
 }
 
 /// Core behind the @csv / @tsv number writers: jq preserves the literal

--- a/tests/contract_fast_path.rs
+++ b/tests/contract_fast_path.rs
@@ -1546,19 +1546,19 @@ fn raw_field_scan_non_object_input_bails() {
 
 #[test]
 fn raw_field_format_string_value_emits() {
-    let mut seen: Vec<(Vec<u8>, Option<Vec<u8>>)> = Vec::new();
+    let mut seen: Vec<(Vec<u8>, Option<Vec<u8>>, bool)> = Vec::new();
     let outcome = apply_field_format_raw(
         b"{\"x\":\"hi\"}",
         "x",
-        |val, content| {
-            seen.push((val.to_vec(), content.map(|c| c.to_vec())));
+        |val, content, clean| {
+            seen.push((val.to_vec(), content.map(|c| c.to_vec()), clean));
             RawApplyOutcome::Emit
         },
     );
     assert!(matches!(outcome, RawApplyOutcome::Emit));
     assert_eq!(
         seen,
-        vec![(b"\"hi\"".to_vec(), Some(b"hi".to_vec()))],
+        vec![(b"\"hi\"".to_vec(), Some(b"hi".to_vec()), true)],
     );
 }
 
@@ -1567,18 +1567,24 @@ fn raw_field_format_non_string_scalar_invokes_with_none() {
     // The helper hands the closure `(val, None)` for non-string scalars; the
     // closure decides whether to Emit (e.g. @json wraps raw bytes) or Bail
     // (e.g. @base64 raises on non-string).
-    for (input, expected_val) in [
-        (&b"{\"x\":42}"[..], &b"42"[..]),
-        (&b"{\"x\":null}"[..], &b"null"[..]),
-        (&b"{\"x\":true}"[..], &b"true"[..]),
+    for (input, expected_val, expected_clean) in [
+        (&b"{\"x\":42}"[..], &b"42"[..], true),
+        (&b"{\"x\":null}"[..], &b"null"[..], true),
+        (&b"{\"x\":true}"[..], &b"true"[..], true),
+        // Non-canonical lexemes still invoke the closure, but classify
+        // dirty so the apply site keeps its canonicalisation gates (#1077).
+        (&b"{\"x\":1e3}"[..], &b"1e3"[..], false),
+        (&b"{\"x\":nan}"[..], &b"nan"[..], false),
+        // Composites always classify dirty.
+        (&b"{\"x\":[1,2]}"[..], &b"[1,2]"[..], false),
     ] {
-        let mut seen: Vec<(Vec<u8>, Option<Vec<u8>>)> = Vec::new();
-        let outcome = apply_field_format_raw(input, "x", |val, content| {
-            seen.push((val.to_vec(), content.map(|c| c.to_vec())));
+        let mut seen: Vec<(Vec<u8>, Option<Vec<u8>>, bool)> = Vec::new();
+        let outcome = apply_field_format_raw(input, "x", |val, content, clean| {
+            seen.push((val.to_vec(), content.map(|c| c.to_vec()), clean));
             RawApplyOutcome::Emit
         });
         assert!(matches!(outcome, RawApplyOutcome::Emit));
-        assert_eq!(seen, vec![(expected_val.to_vec(), None)]);
+        assert_eq!(seen, vec![(expected_val.to_vec(), None, expected_clean)]);
     }
 }
 
@@ -1589,7 +1595,7 @@ fn raw_field_format_propagates_closure_bail_verdict() {
     let outcome = apply_field_format_raw(
         b"{\"x\":42}",
         "x",
-        |_, _| RawApplyOutcome::Bail,
+        |_, _, _| RawApplyOutcome::Bail,
     );
     assert!(matches!(outcome, RawApplyOutcome::Bail));
 }
@@ -1600,7 +1606,7 @@ fn raw_field_format_field_missing_bails_without_invoking_closure() {
     let outcome = apply_field_format_raw(
         b"{\"y\":\"hi\"}",
         "x",
-        |_, _| {
+        |_, _, _| {
             called += 1;
             RawApplyOutcome::Emit
         },
@@ -1615,7 +1621,7 @@ fn raw_field_format_escaped_string_bails_without_invoking_closure() {
     let outcome = apply_field_format_raw(
         br#"{"x":"a\nb"}"#,
         "x",
-        |_, _| {
+        |_, _, _| {
             called += 1;
             RawApplyOutcome::Emit
         },
@@ -1634,7 +1640,7 @@ fn raw_field_format_non_object_input_bails_without_invoking_closure() {
         b"[1,2,3]".as_slice(),
     ] {
         let mut called = 0u32;
-        let outcome = apply_field_format_raw(raw, "x", |_, _| {
+        let outcome = apply_field_format_raw(raw, "x", |_, _, _| {
             called += 1;
             RawApplyOutcome::Emit
         });

--- a/tests/contract_number_format.rs
+++ b/tests/contract_number_format.rs
@@ -160,6 +160,42 @@ fn repr_preserving_corpus_pins() {
     assert_eq!(tojson, "null");
 }
 
+/// #1077: `num_repr_text` short-circuits plain short decimal lexemes with a
+/// single scan instead of the three full checks (validity / exactness /
+/// normalization). Pin the boundary shapes on both sides of the gate so the
+/// fast path can never drift from the semantics it replaces — every
+/// expected value below was cross-checked against jq 1.8.1 (the 16-digit
+/// integer is the known no-decnum fallback, #236/#415).
+#[test]
+fn short_canonical_plain_fast_path_boundary_pins() {
+    let cases: &[(&str, &str)] = &[
+        // Inside the fast path: emitted verbatim.
+        ("123", "123"),
+        ("-7", "-7"),
+        ("1.5", "1.5"),
+        ("1.50", "1.50"),
+        ("0.5", "0.5"),
+        ("-0", "-0"),
+        ("999999999999999", "999999999999999"), // 15 digits, max accepted
+        ("0.000001", "0.000001"),               // 5-zero fraction stays plain
+        ("123.4567890123", "123.4567890123"),
+        // Rejected by the fast path (conservative): the full checks decide.
+        ("1.0000005", "1.0000005"), // 6-zero run but te in canonical window
+        ("0.000000", "0.000000"),   // pure-zero 6-digit fraction stays plain
+        ("0.0000001", "1E-7"),      // #611 normalization
+        ("-0.0000001", "-1E-7"),
+        ("1e3", "1E+3"),            // exponent → canonical uppercase-E form
+        ("9999999999999999", "1e+16"), // 16 digits → repr dropped, f64 form
+    ];
+    for &(lexeme, expected) in cases {
+        let n: f64 = lexeme.parse().expect("test lexeme parses");
+        let repr: Rc<str> = Rc::from(lexeme);
+        let mut out = String::new();
+        push_num_tojson_str(&mut out, n, Some(&repr));
+        assert_eq!(out, expected, "for lexeme {lexeme:?}");
+    }
+}
+
 /// The `--sort-keys` writer used to carry its own number formatter that
 /// normalised `-0` to `0`, splitting `-S` output from every other path
 /// (jq 1.8.1 prints `-0`). Unified in #1028 — pin the fix.


### PR DESCRIPTION
## Summary

Recovers the #1072 serializer regressions tracked in #1077 (`@text`/`@json` ~1.20x, string interpolation ~1.09x vs v1.8.2) by reusing the classification the extraction walk already computes instead of re-scanning every value at the emit sites:

- **`apply_field_format_raw`** now uses `json_object_get_field_raw_classified` and passes the per-value `clean` verdict to the apply sites. A clean value emits verbatim with zero per-value scans — the `@json`/`@text` raw arms previously paid a composite check + a full non-canonical-number classify + an escape scan per record.
- **String-interpolation fast-path loops** (NDJSON + file-content twins) switch to `json_object_get_fields_raw_buf_classified`; when every extracted field classifies clean, the per-record `memchr2` escape gate and all per-field canonicalisation gates collapse to verbatim copies.
- **`num_repr_text`** (shared core of `tojson`/`tostring`/`@csv`/`@tsv`/JIT interpolation) short-circuits plain short decimal lexemes with a single one-pass check (`repr_is_short_canonical_plain`) that provably subsumes `is_valid_json_number` + `repr_is_exact_for_f64` + `normalize_jq_repr == None` for that shape.

## Performance

Same-machine interleaved A/B (best-of-10, 2M-record NDJSON, file input), this branch vs main:

| shape | main | this PR | ratio |
|---|---|---|---|
| `.x \| @text` | 0.0651s | 0.0535s | **0.82** |
| `.x \| @json` | 0.0648s | 0.0532s | **0.82** |
| `"\(.name)=\(.x)"` | 0.1263s | 0.1147s | **0.91** |
| `{a: (.name + "_" + (.x \| tostring)), b: .y}` | 0.1721s | 0.1685s | 0.98 |
| `.x` (passthrough guard) | 0.0511s | 0.0508s | 0.99 |

`@text`/`@json`/interpolation return to their pre-#1072 (v1.8.2) levels. Full `bench/comprehensive.sh` vs the v1.9.2 history column: geomean 0.998, no real regression — the three >1.07 history rows (`tostring` 1.08, `endswith` 1.09, `if len>5` 1.10) re-measured 1.01–1.02 in same-machine interleaved A/B (cross-day noise).

## Correctness

- Full suite passes (`cargo test --release`, zero build warnings).
- 6-filter × 20-input differential battery vs system jq 1.8.1 (stdin + file twins; NaN/Infinity/non-canonical lexemes, `\u`/`\/` escapes, DEL, composites, 16-digit integers): zero divergences introduced vs main (the pre-existing diffs on main reproduce identically).
- New pins: `contract_number_format::short_canonical_plain_fast_path_boundary_pins` (lexeme corpus on both sides of the fast-path gate, cross-checked against jq 1.8.1) and the `clean`-flag contract in `contract_fast_path` (clean/dirty verdicts for canonical scalars, non-canonical lexemes, specials, composites).

Closes #1077

🤖 Generated with [Claude Code](https://claude.com/claude-code)