### PR TITLE
perf(jit): fuse tail-position construct output into direct byte emission

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -536,6 +536,34 @@ construct / cond-chain）は、フィールド境界スキャン
   融合済みなので、新しい per-value ゲートを足す時は classify に
   畳めないか先に検討する。
 
+### Output fusion（#1058 emit plan）の契約
+
+generic（JIT 経由）出力で tail-position の静的 construct（literal key の
+object / 静的 comma-list の array、ネスト可）は、`jit.rs::build_emit_plan`
+が「定数 JSON 断片 + 単一値 hole」の emit plan に lower し、両 backend が
+`JitEnv::emit_buf` に直接 compact バイトを書く（`EmitFrag` / `EmitVal` /
+`EmitEnd`）。host（`bin/jq-jit.rs::process_input`）は execute 後に
+`drain_emit_buf` で出力バッファへ転写する。
+
+- **opt-in**: `jit::set_output_fusion(true)` を立てた状態でコンパイルした
+  プログラムだけが fuse する。host は compact buffered 出力（`-c` 系で
+  `-r`/`-S`/`-C`/`-j`/`-e`/`--seq`/slurp なし）の時のみ立てる。
+- **all-or-nothing**: fused プログラムは全出力が emit 経由。plain Yield
+  （callback 経由）と混在する flatten 結果は `flatten_filter` が検知して
+  fusion なしで再 lower する。**部分 fusion を許すと
+  append-after-execute の drain が出力順を壊す**ので、この再試行を
+  外さないこと。
+- **record-atomic**: hole 値の計算（fallible）は全て最初の Emit op より
+  前。emit 列自体は infallible なので、エラー時に emit_buf へ部分
+  レコードが残ることはない。新しい Emit 系 op を足すなら同じ規約で
+  （emit 列に fallible op を挟まない）。
+- **byte parity**: 断片はコンパイル時に `push_json_string_to_vec` /
+  `push_compact_value` で描画、hole は実行時に `push_compact_value` ——
+  generic 出力（`push_compact_line`）と同一 serializer なので byte 一致が
+  構成的に保証される。escape / number-canon 処理を emit 側に複製しない。
+  `tests/contract_emit_fusion.rs` が両 backend の byte parity・mixed
+  retreat・record-atomicity を pin する。
+
 ### `paths` / `paths(f)` は root を落とす
 
 jq の `paths` は `path(..) | select(length > 0)`。scalar 入力で空 path `[]` を yield しない。派生する `paths(f)` も同じ不変性を持つ。rewrite を書き直す時は `length > 0` の guard を必ず最後に挟む。

--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -2933,6 +2933,22 @@ fn real_main() {
         None
     };
 
+    // Output fusion (#1058): when the output mode is the plain buffered
+    // compact stream — no raw/sorted/colored/joined output, no `-e` exit
+    // status (it inspects each output Value), no `--seq` RS framing, and
+    // no slurp (fused records stage in the env buffer until the host
+    // drains after each execution; a slurped giant input would stage its
+    // whole output) — tail-position static constructs may compile to
+    // direct byte emission. `process_input` below drains the staged bytes
+    // into `compact_buf` after every execution; outputs that still stream
+    // through the callback are unaffected (a compiled program is either
+    // fully fused or not fused at all).
+    let output_fusion = compact && !raw_output && !sort_keys && !join_output
+        && !color_output && !seq && !exit_status && !slurp;
+    if output_fusion {
+        jq_jit::jit::set_output_fusion(true);
+    }
+
     // Lazy JIT: compile only when input is large enough to amortize compilation cost.
     // Exception: always JIT for loop constructs (reduce/foreach/while/until/recurse)
     // since their runtime dominates regardless of input size.
@@ -3006,6 +3022,9 @@ fn real_main() {
     if !force_interp && !force_jit && !force_jitop && !force_cranelift && !filter.has_jit() {
         filter.compile_jitop_program_for_routing();
     }
+    // Drain fused output only when some compiled program actually lowered
+    // with Emit ops — every other filter skips the per-record TLS access.
+    let output_fusion = output_fusion && jq_jit::jit::output_fusion_active();
 
     // Use Vec-based buffering for compact output to avoid per-value write_all overhead
     let use_compact_buf = compact && !raw_output && !sort_keys && !join_output;
@@ -3832,6 +3851,20 @@ fn real_main() {
             }
             Ok(true)
         });
+        // Output fusion (#1058): fused programs stage complete records in
+        // the JIT env's emit buffer instead of streaming Values through
+        // the callback above. Move them into the compact buffer now — the
+        // emit sequence is record-atomic, so even an error mid-execution
+        // leaves only whole records here (matching jq's
+        // print-outputs-then-error behavior). Must run before the halt
+        // drain below so `halt` flushes fused output too.
+        if output_fusion {
+            jq_jit::jit::drain_emit_buf(cbuf);
+            if cbuf.len() >= 1 << 17 {
+                let _ = out.write_all(cbuf);
+                cbuf.clear();
+            }
+        }
         // --unbuffered: flush after every input so consumers get
         // results as they're produced rather than waiting for the
         // 64KB BufWriter to fill.

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -320,6 +320,150 @@ fn can_scalar_collect(expr: &Expr) -> bool {
     }
 }
 
+/// One segment of an output-fusion emit plan (#1058): either a constant
+/// JSON fragment (braces, pre-escaped keys, folded literals) or a hole — a
+/// single-valued scalar sub-expression whose runtime Value is serialized
+/// in place.
+enum EmitPart {
+    Frag(String),
+    Hole(Expr),
+}
+
+/// Build an emit plan for a tail-position construct, or `None` when the
+/// shape is not statically fusable (dynamic keys, duplicate keys,
+/// generator elements, non-scalar holes). Only object / array constructs
+/// are fused at the top — anything else gains nothing over the plain
+/// scalar lowering.
+fn build_emit_plan(expr: &Expr) -> Option<Vec<EmitPart>> {
+    if !matches!(expr, Expr::ObjectConstruct { .. } | Expr::Collect { .. }) {
+        return None;
+    }
+    let mut parts = Vec::new();
+    let mut frag = Vec::new();
+    if !emit_plan_node(expr, &mut parts, &mut frag) {
+        return None;
+    }
+    emit_plan_flush(&mut parts, &mut frag)?;
+    Some(parts)
+}
+
+fn emit_plan_flush(parts: &mut Vec<EmitPart>, frag: &mut Vec<u8>) -> Option<()> {
+    if !frag.is_empty() {
+        // Fragment bytes come from the canonical serializer over decoded
+        // keys/literals, so they are valid UTF-8 JSON text.
+        parts.push(EmitPart::Frag(String::from_utf8(std::mem::take(frag)).ok()?));
+    }
+    Some(())
+}
+
+/// Recursive plan builder for a construct node. Constant keys and literal
+/// values fold into the running fragment; nested constructs recurse;
+/// every other single-valued scalar becomes a hole.
+fn emit_plan_node(expr: &Expr, parts: &mut Vec<EmitPart>, frag: &mut Vec<u8>) -> bool {
+    match expr {
+        Expr::ObjectConstruct { pairs } => {
+            let keys: Vec<&str> = pairs
+                .iter()
+                .filter_map(|(k, _)| match k {
+                    Expr::Literal(Literal::Str(s)) => Some(s.as_str()),
+                    _ => None,
+                })
+                .collect();
+            // Literal distinct keys only: duplicates need jq's last-wins
+            // dedup, dynamic keys need runtime string checks — both stay
+            // on the plain construct lowering. Keys are parser-decoded, so
+            // this comparison also catches escape-aliased duplicates.
+            if keys.len() != pairs.len() {
+                return false;
+            }
+            {
+                let mut uniq = keys.clone();
+                uniq.sort_unstable();
+                uniq.dedup();
+                if uniq.len() != keys.len() {
+                    return false;
+                }
+            }
+            frag.push(b'{');
+            for (i, (_, v)) in pairs.iter().enumerate() {
+                if i > 0 {
+                    frag.push(b',');
+                }
+                crate::value::push_json_string_to_vec(frag, keys[i]);
+                frag.push(b':');
+                if !emit_plan_value(v, parts, frag) {
+                    return false;
+                }
+            }
+            frag.push(b'}');
+            true
+        }
+        Expr::Collect { generator } => {
+            // A static comma-list with strictly single-valued elements is
+            // the only array shape whose element count (and thus comma
+            // placement) is known at compile time. `empty` elements vanish.
+            let mut elems = Vec::new();
+            collect_comma_elements(generator, &mut elems);
+            frag.push(b'[');
+            for (i, e) in elems.iter().enumerate() {
+                if i > 0 {
+                    frag.push(b',');
+                }
+                if !emit_plan_value(e, parts, frag) {
+                    return false;
+                }
+            }
+            frag.push(b']');
+            true
+        }
+        _ => false,
+    }
+}
+
+fn collect_comma_elements<'a>(gen: &'a Expr, out: &mut Vec<&'a Expr>) {
+    match gen {
+        Expr::Comma { left, right } => {
+            collect_comma_elements(left, out);
+            collect_comma_elements(right, out);
+        }
+        Expr::Empty => {}
+        other => out.push(other),
+    }
+}
+
+fn emit_plan_value(expr: &Expr, parts: &mut Vec<EmitPart>, frag: &mut Vec<u8>) -> bool {
+    match expr {
+        Expr::ObjectConstruct { .. } | Expr::Collect { .. } => {
+            // Nested static constructs flatten into the same plan — this is
+            // where fusion beats the plain lowering most (no intermediate
+            // ObjMap / Vec<Value> per record).
+            emit_plan_node(expr, parts, frag)
+        }
+        Expr::Literal(lit) => {
+            // Fold the literal into the fragment with the same serializer
+            // the runtime path would use on the equivalent Value (repr
+            // canonicalization included), so bytes cannot diverge.
+            let val = match lit {
+                Literal::Null => Value::Null,
+                Literal::True => Value::True,
+                Literal::False => Value::False,
+                Literal::Num(n, repr) => Value::number_opt(*n, repr.clone()),
+                Literal::Str(s) => Value::Str(crate::value::KeyStr::from(s.as_str())),
+            };
+            crate::value::push_compact_value(frag, &val);
+            true
+        }
+        _ if is_scalar(expr) => {
+            if emit_plan_flush(parts, frag).is_none() {
+                return false;
+            }
+            parts.push(EmitPart::Hole(expr.clone()));
+            true
+        }
+        _ => false,
+    }
+}
+
 /// True when a `range` seed expression may carry a literal repr the first
 /// yielded value must preserve (#1083). Only a reprless number literal —
 /// the common `range(N)` / `range(0; n)` shape — is provably repr-free;
@@ -559,6 +703,23 @@ enum JitOp {
     /// `emit_yield` plants after native yields, but batched per call.
     DelegateGen { input: SlotId, expr_idx: usize, push: bool, limit: Option<(u32, u32, LabelId)> },
 
+    // Output fusion (#1058): a statically-shaped tail construct (object /
+    // array with literal keys and single-valued holes) lowers to an emit
+    // plan that writes compact JSON bytes into `JitEnv::emit_buf` directly,
+    // skipping output-side Value materialization. All hole values are
+    // computed into slots *before* the first Emit op, so the emit sequence
+    // itself is infallible and the buffer never holds a partial record.
+    // The host drains the buffer after each execution (`drain_emit_buf`).
+    /// Append a constant JSON fragment (pre-rendered at compile time with
+    /// the canonical serializer) to the emit buffer.
+    EmitFrag { bytes: String },
+    /// Serialize the slot's Value compactly into the emit buffer via
+    /// `push_compact_value` — the same serializer the generic output path
+    /// uses, so fused and non-fused bytes are identical by construction.
+    EmitVal { src: SlotId },
+    /// Terminate one fused output record (trailing newline).
+    EmitEnd,
+
     // Control flow
     IfTruthy { src: SlotId, then_label: LabelId, else_label: LabelId },
     /// Combined field access + truthiness check: avoids clone+drop of the field value.
@@ -782,6 +943,11 @@ struct Flattener {
     /// Flattener (same lifetime argument as `funcs_body_block`); consumed
     /// by `funcs_bodies_close_over_vars_outside`.
     funcs_body_closure_vars: Option<Rc<Vec<VarIdx>>>,
+    /// Output fusion enabled for this lowering (#1058): tail-position
+    /// static constructs lower to Emit ops instead of build-then-Yield.
+    /// Set by `flatten_filter` from the host's `set_output_fusion` knob;
+    /// cleared on the mixed-yield retry.
+    output_fusion: bool,
 }
 
 impl Flattener {
@@ -794,7 +960,7 @@ impl Flattener {
                      is_test: false, has_unresolved_recursion: false,
                      emitted_delegate: false, inline_exempt: HashSet::new(),
                      recursion_detected: HashSet::new(), funcs_body_block: None,
-                     funcs_body_closure_vars: None }
+                     funcs_body_closure_vars: None, output_fusion: false }
     }
 
     /// Materialize a Literal into a heap-allocated Value and return a stable pointer.
@@ -834,6 +1000,7 @@ impl Flattener {
         t.inline_exempt = self.inline_exempt.clone();
         t.funcs_body_block = self.funcs_body_block;
         t.funcs_body_closure_vars = self.funcs_body_closure_vars.clone();
+        t.output_fusion = self.output_fusion;
         t
     }
 
@@ -1502,6 +1669,72 @@ impl Flattener {
             limit: limit_payload,
         });
         true
+    }
+
+    /// True when `expr` is a construct with a static emit plan, possibly
+    /// under scalar pipe prefixes (`f | {…}` — the common `select(c) | {…}`
+    /// shape lowers its then-branch as `. | {…}`). Pure pre-check: the
+    /// fusion hook must know the tail is fusable *before* emitting any
+    /// prefix ops, since a failed attempt falls back to the plain lowering.
+    fn has_fusable_tail(expr: &Expr) -> bool {
+        if build_emit_plan(expr).is_some() {
+            return true;
+        }
+        match expr {
+            Expr::Pipe { left, right } => is_scalar(left) && Self::has_fusable_tail(right),
+            _ => false,
+        }
+    }
+
+    /// Lower a fusable tail (see `has_fusable_tail`): peel scalar pipe
+    /// prefixes into intermediate slots, then emit the construct plan
+    /// against the final input. Caller must have checked
+    /// `has_fusable_tail` — this only returns `false` on that contract
+    /// being violated (no ops are emitted in that case beyond the prefix).
+    fn lower_fused_tail(&mut self, expr: &Expr, input_slot: SlotId) -> bool {
+        if let Some(parts) = build_emit_plan(expr) {
+            self.lower_emit_plan(&parts, input_slot);
+            return true;
+        }
+        if let Expr::Pipe { left, right } = expr {
+            if is_scalar(left) && Self::has_fusable_tail(right) {
+                if matches!(left.as_ref(), Expr::Input) {
+                    return self.lower_fused_tail(right, input_slot);
+                }
+                let mid = self.flatten_scalar(left, input_slot);
+                let ok = self.lower_fused_tail(right, mid);
+                self.emit(JitOp::Drop { slot: mid });
+                return ok;
+            }
+        }
+        false
+    }
+
+    /// Lower an emit plan (#1058): compute every hole into a slot first —
+    /// the holes carry all the fallible ops, and any error aborts before a
+    /// single byte is emitted — then run the infallible Emit sequence and
+    /// release the hole slots.
+    fn lower_emit_plan(&mut self, parts: &[EmitPart], input_slot: SlotId) {
+        let mut hole_slots = Vec::new();
+        for p in parts {
+            if let EmitPart::Hole(e) = p {
+                hole_slots.push(self.flatten_scalar(e, input_slot));
+            }
+        }
+        let mut hi = 0;
+        for p in parts {
+            match p {
+                EmitPart::Frag(s) => self.emit(JitOp::EmitFrag { bytes: s.clone() }),
+                EmitPart::Hole(_) => {
+                    self.emit(JitOp::EmitVal { src: hole_slots[hi] });
+                    hi += 1;
+                }
+            }
+        }
+        self.emit(JitOp::EmitEnd);
+        for s in hole_slots {
+            self.emit(JitOp::Drop { slot: s });
+        }
     }
 
     fn emit_yield(&mut self, output: SlotId) {
@@ -2878,6 +3111,21 @@ impl Flattener {
                 let _ = test.flatten_scalar(expr, t_in);
                 if test.has_unresolved_recursion {
                     return self.emit_delegate_gen(expr, input_slot, false);
+                }
+            }
+            // Output fusion (#1058): a tail-position static construct
+            // writes its JSON bytes straight into the emit buffer instead
+            // of materializing the output Value. Only at the top stream
+            // level (collect depth 0) and outside `limit` (whose counter
+            // bookkeeping hangs off Yield ops). If any *other* yield site
+            // in the program emits through the callback, `flatten_filter`
+            // detects the mix and re-lowers without fusion, so the host's
+            // append-after-execute drain can never reorder outputs.
+            if self.output_fusion && self.collect_depth == 0 && self.limit_state.is_none()
+                && Self::has_fusable_tail(expr)
+            {
+                if self.lower_fused_tail(expr, input_slot) {
+                    return true;
                 }
             }
             let out = self.flatten_scalar(expr, input_slot);
@@ -8987,6 +9235,27 @@ extern "C" fn jit_rt_obj_copy_field(
     }
 }
 
+// Output-fusion emit helpers (#1058). All infallible: the lowering
+// computes every hole value before the first emit op, so by the time
+// these run the record is guaranteed to complete.
+extern "C" fn jit_rt_emit_frag(env: *mut JitEnv, ptr: *const u8, len: usize) {
+    unsafe {
+        (*env).emit_buf.extend_from_slice(std::slice::from_raw_parts(ptr, len));
+    }
+}
+
+extern "C" fn jit_rt_emit_val(env: *mut JitEnv, val: *const Value) {
+    unsafe {
+        crate::value::push_compact_value(&mut (*env).emit_buf, &*val);
+    }
+}
+
+extern "C" fn jit_rt_emit_end(env: *mut JitEnv) {
+    unsafe {
+        (*env).emit_buf.push(b'\n');
+    }
+}
+
 /// Batch field extraction: build a new object from multiple fields of src in a single pass.
 /// pair_table is an array of (out_key_ptr, out_key_len, src_field_ptr, src_field_len) tuples.
 /// Replaces ObjNew + N×ObjCopyField with a single function call, scanning the source once.
@@ -9963,6 +10232,13 @@ pub struct JitEnv {
     /// via `env_ptr + offset_of!(JitEnv, error_flag)` in `CheckError` /
     /// `JumpIfError`, avoiding an embedded static address.
     pub error_flag: i64,
+    /// Output-fusion staging buffer (#1058): Emit ops append complete
+    /// compact JSON records here; the host moves them into its output
+    /// buffer via `drain_emit_buf` after each execution. Never cleared by
+    /// `with_jit_env` — the emit sequence is infallible and record-atomic,
+    /// so the buffer only ever holds whole records, and the drain owns the
+    /// lifecycle.
+    pub emit_buf: Vec<u8>,
 }
 
 impl Default for JitEnv {
@@ -9980,6 +10256,7 @@ impl JitEnv {
             try_depth: 0,
             error: None,
             error_flag: 0,
+            emit_buf: Vec::new(),
         }
     }
 }
@@ -10015,6 +10292,7 @@ fn optimize_clone_yield(mut ops: Vec<JitOp>) -> Vec<JitOp> {
                 *use_count.entry(*src).or_insert(0) += 1;
             }
             JitOp::CollectPush { src } => { *use_count.entry(*src).or_insert(0) += 1; }
+            JitOp::EmitVal { src } => { *use_count.entry(*src).or_insert(0) += 1; }
             JitOp::ObjInsert { obj, key, val } => {
                 *use_count.entry(*obj).or_insert(0) += 1;
                 *use_count.entry(*key).or_insert(0) += 1;
@@ -10106,6 +10384,7 @@ fn optimize_clone_yield(mut ops: Vec<JitOp>) -> Vec<JitOp> {
                     *use_count.entry(*src).or_insert(0) += 1;
                 }
                 JitOp::CollectPush { src } => { *use_count.entry(*src).or_insert(0) += 1; }
+                JitOp::EmitVal { src } => { *use_count.entry(*src).or_insert(0) += 1; }
                 JitOp::ObjInsert { obj, key, val } => {
                     *use_count.entry(*obj).or_insert(0) += 1;
                     *use_count.entry(*key).or_insert(0) += 1;
@@ -10280,7 +10559,12 @@ fn observes_interleaved_input_state(expr: &Expr) -> bool {
 /// linear JitOp sequence, publish closure ops for runtime delegation, and
 /// run the clone+yield peephole pass.
 fn flatten_filter(expr: &Expr, funcs: &[CompiledFunc]) -> Result<FlattenedFilter> {
+    flatten_filter_with_fusion(expr, funcs, output_fusion_enabled())
+}
+
+fn flatten_filter_with_fusion(expr: &Expr, funcs: &[CompiledFunc], fuse: bool) -> Result<FlattenedFilter> {
     let mut fl = Flattener::new();
+    fl.output_fusion = fuse;
     fl.funcs = funcs.to_vec();
     // Pre-inline function calls and apply semantic optimizations.
     // Always run to catch to_entries|from_entries and similar rewrites.
@@ -10312,6 +10596,24 @@ fn flatten_filter(expr: &Expr, funcs: &[CompiledFunc]) -> Result<FlattenedFilter
     // Bail here so the binary falls back to the interpreter.
     if fl.has_unresolved_recursion {
         bail!("Expression not JIT-compilable: subtree requested bailout");
+    }
+    // Output fusion sanity (#1058): fused records land in the env emit
+    // buffer (drained by the host after the execution), while plain
+    // yields stream through the callback during it. A program mixing
+    // both — `({a:1}, .x)`, a fused `try` with a plain `catch`, a pull
+    // delegate next to a fused branch — would emit out of order, so
+    // re-lower the whole filter with fusion off.
+    if fuse {
+        let has_emit = fl.ops.iter().any(|op| matches!(op, JitOp::EmitEnd));
+        let has_plain_yield = fl.ops.iter().any(|op| matches!(op,
+            JitOp::Yield { .. } | JitOp::YieldFieldRef { .. }
+            | JitOp::DelegateGen { push: false, .. }));
+        if has_emit && has_plain_yield {
+            return flatten_filter_with_fusion(expr, funcs, false);
+        }
+        if has_emit {
+            OUTPUT_FUSION_ACTIVE.with(|c| c.set(true));
+        }
     }
     fl.emit(JitOp::ReturnContinue);
 
@@ -10424,6 +10726,9 @@ impl JitCompiler {
             ("jit_rt_obj_push_str_key", jit_rt_obj_push_str_key as *const u8),
             ("jit_rt_obj_copy_field", jit_rt_obj_copy_field as *const u8),
             ("jit_rt_obj_from_fields", jit_rt_obj_from_fields as *const u8),
+            ("jit_rt_emit_frag", jit_rt_emit_frag as *const u8),
+            ("jit_rt_emit_val", jit_rt_emit_val as *const u8),
+            ("jit_rt_emit_end", jit_rt_emit_end as *const u8),
             ("jit_rt_is_null_or_false", jit_rt_is_null_or_false as *const u8),
             ("jit_rt_to_f64", jit_rt_to_f64 as *const u8),
             ("jit_rt_to_f64_range_bound", jit_rt_to_f64_range_bound as *const u8),
@@ -11096,6 +11401,20 @@ impl JitCompiler {
                         let two_64 = b.ins().iconst(ptr_ty, 2);
                         let result = b.ins().select(is_truthy, one, two_64);
                         b.ins().store(cranelift_codegen::ir::MemFlags::new(), result, d, 0);
+                    }
+                    JitOp::EmitFrag { bytes } => {
+                        let leaked = Box::leak(bytes.clone().into_boxed_str());
+                        self._string_constants.push(leaked);
+                        let fp = b.ins().iconst(ptr_ty, leaked.as_ptr() as i64);
+                        let fl = b.ins().iconst(ptr_ty, leaked.len() as i64);
+                        b.ins().call(rt["emit_frag"], &[env_ptr, fp, fl]);
+                    }
+                    JitOp::EmitVal { src } => {
+                        let s = slot_addr(&mut b, *src);
+                        b.ins().call(rt["emit_val"], &[env_ptr, s]);
+                    }
+                    JitOp::EmitEnd => {
+                        b.ins().call(rt["emit_end"], &[env_ptr]);
                     }
                     JitOp::Yield { output } => {
                         let oa = slot_addr(&mut b, *output);
@@ -11908,6 +12227,9 @@ fn declare_rt_funcs(module: &mut JITModule, map: &mut HashMap<&'static str, Func
     decl!("obj_push_str_key", [p, p, p, p], []);
     decl!("obj_copy_field", [p, p, p, p, p, p], []);
     decl!("obj_from_fields", [p, p, p, p], []);
+    decl!("emit_frag", [p, p, p], []);
+    decl!("emit_val", [p, p], []);
+    decl!("emit_end", [p], []);
     decl!("is_null_or_false", [p], [p]);
     decl!("to_f64", [p], [f]);
     decl!("to_f64_range_bound", [p], [f]);
@@ -12032,6 +12354,59 @@ unsafe extern "C" fn collect_callback(value: *const Value, ctx: *mut u8) -> i64 
 // vector on every `execute_jit` call.
 thread_local! {
     static REUSABLE_ENV: UnsafeCell<Option<JitEnv>> = const { UnsafeCell::new(None) };
+}
+
+// Output-fusion knob (#1058). The host enables it before compiling its
+// top-level filter when — and only when — it commits to (a) compact
+// buffered output with no per-value flags (`-r`/`-S`/`-C`/`-e`/`--seq`)
+// and (b) draining the emit buffer after every execution. Filters
+// compiled while the knob is off (tests, probes in other contexts) lower
+// exactly as before.
+thread_local! {
+    static OUTPUT_FUSION: Cell<bool> = const { Cell::new(false) };
+}
+
+/// Enable output fusion for filters compiled after this call (#1058).
+/// Contract: the caller must drain the emit buffer (`drain_emit_buf`)
+/// into its output stream after every `execute_cb` of a filter compiled
+/// with the knob on — fused programs do not stream their outputs through
+/// the yield callback.
+pub fn set_output_fusion(on: bool) {
+    OUTPUT_FUSION.with(|c| c.set(on));
+}
+
+fn output_fusion_enabled() -> bool {
+    OUTPUT_FUSION.with(|c| c.get())
+}
+
+// Latched by the shared lowering when a compiled program actually
+// contains Emit ops, so the host can skip the per-record drain (a TLS
+// access, ~4ns/record on the 2M NDJSON loop) for the overwhelming
+// majority of filters that lower without fusion. Never cleared: a stale
+// `true` (e.g. a discarded probe) only costs the no-op drain.
+thread_local! {
+    static OUTPUT_FUSION_ACTIVE: Cell<bool> = const { Cell::new(false) };
+}
+
+/// True when some compiled program on this thread lowered with output
+/// fusion — i.e. `drain_emit_buf` may have bytes to move.
+pub fn output_fusion_active() -> bool {
+    OUTPUT_FUSION_ACTIVE.with(|c| c.get())
+}
+
+/// Move any fused output records produced by the last execution into
+/// `into` (#1058). No-op when the thread never ran a fused program or the
+/// buffer is already drained.
+pub fn drain_emit_buf(into: &mut Vec<u8>) {
+    REUSABLE_ENV.with(|cell| {
+        let env_opt = unsafe { &mut *cell.get() };
+        if let Some(env) = env_opt {
+            if !env.emit_buf.is_empty() {
+                into.extend_from_slice(&env.emit_buf);
+                env.emit_buf.clear();
+            }
+        }
+    })
 }
 
 /// Copy live LoadVar bindings from the JIT env into the eval Env before we delegate
@@ -12579,6 +12954,15 @@ impl JitProgram {
                 }
                 JitOp::Not { dst, src } => {
                     jit_rt_not(sp(*dst), sp(*src));
+                }
+                JitOp::EmitFrag { bytes } => {
+                    jit_rt_emit_frag(env_ptr, bytes.as_ptr(), bytes.len());
+                }
+                JitOp::EmitVal { src } => {
+                    jit_rt_emit_val(env_ptr, sp(*src));
+                }
+                JitOp::EmitEnd => {
+                    jit_rt_emit_end(env_ptr);
                 }
                 JitOp::Yield { output } => {
                     let r = unsafe { cb(sp(*output), ctx) };

--- a/src/value.rs
+++ b/src/value.rs
@@ -7228,7 +7228,7 @@ fn push_indent_bytes(buf: &mut Vec<u8>, n: usize, use_tab: bool) {
     }
 }
 
-fn push_compact_value(buf: &mut Vec<u8>, v: &Value) {
+pub(crate) fn push_compact_value(buf: &mut Vec<u8>, v: &Value) {
     match v {
         Value::Null => buf.extend_from_slice(b"null"),
         Value::False => buf.extend_from_slice(b"false"),
@@ -7289,7 +7289,7 @@ pub fn push_jq_number_bytes(buf: &mut Vec<u8>, n: f64) {
 }
 
 #[inline]
-fn push_json_string_to_vec(buf: &mut Vec<u8>, s: &str) {
+pub(crate) fn push_json_string_to_vec(buf: &mut Vec<u8>, s: &str) {
     let bytes = s.as_bytes();
     let len = bytes.len();
     // Ultra-fast path for single-byte strings (common object keys like "x", "y")

--- a/tests/contract_emit_fusion.rs
+++ b/tests/contract_emit_fusion.rs
@@ -1,0 +1,152 @@
+//! #1058: output fusion. A tail-position static construct compiled with the
+//! host's output-fusion knob stages its compact JSON bytes in the JIT env
+//! emit buffer (drained by the host) instead of streaming Values through
+//! the yield callback. These contracts pin the three load-bearing
+//! properties:
+//!
+//!  1. byte parity — drained bytes are identical to serializing the
+//!     non-fused program's outputs with the shared compact serializer,
+//!     on both backends (JitOp interpreter and Cranelift);
+//!  2. all-or-nothing — a program mixing fused and callback yields
+//!     re-lowers without fusion, so output order can never be scrambled;
+//!  3. opt-in — filters compiled without the knob never stage bytes.
+
+use jq_jit::interpreter::Filter;
+use jq_jit::jit;
+use jq_jit::value::{json_to_value, push_compact_line, Value};
+
+/// Corpus of fusable filters × inputs covering the plan-builder surface:
+/// nesting, literal folding (repr canonicalization, string escapes),
+/// string/composite/missing holes, arrays of objects, branches.
+const CASES: &[(&str, &str)] = &[
+    ("{a: {b: .x}}", r#"{"x":1}"#),
+    ("[{a: .x, b: .y}]", r#"{"x":1,"y":2}"#),
+    ("{a: .x, b: {c: [.y, {d: .name}], e: 1}}", r#"{"x":1,"y":2,"name":"n"}"#),
+    (r#"{a: 1e3, b: [0.1], c: "li\"t\n", d: null}"#, "null"),
+    ("{k: .s}", r#"{"s":"a\/bA\t"}"#),
+    ("{n: .v}", r#"{"v":1e3}"#),
+    ("{o: .v}", r#"{"v":{"q":"x\"y","a":[1,"\/"]}}"#),
+    ("{m: .missing}", "{}"),
+    ("[{a: .x}, {b: 2}, [3, {c: .y}]]", r#"{"x":1,"y":4}"#),
+    ("if .x > 1 then {hit: .x} else empty end", r#"{"x":2}"#),
+    ("{s: (.x | tostring), t: [.x * 2]}", r#"{"x":3}"#),
+    // scalar pipe prefixes peel into the fused tail
+    ("select(.x > 1) | {a: {b: .x}}", r#"{"x":2}"#),
+    (".x + 1 | {v: ., w: [.]}", r#"{"x":2}"#),
+];
+
+/// Reset the thread-local knob even on panic so a failing assertion does
+/// not leak fusion into other tests running on the same thread.
+struct KnobGuard;
+impl Drop for KnobGuard {
+    fn drop(&mut self) {
+        jit::set_output_fusion(false);
+    }
+}
+
+enum Backend {
+    Jitop,
+    Cranelift,
+}
+
+/// Compile `filter` with the given knob state and backend, run it on
+/// `input`, and return (values seen by the yield callback, drained bytes).
+fn run(filter: &str, input: &str, fused: bool, backend: Backend) -> (Vec<Value>, Vec<u8>) {
+    let _guard = KnobGuard;
+    jit::set_output_fusion(fused);
+    let mut f = Filter::with_options(filter, &[], false).expect("parse");
+    match backend {
+        Backend::Jitop => {
+            f.compile_jitop_program();
+            assert!(f.has_jitop_program(), "{filter:?} must flatten");
+        }
+        Backend::Cranelift => {
+            f.compile_jit_with_delegates();
+            assert!(f.has_jit(), "{filter:?} must codegen");
+        }
+    }
+    jit::set_output_fusion(false);
+    let inp = json_to_value(input).expect("parse input");
+    let mut seen = Vec::new();
+    // Pre-drain any stale bytes so the assertion below sees only this run.
+    let mut stale = Vec::new();
+    jit::drain_emit_buf(&mut stale);
+    f.execute_cb(&inp, &mut |v| {
+        seen.push(v.clone());
+        Ok(true)
+    })
+    .expect("execute");
+    let mut drained = Vec::new();
+    jit::drain_emit_buf(&mut drained);
+    (seen, drained)
+}
+
+fn serialize(values: &[Value]) -> Vec<u8> {
+    let mut buf = Vec::new();
+    for v in values {
+        push_compact_line(&mut buf, v);
+    }
+    buf
+}
+
+#[test]
+fn fused_bytes_match_serialized_plain_outputs_jitop() {
+    for &(filter, input) in CASES {
+        let (plain_vals, plain_bytes) = run(filter, input, false, Backend::Jitop);
+        assert!(plain_bytes.is_empty(), "{filter:?}: knob off must not stage bytes");
+        let (fused_vals, fused_bytes) = run(filter, input, true, Backend::Jitop);
+        assert!(fused_vals.is_empty(), "{filter:?}: fused program must not stream via cb");
+        assert_eq!(
+            String::from_utf8(fused_bytes).unwrap(),
+            String::from_utf8(serialize(&plain_vals)).unwrap(),
+            "{filter:?} on {input:?}"
+        );
+    }
+}
+
+#[test]
+fn fused_bytes_match_serialized_plain_outputs_cranelift() {
+    for &(filter, input) in CASES {
+        let (plain_vals, _) = run(filter, input, false, Backend::Cranelift);
+        let (fused_vals, fused_bytes) = run(filter, input, true, Backend::Cranelift);
+        assert!(fused_vals.is_empty(), "{filter:?}: fused program must not stream via cb");
+        assert_eq!(
+            String::from_utf8(fused_bytes).unwrap(),
+            String::from_utf8(serialize(&plain_vals)).unwrap(),
+            "{filter:?} on {input:?}"
+        );
+    }
+}
+
+/// A program with both a fused construct and a plain yield site must
+/// retreat to the non-fused lowering entirely — partial fusion would let
+/// the host's append-after-execute drain reorder outputs.
+#[test]
+fn mixed_yield_program_retreats_from_fusion() {
+    for filter in ["({a: .x}, .x)", "(.x, {a: .x})", "({a: .x}, {b: .x} | .b)"] {
+        let (vals, bytes) = run(filter, r#"{"x":7}"#, true, Backend::Jitop);
+        assert_eq!(vals.len(), 2, "{filter:?}: both outputs stream via cb");
+        assert!(bytes.is_empty(), "{filter:?}: no bytes may be staged");
+    }
+}
+
+/// A hole error aborts before any byte of the record is emitted: the
+/// emit buffer stays empty (whole-record atomicity), and the error
+/// surfaces exactly like the non-fused lowering.
+#[test]
+fn hole_error_stages_no_partial_record() {
+    let _guard = KnobGuard;
+    jit::set_output_fusion(true);
+    let mut f = Filter::with_options("{a: .x, b: (.x + \"s\")}", &[], false).expect("parse");
+    f.compile_jitop_program();
+    assert!(f.has_jitop_program());
+    jit::set_output_fusion(false);
+    let inp = json_to_value(r#"{"x":1}"#).expect("parse input");
+    let mut stale = Vec::new();
+    jit::drain_emit_buf(&mut stale);
+    let err = f.execute_cb(&inp, &mut |_| Ok(true)).expect_err("hole must error");
+    assert!(err.to_string().contains("cannot be added"), "got: {err}");
+    let mut drained = Vec::new();
+    jit::drain_emit_buf(&mut drained);
+    assert!(drained.is_empty(), "partial record staged: {:?}", String::from_utf8_lossy(&drained));
+}

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -14102,3 +14102,74 @@ null
 [919895839836842.3 + 0] | @csv
 null
 "919895839836842.2"
+
+# #1058: output fusion — nested static construct emits bytes directly (jit-routed)
+{a: {b: .x}}
+{"x":1}
+{"a":{"b":1}}
+
+# #1058: fused array-of-objects collect
+[{a: .x, b: .y}]
+{"x":1,"y":2}
+[{"a":1,"b":2}]
+
+# #1058: deep static nesting with literal folding
+{a: .x, b: {c: [.y, {d: .name}], e: 1}}
+{"x":1,"y":2,"name":"n"}
+{"a":1,"b":{"c":[2,{"d":"n"}],"e":1}}
+
+# #1058: literal values fold through the canonical serializer (repr, escapes)
+{a: 1e3, b: [0.1, -0], c: "li\"t\n", d: null}
+null
+{"a":1E+3,"b":[0.1,0],"c":"li\"t\n","d":null}
+
+# #1058: escape canonicalization through a fused string hole (solidus, control escape)
+{k: .s}
+{"s":"a\/bA\t"}
+{"k":"a/bA\t"}
+
+# #1058: number canonicalization through a fused hole
+{n: .v}
+{"v":1e3}
+{"n":1E+3}
+
+# #1058: composite hole re-serializes via the shared compact serializer
+{o: .v}
+{"v":{"q":"x\"y","a":[1,"\/"]}}
+{"o":{"q":"x\"y","a":[1,"/"]}}
+
+# #1058: mixed plain+construct outputs retreat from fusion, order preserved
+({a:.x}, .x)
+{"x":7}
+{"a":7}
+7
+
+# #1058: fused branch beside an empty branch
+if .x > 1 then {hit: .x} else empty end
+{"x":2}
+{"hit":2}
+
+# #1058: missing field hole emits null
+{m: .missing}
+{}
+{"m":null}
+
+# #1058: nested arrays and objects in one fused plan
+[{a: .x}, {b: 2}, [3, {c: .y}]]
+{"x":1,"y":4}
+[{"a":1},{"b":2},[3,{"c":4}]]
+
+# #1058: hole error aborts before any byte is emitted (catch yields instead)
+try {a: (.x + 1)} catch {err: 1}
+{"x":"s"}
+{"err":1}
+
+# #1058: scalar pipe prefix peels into the fused tail (select-then-construct)
+select(.x > 100) | {a: {b: .x}}
+{"x":200}
+{"a":{"b":200}}
+
+# #1058: pipe prefix with a computed mid value feeding the fused construct
+.x + 1 | {v: ., w: [.]}
+{"x":2}
+{"v":3,"w":[3]}


### PR DESCRIPTION
## Summary

Implements the output-side serialization fusion sketched in #1058: statically-shaped tail constructs no longer build an output `Value` tree per record. The shared lowering (`flatten_filter`) compiles them to an **emit plan** — alternating constant JSON fragments (braces, pre-escaped literal keys, folded literal values) and single-valued holes — executed by three new infallible ops (`EmitFrag` / `EmitVal` / `EmitEnd`) on **both backends** (JitOp interpreter, Cranelift via `jit_rt_emit_*` helpers). Bytes land in a `JitEnv` staging buffer; the host drains them into its 128KB compact buffer after each execution.

### Covered shapes

- object constructs with literal distinct keys, array constructs with a static comma-list, arbitrary static nesting of the two (`{a: {b: .x}}`, `[{a:.x, b:.y}]`, `{r: [.x, {n: .name}]}`)
- literal values fold into the fragments through the canonical serializer (repr canonicalization included)
- scalar pipe prefixes peel into the fused tail — `select(c) | {…}` (whose then-branch lowers as `. | {…}`) and `.x + 1 | {v: ., …}`

### Correctness containment (documented in `docs/maintenance.md`)

- **opt-in**: only the main binary enables fusion (`jit::set_output_fusion`), and only for plain buffered compact output (no `-r`/`-S`/`-C`/`-j`/`-e`/`--seq`/slurp)
- **all-or-nothing**: a flatten result mixing Emit ops with plain `Yield`/pull-delegate sites re-lowers without fusion, so the append-after-execute drain can never reorder outputs
- **record-atomic**: all (fallible) hole computation precedes the first Emit op — an error never stages a partial record (issue's escape-leak concern: no new escape-handling site exists; fragments and holes go through `push_json_string_to_vec` / `push_compact_value`, the same serializer as the generic path)
- per-record drain is gated on a program actually compiling with Emit ops, so non-fused filters pay nothing

## Verification

- `cargo build --release` zero warnings; full `cargo test --release` green (76 test binaries), including the new `tests/contract_emit_fusion.rs` (backend byte parity, mixed-yield retreat, record-atomicity) and 14 new `tests/regression.test` groups
- 3-backend sweep (FORCE_CRANELIFT / FORCE_JITOP_INTERP / FORCE_INTERPRETER, stdout+exit) over regression + differential corpus (4034 groups): only the 4 pre-existing exit-code divergences, all reproducing on main
- escape/number canonicalization corpus (`\/`, `\uXXXX`, control escapes, emoji, `1e3`, `-0.0000001`, 18-digit integers, composite holes) byte-identical to jq 1.8.1 and main
- 2M-record output md5 parity vs main on both stdin and file input

## Perf (same-machine interleaved A/B, 2M NDJSON records, `-c`)

| filter | ratio vs main |
|---|---|
| `{a: {b: .x}}` | **0.72x** |
| `[{a:.x, b:.y}]` | **0.72x** |
| `{r: [.x, {n: .name}]}` | **0.64x** |
| `select(.x > 100) \| {a:{b:.x}}` | **0.68x** |
| `{id: .x, meta: {name: .name, scaled: (.y*2)}}` | **0.76x** |
| fast-path rows (`{a:.x,b:.y}`, `[.name,.x]`, `.name`, `.`) | 1.00–1.04x (neutral) |
| non-fused jitop row (`.x \| tostring \| ltrimstr`) | 1.01x (neutral) |

Comprehensive bench geomean **0.991** vs v1.9.2; the two flagged micro rows (`large obj construct` 1.25x, `reduce (array build)` 1.20x, both ~1ms absolute) re-measured at 1.07x / 1.00x in interleaved A/B — cross-day noise / layout-lottery band, and neither shape fuses (dynamic keys / reduce).

Closes #1058

🤖 Generated with [Claude Code](https://claude.com/claude-code)