### PR TITLE
perf: generalize projection pushdown extraction across the IR

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -564,6 +564,39 @@ object / 静的 comma-list の array、ネスト可）は、`jit.rs::build_emit_
   `tests/contract_emit_fusion.rs` が両 backend の byte parity・mixed
   retreat・record-atomicity を pin する。
 
+### Projection pushdown（#251 / #1055 `needed_input_fields`）の契約
+
+raw fast path が一つもマッチしなかった filter は、
+`classify.rs::needed_input_fields()` が「読む top-level field の静的集合」を
+導出できれば、host が `json_stream_project` で **その field だけ** を
+materialize する（他 field は `skip_json_value` で素通し、欠落 field は
+`Null` で backfill、重複キーは last-wins）。projected `Value` はそのまま
+generic 実行（JIT / eval）に流れるので、emit 側に別実装は無い。
+
+- **安全アンカー**: strict walk（`collect_input_fields`）で bare `Input`
+  は常に `false`。各 arm は「出力が literal か完全 parse 済みの派生値で、
+  record そのものを出力し得ない」場合のみ通してよい。**暗黙に record を
+  passthrough する node に注意**: `recurse(f)`（先頭で `.` を yield）、
+  `debug(msg)` / `stderr`（expr は印字するだけで `.` を通す）、引数なし
+  `error`（`.` を error payload に積む）は strict で必ず bail。
+- **pipe 右辺は集合不要**: `Pipe { left, right }` で left が strict を通れば
+  left の出力は完全な派生値なので、right は field 収集なしで
+  `projection_stream_safe`（`input` / `inputs` / `input_line_number` /
+  `input_filename` / 不透明 `FuncCall` を含まない）だけ満たせばよい。
+  逆に left が record を素通しする形（bare `.`、`select(cond)` desugar =
+  branch が `Input` / `Empty` の `IfThenElse`）なら right も strict で歩く
+  （`pipe_passes_record_through`）。
+- **`Expr` variant を増やしたら両 walk を見直す**:
+  `projection_stream_safe` は意図的に wildcard なしの exhaustive match
+  なのでコンパイルが落ちて気付ける。strict 側は `_ => false` で安全側。
+- **64 field 上限**: projecting parser の found 追跡は u64 bitset。
+  `needed_input_fields` は 65 個以上で `None` を返す（超えると欠落
+  backfill が重複キーを作り得る）。
+- 検証は `tests/contract_projection.rs`（projected vs full parse の
+  出力・エラー同値、refuse 一覧、bitset 上限）と、PR 時の
+  projection on/off 全 group sweep（regression + corpus、`-c -L
+  tests/modules` で stdout+exit 比較）。
+
 ### `paths` / `paths(f)` は root を落とす
 
 jq の `paths` は `path(..) | select(length > 0)`。scalar 入力で空 path `[]` を yield しない。派生する `paths(f)` も同じ不変性を持つ。rewrite を書き直す時は `length > 0` の guard を必ず最後に挟む。

--- a/src/classify.rs
+++ b/src/classify.rs
@@ -9192,7 +9192,9 @@ impl Filter {
         if collect_input_fields(&self.simplified, &mut fields) {
             fields.sort();
             fields.dedup();
-            if !fields.is_empty() {
+            // The projecting parser tracks found keys in a u64 bitset; past 64
+            // distinct fields the missing-field backfill could duplicate keys.
+            if !fields.is_empty() && fields.len() <= 64 {
                 return Some(fields);
             }
         }
@@ -9275,7 +9277,7 @@ fn collect_comma_fields(expr: &crate::ir::Expr, fields: &mut Vec<String>) -> boo
 }
 
 fn collect_input_fields(expr: &crate::ir::Expr, fields: &mut Vec<String>) -> bool {
-    use crate::ir::{Expr, Literal};
+    use crate::ir::{Expr, Literal, StringPart};
     match expr {
         // Accessing a specific field of input: .foo
         Expr::Index { expr: base, key } => {
@@ -9297,12 +9299,38 @@ fn collect_input_fields(expr: &crate::ir::Expr, fields: &mut Vec<String>) -> boo
             }
             collect_input_fields(base, fields) && collect_input_fields(key, fields)
         }
-        // Bare input access — needs full object
+        // Bare input access — the record itself reaches the output (or an
+        // expression we cannot see through). This arm is the safety anchor:
+        // every other arm may only pass when its outputs are literals or
+        // fully-parsed derived values, never the (projected) record.
         Expr::Input => false,
-        // Literals and variables don't access input
+        // Literals, variables and input-independent leaves
         Expr::Literal(_) | Expr::LoadVar { .. } => true,
-        // Pipe: both sides
-        Expr::Pipe { left, right } => collect_input_fields(left, fields) && collect_input_fields(right, fields),
+        Expr::Empty | Expr::Not | Expr::Env | Expr::Loc { .. } | Expr::Builtins => true,
+        // Pipe: when the left side passes the record through unchanged (bare
+        // `.`, or the `select(cond)` desugar `if cond then . else empty end`),
+        // the right side still reads top-level fields — walk it strictly.
+        // Otherwise the left side's outputs are complete derived values, so
+        // the right side needs no field collection at all; it only must not
+        // touch the input stream.
+        Expr::Pipe { left, right } => {
+            if pipe_passes_record_through(left, fields) {
+                collect_input_fields(right, fields)
+            } else {
+                collect_input_fields(left, fields) && projection_stream_safe(right)
+            }
+        }
+        Expr::Comma { left, right } => {
+            collect_input_fields(left, fields) && collect_input_fields(right, fields)
+        }
+        // Array construct and iteration over a derived value. Bare `.[]`
+        // (`Each { input_expr: Input }`) is anchored by the Input arm.
+        // NOTE: `Recurse { input_expr }` must NOT get this treatment:
+        // `recurse(f)` yields the record itself before f's outputs.
+        Expr::Collect { generator } => collect_input_fields(generator, fields),
+        Expr::Each { input_expr } | Expr::EachOpt { input_expr } => {
+            collect_input_fields(input_expr, fields)
+        }
         // Object construct: check keys and values
         Expr::ObjectConstruct { pairs } => {
             pairs.iter().all(|(k, v)| collect_input_fields(k, fields) && collect_input_fields(v, fields))
@@ -9315,12 +9343,222 @@ fn collect_input_fields(expr: &crate::ir::Expr, fields: &mut Vec<String>) -> boo
         Expr::BinOp { lhs, rhs, .. } => collect_input_fields(lhs, fields) && collect_input_fields(rhs, fields),
         Expr::UnaryOp { operand, .. } => collect_input_fields(operand, fields),
         Expr::Negate { operand } => collect_input_fields(operand, fields),
-        Expr::Not => true,
-        // Let binding
+        // Let binding (`e as $x | body` keeps `.` bound to the record in body)
         Expr::LetBinding { value, body, .. } => collect_input_fields(value, fields) && collect_input_fields(body, fields),
         // Select, alternative
         Expr::Alternative { primary, fallback } => collect_input_fields(primary, fields) && collect_input_fields(fallback, fields),
+        // try/catch: the catch body sees the error value, which a strict-
+        // passing try can only build from message strings or derived values —
+        // never the record. The `?//` desugar (restore_dot) re-runs the catch
+        // against the try's input, i.e. the record, so it stays strict.
+        Expr::TryCatch { try_expr, catch_expr, restore_dot } => {
+            collect_input_fields(try_expr, fields)
+                && if *restore_dot {
+                    collect_input_fields(catch_expr, fields)
+                } else {
+                    projection_stream_safe(catch_expr)
+                }
+        }
+        Expr::StringInterpolation { parts } => parts.iter().all(|p| match p {
+            StringPart::Literal(_) => true,
+            StringPart::Expr(e) => collect_input_fields(e, fields),
+        }),
+        Expr::Format { expr, .. } => collect_input_fields(expr, fields),
+        // Slice bounds are evaluated against the same `.` as the sliced expr
+        Expr::Slice { expr, from, to } => {
+            collect_input_fields(expr, fields)
+                && from.as_ref().is_none_or(|e| collect_input_fields(e, fields))
+                && to.as_ref().is_none_or(|e| collect_input_fields(e, fields))
+        }
+        Expr::Limit { count, generator } => {
+            collect_input_fields(count, fields) && collect_input_fields(generator, fields)
+        }
+        Expr::Range { from, to, step } => {
+            collect_input_fields(from, fields)
+                && collect_input_fields(to, fields)
+                && step.as_ref().is_none_or(|e| collect_input_fields(e, fields))
+        }
+        // reduce/foreach: source and init run against the record; update and
+        // extract run against the accumulator/element, which are complete.
+        Expr::Reduce { source, init, update, .. } => {
+            collect_input_fields(source, fields)
+                && collect_input_fields(init, fields)
+                && projection_stream_safe(update)
+        }
+        Expr::Foreach { source, init, update, extract, .. } => {
+            collect_input_fields(source, fields)
+                && collect_input_fields(init, fields)
+                && projection_stream_safe(update)
+                && extract.as_ref().is_none_or(|e| projection_stream_safe(e))
+        }
+        Expr::Label { body, .. } => collect_input_fields(body, fields),
+        Expr::Break { value, .. } => collect_input_fields(value, fields),
+        // all/any predicates run against the generated elements (complete)
+        Expr::AllShort { generator, predicate } | Expr::AnyShort { generator, predicate } => {
+            collect_input_fields(generator, fields) && projection_stream_safe(predicate)
+        }
+        // NOTE: `Debug`/`Stderr` print their expr but pass the record
+        // through, so they stay in the catch-all bail below.
+        // Bare `error` throws the record itself as the error payload
+        Expr::Error { msg } => msg.as_ref().is_some_and(|m| collect_input_fields(m, fields)),
         // Anything else: assume full input needed
         _ => false,
+    }
+}
+
+/// True for pipe left-hand sides that yield the raw record itself (or
+/// nothing): bare `.`, the `select(cond)` desugar (`if cond then . else
+/// empty end`, either branch order), and chains of those. Field reads in
+/// the conditions are collected; the caller then walks the right-hand side
+/// strictly because the record flows into it.
+fn pipe_passes_record_through(expr: &crate::ir::Expr, fields: &mut Vec<String>) -> bool {
+    use crate::ir::Expr;
+    match expr {
+        Expr::Input => true,
+        Expr::IfThenElse { cond, then_branch, else_branch } => {
+            matches!(then_branch.as_ref(), Expr::Input | Expr::Empty)
+                && matches!(else_branch.as_ref(), Expr::Input | Expr::Empty)
+                && collect_input_fields(cond, fields)
+        }
+        Expr::Pipe { left, right } => {
+            pipe_passes_record_through(left, fields) && pipe_passes_record_through(right, fields)
+        }
+        _ => false,
+    }
+}
+
+/// Scan a sub-expression whose `.` is bound to a *derived* (complete) value —
+/// a pipe output, accumulator, generated element or error payload — rather
+/// than the raw top-level record. Such an expression cannot read record
+/// fields, so it needs no field collection; it only must not (a) pull more
+/// records from the host input stream (`input`/`inputs` would observe
+/// projected records), (b) read parser bookkeeping the projecting scanner is
+/// not guaranteed to maintain (`input_line_number`/`input_filename`), or
+/// (c) call an opaque function whose body this scan cannot see (recursive
+/// user functions survive beta-reduction). The match is exhaustive on
+/// purpose: a new `Expr` variant must be reviewed against (a)–(c) here.
+fn projection_stream_safe(expr: &crate::ir::Expr) -> bool {
+    use crate::ir::{BuiltinOp, Expr, StringPart};
+    match expr {
+        Expr::ReadInput | Expr::ReadInputs | Expr::FuncCall { .. } => false,
+        Expr::CallBuiltin { op, args } => {
+            !matches!(op, BuiltinOp::InputFilename | BuiltinOp::InputLineNumber)
+                && args.iter().all(projection_stream_safe)
+        }
+        Expr::Input
+        | Expr::Literal(_)
+        | Expr::LoadVar { .. }
+        | Expr::Empty
+        | Expr::Not
+        | Expr::Loc { .. }
+        | Expr::Env
+        | Expr::Builtins
+        | Expr::ModuleMeta
+        | Expr::GenLabel => true,
+        Expr::BinOp { lhs, rhs, .. } => projection_stream_safe(lhs) && projection_stream_safe(rhs),
+        Expr::UnaryOp { operand, .. } | Expr::Negate { operand } => projection_stream_safe(operand),
+        Expr::Index { expr, key } | Expr::IndexOpt { expr, key } => {
+            projection_stream_safe(expr) && projection_stream_safe(key)
+        }
+        Expr::Pipe { left, right } | Expr::Comma { left, right } => {
+            projection_stream_safe(left) && projection_stream_safe(right)
+        }
+        Expr::IfThenElse { cond, then_branch, else_branch } => {
+            projection_stream_safe(cond)
+                && projection_stream_safe(then_branch)
+                && projection_stream_safe(else_branch)
+        }
+        Expr::TryCatch { try_expr, catch_expr, .. } => {
+            projection_stream_safe(try_expr) && projection_stream_safe(catch_expr)
+        }
+        Expr::Each { input_expr } | Expr::EachOpt { input_expr } | Expr::Recurse { input_expr } => {
+            projection_stream_safe(input_expr)
+        }
+        Expr::LetBinding { value, body, .. } => {
+            projection_stream_safe(value) && projection_stream_safe(body)
+        }
+        Expr::Reduce { source, init, update, .. } => {
+            projection_stream_safe(source)
+                && projection_stream_safe(init)
+                && projection_stream_safe(update)
+        }
+        Expr::Foreach { source, init, update, extract, .. } => {
+            projection_stream_safe(source)
+                && projection_stream_safe(init)
+                && projection_stream_safe(update)
+                && extract.as_ref().is_none_or(|e| projection_stream_safe(e))
+        }
+        Expr::Collect { generator } => projection_stream_safe(generator),
+        Expr::ObjectConstruct { pairs } => pairs
+            .iter()
+            .all(|(k, v)| projection_stream_safe(k) && projection_stream_safe(v)),
+        Expr::Alternative { primary, fallback } => {
+            projection_stream_safe(primary) && projection_stream_safe(fallback)
+        }
+        Expr::Range { from, to, step } => {
+            projection_stream_safe(from)
+                && projection_stream_safe(to)
+                && step.as_ref().is_none_or(|e| projection_stream_safe(e))
+        }
+        Expr::Label { body, .. } => projection_stream_safe(body),
+        Expr::Break { value, .. } => projection_stream_safe(value),
+        Expr::Update { path_expr, update_expr } => {
+            projection_stream_safe(path_expr) && projection_stream_safe(update_expr)
+        }
+        Expr::Assign { path_expr, value_expr } | Expr::Mutate { path_expr, value_expr, .. } => {
+            projection_stream_safe(path_expr) && projection_stream_safe(value_expr)
+        }
+        Expr::PathExpr { expr } => projection_stream_safe(expr),
+        Expr::SetPath { path, value } => {
+            projection_stream_safe(path) && projection_stream_safe(value)
+        }
+        Expr::GetPath { path } => projection_stream_safe(path),
+        Expr::DelPaths { paths } => projection_stream_safe(paths),
+        Expr::StringInterpolation { parts } => parts.iter().all(|p| match p {
+            StringPart::Literal(_) => true,
+            StringPart::Expr(e) => projection_stream_safe(e),
+        }),
+        Expr::Limit { count, generator } => {
+            projection_stream_safe(count) && projection_stream_safe(generator)
+        }
+        Expr::While { cond, update } | Expr::Until { cond, update } => {
+            projection_stream_safe(cond) && projection_stream_safe(update)
+        }
+        Expr::Repeat { update } => projection_stream_safe(update),
+        Expr::AllShort { generator, predicate } | Expr::AnyShort { generator, predicate } => {
+            projection_stream_safe(generator) && projection_stream_safe(predicate)
+        }
+        Expr::Error { msg } => msg.as_ref().is_none_or(|m| projection_stream_safe(m)),
+        Expr::Format { expr, .. } => projection_stream_safe(expr),
+        Expr::ClosureOp { input_expr, key_expr, .. } => {
+            projection_stream_safe(input_expr) && projection_stream_safe(key_expr)
+        }
+        Expr::RegexTest { input_expr, re, flags }
+        | Expr::RegexMatch { input_expr, re, flags }
+        | Expr::RegexCapture { input_expr, re, flags }
+        | Expr::RegexScan { input_expr, re, flags } => {
+            projection_stream_safe(input_expr)
+                && projection_stream_safe(re)
+                && projection_stream_safe(flags)
+        }
+        Expr::RegexSub { input_expr, re, tostr, flags }
+        | Expr::RegexGsub { input_expr, re, tostr, flags } => {
+            projection_stream_safe(input_expr)
+                && projection_stream_safe(re)
+                && projection_stream_safe(tostr)
+                && projection_stream_safe(flags)
+        }
+        Expr::AlternativeDestructure { alternatives } => {
+            alternatives.iter().all(projection_stream_safe)
+        }
+        Expr::Slice { expr, from, to } => {
+            projection_stream_safe(expr)
+                && from.as_ref().is_none_or(|e| projection_stream_safe(e))
+                && to.as_ref().is_none_or(|e| projection_stream_safe(e))
+        }
+        Expr::Debug { expr } | Expr::Stderr { expr } => projection_stream_safe(expr),
+        Expr::Memoize { key, body, .. } => {
+            key.as_ref().is_none_or(|k| projection_stream_safe(k)) && projection_stream_safe(body)
+        }
     }
 }

--- a/tests/contract_projection.rs
+++ b/tests/contract_projection.rs
@@ -1,0 +1,188 @@
+//! #1055: IR-driven projection pushdown. `Filter::needed_input_fields`
+//! derives the static set of top-level fields a filter reads; the host then
+//! parses only those fields per record (`json_stream_project`), skipping
+//! Value materialization for the rest. These contracts pin the two
+//! load-bearing properties:
+//!
+//!  1. extraction soundness — a filter executed against the projected
+//!     record produces byte-for-byte the same outputs (and the same
+//!     errors) as against the fully parsed record;
+//!  2. extraction coverage — shapes the walk is supposed to handle keep
+//!     projecting, and shapes that observe the whole record (identity,
+//!     iteration over `.`, `keys`, `input`, bare `error`, ...) keep
+//!     refusing, since projection would change their observable output.
+
+use jq_jit::interpreter::Filter;
+use jq_jit::value::{json_stream, json_stream_project, Value};
+
+/// Filters that must project, with the exact expected field set.
+const PROJECTING: &[(&str, &[&str])] = &[
+    (".x", &["x"]),
+    ("{a: {b: .x}}", &["x"]),
+    (".x, .y", &["x", "y"]),
+    ("[.x, .y, .name]", &["name", "x", "y"]),
+    ("[.x, .y] | min", &["x", "y"]),
+    ("select(.x > 1) | {a: .x}", &["x"]),
+    ("select(.x > 1) | select(.y < 9) | [.x, .y]", &["x", "y"]),
+    (".x | tostring", &["x"]),
+    (".x | keys", &["x"]),
+    (".x | ..", &["x"]),
+    (".x[]", &["x"]),
+    (".x[] | .k", &["x"]),
+    (".a.b.c", &["a"]),
+    (".tags[0]", &["tags"]),
+    (".x[1:3]", &["x"]),
+    ("if .a then .b else .c end", &["a", "b", "c"]),
+    (".x // 0", &["x"]),
+    (".x?", &["x"]),
+    ("\"\\(.x)-\\(.y)\"", &["x", "y"]),
+    (".x | @base64", &["x"]),
+    ("limit(2; .x[])", &["x"]),
+    ("first(.x[])", &["x"]),
+    ("reduce .x[] as $v (0; . + $v)", &["x"]),
+    ("foreach .x[] as $v (0; . + $v)", &["x"]),
+    ("[.x[] | select(. > 2)]", &["x"]),
+    (".x as $a | .y + $a", &["x", "y"]),
+    ("{(.k): .v}", &["k", "v"]),
+    ("try .x catch .", &["x"]),
+    ("error(.msg) // 1", &["msg"]),
+    (".x | match(\"a\")", &["x"]),
+    (".name | test(\"z\")", &["name"]),
+    (".x | tonumber + 1", &["x"]),
+    ("all(.x[]; . > 0)", &["x"]),
+    (".x | while(. < 30; . * 2)", &["x"]),
+];
+
+/// Filters that must NOT project: their output (or stream consumption)
+/// observes parts of the record outside any static field set.
+const NON_PROJECTING: &[&str] = &[
+    ".",
+    ".[]",
+    "keys",
+    "to_entries",
+    "has(\"x\")",
+    "select(.x > 1)",       // outputs the record itself
+    "..",                   // yields the record first
+    "error",                // throws the record as the error payload
+    "input",
+    ".x | input",            // pulls a (projected) record from the stream
+    ".x | input_line_number", // parser bookkeeping, not derived data
+    "while(.x < 3; .x + 1)", // iterates record-derived snapshots of `.`
+    ". as $r | .x | $r",     // smuggles the record out through a variable
+    "recurse(.children[]?)", // recurse(f) yields the record before f's outputs
+    "recurse(.children[]?; . != null) | .name",
+    "[.x, debug(\"m\")]",    // debug prints its arg but passes the record through
+    "[.x, stderr]",
+];
+
+/// Inputs exercising the projecting parser's edges: extra fields before /
+/// after / between the needed ones, missing fields (null backfill),
+/// duplicate keys (last-wins), escaped keys, nested composites in both
+/// kept and skipped fields, empty objects, and non-object records (which
+/// bypass projection entirely and must still flow through).
+const INPUTS: &[&str] = &[
+    r#"{"x":1,"y":2,"name":"n","k":"kk","v":7,"a":{"b":{"c":3}},"tags":[9,8],"msg":"m"}"#,
+    r#"{"skip0":[1,{"q":2}],"x":[3,4,5],"skip1":"zz","y":[6],"name":"item","a":{"b":{"c":null}},"tags":[],"k":"K","v":[1],"msg":"e","skipN":{"deep":{"er":1}}}"#,
+    r#"{}"#,
+    r#"{"unrelated":1,"other":"s"}"#,
+    r#"{"x":2,"x":3,"y":1,"y":{"z":9}}"#,
+    r#"{"x":5,"y":6,"name":"esc"}"#,
+    r#"{"x":"a\/bA\t","y":1e3,"name":"s"}"#,
+    "[1,2,3]",
+    "\"scalar\"",
+    "null",
+    "42",
+    r#"{"x":{"big":[1,2,{"n":3}]},"y":true,"name":null}"#,
+];
+
+fn run_filter(f: &mut Filter, inputs: &[Value]) -> Vec<Result<Value, String>> {
+    let mut out = Vec::new();
+    for inp in inputs {
+        let mut vals = Vec::new();
+        match f.execute_cb(inp, &mut |v| {
+            vals.push(v.clone());
+            Ok(true)
+        }) {
+            Ok(_) => out.extend(vals.into_iter().map(Ok)),
+            Err(e) => {
+                out.extend(vals.into_iter().map(Ok));
+                out.push(Err(e.to_string()));
+            }
+        }
+    }
+    out
+}
+
+#[test]
+fn projected_execution_matches_full_parse() {
+    // One multi-record stream per input string plus one combined stream,
+    // so the streaming entry point sees record boundaries too.
+    let combined = INPUTS.join("\n");
+    let mut streams: Vec<&str> = INPUTS.to_vec();
+    streams.push(&combined);
+
+    for &(filter, expected_fields) in PROJECTING {
+        let mut f = Filter::with_options(filter, &[], false).expect(filter);
+        let fields = f
+            .needed_input_fields()
+            .unwrap_or_else(|| panic!("{filter:?} must project"));
+        assert_eq!(
+            fields,
+            expected_fields.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+            "{filter:?} projected field set"
+        );
+        let field_refs: Vec<&str> = fields.iter().map(|s| s.as_str()).collect();
+
+        for stream in &streams {
+            let mut full = Vec::new();
+            json_stream(stream, |v| {
+                full.push(v);
+                Ok(())
+            })
+            .expect("full parse");
+            let mut projected = Vec::new();
+            json_stream_project(stream, &field_refs, |v| {
+                projected.push(v);
+                Ok(())
+            })
+            .expect("projected parse");
+
+            let out_full = run_filter(&mut f, &full);
+            let out_proj = run_filter(&mut f, &projected);
+            assert_eq!(
+                out_full, out_proj,
+                "{filter:?} diverges between full and projected parse on {stream:?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn record_observers_refuse_projection() {
+    for filter in NON_PROJECTING {
+        let f = Filter::with_options(filter, &[], false).expect(filter);
+        assert_eq!(
+            f.needed_input_fields(),
+            None,
+            "{filter:?} must not project — it observes the whole record"
+        );
+    }
+}
+
+/// The projecting parser tracks found keys in a u64 bitset; the extraction
+/// must refuse field sets that would overflow it.
+#[test]
+fn field_set_capped_at_bitset_width() {
+    let wide: Vec<String> = (0..65).map(|i| format!(".f{i:02}")).collect();
+    let filter65 = format!("[{}]", wide.join(", "));
+    let f = Filter::with_options(&filter65, &[], false).expect("parse");
+    assert_eq!(f.needed_input_fields(), None, "65 fields must refuse");
+
+    let filter64 = format!("[{}]", wide[..64].join(", "));
+    let f = Filter::with_options(&filter64, &[], false).expect("parse");
+    assert_eq!(
+        f.needed_input_fields().map(|v| v.len()),
+        Some(64),
+        "64 fields must still project"
+    );
+}

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -14173,3 +14173,38 @@ select(.x > 100) | {a: {b: .x}}
 .x + 1 | {v: ., w: [.]}
 {"x":2}
 {"v":3,"w":[3]}
+
+# #1055: projection — reduce over a projected field, duplicate keys keep last-wins
+reduce .x[] as $v (0; . + $v)
+{"noise":{"a":1},"x":[1,2,3],"x":[4,5],"z":"s"}
+9
+
+# #1055: projection — select piping the record into a nested construct
+select(.x > 1) | {a: {b: .x}}
+{"pad":[1,2],"x":2,"more":"mm"}
+{"a":{"b":2}}
+
+# #1055: projection — missing projected field backfills null exactly like full parse
+try .x catch "e"
+{"other":1}
+null
+
+# #1055: projection — escaped input key still matches the projected field
+[limit(2; .k[])]
+{"k":[7,8,9],"skip":0}
+[7,8]
+
+# #1055: projection — non-object records bypass projection and error identically
+try .x catch "err"
+[1,2]
+"err"
+
+# #1055: projection — iterate-then-filter over a projected field
+[.x[] | select(. > 1)]
+{"q":"noise","x":[1,2,3]}
+[2,3]
+
+# #1055: projection — foreach over a projected field
+[foreach .x[] as $v (0; . + $v)]
+{"x":[1,2,3],"pad":null}
+[1,3,6]


### PR DESCRIPTION
## Summary

Phase 1 of #1055: extend `needed_input_fields` / `collect_input_fields` (the IR walk behind the projection-steered parser from #251) so far more filter shapes derive a static top-level field set and route through `json_stream_project`, skipping `Value` materialization for fields the filter never reads.

The projecting parser, the host dispatch and its gating (`!has_raw_fast_path && !slurp && !raw_input`) are unchanged — this PR only widens what the extraction walk can prove safe, plus one hardening fix (the 64-field bitset cap).

## What newly projects

- `Comma` / `Collect` / `Each`/`EachOpt` / `Empty` / `TryCatch` / `StringInterpolation` / `Format` / `Slice` / `Limit` / `Range` / `Reduce` / `Foreach` / `Label`/`Break` / `AllShort`/`AnyShort` / `error(msg)` / `Env`/`Loc`/`Builtins`
- **Pipe right-hand sides need no field collection**: when the left side passes the strict walk, its outputs are complete derived values, so the right side may be anything that does not touch the host input stream (`projection_stream_safe`: rejects `input`/`inputs`, `input_line_number`/`input_filename`, opaque `FuncCall`; exhaustive match so new `Expr` variants fail compilation until reviewed)
- Pipe left-hand sides that pass the record through (bare `.`, the `select(cond)` desugar, chains of those) keep the strict walk on the right (`pipe_passes_record_through`), so `select(.x > 1) | {a: .x}` projects

Examples: `reduce .x[] as $v (0; . + $v)`, `[.x[] | select(. > 2)]`, `limit(2; .x[])`, `try .x catch "e"`, `.x | match("a")`, `"\(.x)-\(.y)"`, `select(.c) | <construct>`.

## Safety anchor (documented in `docs/maintenance.md`)

Bare `Input` is always `false` in the strict walk; every arm may only pass when its outputs are literals or fully-parsed derived values, never the (projected) record. Nodes that implicitly pass the record through stay bailed — the existing regression corpus caught `recurse(f)` (yields the record before `f`'s outputs) during development; `debug`/`stderr` (print their expr, pass `.` through) and bare `error` (throws `.`) are bailed for the same reason and pinned in the new contract test.

Hardening: `needed_input_fields` now refuses sets larger than 64 fields — the projecting parser tracks found keys in a u64 bitset, and past 64 the missing-field backfill could produce duplicate keys.

## Performance (same-machine interleaved A/B, best-of-N)

1M-record NDJSON, 16 fields/record, `-c`:

| filter | main | PR | ratio |
|---|---|---|---|
| `reduce .f10[] as $v (0; . + $v)` | 0.746s | 0.446s | **0.60** |
| `[.f10[] \| select(. > 2)]` | 0.719s | 0.413s | **0.58** |
| `limit(2; .f10[])` | 0.685s | 0.360s | **0.53** |
| `try .x catch "e"` | 0.661s | 0.320s | **0.48** |
| guard: `{a: {b: .x}}` (already projected) | 0.332s | 0.328s | 0.99 |
| guard: identity | 0.946s | 0.952s | 1.01 |

Narrow 3-field 2M records: `select(.x > 100) | {a: {b: .x}}` 0.90 (composes with #1058 fusion). Full `bench/comprehensive.sh` vs v1.9.2 history: 3 rows flagged >1.05 (`[[x,y],[n]]|flat` 1.14, `objects` 1.06, `path(.name,.x)` 1.06) — all re-measured same-machine interleaved at 1.02 / 1.00 / 1.04, i.e. cross-day drift / known layout-lottery rows, no real regression.

## Verification

- `cargo build --release` zero warnings; `cargo test --release` green (77 binaries) including the new `tests/contract_projection.rs` (projected-vs-full output **and error** equivalence over a filter × input corpus covering duplicate keys, escaped keys, missing-field backfill, non-object records, multi-record streams; the refuse list; the bitset cap)
- Projection on/off sweep over `tests/regression.test` + `tests/differential/corpus.test` (4050 groups, `-c -L tests/modules`, stdout+exit): **0 diffs**
- 3-backend sweep (Cranelift / JitOp-interp / forced interpreter): only the 4 pre-existing known diffs that reproduce on main
- File-input mode and stdin parity on projecting filters (md5 over 200K records); `-n` + `inputs` matches jq 1.8.1
- 7 new `tests/regression.test` groups pin end-to-end binary behavior (verified against jq 1.8.1)

Closes #1055

🤖 Generated with [Claude Code](https://claude.com/claude-code)