### PR TITLE
feat(cli): add --parallel for per-record NDJSON execution of stateless filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A JIT-compiling [jq](https://jqlang.github.io/jq/) in Rust using [Cranelift](htt
 - **JIT compilation** via Cranelift for hot execution paths
 - **Raw byte fast paths** — 70+ filter shapes operate directly on raw bytes, skipping JSON parsing entirely; 180+ shapes in total route to specialized fast paths
 - **Streaming JSON parser** for memory-efficient NDJSON processing
+- **Parallel per-record execution** — `--parallel` shards a stateless filter over an NDJSON stream across a worker pool, byte-identically to sequential mode (see [Parallel execution](#parallel-execution))
 - **Memory-mapped file I/O** — mmap-based file reading with no upfront allocation
 - **Optimized value representation** with compact strings, mimalloc, and inline Cranelift codegen
 - **jqx extensions** — shell command execution (`exec`/`execv`), CSV/TSV parsing (`fromcsv`/`fromcsvh`/`fromtsv`/`fromtsvh`), function-result memoization (`memoize`), and the in-place path-update contract (`mutate`)
@@ -110,6 +111,7 @@ jq-jit [OPTIONS] <FILTER> [FILE...]
 | `--indent N` | Use N spaces for indentation (range -1..=7; -1 means tab; default: 2) |
 | `--unbuffered` | Flush output after each value |
 | `--seq` | Frame each output with `RS` (0x1E) per RFC 7464 |
+| `--parallel[=N]` | _(jqx)_ Run a stateless filter per-record across N worker threads (default: core count); see [Parallel execution](#parallel-execution) |
 | `-f`, `--from-file FILE` | Read filter from file |
 | `-L`, `--library-path DIR` | Add DIR to the module search path (repeatable) |
 | `--arg NAME VALUE` | Set `$NAME` to string VALUE |
@@ -298,6 +300,42 @@ jq-jit --debug-memo -n 'def fib: memoize(if . < 2 then . else ((. - 1) | fib) + 
 The 1-arg form keys only by the current input. If your body closes over a
 `$var` that varies between calls, results will be stale — pull the var into
 the key explicitly with the 2-arg form: `memoize(. + $x; [., $x])`.
+
+### Parallel execution
+
+For a **stateless** filter over an NDJSON document stream, every input record
+is independent: there is nothing to share between records, so they can run on
+a worker pool with the output reassembled in record order. `--parallel[=N]`
+does exactly that — something single-threaded jq structurally cannot.
+
+```bash
+# Spread the filter across all cores
+jq-jit -c --parallel 'select(.level == "error") | {ts, msg}' < events.ndjson
+
+# Pin the worker count
+jq-jit -c --parallel=4 '{id, total: (.items | map(.qty * .price) | add)}' < orders.ndjson
+```
+
+Output is **byte-identical** to sequential mode: each worker runs the same
+compiled filter and serializer, and a single writer drains a reorder buffer in
+stream order. Per-record errors still surface in record order, and `-e` still
+reflects the last output value across the whole stream.
+
+`--parallel` only engages when the filter is provably independent per record.
+Anything that observes cross-record state, stream position, shared mutable
+state, side effects, or non-determinism transparently falls back to sequential
+execution — including `input`/`inputs`, `limit`/`first` over the input stream,
+`input_line_number`, `$__loc__`, `memoize`, `mutate`, `exec`/`execv`,
+`debug`/`stderr`, `halt`/`halt_error`, and `now`. The check follows
+user-defined function calls, so a stream read hidden behind a `def` is still
+detected. It also only applies to plain buffered compact/pretty output (not
+`-r`/`-S`/`-j`/`-C`/`--seq`/`--unbuffered` or `-n` null-input); other modes run
+sequentially. Tiny inputs run inline regardless, since thread setup would
+dominate.
+
+The speedup tracks the per-record work: light projections are bounded by the
+serial input scan and output write (Amdahl), while heavier per-record filters
+scale close to the worker count.
 
 ## Testing
 

--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -300,6 +300,335 @@ fn print_jq_error_typed(e: &anyhow::Error) {
     }
 }
 
+/// Format a per-record runtime error into the line jq writes to stderr,
+/// mirroring [`print_jq_error_typed`] but returning a `String` so a worker
+/// thread can hand it back to the writer (an `anyhow::Error` may carry a
+/// `Value`/`Rc` payload and is not `Send`). The `<stdin>:N` line number
+/// reflects the worker's thread-local counter, which `--parallel` never
+/// advances (it rejects `input_line_number`), so it reads `:0` — a cosmetic
+/// divergence on stderr only; stdout stays byte-identical to sequential.
+fn format_record_error(e: &anyhow::Error) -> String {
+    let line = jq_jit::eval::get_input_line_number();
+    if let Some(ev) = e.downcast_ref::<jq_jit::signal::ErrorValue>() {
+        match jq_jit::signal::take_error_payload(ev) {
+            Value::Str(s) => format!("jq: error (at <stdin>:{}): {}", line, s.as_str()),
+            other => format!(
+                "jq: error (at <stdin>:{}) (not a string): {}",
+                line,
+                value_to_json_precise(&other),
+            ),
+        }
+    } else {
+        format!("jq: error (at <stdin>:{}): {}", line, e)
+    }
+}
+
+/// Per-record output-formatting knobs for the `--parallel` worker pool
+/// (#1054). Covers exactly the subset of `process_input`'s buffered branches
+/// that `parallel_active` permits: compact or pretty, no color / seq / raw /
+/// sort-keys / join. Copied into each worker so threads share no state.
+#[derive(Clone, Copy)]
+struct ParFmt {
+    /// `use_pretty_buf` (true) vs `use_compact_buf` (false).
+    pretty: bool,
+    indent_n: usize,
+    tab: bool,
+    exit_status: bool,
+    /// Engage output fusion (#1058) for compact, non-`-e` output.
+    output_fusion: bool,
+}
+
+/// One batch's serialized output, moved from a worker thread back to the
+/// single writer. Holds only `Send` data (no `Rc`/`Value`).
+#[derive(Default)]
+struct BatchOut {
+    bytes: Vec<u8>,
+    errors: Vec<String>,
+    had_error: bool,
+    /// Whether any output value was emitted (for the `-e` running state).
+    emitted_any: bool,
+    /// Last output's `-e` verdict: 1 = truthy, 2 = falsy.
+    last_state: u8,
+}
+
+/// A per-thread compiled filter plus the formatting knobs. Each worker owns
+/// its own `Filter` (compiled inside the worker thread, never moved across
+/// threads — `Filter` holds `Rc` and is not `Send`).
+struct Worker {
+    filter: Filter,
+    fmt: ParFmt,
+    fusion_active: bool,
+}
+
+impl Worker {
+    fn compile(
+        filter_str: &str,
+        lib_dirs: &[String],
+        memo_max_entries: Option<usize>,
+        fmt: ParFmt,
+    ) -> anyhow::Result<Worker> {
+        if fmt.output_fusion {
+            jq_jit::jit::set_output_fusion(true);
+        }
+        let mut filter = Filter::with_options(filter_str, lib_dirs, false)?;
+        if let Some(m) = memo_max_entries {
+            filter.set_memo_max_entries(m);
+        }
+        // Parallel only engages on large inputs, so arm like the binary's
+        // large-stdin path: Cranelift, then the JitOp routing fallback for
+        // whatever Cranelift declined. Output is backend-independent (the
+        // selfdiff invariant), so this only affects throughput.
+        filter.compile_jit();
+        if !filter.has_jit() {
+            filter.compile_jitop_program_for_routing();
+        }
+        let fusion_active = jq_jit::jit::output_fusion_active();
+        Ok(Worker { filter, fmt, fusion_active })
+    }
+
+    /// Execute the filter on one record's raw bytes, appending formatted
+    /// output to `out.bytes` exactly as `process_input`'s compact / pretty
+    /// buffered branches would, so the result is byte-identical to
+    /// sequential mode.
+    fn run_record(&self, raw: &[u8], out: &mut BatchOut) {
+        let input = match json_to_value(unsafe { std::str::from_utf8_unchecked(raw) }) {
+            Ok(v) => v,
+            Err(e) => {
+                // json_stream_raw already validated each record boundary, so a
+                // full parse should not fail here; record defensively.
+                out.had_error = true;
+                out.errors.push(format!("jq: error (at <stdin>:0): {}", e));
+                return;
+            }
+        };
+        let fmt = self.fmt;
+        let res = self.filter.execute_cb(&input, &mut |result| {
+            if fmt.exit_status {
+                out.emitted_any = true;
+                out.last_state = if result.is_true() { 1 } else { 2 };
+            }
+            if fmt.pretty {
+                push_pretty_line(&mut out.bytes, result, fmt.indent_n, fmt.tab);
+            } else if std::ptr::eq(result, &input)
+                && is_json_compact(raw)
+                && !raw_contains_non_canonical_number(raw)
+                && !json_value_has_duplicate_keys(raw)
+            {
+                // Compact raw passthrough — same decision as process_input's
+                // `use_compact_buf && !color_output` branch (#780/#1090).
+                if raw_contains_noncanon_escape(raw) {
+                    push_raw_canon_escapes(&mut out.bytes, raw);
+                } else {
+                    out.bytes.extend_from_slice(raw);
+                }
+                out.bytes.push(b'\n');
+            } else {
+                push_compact_line(&mut out.bytes, result);
+            }
+            Ok(true)
+        });
+        // Output fusion (#1058): fused programs stage whole records in the
+        // JIT env's (thread-local) emit buffer instead of streaming through
+        // the callback; drain into this batch's buffer.
+        if self.fusion_active {
+            jq_jit::jit::drain_emit_buf(&mut out.bytes);
+        }
+        if let Err(e) = res {
+            // `halt`/`halt_error` are rejected by is_parallel_safe, so a
+            // terminal HaltSignal cannot reach here — every error is a normal
+            // per-record error that jq prints and steps past.
+            out.had_error = true;
+            out.errors.push(format_record_error(&e));
+        }
+    }
+}
+
+/// Commit one batch's output in stream order: errors to stderr, bytes to
+/// stdout, folding the running `-e` state and the error flag.
+fn commit_batch(
+    b: &BatchOut,
+    out: &mut io::BufWriter<io::StdoutLock>,
+    running: &mut u8,
+    had_error: &mut bool,
+) {
+    for msg in &b.errors {
+        eprintln!("{}", msg);
+    }
+    let _ = out.write_all(&b.bytes);
+    if b.had_error {
+        *had_error = true;
+    }
+    if b.emitted_any {
+        *running = b.last_state;
+    }
+}
+
+/// Run a stateless filter over an NDJSON document stream across a worker
+/// pool, writing output in record order byte-identically to sequential mode
+/// (#1054). The caller guarantees `is_parallel_safe()` and a buffered
+/// compact/pretty mode (see `parallel_active`). On a malformed document the
+/// leading valid records are flushed and the parse error returned (jq's
+/// lazy-stream exit-5 behavior, #856).
+fn run_parallel_json_stream(
+    content: &str,
+    jobs: usize,
+    filter_str: &str,
+    lib_dirs: &[String],
+    memo_max_entries: Option<usize>,
+    fmt: ParFmt,
+    out: &mut io::BufWriter<io::StdoutLock>,
+    exit_state: &std::cell::Cell<u8>,
+    had_error: &mut bool,
+) -> anyhow::Result<()> {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::mpsc;
+    use std::sync::Mutex;
+
+    // Record byte ranges in stream order. A malformed document stops the scan
+    // with the leading valid ranges retained.
+    let mut ranges: Vec<(usize, usize)> = Vec::new();
+    let parse_err = match json_stream_raw(content, |s, e| {
+        ranges.push((s, e));
+        Ok(())
+    }) {
+        Ok(()) => None,
+        Err(e) => Some(e),
+    };
+
+    let content_bytes = content.as_bytes();
+    // Seed the running `-e` state from any prior input source (the file loop
+    // calls this once per file) so a later empty file does not clobber an
+    // earlier verdict.
+    let mut running_state: u8 = exit_state.get();
+
+    // Below the spawn threshold (tiny inputs), run inline on this thread —
+    // worker creation would dominate.
+    const PAR_MIN_RECORDS: usize = 256;
+    let workers = if ranges.len() < PAR_MIN_RECORDS { 1 } else { jobs.max(1) };
+
+    if workers <= 1 {
+        let worker = Worker::compile(filter_str, lib_dirs, memo_max_entries, fmt)?;
+        let mut b = BatchOut::default();
+        for &(s, e) in &ranges {
+            worker.run_record(&content_bytes[s..e], &mut b);
+        }
+        commit_batch(&b, out, &mut running_state, had_error);
+        exit_state.set(running_state);
+        return match parse_err {
+            Some(e) => Err(e),
+            None => Ok(()),
+        };
+    }
+
+    // Split into contiguous batches — more than workers so a slow batch can't
+    // strand idle threads. Workers claim batch indices off a shared counter,
+    // run them, and ship each finished batch to a dedicated writer thread that
+    // drains a reorder buffer in stream order. The writer runs *concurrently*
+    // with the workers, so output is flushed as the in-order prefix becomes
+    // available rather than buffering the whole stream in memory.
+    let nbatch = (workers * 8).min(ranges.len()).max(1);
+    let per = ranges.len().div_ceil(nbatch);
+    let batches: Vec<&[(usize, usize)]> = ranges.chunks(per).collect();
+    let nbatch = batches.len();
+    let next = AtomicUsize::new(0);
+    let compile_err: Mutex<Option<String>> = Mutex::new(None);
+
+    // Match the main thread's 2 GiB stack (real_main itself runs on one) so
+    // deeply nested documents recurse identically to sequential mode.
+    const WORKER_STACK: usize = 2048 * 1024 * 1024;
+
+    let (tx, rx) = mpsc::channel::<(usize, BatchOut)>();
+
+    // The main thread is the writer: it drains finished batches off the
+    // channel and reassembles them in index (stream) order, holding only the
+    // out-of-order tail in memory. `out`/`StdoutLock` are `!Send`, so keeping
+    // the writes here (rather than on a spawned thread) is also what lets the
+    // workers ship only the `Send` `BatchOut` across the boundary.
+    std::thread::scope(|scope| {
+        // Shared, read-only views the `move` worker closures capture by
+        // reference (so each spawn does not try to own them).
+        let batches = &batches;
+        let next = &next;
+        let compile_err = &compile_err;
+        for _ in 0..workers {
+            let builder = std::thread::Builder::new().stack_size(WORKER_STACK);
+            let tx = tx.clone();
+            let spawn = builder.spawn_scoped(scope, move || {
+                let worker = match Worker::compile(filter_str, lib_dirs, memo_max_entries, fmt) {
+                    Ok(w) => w,
+                    Err(e) => {
+                        let mut ce = compile_err.lock().unwrap();
+                        if ce.is_none() {
+                            *ce = Some(format!("{}", e));
+                        }
+                        return;
+                    }
+                };
+                // Workers claim batch indices dynamically, so a single
+                // surviving worker still covers every batch if others fail to
+                // compile.
+                loop {
+                    let bi = next.fetch_add(1, Ordering::Relaxed);
+                    if bi >= nbatch {
+                        break;
+                    }
+                    let mut b = BatchOut::default();
+                    for &(s, e) in batches[bi] {
+                        worker.run_record(&content_bytes[s..e], &mut b);
+                    }
+                    // Fails only if the receiver (main thread) is gone, which
+                    // does not happen before the drain below completes.
+                    let _ = tx.send((bi, b));
+                }
+            });
+            if let Err(e) = spawn {
+                let mut ce = compile_err.lock().unwrap();
+                if ce.is_none() {
+                    *ce = Some(format!("failed to spawn parallel worker: {}", e));
+                }
+            }
+        }
+        // Drop the original sender so `rx.recv()` ends once all worker clones
+        // are gone (every batch sent, or a worker died).
+        drop(tx);
+
+        // Drain in stream order, flushing the in-order prefix as it arrives.
+        let mut pending: Vec<Option<BatchOut>> = (0..nbatch).map(|_| None).collect();
+        let mut next_write = 0usize;
+        while let Ok((bi, b)) = rx.recv() {
+            pending[bi] = Some(b);
+            while next_write < nbatch {
+                match pending[next_write].take() {
+                    Some(b) => {
+                        commit_batch(&b, out, &mut running_state, had_error);
+                        next_write += 1;
+                    }
+                    None => break,
+                }
+            }
+        }
+    });
+
+    // A worker compile/spawn failure is fatal — surface it like the sequential
+    // compile-time error (exit 3). With an already-parsed, parallel-safe
+    // filter this realistically only fires on resource limits. (A compile
+    // failure stops a worker before it sends, so the writer simply stops at
+    // the gap; any prefix already written is harmless since we exit non-zero.)
+    if let Some(msg) = compile_err.into_inner().unwrap() {
+        // `out` was moved into the writer thread; its buffer is flushed by
+        // real_main's owned BufWriter on the normal path, but here we exit
+        // immediately on an unreachable-in-practice resource failure.
+        eprintln!("jq: error: {}", msg);
+        std::process::exit(3);
+    }
+
+    exit_state.set(running_state);
+    match parse_err {
+        Some(e) => Err(e),
+        None => Ok(()),
+    }
+}
+
 use jq_jit::value::{Value, json_to_value, json_stream, json_stream_offsets, json_stream_raw, json_stream_project, json_value_has_duplicate_keys, json_stream_has_duplicate_keys, json_object_get_num, json_object_get_two_nums, json_object_get_field_raw, json_object_get_fields_raw_buf, parse_json_num, json_value_length, json_object_keys_unsorted_to_buf,json_object_keys_join_to_buf, json_object_has_key, json_object_has_all_keys, json_object_has_any_key, json_object_del_field, json_object_del_fields, json_object_merge_literal, json_object_sort_keys, json_each_value_raw, json_each_value_cb, json_to_entries_raw, json_object_set_field_raw, json_object_update_field_num, json_object_update_field_num_chain,json_object_select_then_update_num, json_object_select_then_update_str_concat, json_object_select_compound_then_update_num, json_object_select_str_then_update_num, is_json_compact, push_json_compact_raw, push_tojson_raw, push_json_pretty_raw, push_json_pretty_raw_at, value_to_json_precise, value_to_json_pretty_ext, push_compact_line, push_compact_line_color, push_pretty_line, push_pretty_line_color, push_jq_number_bytes, write_value_compact_ext, write_value_compact_line, write_value_pretty_line_color, value_to_json_pretty_color, walk_json_transform_nums, pool_value, skip_json_value, raw_contains_non_canonical_number, append_canonical_value, raw_contains_noncanon_escape, push_raw_canon_escapes};
 use jq_jit::interpreter::Filter;
 use jq_jit::fast_path::{
@@ -2499,6 +2828,10 @@ fn real_main() {
     let mut color_output = false;
     let mut unbuffered = false;
     let mut seq = false;
+    // 0 = parallel disabled. `--parallel` sets it to the detected core count,
+    // `--parallel=N` to N. Per-record worker-pool execution for stateless
+    // filters on NDJSON streams (#1054); gated further by `parallel_active`.
+    let mut parallel_jobs: usize = 0;
     let mut arg_vars: Vec<(String, Value)> = Vec::new();
     let mut argjson_vars: Vec<(String, Value)> = Vec::new();
     let mut lib_dirs: Vec<String> = Vec::new();
@@ -2574,6 +2907,20 @@ fn real_main() {
             "-M" | "--monochrome-output" => color_output = false,
             "--unbuffered" => unbuffered = true,
             "--seq" => seq = true,
+            "--parallel" => {
+                parallel_jobs = std::thread::available_parallelism()
+                    .map(|n| n.get())
+                    .unwrap_or(1);
+            }
+            s if s.starts_with("--parallel=") => {
+                match s["--parallel=".len()..].parse::<usize>() {
+                    Ok(n) => parallel_jobs = n,
+                    Err(_) => {
+                        eprintln!("jq: --parallel expects a non-negative integer");
+                        process::exit(2);
+                    }
+                }
+            }
             "--force-jit" => { force_jit = true; force_interp = false; }
             "--force-interp" | "--force-interpreter" => { force_interp = true; force_jit = false; }
             "--memo-max-entries" => {
@@ -3029,6 +3376,33 @@ fn real_main() {
     // Use Vec-based buffering for compact output to avoid per-value write_all overhead
     let use_compact_buf = compact && !raw_output && !sort_keys && !join_output;
     let use_pretty_buf = !compact && !raw_output && !sort_keys && !join_output && !tab;
+
+    // --parallel (#1054): shard the per-record NDJSON stream across a worker
+    // pool when the filter is stateless and the output mode is a plain
+    // buffered compact/pretty stream. The buffered modes already exclude
+    // -r/-S/-j/--tab(pretty); we additionally require no color/seq/unbuffered
+    // (those alter or interleave per-record output) and not null-input (a
+    // different, single-document code path). Output stays byte-identical to
+    // sequential because each worker reuses the same serializer and the
+    // writer reassembles batches in record order.
+    let parallel_active = parallel_jobs >= 2
+        && (use_compact_buf || use_pretty_buf)
+        && !color_output
+        && !seq
+        && !unbuffered
+        && !null_input
+        && filter.is_parallel_safe();
+    let par_fmt = ParFmt {
+        pretty: use_pretty_buf,
+        indent_n,
+        tab,
+        exit_status,
+        // Fusion (#1058) only applies to compact output and needs the
+        // yield callback unused; -e must observe each value, so disable it
+        // there (matching the binary's own fusion gate).
+        output_fusion: use_compact_buf && !exit_status,
+    };
+
     // Helper macro: emit raw JSON bytes to buffer with trailing newline,
     // handling compact vs pretty output.
     //
@@ -4044,7 +4418,12 @@ fn real_main() {
                 // value was terminated).
                 let total_nl: u64 = input_bytes.iter().filter(|&&b| b == b'\n').count() as u64;
                 let line_state = std::cell::Cell::new((0u64, 0usize));
-                let parse_result = if filter.is_empty() {
+                let parse_result = if parallel_active {
+                    run_parallel_json_stream(
+                        &input_str, parallel_jobs, &filter_str, &lib_dirs,
+                        memo_max_entries, par_fmt, &mut out, &exit_state, &mut had_error,
+                    )
+                } else if filter.is_empty() {
                     json_stream_raw(&input_str, |_, _| Ok(()))
                 } else if let Some(ref lit) = literal_output {
                     json_stream_raw(&input_str, |_, _| {
@@ -13191,7 +13570,12 @@ fn real_main() {
                 content = "";
             }
             let _ = &mmap; // keep mmap alive
-            let parse_result = if slurp {
+            let parse_result = if parallel_active && !slurp && !raw_input {
+                run_parallel_json_stream(
+                    content, parallel_jobs, &filter_str, &lib_dirs,
+                    memo_max_entries, par_fmt, &mut out, &exit_state, &mut had_error,
+                )
+            } else if slurp {
                 // Slurp: collect all JSON values into an array, process once
                 let mut values = Vec::new();
                 let r = if raw_input {
@@ -22115,6 +22499,7 @@ fn print_usage() {
     eprintln!("  -M, --monochrome-output  Disable color output (default)");
     eprintln!("  --args                   Remaining args are string $ARGS.positional");
     eprintln!("  --jsonargs               Remaining args are JSON $ARGS.positional");
+    eprintln!("  --parallel[=N]           Run stateless filters per-record across N workers (jqx; default: cores)");
     eprintln!("  --memo-max-entries N     Per-slot cap for memoize/1 cache (jqx; default 1000000)");
     eprintln!("  --debug-memo             Print per-slot memoize cache stats to stderr on exit (jqx)");
     eprintln!("  --trace-mutate           Print one line per mutate(...) invocation to stderr (jqx)");

--- a/src/classify.rs
+++ b/src/classify.rs
@@ -525,6 +525,138 @@ fn push_const_comma_list(expr: &crate::ir::Expr, buf: &mut Vec<u8>, first: bool)
 }
 
 impl Filter {
+    /// Returns true if this filter can be applied to each top-level input
+    /// document independently, with no observation of cross-record state,
+    /// stream position, shared mutable cache, side effects, or
+    /// non-determinism. This is the gate for `--parallel` per-record
+    /// execution (#1054): when true, the binary may shard the NDJSON input
+    /// across a worker pool and reassemble the output in record order,
+    /// byte-identically to sequential mode.
+    ///
+    /// The walk follows `FuncCall` into the callee body (a `def f: input; f`
+    /// hides the stream read behind the call, like [`Filter::uses_inputs`]),
+    /// guarding recursion via `visited`. The per-variant match is
+    /// deliberately exhaustive — no `_` wildcard — so a future `Expr`
+    /// variant fails to compile here until its parallel-safety is decided
+    /// explicitly rather than silently inheriting "safe".
+    pub fn is_parallel_safe(&self) -> bool {
+        let (ref expr, ref funcs) = self.parsed;
+        Self::expr_is_parallel_safe(expr, funcs, &mut Vec::new())
+    }
+
+    fn expr_is_parallel_safe(
+        e: &crate::ir::Expr,
+        funcs: &[crate::ir::CompiledFunc],
+        visited: &mut Vec<crate::ir::FuncId>,
+    ) -> bool {
+        use crate::ir::{Expr, StringPart, UnaryOp};
+        macro_rules! safe { ($x:expr) => { Self::expr_is_parallel_safe($x, funcs, visited) }; }
+        macro_rules! opt { ($x:expr) => { $x.as_ref().map_or(true, |e| safe!(e)) }; }
+        match e {
+            // --- Non-parallel-safe: reject (the only `false`-returning arms) ---
+
+            // Consume the shared input stream — each record is no longer
+            // independent.
+            Expr::ReadInput | Expr::ReadInputs => false,
+            // Observe the program/stream position; `$__loc__` is constant but
+            // rejected to mirror the issue's conservative spec.
+            Expr::Loc { .. } => false,
+            // Shared cache across records (the slot map is per-Env, but a
+            // worker pool would split it and reorder lookups).
+            Expr::Memoize { .. } => false,
+            // jqx in-place mutation: aliasing-sensitive, treated as a side
+            // effect (see issue #666 semantics).
+            Expr::Mutate { .. } => false,
+            // Side effects whose ordering relative to other records matters.
+            Expr::Debug { .. } | Expr::Stderr { .. } => false,
+            // Clock read — non-deterministic, would break byte-identity
+            // between sequential and parallel runs.
+            Expr::UnaryOp { op: UnaryOp::Now, .. } => false,
+
+            // --- Structural: safe iff every sub-expression is safe ---
+
+            Expr::Input | Expr::Literal(_) | Expr::LoadVar { .. } | Expr::Empty
+            | Expr::Not | Expr::Env | Expr::Builtins | Expr::ModuleMeta
+            | Expr::GenLabel => true,
+
+            Expr::UnaryOp { operand, .. } | Expr::Negate { operand } => safe!(operand),
+            Expr::BinOp { lhs, rhs, .. } => safe!(lhs) && safe!(rhs),
+            Expr::Index { expr, key } | Expr::IndexOpt { expr, key } => safe!(expr) && safe!(key),
+            Expr::Pipe { left, right } | Expr::Comma { left, right } => safe!(left) && safe!(right),
+            Expr::Alternative { primary, fallback } => safe!(primary) && safe!(fallback),
+            Expr::IfThenElse { cond, then_branch, else_branch } =>
+                safe!(cond) && safe!(then_branch) && safe!(else_branch),
+            Expr::TryCatch { try_expr, catch_expr, .. } => safe!(try_expr) && safe!(catch_expr),
+            Expr::Each { input_expr } | Expr::EachOpt { input_expr }
+            | Expr::Recurse { input_expr } => safe!(input_expr),
+            Expr::LetBinding { value, body, .. } => safe!(value) && safe!(body),
+            Expr::Reduce { source, init, update, .. } => safe!(source) && safe!(init) && safe!(update),
+            Expr::Foreach { source, init, update, extract, .. } =>
+                safe!(source) && safe!(init) && safe!(update) && opt!(extract),
+            Expr::Collect { generator } => safe!(generator),
+            Expr::ObjectConstruct { pairs } => pairs.iter().all(|(k, v)| safe!(k) && safe!(v)),
+            Expr::Range { from, to, step } => safe!(from) && safe!(to) && opt!(step),
+            Expr::Label { body, .. } => safe!(body),
+            Expr::Break { value, .. } => safe!(value),
+            Expr::Update { path_expr, update_expr } => safe!(path_expr) && safe!(update_expr),
+            Expr::Assign { path_expr, value_expr } => safe!(path_expr) && safe!(value_expr),
+            Expr::PathExpr { expr } => safe!(expr),
+            Expr::SetPath { path, value } => safe!(path) && safe!(value),
+            Expr::GetPath { path } => safe!(path),
+            Expr::DelPaths { paths } => safe!(paths),
+            Expr::StringInterpolation { parts } => parts.iter().all(|p| match p {
+                StringPart::Expr(e) => safe!(e),
+                StringPart::Literal(_) => true,
+            }),
+            Expr::Limit { count, generator } => safe!(count) && safe!(generator),
+            Expr::While { cond, update } | Expr::Until { cond, update } => safe!(cond) && safe!(update),
+            Expr::Repeat { update } => safe!(update),
+            Expr::AllShort { generator, predicate }
+            | Expr::AnyShort { generator, predicate } => safe!(generator) && safe!(predicate),
+            Expr::Error { msg } => opt!(msg),
+            Expr::Format { expr, .. } => safe!(expr),
+            Expr::ClosureOp { input_expr, key_expr, .. } => safe!(input_expr) && safe!(key_expr),
+            Expr::RegexTest { input_expr, re, flags }
+            | Expr::RegexMatch { input_expr, re, flags }
+            | Expr::RegexCapture { input_expr, re, flags }
+            | Expr::RegexScan { input_expr, re, flags } => safe!(input_expr) && safe!(re) && safe!(flags),
+            Expr::RegexSub { input_expr, re, tostr, flags }
+            | Expr::RegexGsub { input_expr, re, tostr, flags } =>
+                safe!(input_expr) && safe!(re) && safe!(tostr) && safe!(flags),
+            Expr::AlternativeDestructure { alternatives } => alternatives.iter().all(|a| safe!(a)),
+            Expr::Slice { expr, from, to } => safe!(expr) && opt!(from) && opt!(to),
+
+            // Runtime-dispatched builtins: reject the stateful / side-effecting
+            // / position-observing set, otherwise safe iff the args are safe.
+            Expr::CallBuiltin { op, args } => {
+                !matches!(
+                    op,
+                    BuiltinOp::Halt
+                        | BuiltinOp::HaltError
+                        | BuiltinOp::InputFilename
+                        | BuiltinOp::InputLineNumber
+                        | BuiltinOp::Exec
+                        | BuiltinOp::Execv
+                ) && args.iter().all(|a| safe!(a))
+            }
+
+            // A user-defined call hides its work in the callee body; descend
+            // into it (guarding recursion) plus its argument expressions.
+            Expr::FuncCall { func_id, args } => {
+                if !args.iter().all(|a| safe!(a)) {
+                    return false;
+                }
+                if visited.contains(func_id) {
+                    return true;
+                }
+                visited.push(*func_id);
+                funcs
+                    .get(func_id.idx())
+                    .map_or(false, |f| Self::expr_is_parallel_safe(&f.body, funcs, visited))
+            }
+        }
+    }
+
     /// Returns true if this filter is a simple identity (`.`) that passes through input unchanged.
     /// Also recognizes semantic equivalences like `to_entries | from_entries`.
     pub fn is_identity(&self) -> bool {

--- a/tests/parallel_ndjson.rs
+++ b/tests/parallel_ndjson.rs
@@ -1,0 +1,191 @@
+//! Issue #1054: `--parallel[=N]` shards a stateless filter over an NDJSON
+//! document stream across a worker pool and reassembles the output in record
+//! order. The core correctness contract is that the stdout bytes and the
+//! process exit code are *identical* to sequential mode for any
+//! parallel-safe filter. These tests pin that equivalence by running the
+//! same input through the binary with and without `--parallel`, exercising
+//! CLI/stdin behavior the 3-line regression harness cannot express.
+//!
+//! The corpus is deliberately >256 records (the inline-fallback threshold)
+//! so the real worker-pool path engages, and mixes shapes that hit the
+//! compact raw-passthrough decision (non-canonical numbers, duplicate keys,
+//! escaped solidus) plus per-record-stateful-but-parallel-safe constructs
+//! (reduce / foreach / limit / regex / string ops).
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+/// Run the binary with the given extra args, feeding `input` on stdin.
+/// Returns (stdout bytes, exit code).
+fn run(args: &[&str], input: &str) -> (Vec<u8>, Option<i32>) {
+    let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
+    let mut child = Command::new(jq_jit)
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn jq-jit");
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(input.as_bytes())
+        .expect("failed to write stdin");
+    let out = child.wait_with_output().expect("failed to wait jq-jit");
+    (out.stdout, out.status.code())
+}
+
+/// A varied NDJSON corpus of `n` records (n well above the 256 inline
+/// threshold), cycling through shapes that stress the formatter.
+fn corpus(n: usize) -> String {
+    let mut s = String::new();
+    for i in 0..n {
+        let line = match i % 8 {
+            0 => format!(r#"{{"id":{i},"name":"u{i}","vals":[{a},{b},{c}],"on":{on}}}"#,
+                         a = i % 7, b = (i * 3) % 11, c = i % 2, on = i % 2 == 0),
+            1 => format!(r#"{{"id":{i},"f":{i}.5e2,"path":"a\/b\/c"}}"#),
+            2 => format!(r#"{{"id":{i},"dup":1,"dup":{i},"s":"tab\there"}}"#),
+            3 => format!(r#"[{i},{},"x{i}"]"#, i * 2),
+            4 => format!(r#"{{"id":{i},"big":1E+{}}}"#, i % 10),
+            5 => format!(r#""string-{i}""#),
+            6 => format!("{i}"),
+            _ => format!(r#"{{"id":{i},"nested":{{"k":[{i}]}},"flag":{}}}"#, i % 3 == 0),
+        };
+        s.push_str(&line);
+        s.push('\n');
+    }
+    s
+}
+
+/// Assert sequential and `--parallel` produce byte-identical stdout and the
+/// same exit code for `filter` under the given base flags.
+fn assert_parallel_matches(base: &[&str], filter: &str, input: &str) {
+    let mut seq_args: Vec<&str> = base.to_vec();
+    seq_args.push(filter);
+    let (seq_out, seq_code) = run(&seq_args, input);
+
+    let mut par_args: Vec<&str> = base.to_vec();
+    par_args.push("--parallel=4");
+    par_args.push(filter);
+    let (par_out, par_code) = run(&par_args, input);
+
+    assert_eq!(
+        seq_code, par_code,
+        "exit code differs for filter `{filter}` (base {base:?})"
+    );
+    assert!(
+        seq_out == par_out,
+        "stdout differs for filter `{filter}` (base {base:?})\n--- seq ({} bytes) ---\n{}\n--- par ({} bytes) ---\n{}",
+        seq_out.len(),
+        String::from_utf8_lossy(&seq_out),
+        par_out.len(),
+        String::from_utf8_lossy(&par_out),
+    );
+}
+
+const COMPACT_FILTERS: &[&str] = &[
+    ".",
+    ".|.",
+    ".id",
+    "{wrap: .}",
+    "if type == \"object\" then {id, name} else . end",
+    "try (.vals | add) catch \"err\"",
+    "try (.vals | map(. * 2)) catch empty",
+    "[paths] | length",
+    "reduce (.vals // [])[] as $v (0; . + $v)",
+    "foreach (.vals // [])[] as $v (0; . + $v; .)",
+    "[limit(2; (.vals // [])[])]",
+    "try (.name | ascii_upcase | explode | reverse | implode) catch empty",
+    "try (.path | gsub(\"/\"; \"-\")) catch empty",
+    "try (.s | @base64) catch empty",
+    "try (.f * 2) catch empty",
+    "..",
+    "tostring | length",
+];
+
+#[test]
+fn parallel_matches_sequential_compact() {
+    let input = corpus(3000);
+    for f in COMPACT_FILTERS {
+        assert_parallel_matches(&["-c"], f, &input);
+    }
+}
+
+#[test]
+fn parallel_matches_sequential_pretty() {
+    let input = corpus(2000);
+    // Pretty (no -c) goes through push_pretty_line; default and explicit indent.
+    for f in &[".", "{wrap: .}", "try {id, name} catch ."] {
+        assert_parallel_matches(&[], f, &input);
+        assert_parallel_matches(&["--indent", "4"], f, &input);
+    }
+}
+
+#[test]
+fn parallel_matches_sequential_exit_status() {
+    let input = corpus(1500);
+    // -e: exit code reflects the last output value across the whole stream.
+    for f in &[
+        "try (.id) catch empty",
+        "try (.on) catch true",
+        "select(type == \"object\")",
+        "empty",
+    ] {
+        assert_parallel_matches(&["-ce"], f, &input);
+    }
+}
+
+#[test]
+fn parallel_preserves_record_order() {
+    // A monotonically increasing field must come out strictly in order even
+    // though records are processed out of order across workers.
+    let mut input = String::new();
+    for i in 0..5000 {
+        input.push_str(&format!("{{\"n\":{i}}}\n"));
+    }
+    let (out, code) = run(&["-c", "--parallel=4", ".n"], &input);
+    assert_eq!(code, Some(0));
+    let got = String::from_utf8(out).unwrap();
+    let expected: String = (0..5000).map(|i| format!("{i}\n")).collect();
+    assert_eq!(got, expected, "record order not preserved under --parallel");
+}
+
+#[test]
+fn parallel_malformed_stream_flushes_leading_then_exits_5() {
+    // jq emits each valid leading document's result, then exits 5 at the
+    // malformed token (`jq: parse error ...`). The parallel path scans record
+    // boundaries with json_stream_raw, so it reproduces exactly that: flush
+    // the 1000 valid `.a` values, then exit 5. (Note: the *sequential* `.a`
+    // projection fast path has a latent divergence here — it exits 0 and
+    // over-emits — so this case is pinned against jq's documented behavior
+    // directly rather than against sequential mode.)
+    let mut input = String::new();
+    for i in 0..1000 {
+        input.push_str(&format!("{{\"a\":{i}}}\n"));
+    }
+    input.push_str("{bad\n"); // malformed tail
+    let (out, code) = run(&["-c", "--parallel=4", ".a"], &input);
+    assert_eq!(code, Some(5), "malformed stream must exit 5");
+    let got = String::from_utf8(out).unwrap();
+    let expected: String = (0..1000).map(|i| format!("{i}\n")).collect();
+    assert_eq!(got, expected, "leading valid records must be flushed in order");
+}
+
+#[test]
+fn parallel_unsafe_filters_fall_back_and_match() {
+    // Filters rejected by is_parallel_safe must fall back to the sequential
+    // path transparently — output and exit code identical to no `--parallel`.
+    let input = "1\n2\n3\n4\n5\n";
+    for f in &[
+        ". , input",
+        "[inputs] | length",
+        "input_line_number",
+        "$__loc__ | .file",
+    ] {
+        assert_parallel_matches(&["-c"], f, input);
+    }
+    // A `def` hides the stream read behind a call; the classifier must still
+    // descend into the body and reject it.
+    assert_parallel_matches(&["-c"], "def f: input; ., f", input);
+}


### PR DESCRIPTION
## Summary

Implements per-record parallel execution for stateless filters on NDJSON streams (#1054). For a filter that observes no cross-record state, each input document is independent, so records can run on a worker pool with the output reassembled in record order — a win single-threaded jq structurally cannot achieve.

Opt-in behind `--parallel[=N]` (default N = core count); everything outside the supported window falls back to the existing sequential path transparently.

## Design

- **Purity classifier** — `Filter::is_parallel_safe()` (classify.rs): an exhaustive IR walk (no `_` wildcard, so a future `Expr` variant fails to compile until its safety is decided) that rejects anything observing cross-record state, stream position, shared mutable cache, side effects, or non-determinism: `input`/`inputs`, `input_line_number`, `$__loc__`, `memoize`, `mutate`, `exec`/`execv`, `debug`/`stderr`, `halt`/`halt_error`, `now`. Follows `FuncCall` into callee bodies (a stream read hidden behind a `def` is still caught), guarding recursion with a visited set — same pattern as `uses_inputs()`.

- **Activation gate** — `--parallel` engages only for a parallel-safe filter in a plain buffered compact/pretty mode (no `-r`/`-S`/`-j`/`-C`/`--seq`/`--unbuffered`/`-n`). Default runs short-circuit on `parallel_jobs >= 2` before ever calling the classifier, so the sequential hot path is unchanged (one always-false bool).

- **Worker pool** — each worker compiles its own `Filter` (Cranelift + JitOp routing fallback, output fusion when applicable) on a 2 GiB stack matching `real_main`, and reuses the exact same serializer as `process_input` (including the compact raw-passthrough decision), so output is **byte-identical** to sequential. Workers claim contiguous batches off a shared atomic counter and ship the `Send` `BatchOut` to the main thread, which drains a reorder buffer in stream order — flushing the in-order prefix as it arrives, so memory stays bounded and `StdoutLock` (`!Send`) never leaves the main thread. Per-record errors surface in record order; `-e` and exit-5 semantics hold across the whole stream.

## Correctness

`tests/parallel_ndjson.rs` pins byte-identical stdout + exit code between sequential and `--parallel` over a varied NDJSON corpus (>256 records so the real pool engages), covering compact/pretty/indent, `-e`, record-order preservation, malformed-tail flush, and unsafe-filter fallback (including the `def`-hidden stream read).

- Full suite green (`cargo test --release`, zero warnings).
- Determinism: 9+ runs across `--parallel=4/8/16` byte-identical to sequential.

One note pinned in the test: the **sequential** `.a` projection fast path has a latent divergence on a truncated trailing token (exits 0, over-emits) where the parallel path's `json_stream_raw` boundary scan matches jq exactly (flush leading valid records, exit 5). So that edge is pinned against jq's documented behavior rather than against the buggy sequential projection.

## Performance

Sequential path unaffected. With `--parallel`, speedup tracks per-record work (Amdahl-bounded by the serial input scan + output write):

| Workload (2M records) | seq | `--parallel=8` |
|---|---|---|
| light projection `{id, doubled:(.v*2)}` | 0.20s | 0.09s (~2.2x) |
| heavy per-record filter | 2.28s | 0.72s (~3.2x, 721% CPU) |

Peak RSS for 2M-record identity: 234 MB seq vs 267 MB par=8 (reorder buffer stays small).

Closes #1054

🤖 Generated with [Claude Code](https://claude.com/claude-code)