### PR TITLE
perf(jit): share callee body Rc during function inlining (#1030)

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -3296,9 +3296,24 @@ fn real_main() {
         jq_jit::jit::set_output_fusion(true);
     }
 
-    // Lazy JIT: compile only when input is large enough to amortize compilation cost.
-    // Exception: always JIT for loop constructs (reduce/foreach/while/until/recurse)
-    // since their runtime dominates regardless of input size.
+    // Lazy JIT: Cranelift-compile only when the input is large enough to
+    // amortize codegen cost. Exception: always compile for loop constructs
+    // (reduce/foreach/while/until/recurse) since their runtime dominates
+    // regardless of input size.
+    //
+    // Rationale (#1030). The crossover this threshold guards moved with
+    // #1059: a sub-threshold *flattenable* filter no longer falls back to the
+    // tree-walking evaluator but to the JitOp interpreter (shared lowering, no
+    // codegen — see the `compile_jitop_program_for_routing` catch-all below).
+    // So 4096 now marks where one-shot Cranelift codegen begins to pay for
+    // itself against the JitOp interpreter's per-byte execution cost, not
+    // against eval. It is a conservative amortization point, not a sharp
+    // cliff: in the sub-100KB regime the codegen/exec gap for typical filters
+    // is small next to fixed per-process startup, so a CLI timing sweep is
+    // startup-dominated and cannot resolve the byte-level crossover. Deriving
+    // it precisely would need an in-process (criterion-style) harness that
+    // compiles+runs each backend without a process restart; left at 4096
+    // pending such a harness.
     // Must be done before process_input closure captures &filter.
     const JIT_THRESHOLD: usize = 4096;
     // For null_input, there is no input to amortize JIT compile cost against.

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -813,11 +813,17 @@ pub enum ClosureOpKind {
 }
 
 /// A compiled function (subfunction from jq bytecode).
+///
+/// `body` is wrapped in `Rc` so that cloning a `CompiledFunc` — and, in the
+/// hot path, the per-call-site inlining in `jit.rs` — only bumps a refcount
+/// instead of deep-copying the whole `Expr` tree. Inlining never mutates the
+/// stored body (it reads it and produces a fresh inlined/substituted tree), so
+/// sharing is sound (#1030).
 #[derive(Debug, Clone)]
 pub struct CompiledFunc {
     pub name: Option<String>,
     pub nargs: usize,
-    pub body: Expr,
+    pub body: std::rc::Rc<Expr>,
     pub param_vars: Vec<VarIdx>,
 }
 

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -1058,9 +1058,14 @@ impl Flattener {
                     self.has_unresolved_recursion = true;
                     return expr.clone();
                 }
-                let func = self.funcs[func_id.idx()].clone();
-                let body = if !func.param_vars.is_empty() && !args.is_empty() {
-                    crate::eval::substitute_params(&func.body, &func.param_vars, args)
+                // Borrow the callee instead of cloning the whole CompiledFunc
+                // (its `body` Rc bump is cheap, but the old `.clone()` also
+                // deep-copied the body once more). With params we still build a
+                // substituted tree; without, we share the body Rc and recurse
+                // on it directly — zero deep clones at the call site (#1030).
+                let func = &self.funcs[func_id.idx()];
+                let body: Rc<Expr> = if !func.param_vars.is_empty() && !args.is_empty() {
+                    Rc::new(crate::eval::substitute_params(&func.body, &func.param_vars, args))
                 } else {
                     func.body.clone()
                 };
@@ -2959,9 +2964,10 @@ impl Flattener {
             Expr::FuncCall { func_id, args } if func_id.idx() < self.funcs.len()
                 && !self.expanding_funcs.contains(func_id) => {
                 self.expanding_funcs.insert(*func_id);
-                let func = &self.funcs[func_id.idx()].clone();
-                let body = if !func.param_vars.is_empty() && !args.is_empty() {
-                    crate::eval::substitute_params(&func.body, &func.param_vars, args)
+                // Share the callee body Rc instead of deep-cloning it (#1030).
+                let func = &self.funcs[func_id.idx()];
+                let body: Rc<Expr> = if !func.param_vars.is_empty() && !args.is_empty() {
+                    Rc::new(crate::eval::substitute_params(&func.body, &func.param_vars, args))
                 } else {
                     func.body.clone()
                 };
@@ -4342,9 +4348,10 @@ impl Flattener {
                 // Detect recursive function calls — not JIT-compilable
                 if self.expanding_funcs.contains(func_id) { return false; }
                 self.expanding_funcs.insert(*func_id);
-                let func = &self.funcs[func_id.idx()].clone();
-                let body = if !func.param_vars.is_empty() && !args.is_empty() {
-                    crate::eval::substitute_params(&func.body, &func.param_vars, args)
+                // Share the callee body Rc instead of deep-cloning it (#1030).
+                let func = &self.funcs[func_id.idx()];
+                let body: Rc<Expr> = if !func.param_vars.is_empty() && !args.is_empty() {
+                    Rc::new(crate::eval::substitute_params(&func.body, &func.param_vars, args))
                 } else {
                     func.body.clone()
                 };

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -98,7 +98,7 @@ impl Scope {
         self.compiled_funcs.push(CompiledFunc {
             name: Some(name.to_string()),
             nargs,
-            body,
+            body: Rc::new(body),
             param_vars,
         });
         func_id
@@ -113,7 +113,7 @@ impl Scope {
         self.compiled_funcs.push(CompiledFunc {
             name: None,
             nargs,
-            body,
+            body: Rc::new(body),
             param_vars,
         });
         func_id
@@ -121,7 +121,7 @@ impl Scope {
 
     fn update_func_body(&mut self, func_id: FuncId, body: Expr, param_vars: Vec<VarIdx>) {
         if let Some(f) = self.compiled_funcs.get_mut(func_id.idx()) {
-            f.body = body;
+            f.body = Rc::new(body);
             f.param_vars = param_vars;
         }
     }
@@ -1625,7 +1625,7 @@ impl Parser {
         // Second pass: remap func_ids in bodies and install them
         for (mod_func_id, new_func_id) in &func_id_map {
             let func = mod_parser.scope.compiled_funcs[mod_func_id.idx()].clone();
-            let mut body = remap_func_ids(func.body, &func_id_map);
+            let mut body = remap_func_ids(func.body.as_ref().clone(), &func_id_map);
             // Wrap function body with data import bindings (in reverse order)
             for (var_idx, value_expr) in data_bindings.iter().rev() {
                 body = Expr::LetBinding {

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -14208,3 +14208,23 @@ try .x catch "err"
 [foreach .x[] as $v (0; . + $v)]
 {"x":[1,2,3],"pad":null}
 [1,3,6]
+
+# #1030: function inlining shares the callee body Rc — no-param nested defs
+def f: .+1; def g: f|f|f; g|g
+0
+6
+
+# #1030: param def inlining across multiple call sites
+def addn(x): . + x; addn(10) | addn(20)
+5
+35
+
+# #1030: recursive def (inline-exempt path) stays correct under shared bodies
+def r: if . <= 0 then 0 else . + (. - 1 | r) end; r
+5
+15
+
+# #1030: higher-order def inlining a no-param def at multiple sites
+def dbl: . * 2; def f(g): [.[] | g]; f(dbl) | f(dbl)
+[1,2,3]
+[4,8,12]


### PR DESCRIPTION
## Summary

Addresses #1030 — compile-side costs on JIT startup latency.

### Proposal #2: reduce inlining clones (done)

`Flattener::inline_func_calls` and the two `FuncCall` flatten arms
(`flatten_scalar` / `flatten_gen`) cloned the **entire `CompiledFunc`** —
deep-copying its `body` Expr tree — at every call site, purely to release the
immutable borrow on `self` before recursing. In the no-param case the body was
then cloned a *second* time. For filters with many call sites of nontrivial
functions this is quadratic-ish compile-time copying that lands directly on
JIT startup latency.

Fix: wrap `CompiledFunc.body` in `Rc<Expr>`. The stored tree is only ever read
during inlining (which produces a fresh inlined/substituted tree), so sharing
is sound. Each call site now borrows the callee and either:
- **with params** — builds a substituted tree (inherent), or
- **without params** — bumps the body `Rc` and recurses on it directly.

This removes the redundant whole-`CompiledFunc` clone in both cases and the
deep body clone entirely in the no-param case. All `&f.body` reads elsewhere
keep working via deref coercion; only construction/move sites changed.

### Proposal #1: re-derive `JIT_THRESHOLD` (rationale recorded, value unchanged)

Since #1059 a sub-threshold *flattenable* filter no longer falls back to the
tree-walking evaluator but to the **JitOp interpreter** (shared lowering, no
codegen). So `4096` now marks where one-shot Cranelift codegen amortizes
against the interpreter's per-byte execution cost — a conservative point, not a
sharp cliff. The sub-100KB regime is process-startup-dominated, so a CLI timing
sweep cannot resolve the byte-level crossover; deriving it precisely needs an
in-process (criterion-style) harness that compiles+runs each backend without a
process restart. The constant is left at `4096` with this rationale recorded
next to it (as #658 did for the `-n` cap). The `NULL_INPUT_JIT_AST_LIMIT` cap
already carries its #658 rationale and is unchanged.

## Testing

- `cargo build --release` — zero warnings
- `cargo test --release` — full suite green (official 509/509, regression
  2762/2762, both JitOp self-diff backends 2573/2573, contracts, fuzz,
  differential)
- 4 regression cases added: no-param nested defs, param defs across multiple
  call sites, recursive (inline-exempt) defs, higher-order defs
- `bench/comprehensive.sh` — execution throughput in normal historical range
  (compile-path-only change; execution ops are byte-identical)

Closes #1030

🤖 Generated with [Claude Code](https://claude.com/claude-code)