### PR TITLE
fix(jit): re-render composite tostring operands in file-input string chains

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -2647,9 +2647,17 @@ fn emit_resolved_value(
                                 buf.extend_from_slice(content);
                             }
                         } else {
-                            // Number/bool/null — tostring form; a NaN/Infinity
-                            // or non-canonical lexeme re-renders (#1021).
-                            push_interp_num_canon(buf, val);
+                            // Number/bool/null/composite — tostring form. Bare
+                            // numbers canonicalise (NaN/Infinity/non-canonical
+                            // lexemes re-render, #1021); composites re-render
+                            // nested non-canonical numbers and escape their
+                            // inner `"`/`\` for embedding so the surrounding
+                            // string stays valid JSON (#1127).
+                            if strings_clean {
+                                emit_interp_field_raw_clean(buf, val);
+                            } else {
+                                emit_interp_field_raw(buf, val);
+                            }
                         }
                     }
                     ResolvedStringChainPart::FieldArithToString(idx, ref ops) => {

--- a/tests/stringchain_composite_file.rs
+++ b/tests/stringchain_composite_file.rs
@@ -1,0 +1,71 @@
+//! Issue #1127: the file-input StringChain remap fast path
+//! (`{a: (.name + "_" + (.x | tostring)), b: .a}`) must re-render a *composite*
+//! tostring operand instead of copying its raw lexeme verbatim:
+//!
+//!   - a nested non-canonical number lexeme must canonicalise (`[1e3]` → `[1E+3]`), and
+//!   - the composite's inner `"`/`\` must be escaped for string embedding so the
+//!     surrounding string stays valid JSON.
+//!
+//! The bug only fires through the file-argument fast path (`ResolvedRemap::StringChain`);
+//! the stdin streaming twin already bailed composites to generic eval. The
+//! single-stdin-document regression harness routes through the stdin twin and so
+//! can't observe it — hence this shell-out test drives a real file argument and
+//! cross-checks the stdin twin for parity. Expectations captured from jq 1.8.1.
+
+use std::process::{Command, Stdio};
+
+fn jq_jit() -> &'static str {
+    env!("CARGO_BIN_EXE_jq-jit")
+}
+
+fn write_tmp(name: &str, content: &str) -> String {
+    let mut path = std::env::temp_dir();
+    path.push(format!("jqjit_sc1127_{}_{}", std::process::id(), name));
+    std::fs::write(&path, content).unwrap();
+    path.to_str().unwrap().to_string()
+}
+
+/// Run with `input` as a file argument (drives the file-input fast path).
+fn run_file(filter: &str, input: &str, name: &str) -> String {
+    let path = write_tmp(name, input);
+    let out = Command::new(jq_jit())
+        .args(["-c", filter, &path])
+        .stdin(Stdio::null())
+        .output()
+        .expect("failed to spawn jq-jit");
+    String::from_utf8(out.stdout).expect("non-utf8 stdout").trim_end().to_string()
+}
+
+/// Run the same filter feeding `input` on stdin (the streaming twin).
+fn run_stdin(filter: &str, input: &str) -> String {
+    use std::io::Write;
+    let mut child = Command::new(jq_jit())
+        .args(["-c", filter])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn jq-jit");
+    child.stdin.take().unwrap().write_all(input.as_bytes()).unwrap();
+    let out = child.wait_with_output().expect("wait failed");
+    String::from_utf8(out.stdout).expect("non-utf8 stdout").trim_end().to_string()
+}
+
+const FILTER: &str = r#"{a: (.name + "_" + (.x | tostring)), b: .a}"#;
+
+#[test]
+fn nested_noncanonical_number_canonicalises() {
+    let input = r#"{"a":[1e3,"s"],"name":"n","x":[1e3]}"#;
+    let expected = r#"{"a":"n_[1E+3]","b":[1E+3,"s"]}"#;
+    assert_eq!(run_file(FILTER, input, "num"), expected);
+    // The stdin twin must agree (it was already correct; guard parity).
+    assert_eq!(run_stdin(FILTER, input), expected);
+}
+
+#[test]
+fn composite_inner_quotes_escaped_valid_json() {
+    let input = r#"{"a":{"k":1e3},"name":"n","x":{"k":nan}}"#;
+    let expected = r#"{"a":"n_{\"k\":null}","b":{"k":1E+3}}"#;
+    assert_eq!(run_file(FILTER, input, "obj"), expected);
+    assert_eq!(run_stdin(FILTER, input), expected);
+}


### PR DESCRIPTION
## Summary

The file-input StringChain remap fast path (`{a: (.name + "_" + (.x | tostring)), b: .a}`) emitted a **composite** tostring operand verbatim, so a nested non-canonical number lexeme was not canonicalised and the composite's inner quotes were not escaped for string embedding — producing **invalid JSON**.

The non-string `FieldToString` operand went through `push_interp_num_canon`, whose re-render guard (`if let Ok(v @ Value::Num(..))`) only matches bare numbers; a composite fell through to `extend_from_slice`. Fix routes it through the existing `emit_interp_field_raw`(`_clean`) helpers, which already re-render nested non-canonical numbers via the typed tojson writer and escape `"`/`\` for embedding (#1021). The common bare-number case is unchanged — those helpers' scalar arm is the same `push_interp_num_canon`.

## Repro (before → after, vs jq 1.8.1)

```console
$ printf '%s\n' '{"a":[1e3,"s"],"name":"n","x":[1e3]}' > r1.json
$ jq     -c '{a: (.name + "_" + (.x | tostring)), b: .a}' r1.json
{"a":"n_[1E+3]","b":[1E+3,"s"]}
# before: {"a":"n_[1e3]","b":[1E+3,"s"]}      (nested 1e3 not canonicalised)
# after : {"a":"n_[1E+3]","b":[1E+3,"s"]}     ✓

$ printf '%s\n' '{"a":{"k":1e3},"name":"n","x":{"k":nan}}' > r2.json
$ jq     -c '{a: (.name + "_" + (.x | tostring)), b: .a}' r2.json
{"a":"n_{\"k\":null}","b":{"k":1E+3}}
# before: {"a":"n_{"k":nan}","b":{"k":1E+3}}  (unescaped quotes → invalid JSON)
# after : {"a":"n_{\"k\":null}","b":{"k":1E+3}} ✓
```

## Tests

- The stdin streaming twin already bailed composites to generic eval, so the single-stdin-document `regression.test` harness can't observe this. New shell-out test `tests/stringchain_composite_file.rs` drives a real **file argument** (the buggy path) and cross-checks the stdin twin for parity; expectations captured from jq 1.8.1.
- Verified the new test **fails without the fix** (both cases) and passes with it.
- Full suite green (`cargo test --release`, zero warnings).

Closes #1127

🤖 Generated with [Claude Code](https://claude.com/claude-code)