### PR TITLE
fix(cli): stream --unbuffered JSON stdin instead of pre-reading to EOF

### DIFF
--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -629,7 +629,7 @@ fn run_parallel_json_stream(
     }
 }
 
-use jq_jit::value::{Value, json_to_value, json_stream, json_stream_offsets, json_stream_raw, json_stream_project, json_value_has_duplicate_keys, json_stream_has_duplicate_keys, json_object_get_num, json_object_get_two_nums, json_object_get_field_raw, json_object_get_fields_raw_buf, parse_json_num, json_value_length, json_object_keys_unsorted_to_buf,json_object_keys_join_to_buf, json_object_has_key, json_object_has_all_keys, json_object_has_any_key, json_object_del_field, json_object_del_fields, json_object_merge_literal, json_object_sort_keys, json_each_value_raw, json_each_value_cb, json_to_entries_raw, json_object_set_field_raw, json_object_update_field_num, json_object_update_field_num_chain,json_object_select_then_update_num, json_object_select_then_update_str_concat, json_object_select_compound_then_update_num, json_object_select_str_then_update_num, is_json_compact, push_json_compact_raw, push_tojson_raw, push_json_pretty_raw, push_json_pretty_raw_at, value_to_json_precise, value_to_json_pretty_ext, push_compact_line, push_compact_line_color, push_pretty_line, push_pretty_line_color, push_jq_number_bytes, write_value_compact_ext, write_value_compact_line, write_value_pretty_line_color, value_to_json_pretty_color, walk_json_transform_nums, pool_value, skip_json_value, raw_contains_non_canonical_number, append_canonical_value, raw_contains_noncanon_escape, push_raw_canon_escapes};
+use jq_jit::value::{Value, json_to_value, json_stream, json_stream_reader, json_stream_offsets, json_stream_raw, json_stream_project, json_value_has_duplicate_keys, json_stream_has_duplicate_keys, json_object_get_num, json_object_get_two_nums, json_object_get_field_raw, json_object_get_fields_raw_buf, parse_json_num, json_value_length, json_object_keys_unsorted_to_buf,json_object_keys_join_to_buf, json_object_has_key, json_object_has_all_keys, json_object_has_any_key, json_object_del_field, json_object_del_fields, json_object_merge_literal, json_object_sort_keys, json_each_value_raw, json_each_value_cb, json_to_entries_raw, json_object_set_field_raw, json_object_update_field_num, json_object_update_field_num_chain,json_object_select_then_update_num, json_object_select_then_update_str_concat, json_object_select_compound_then_update_num, json_object_select_str_then_update_num, is_json_compact, push_json_compact_raw, push_tojson_raw, push_json_pretty_raw, push_json_pretty_raw_at, value_to_json_precise, value_to_json_pretty_ext, push_compact_line, push_compact_line_color, push_pretty_line, push_pretty_line_color, push_jq_number_bytes, write_value_compact_ext, write_value_compact_line, write_value_pretty_line_color, value_to_json_pretty_color, walk_json_transform_nums, pool_value, skip_json_value, raw_contains_non_canonical_number, append_canonical_value, raw_contains_noncanon_escape, push_raw_canon_escapes};
 use jq_jit::interpreter::Filter;
 use jq_jit::fast_path::{
     apply_arith_chain_cmp_raw, apply_field_access_raw, apply_field_alternative_raw,
@@ -3258,8 +3258,23 @@ fn real_main() {
 
     let mut had_error = false;
 
+    // --unbuffered JSON stdin: stream values incrementally instead of pre-reading
+    // the whole stream, so continuous/infinite inputs (e.g. `tail -f`, `pw-dump
+    // -m`) emit per value in real time (#1133). Scoped to plain per-document
+    // JSON stdin — slurp, `input`/`inputs`, --seq framing and raw input keep
+    // their existing whole-stream handling (they cannot stream by definition or
+    // need the full buffer for framing/line accounting). Without --unbuffered,
+    // the pre-read below is retained as a deliberate throughput tradeoff.
+    let stream_unbuffered = unbuffered
+        && !null_input
+        && files.is_empty()
+        && !raw_input
+        && !slurp
+        && !seq
+        && !filter.uses_inputs();
+
     // Pre-read stdin so we can estimate input size for JIT decision.
-    let stdin_data: Option<String> = if !null_input && files.is_empty() && !raw_input {
+    let stdin_data: Option<String> = if !null_input && files.is_empty() && !raw_input && !stream_unbuffered {
         let mut s = String::new();
         io::stdin().lock().read_to_string(&mut s).unwrap_or(0);
         if seq {
@@ -4363,6 +4378,29 @@ fn real_main() {
             process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
         }
         jq_jit::eval::clear_inputs_queue();
+    } else if stream_unbuffered {
+        // #1133: --unbuffered JSON stdin streams value-by-value so a continuous
+        // input flushes results as they arrive rather than blocking on EOF.
+        // `process_input` already flushes after each value under --unbuffered,
+        // so feeding values through it suffices.
+        jq_jit::eval::set_input_filename(Some(std::rc::Rc::from("<stdin>")));
+        let stdin = io::stdin();
+        let parse_result = json_stream_reader(stdin.lock(), |v, nl| {
+            jq_jit::eval::set_input_line_number(nl);
+            process_input(&v, None, &mut out, &mut compact_buf, &mut any_output_false, &mut had_error);
+            Ok(())
+        });
+        if let Err(e) = parse_result {
+            // Match the batch stream path (#856): leading documents already
+            // flushed per value; report the parse error and exit 5.
+            if !compact_buf.is_empty() {
+                let _ = out.write_all(&compact_buf);
+                compact_buf.clear();
+            }
+            let _ = out.flush();
+            eprintln!("jq: error (at <stdin>:0): {}", e);
+            process::exit(5);
+        }
     } else if files.is_empty() {
         // Read from stdin
         // `input_filename` reports "<stdin>" for the stdin stream (#926).

--- a/src/value.rs
+++ b/src/value.rs
@@ -839,6 +839,119 @@ where F: FnMut(Value) -> Result<()> {
     Ok(())
 }
 
+/// Incrementally parse a top-level JSON value stream from a byte reader,
+/// invoking `cb` for each complete value as soon as it is fully available —
+/// without waiting for EOF. This is the streaming counterpart to `json_stream`
+/// (which needs the whole input up front) and backs `--unbuffered` JSON input
+/// so `tail -f`-style infinite streams emit results in real time (#1133).
+///
+/// `cb` receives the parsed value and its `input_line_number` — the count of
+/// `\n` bytes consumed through the end of the line the value sits on, matching
+/// jq (a value on a terminated line reports that line's number; an unterminated
+/// final value at EOF reports the newlines seen before it).
+///
+/// Model: jq reads line-buffered, so a value is only yielded once its line is
+/// terminated by a newline (or EOF closes the stream). This reader mirrors that
+/// — only the buffer prefix up to the last seen `\n` is parsed mid-stream, which
+/// also makes chunk splits safe (a `12` arriving before `34` is never emitted as
+/// a truncated `12`, since neither has reached a newline yet). A parse failure
+/// inside a complete-line region is treated as an incomplete multi-line value
+/// while more input may arrive, and only surfaced as an error once the reader
+/// reaches EOF — matching jq, which errors on a malformed trailing document.
+pub fn json_stream_reader<R, F>(mut reader: R, mut cb: F) -> Result<()>
+where
+    R: std::io::Read,
+    F: FnMut(Value, u64) -> Result<()>,
+{
+    let count_nl = |s: &[u8]| s.iter().filter(|&&b| b == b'\n').count() as u64;
+    let mut buf: Vec<u8> = Vec::new();
+    let mut consumed = 0usize; // start of the not-yet-emitted region of `buf`
+    let mut nl_total = 0u64; // '\n' bytes consumed up to `consumed`
+    let mut chunk = [0u8; 1 << 16];
+    let mut eof = false;
+    let mut bom_checked = false;
+    loop {
+        // Fill: pull one chunk unless we have already hit EOF and are draining.
+        if !eof {
+            match reader.read(&mut chunk) {
+                Ok(0) => eof = true,
+                Ok(n) => buf.extend_from_slice(&chunk[..n]),
+                Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+                Err(e) => return Err(e.into()),
+            }
+        }
+        // Strip a leading BOM once, before the first value is parsed.
+        if !bom_checked && (buf.len() - consumed >= 3 || eof) {
+            if buf.len() - consumed >= 3
+                && buf[consumed] == 0xEF
+                && buf[consumed + 1] == 0xBB
+                && buf[consumed + 2] == 0xBF
+            {
+                consumed += 3;
+            }
+            bom_checked = true;
+        }
+        // Only the region up to the last newline is safe to parse mid-stream:
+        // a value (possibly multi-line) is committed once its line is complete.
+        // At EOF the whole remaining buffer is fair game (final line need not be
+        // newline-terminated).
+        let safe_end = if eof {
+            buf.len()
+        } else {
+            match buf[consumed..].iter().rposition(|&b| b == b'\n') {
+                Some(off) => consumed + off + 1,
+                None => consumed,
+            }
+        };
+        // Drain every complete value within the safe region.
+        loop {
+            let start = skip_ws(&buf, consumed);
+            if start >= safe_end {
+                // Only whitespace remains in the complete-line region; consume
+                // it (counting newlines) and wait for the next line.
+                nl_total += count_nl(&buf[consumed..safe_end]);
+                consumed = safe_end;
+                break;
+            }
+            match parse_json_value(&buf, start, 0) {
+                Ok((val, end)) => {
+                    // A value spilling past the last newline may still be an
+                    // in-flight multi-line document — wait for more input.
+                    if end > safe_end {
+                        break;
+                    }
+                    reject_adjacent_word_token(&buf, end)?;
+                    let nl_before = nl_total + count_nl(&buf[consumed..end]);
+                    // jq's input_line_number for a value on a terminated line is
+                    // that line's number (newlines-before + 1); an unterminated
+                    // final value at EOF keeps newlines-before (#925 semantics).
+                    let terminated = buf[end..].iter().any(|&b| b == b'\n');
+                    let line = if terminated { nl_before + 1 } else { nl_before };
+                    nl_total = nl_before;
+                    consumed = end;
+                    cb(val, line)?;
+                }
+                Err(e) => {
+                    // Incomplete value: wait for more input. At EOF this is a
+                    // genuine malformed trailing document — surface the error.
+                    if eof {
+                        return Err(e);
+                    }
+                    break;
+                }
+            }
+        }
+        // Drop the drained prefix to keep memory bounded on long streams.
+        if consumed > 0 {
+            buf.drain(..consumed);
+            consumed = 0;
+        }
+        if eof {
+            return Ok(());
+        }
+    }
+}
+
 /// Reject two bare-word/number tokens jammed together with no separator at the
 /// top level (`nullnull`, `true123`, `123true`, `false0`). jq tokenises a
 /// contiguous run of literal/number characters as a single token and errors;

--- a/tests/io_stream_unbuffered.rs
+++ b/tests/io_stream_unbuffered.rs
@@ -1,0 +1,146 @@
+//! Issue #1133: `--unbuffered` JSON input must flush each result as it arrives
+//! on a continuous stream, instead of blocking on EOF. jq-jit previously
+//! pre-read all of stdin (`read_to_string`) to size the JIT decision, so an
+//! infinite stream (`pw-dump -m`, `tail -f`, a `while … echo` loop) produced no
+//! output at all — the pre-read never returned.
+//!
+//! These cases shell out: a stream that emits, pauses, then emits again cannot
+//! be expressed in the single-input regression harness.
+
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Child, ChildStdout, Command, Stdio};
+use std::sync::mpsc::{self, Receiver};
+use std::thread;
+use std::time::Duration;
+
+fn spawn(args: &[&str]) -> Child {
+    let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
+    Command::new(jq_jit)
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn jq-jit")
+}
+
+/// Drain the child's stdout line by line over a channel from a persistent
+/// reader thread, so the test can pull lines with a timeout without ever losing
+/// the handle (a line that arrives before stdin is closed proves the stream is
+/// not buffered until EOF).
+fn line_reader(stdout: ChildStdout) -> Receiver<String> {
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        let mut reader = BufReader::new(stdout);
+        loop {
+            let mut line = String::new();
+            if reader.read_line(&mut line).unwrap_or(0) == 0 {
+                break; // EOF
+            }
+            if tx.send(line).is_err() {
+                break;
+            }
+        }
+    });
+    rx
+}
+
+/// Next line within `timeout`, trimmed; None means nothing arrived (buffered).
+fn next_line(rx: &Receiver<String>, timeout: Duration) -> Option<String> {
+    rx.recv_timeout(timeout).ok().map(|l| l.trim().to_string())
+}
+
+#[test]
+fn flushes_each_value_before_eof() {
+    let mut child = spawn(&["-c", "--unbuffered", "."]);
+    let mut stdin = child.stdin.take().unwrap();
+    let rx = line_reader(child.stdout.take().unwrap());
+
+    // First value, then keep stdin open (no EOF).
+    stdin.write_all(b"{\"a\":1}\n").unwrap();
+    stdin.flush().unwrap();
+    assert_eq!(
+        next_line(&rx, Duration::from_secs(5)).as_deref(),
+        Some("{\"a\":1}"),
+        "first value must reach stdout while stdin is still open"
+    );
+
+    // Second value, still no EOF.
+    stdin.write_all(b"{\"a\":2}\n").unwrap();
+    stdin.flush().unwrap();
+    assert_eq!(
+        next_line(&rx, Duration::from_secs(5)).as_deref(),
+        Some("{\"a\":2}")
+    );
+
+    drop(stdin); // EOF
+    assert_eq!(child.wait().unwrap().code(), Some(0));
+}
+
+#[test]
+fn value_split_across_writes_is_not_truncated() {
+    // A number split mid-token across two writes must emit `1234`, never `12`.
+    let mut child = spawn(&["-c", "--unbuffered", "."]);
+    let mut stdin = child.stdin.take().unwrap();
+    let rx = line_reader(child.stdout.take().unwrap());
+
+    stdin.write_all(b"12").unwrap();
+    stdin.flush().unwrap();
+    // Nothing should surface yet — the token boundary is unconfirmed.
+    assert_eq!(
+        next_line(&rx, Duration::from_millis(500)),
+        None,
+        "a partial number must not be emitted before its boundary is known"
+    );
+
+    stdin.write_all(b"34\n").unwrap();
+    stdin.flush().unwrap();
+    assert_eq!(next_line(&rx, Duration::from_secs(5)).as_deref(), Some("1234"));
+
+    drop(stdin);
+    assert_eq!(child.wait().unwrap().code(), Some(0));
+}
+
+#[test]
+fn multi_line_value_streams_when_complete() {
+    let mut child = spawn(&["-c", "--unbuffered", "."]);
+    let mut stdin = child.stdin.take().unwrap();
+    let rx = line_reader(child.stdout.take().unwrap());
+
+    // Object spread over several lines; only the closing line completes it.
+    stdin.write_all(b"{\n  \"a\": 1,\n").unwrap();
+    stdin.flush().unwrap();
+    assert_eq!(
+        next_line(&rx, Duration::from_millis(500)),
+        None,
+        "an incomplete multi-line value must not emit early"
+    );
+
+    stdin.write_all(b"  \"b\": 2\n}\n").unwrap();
+    stdin.flush().unwrap();
+    assert_eq!(
+        next_line(&rx, Duration::from_secs(5)).as_deref(),
+        Some("{\"a\":1,\"b\":2}")
+    );
+
+    drop(stdin);
+    assert_eq!(child.wait().unwrap().code(), Some(0));
+}
+
+#[test]
+fn parse_error_flushes_leading_then_exits_5() {
+    // Matches the batch stream path (#856): valid leading documents reach
+    // stdout, then a malformed token exits 5.
+    let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
+    let mut child = Command::new(jq_jit)
+        .args(["-c", "--unbuffered", "."])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    child.stdin.take().unwrap().write_all(b"1 2 xx").unwrap();
+    let out = child.wait_with_output().unwrap();
+    assert_eq!(String::from_utf8_lossy(&out.stdout).trim_end(), "1\n2");
+    assert_eq!(out.status.code(), Some(5));
+}


### PR DESCRIPTION
## Problem

`--unbuffered` JSON input over a continuous stream produced **no output at all** and appeared to hang (#1133):

```bash
pw-dump -Nm | jq-jit -Mcrj --unbuffered .
while true; do echo '{"status":"ok"}'; sleep 1; done | jq-jit -c --unbuffered .
```

The per-result flush was already correct. The real cause was on the **input** side: the JSON stdin path pre-read the entire stream with `read_to_string` to size the JIT compile decision, so an input that never sends EOF blocked forever before a single value was parsed. Raw input (`-R`) already streamed incrementally via `read_until`; JSON input did not — an asymmetry.

## Fix

- Add `json_stream_reader` in `value.rs`: a line-buffered incremental JSON value reader that mirrors jq. A value is emitted once its line is terminated (or EOF closes the stream). This:
  - keeps chunk splits safe — a `12` arriving before `34` is never emitted as a truncated `12`;
  - handles multi-line values (emitted when complete);
  - reports `input_line_number` matching jq.
- Route `--unbuffered` JSON stdin through it, scoped to plain per-document input. `slurp`, `input`/`inputs`, `--seq` framing and raw input keep their whole-stream handling (they can't stream by definition or need the full buffer).
- A mid-stream parse error flushes the already-emitted leading documents and exits 5, matching the batch path (#856).
- Without `--unbuffered`, the pre-read is retained as a deliberate throughput tradeoff.

## Verification

- New integration test `tests/io_stream_unbuffered.rs` (4 cases): real-time emission before EOF, chunk-split safety, multi-line streaming, and leading-flush-then-exit-5.
- Parity with jq confirmed for `input_line_number`, output, and exit codes.
- Full suite passes (official 509 + regression + differential + fuzz + self-diff), zero build warnings.

Closes #1133

🤖 Generated with [Claude Code](https://claude.com/claude-code)