### PR TITLE
perf(fast-path): fuse value classification into the del boundary scan

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -1874,14 +1874,18 @@ pub fn json_object_del_field(b: &[u8], pos: usize, field: &str, buf: &mut Vec<u8
             if i >= b.len() || b[i] != b':' { break; }
             i += 1;
             let val_start = i;
-            let val_end = match skip_json_value(b, i) { Ok(e) => e, Err(_) => break };
+            let (val_end, vclean) = match skip_json_value_classify(b, i) { Ok(r) => r, Err(_) => break };
             if !key_matches {
                 if !first_out { buf.push(b','); }
                 first_out = false;
                 buf.extend_from_slice(&b[key_start..val_start]); // "key":
-                // Canonicalise a non-canonical number repr in the retained
-                // value rather than echo the source lexeme (#729).
-                if !append_canonical_value(buf, &b[val_start..val_end]) {
+                // The boundary scan already proved a clean scalar verbatim-safe
+                // (no escape/DEL/non-canonical number); copy it directly and only
+                // re-render through the canonicaliser otherwise (#729 number
+                // reprs, #780/#1027 escapes) — the #758 del passthrough tax.
+                if vclean {
+                    buf.extend_from_slice(&b[val_start..val_end]);
+                } else if !append_canonical_value(buf, &b[val_start..val_end]) {
                     buf.truncate(buf_start);
                     return false;
                 }
@@ -1915,14 +1919,17 @@ pub fn json_object_del_field(b: &[u8], pos: usize, field: &str, buf: &mut Vec<u8
         if i >= b.len() || b[i] != b':' { break; }
         i += 1;
         while i < b.len() && matches!(b[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
-        let val_end = match skip_json_value(b, i) { Ok(e) => e, Err(_) => break };
+        let (val_end, vclean) = match skip_json_value_classify(b, i) { Ok(r) => r, Err(_) => break };
         if !key_matches {
             if !first_out { buf.push(b','); }
             first_out = false;
             buf.extend_from_slice(&b[key_start..key_end]);
             buf.push(b':');
-            // Canonicalise a non-canonical number repr (#729).
-            if !append_canonical_value(buf, &b[i..val_end]) {
+            // Verbatim-copy a clean scalar; canonicalise otherwise (#729/#780,
+            // the #758 del passthrough tax).
+            if vclean {
+                buf.extend_from_slice(&b[i..val_end]);
+            } else if !append_canonical_value(buf, &b[i..val_end]) {
                 buf.truncate(buf_start);
                 return false;
             }
@@ -1967,14 +1974,17 @@ pub fn json_object_del_fields(b: &[u8], pos: usize, fields: &[&str], buf: &mut V
         if i >= b.len() || b[i] != b':' { break; }
         i += 1;
         while i < b.len() && matches!(b[i], b' ' | b'\t' | b'\n' | b'\r') { i += 1; }
-        let val_end = match skip_json_value(b, i) { Ok(e) => e, Err(_) => break };
+        let (val_end, vclean) = match skip_json_value_classify(b, i) { Ok(r) => r, Err(_) => break };
         if !key_matches {
             if !first_out { buf.push(b','); }
             first_out = false;
             buf.extend_from_slice(&b[key_start..key_end]);
             buf.push(b':');
-            // Canonicalise a non-canonical number repr (#729).
-            if !append_canonical_value(buf, &b[i..val_end]) {
+            // Verbatim-copy a clean scalar; canonicalise otherwise (#729/#780,
+            // the #758 del passthrough tax).
+            if vclean {
+                buf.extend_from_slice(&b[i..val_end]);
+            } else if !append_canonical_value(buf, &b[i..val_end]) {
                 buf.truncate(buf_start);
                 return false;
             }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -14228,3 +14228,18 @@ def r: if . <= 0 then 0 else . + (. - 1 | r) end; r
 def dbl: . * 2; def f(g): [.[] | g]; f(dbl) | f(dbl)
 [1,2,3]
 [4,8,12]
+
+# #758: del passthrough re-renders non-canonical retained numbers (#729)
+del(.b)
+{"a":1e10,"b":2}
+{"a":1E+10}
+
+# #758: del passthrough rewrites escaped solidus in retained string (#780)
+del(.b)
+{"a":"p\/q","b":2}
+{"a":"p/q"}
+
+# #758: del passthrough preserves clean scalar literals verbatim
+del(.name)
+{"x":1,"y":1e3,"name":"n"}
+{"x":1,"y":1E+3}


### PR DESCRIPTION
## Summary

The `del(.field)` / `del(.a,.b)` raw-byte fast paths walked each retained
value twice — once in the boundary scan (`skip_json_value`) and again in
`append_canonical_value`, which re-scans every retained scalar for
non-canonical number lexemes (#729) and escapes (#780/#1027). Even clean
integers paid the second walk, leaving these paths ~1.1x slower than the
pre-#753 verbatim copy.

This swaps the del streamers to `skip_json_value_classify`, which reports
a `clean` flag from the boundary walk for nearly free — the same fusion
already applied to the field-access / construct fast paths in #1079. A
clean scalar copies verbatim; dirty values (non-canonical numbers,
escaped/DEL strings, composites) still route through the canonicaliser.

## Data (same-machine A/B, best-of-12, 2M NDJSON, vs v1.8.0 tag)

| filter      | before | after |
|-------------|--------|-------|
| `del(.name)`| 1.11x  | 0.98x |
| `del(.x)`   | 1.14x  | 0.98x |
| `del(.x,.y)`| 1.09x  | 0.96x |

This was the last remaining #758 outlier; the other value-passthrough
shapes (field access, array/object construct, merge, nested) were already
recovered to ≤1.0x by #1079, confirmed in the same A/B sweep.

## Tests

- 3 regression cases pinning del passthrough of non-canonical numbers,
  escaped solidus, and clean scalar literals.
- Full suite green (official 509, regression, differential, fuzz,
  self-diff, contracts); zero build warnings.

Closes #758

🤖 Generated with [Claude Code](https://claude.com/claude-code)