### PR TITLE
perf(parse): adaptive projection fallback for no-skip streams

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -4974,7 +4974,12 @@ pub fn skip_json_value_classify(b: &[u8], pos: usize) -> Result<(usize, bool)> {
 
 /// Parse a JSON object, only parsing values for keys in `fields`. Other values are skipped.
 /// Uses the same key parsing as parse_json_object but skips value parsing for non-matching keys.
-fn parse_json_object_project(b: &[u8], pos: usize, depth: usize, fields: &[&str]) -> Result<(Value, usize)> {
+///
+/// The third tuple element is the number of object keys that were *skipped*
+/// (not in `fields`); [`json_stream_project`] uses it as an adaptive signal —
+/// a stream of records that skip nothing pays the per-key field match for no
+/// gain, so it falls back to the plain pooled parser (#1135).
+fn parse_json_object_project(b: &[u8], pos: usize, depth: usize, fields: &[&str]) -> Result<(Value, usize, u32)> {
     debug_assert_eq!(b[pos], b'{');
     let mut i = skip_ws(b, pos + 1);
     let n = fields.len();
@@ -4986,9 +4991,10 @@ fn parse_json_object_project(b: &[u8], pos: usize, depth: usize, fields: &[&str]
     let map = Rc::get_mut(&mut rc).unwrap();
     if i < b.len() && b[i] == b'}' {
         for &f in fields { map.push_unique(KeyStr::from(f), Value::Null); }
-        return Ok((Value::Obj(ObjInner(rc)), i + 1));
+        return Ok((Value::Obj(ObjInner(rc)), i + 1, 0));
     }
     let mut found = 0u64;
+    let mut skipped = 0u32;
     loop {
         if i >= b.len() || b[i] != b'"' { bail!("Expected string key at position {}", i); }
         // Scan key bytes directly without creating KeyStr for non-matching keys
@@ -5037,6 +5043,7 @@ fn parse_json_object_project(b: &[u8], pos: usize, depth: usize, fields: &[&str]
         }
         if !matched {
             i = skip_json_value(b, i)?;
+            skipped += 1;
         }
         i = skip_ws(b, i);
         if i >= b.len() { bail!("Unterminated object"); }
@@ -5048,7 +5055,7 @@ fn parse_json_object_project(b: &[u8], pos: usize, depth: usize, fields: &[&str]
         if fi < 64 && (found & (1u64 << fi)) != 0 { continue; }
         map.push_unique(KeyStr::from(f), Value::Null);
     }
-    Ok((Value::Obj(ObjInner(rc)), i + 1))
+    Ok((Value::Obj(ObjInner(rc)), i + 1, skipped))
 }
 
 /// Stream JSON values from input, only parsing specified fields from top-level objects.
@@ -5059,9 +5066,40 @@ where F: FnMut(Value) -> Result<()> {
     let mut pos = 0;
     if bytes.len() >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF { pos = 3; }
     pos = skip_ws(bytes, pos);
+    // Adaptive projection: projecting only pays off when records carry extra
+    // fields to skip. Probe the first PROBE objects; if not one of them skipped
+    // a field (a stream of narrow records that keep everything), drop to the
+    // plain pooled parser for the remainder — projecting an all-kept record
+    // adds a per-key field match for zero skip benefit (#1135). A full parse is
+    // a safe substitute because `needed_input_fields` only projects filters
+    // that read exactly this field set, so the extra materialized fields are
+    // never observed (the same invariant that makes projection itself sound;
+    // pinned by tests/contract_projection.rs). One probe record with a skip is
+    // enough to keep projecting, preserving the wide-record wins.
+    const PROBE: u32 = 64;
+    let mut probed = 0u32;
+    let mut keep_projecting = true;
     while pos < bytes.len() {
         let (val, end) = if bytes[pos] == b'{' {
-            parse_json_object_project(bytes, pos, 0, fields)?
+            if probed < PROBE {
+                let (v, e, skipped) = parse_json_object_project(bytes, pos, 0, fields)?;
+                if skipped > 0 {
+                    // Projection earned its keep; stop probing and lock it in.
+                    probed = PROBE;
+                } else {
+                    probed += 1;
+                    if probed >= PROBE {
+                        // Probe window closed with zero skips across every record.
+                        keep_projecting = false;
+                    }
+                }
+                (v, e)
+            } else if keep_projecting {
+                let (v, e, _) = parse_json_object_project(bytes, pos, 0, fields)?;
+                (v, e)
+            } else {
+                parse_json_value(bytes, pos, 0)?
+            }
         } else {
             parse_json_value(bytes, pos, 0)?
         };

--- a/tests/contract_projection.rs
+++ b/tests/contract_projection.rs
@@ -169,6 +169,59 @@ fn record_observers_refuse_projection() {
     }
 }
 
+/// #1135: `json_stream_project` probes the first 64 objects and, if none
+/// skipped a field (a stream of narrow records that keep everything), falls
+/// back to the plain pooled parser for the remainder. The fallback emits the
+/// full record instead of the projected one, so this pins that the substituted
+/// full parse still produces identical filter output past the probe window —
+/// across both all-kept narrow streams (fallback engages) and streams that
+/// skip fields (projection stays on). Records with missing fields are included
+/// so the null-backfill-vs-absent-key equivalence is exercised on both paths.
+#[test]
+fn adaptive_fallback_matches_full_parse_past_probe_window() {
+    // 200 > the 64-record probe window. Build both an all-kept narrow stream
+    // (every key is in {x,y,name} → zero skips → fallback) and a wide stream
+    // (extra keys → skips → projection stays engaged).
+    let mut narrow = String::new();
+    let mut wide = String::new();
+    for i in 0..200 {
+        // Vary presence so some records miss x / y / name (null backfill path).
+        let mut narrow_rec = String::from("{");
+        if i % 5 != 0 { narrow_rec.push_str(&format!(r#""x":{i},"#)); }
+        if i % 3 != 0 { narrow_rec.push_str(&format!(r#""y":{},"#, i * 2)); }
+        narrow_rec.push_str(&format!(r#""name":"n{i}""#));
+        narrow_rec.push('}');
+        narrow.push_str(&narrow_rec);
+        narrow.push('\n');
+
+        wide.push_str(&format!(
+            r#"{{"a":1,"x":{i},"b":2,"y":{},"name":"w{i}","c":3}}"#,
+            i * 2
+        ));
+        wide.push('\n');
+    }
+
+    for filter in ["[[.x,.y],[.name]] | flatten", ".x", "[.x, .y, .name]", ".name // \"d\""] {
+        let mut f = Filter::with_options(filter, &[], false).expect(filter);
+        let fields = f.needed_input_fields().expect("must project");
+        let field_refs: Vec<&str> = fields.iter().map(|s| s.as_str()).collect();
+
+        for stream in [&narrow, &wide] {
+            let mut full = Vec::new();
+            json_stream(stream, |v| { full.push(v); Ok(()) }).expect("full parse");
+            let mut projected = Vec::new();
+            json_stream_project(stream, &field_refs, |v| { projected.push(v); Ok(()) })
+                .expect("projected parse");
+
+            assert_eq!(
+                run_filter(&mut f, &full),
+                run_filter(&mut f, &projected),
+                "{filter:?} diverges between full and projected parse past the probe window"
+            );
+        }
+    }
+}
+
 /// The projecting parser tracks found keys in a u64 bitset; the extraction
 /// must refuse field sets that would overflow it.
 #[test]


### PR DESCRIPTION
## Summary

Projection pushdown (#1055) routes field-reading filters with no raw fast
path through `parse_json_object_project`, which materializes only the
needed fields. On a stream of narrow records that keep **every** field
(e.g. `[[.x,.y],[.name]] | flatten` over `{x,y,name}`), projection skips
nothing yet still pays a per-key linear field match, leaving that filter
~1.13x slower than the pooled full parse v1.9.2 used (#1135).

`needed_input_fields` only projects filters that read exactly the projected
field set, so a **full parse is a sound substitute** — the extra
materialized fields are never observed (the same invariant that makes
projection itself correct; pinned by `tests/contract_projection.rs`). This
uses that signal: probe the first 64 objects in `json_stream_project`, and
if not one skipped a field, drop to the plain pooled parser for the rest. A
single probe record with a skip locks projection in, so wide-record streams
keep their large wins.

## Data (same-machine A/B, best-of-12, 2M records, ratios vs v1.9.2 pooled parse)

| stream            | filter    | v1.10.0 | this   |
|-------------------|-----------|---------|--------|
| narrow {x,y,name} | `flatten` | 1.13x   | 1.10x  |
| wide (+16 fields) | `flatten` | 0.561x  | 0.557x |

The narrow case recovers the projection-attributable overhead; the
wide-record win is fully preserved (`new/v1.10.0` = 0.998). The remaining
narrow residual is the **separate** #1128 output-fusion contribution the
issue already attributed elsewhere — not the projection path. Folding the
literal collect + `flatten` away (issue direction 3) is unsound because
`flatten/0` is deep (`[[.x,.y],[.name]]|flatten` ≠ `[.x,.y,.name]` when
`.x` is itself an array), so this leaves #1135 open for that residual.

## Tests

- New `adaptive_fallback_matches_full_parse_past_probe_window` contract:
  drives 200-record narrow (fallback engages) and wide (projection stays
  on) streams, including missing-field records, asserting projected ==
  full-parse filter output past the 64-record probe window.
- Full suite green (official 509, regression, differential, fuzz,
  self-diff×3, contracts); zero build warnings.

Refs #1135

🤖 Generated with [Claude Code](https://claude.com/claude-code)