### PR TITLE
feat(cli): add --jsonc flag to accept comments in JSON input

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ jq-jit [OPTIONS] <FILTER> [FILE...]
 | `--indent N` | Use N spaces for indentation (range -1..=7; -1 means tab; default: 2) |
 | `--unbuffered` | Flush output after each value |
 | `--seq` | Frame each output with `RS` (0x1E) per RFC 7464 |
+| `--jsonc` | _(jqx)_ Allow `//` and `/* */` comments in JSON input; see [JSONC input](#jsonc-input) |
 | `--parallel[=N]` | _(jqx)_ Run a stateless filter per-record across N worker threads (default: core count); see [Parallel execution](#parallel-execution) |
 | `-f`, `--from-file FILE` | Read filter from file |
 | `-L`, `--library-path DIR` | Add DIR to the module search path (repeatable) |
@@ -300,6 +301,31 @@ jq-jit --debug-memo -n 'def fib: memoize(if . < 2 then . else ((. - 1) | fib) + 
 The 1-arg form keys only by the current input. If your body closes over a
 `$var` that varies between calls, results will be stale — pull the var into
 the key explicitly with the 2-arg form: `memoize(. + $x; [., $x])`.
+
+### JSONC input
+
+`--jsonc` lets the JSON input parser accept `//` line comments and `/* */`
+block comments, for running filters directly over JSONC-style config files
+(`tsconfig.json`, editor settings, `.jsonc`) without a comment-stripping
+preprocessing step:
+
+```bash
+jq-jit --jsonc '.compilerOptions.strict' tsconfig.json
+```
+
+Scope is deliberately **comments only** — trailing commas, single-quoted
+strings, unquoted keys, and the rest of JSON5 remain parse errors. Comments
+are stripped once at the input boundary (string-aware, so `"http://x"` is
+untouched); with the flag off, the input path is byte-identical to before.
+
+Notes:
+
+- Applies to top-level JSON input (stdin and input files, including the
+  `input` / `inputs` builtins). `fromjson`, `--argjson`, and `--slurpfile`
+  stay strict JSON.
+- Not combinable with `--unbuffered` streaming JSON stdin (the incremental
+  reader never holds the whole buffer); `--jsonc --unbuffered` with file
+  inputs works normally.
 
 ### Parallel execution
 

--- a/src/bin/jq-jit.rs
+++ b/src/bin/jq-jit.rs
@@ -2835,6 +2835,7 @@ fn real_main() {
     let mut exit_status = false;
     let mut color_output = false;
     let mut unbuffered = false;
+    let mut jsonc = false;
     let mut seq = false;
     // 0 = parallel disabled. `--parallel` sets it to the detected core count,
     // `--parallel=N` to N. Per-record worker-pool execution for stateless
@@ -2914,6 +2915,7 @@ fn real_main() {
             "-C" | "--color-output" => color_output = true,
             "-M" | "--monochrome-output" => color_output = false,
             "--unbuffered" => unbuffered = true,
+            "--jsonc" => jsonc = true,
             "--seq" => seq = true,
             "--parallel" => {
                 parallel_jobs = std::thread::available_parallelism()
@@ -3273,6 +3275,15 @@ fn real_main() {
         && !seq
         && !filter.uses_inputs();
 
+    // --jsonc strips comments with one whole-buffer pass at the input
+    // boundary; the incremental --unbuffered stdin reader never holds the
+    // whole buffer, so a comment straddling a read boundary cannot be handled
+    // there. Reject the combination explicitly rather than degrade it (#1141).
+    if jsonc && stream_unbuffered {
+        eprintln!("jq: error: --jsonc cannot be combined with --unbuffered streaming JSON stdin");
+        process::exit(2);
+    }
+
     // Pre-read stdin so we can estimate input size for JIT decision.
     let stdin_data: Option<String> = if !null_input && files.is_empty() && !raw_input && !stream_unbuffered {
         let mut s = String::new();
@@ -3297,6 +3308,9 @@ fn real_main() {
                 );
                 s.clear();
             }
+        }
+        if jsonc {
+            jq_jit::value::strip_json_comments(&mut s);
         }
         Some(s)
     } else {
@@ -4321,6 +4335,9 @@ fn real_main() {
                 if raw_input {
                     inputs_values.extend(tag_filename(raw_inputs_with_lines(&input_str), &stdin_name));
                 } else {
+                    if jsonc {
+                        jq_jit::value::strip_json_comments(&mut input_str);
+                    }
                     match json_inputs_with_lines(&input_str) {
                         Ok(vs) => inputs_values.extend(tag_filename(vs, &stdin_name)),
                         Err(e) => { eprintln!("jq: error (at <stdin>:0): {}", e); process::exit(2); }
@@ -4331,13 +4348,16 @@ fn real_main() {
                 // `input_filename` reflects the file the value came from (#926).
                 for file in &files {
                     let fname: std::rc::Rc<str> = std::rc::Rc::from(file.as_str());
-                    let content = match std::fs::read_to_string(file) {
+                    let mut content = match std::fs::read_to_string(file) {
                         Ok(c) => c,
                         Err(e) => { eprintln!("jq: error: Could not open file {}: {}", file, e); process::exit(2); }
                     };
                     if raw_input {
                         inputs_values.extend(tag_filename(raw_inputs_with_lines(&content), &fname));
                     } else {
+                        if jsonc {
+                            jq_jit::value::strip_json_comments(&mut content);
+                        }
                         match json_inputs_with_lines(&content) {
                             Ok(vs) => inputs_values.extend(tag_filename(vs, &fname)),
                             Err(e) => { eprintln!("jq: error (at {}:0): {}", file, e); process::exit(2); }
@@ -13574,6 +13594,9 @@ fn real_main() {
             if file == "-" {
                 let mut s = String::new();
                 io::stdin().lock().read_to_string(&mut s).unwrap_or(0);
+                if jsonc && !raw_input {
+                    jq_jit::value::strip_json_comments(&mut s);
+                }
                 if slurp {
                     if raw_input {
                         for line in split_raw_lines(&s) {
@@ -13631,6 +13654,18 @@ fn real_main() {
                 content = "";
             }
             let _ = &mmap; // keep mmap alive
+            // --jsonc: the mmap is read-only, so comment blanking takes an
+            // owned copy — a cost paid only when the flag is on; the flag-off
+            // path stays zero-copy (#1141).
+            let jsonc_owned;
+            let content = if jsonc && !raw_input {
+                let mut s = content.to_string();
+                jq_jit::value::strip_json_comments(&mut s);
+                jsonc_owned = s;
+                jsonc_owned.as_str()
+            } else {
+                content
+            };
             let parse_result = if parallel_active && !slurp && !raw_input {
                 run_parallel_json_stream(
                     content, parallel_jobs, &filter_str, &lib_dirs,
@@ -22560,6 +22595,7 @@ fn print_usage() {
     eprintln!("  -M, --monochrome-output  Disable color output (default)");
     eprintln!("  --args                   Remaining args are string $ARGS.positional");
     eprintln!("  --jsonargs               Remaining args are JSON $ARGS.positional");
+    eprintln!("  --jsonc                  Allow // and /* */ comments in JSON input (jqx)");
     eprintln!("  --parallel[=N]           Run stateless filters per-record across N workers (jqx; default: cores)");
     eprintln!("  --memo-max-entries N     Per-slot cap for memoize/1 cache (jqx; default 1000000)");
     eprintln!("  --debug-memo             Print per-slot memoize cache stats to stderr on exit (jqx)");

--- a/src/value.rs
+++ b/src/value.rs
@@ -821,6 +821,63 @@ pub fn json_to_value(json: &str) -> Result<Value> {
     Ok(val)
 }
 
+/// Blank `//` line comments and `/* */` block comments outside strings with
+/// spaces, in place (`--jsonc`, #1141). Blanking instead of removing keeps the
+/// buffer length and every `\n` position intact, so byte-offset accounting
+/// (`json_stream_raw` ranges, projection fast paths) and `input_line_number`
+/// need no comment-awareness downstream — the buffer is standard JSON after
+/// this pass. String contents are left untouched (`"http://x"` keeps its
+/// slashes); an unescaped `"` toggles in-string state, `\` escapes the next
+/// byte. An unterminated block comment blanks to EOF. Only ASCII spaces are
+/// written, so UTF-8 validity is preserved even inside multi-byte comment text.
+pub fn strip_json_comments(s: &mut String) {
+    // SAFETY: only ASCII 0x20 is ever written, never into a multi-byte
+    // sequence boundary shift — length and UTF-8 validity are preserved.
+    let b = unsafe { s.as_mut_vec() };
+    let n = b.len();
+    let mut i = 0;
+    let mut in_string = false;
+    while i < n {
+        let c = b[i];
+        if in_string {
+            if c == b'\\' {
+                i += 2;
+                continue;
+            }
+            if c == b'"' {
+                in_string = false;
+            }
+            i += 1;
+        } else if c == b'"' {
+            in_string = true;
+            i += 1;
+        } else if c == b'/' && i + 1 < n && b[i + 1] == b'/' {
+            while i < n && b[i] != b'\n' {
+                b[i] = b' ';
+                i += 1;
+            }
+        } else if c == b'/' && i + 1 < n && b[i + 1] == b'*' {
+            b[i] = b' ';
+            b[i + 1] = b' ';
+            i += 2;
+            while i < n {
+                if b[i] == b'*' && i + 1 < n && b[i + 1] == b'/' {
+                    b[i] = b' ';
+                    b[i + 1] = b' ';
+                    i += 2;
+                    break;
+                }
+                if b[i] != b'\n' {
+                    b[i] = b' ';
+                }
+                i += 1;
+            }
+        } else {
+            i += 1;
+        }
+    }
+}
+
 /// Parse multiple JSON values from a single string, calling a callback for each.
 /// Avoids the double-scan of split_json_values + json_to_value.
 pub fn json_stream<F>(input: &str, mut cb: F) -> Result<()>

--- a/tests/jsonc_input.rs
+++ b/tests/jsonc_input.rs
@@ -1,0 +1,173 @@
+//! Issue #1141: `--jsonc` accepts `//` line and `/* */` block comments in JSON
+//! input by blanking them with spaces at the input boundary, so the downstream
+//! parser (and every raw-byte fast path) sees standard JSON with unchanged
+//! byte offsets and line numbers. Comment-only scope — no trailing commas or
+//! other JSON5. Default behavior (flag off) is unchanged.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+use jq_jit::value::strip_json_comments;
+
+fn run_stdin(args: &[&str], input: &str) -> (String, String, Option<i32>) {
+    let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
+    let mut child = Command::new(jq_jit)
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn jq-jit");
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(input.as_bytes())
+        .unwrap();
+    let out = child.wait_with_output().unwrap();
+    (
+        String::from_utf8_lossy(&out.stdout).to_string(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+        out.status.code(),
+    )
+}
+
+// --- strip_json_comments unit-level coverage ---------------------------------
+
+fn stripped(s: &str) -> String {
+    let mut owned = s.to_string();
+    strip_json_comments(&mut owned);
+    owned
+}
+
+#[test]
+fn strip_blanks_line_and_block_comments() {
+    assert_eq!(stripped("// c\n{\"a\":1}"), "    \n{\"a\":1}");
+    assert_eq!(stripped("{\"a\":/*x*/1}"), "{\"a\":     1}");
+}
+
+#[test]
+fn strip_preserves_length_and_newlines() {
+    let src = "/* a\n b */\n{\"a\":1} // t\n";
+    let out = stripped(src);
+    assert_eq!(out.len(), src.len());
+    let nl = |s: &str| s.bytes().filter(|&b| b == b'\n').count();
+    assert_eq!(nl(&out), nl(src));
+    assert_eq!(out, "    \n     \n{\"a\":1}     \n");
+}
+
+#[test]
+fn strip_leaves_string_contents_alone() {
+    assert_eq!(stripped("{\"u\":\"http://x\"}"), "{\"u\":\"http://x\"}");
+    assert_eq!(stripped("\"a//b\""), "\"a//b\"");
+    assert_eq!(stripped("\"/* not a comment */\""), "\"/* not a comment */\"");
+}
+
+#[test]
+fn strip_handles_escaped_quotes_in_strings() {
+    // The escaped quote must not end the string; the // inside stays.
+    assert_eq!(stripped("\"a\\\"//b\""), "\"a\\\"//b\"");
+    // A string ending in a literal backslash-escape, then a real comment.
+    assert_eq!(stripped("\"a\\\\\" // c"), "\"a\\\\\"     ");
+}
+
+#[test]
+fn strip_blanks_multibyte_comment_text_to_valid_utf8() {
+    let out = stripped("// コメント\n1");
+    assert!(std::str::from_utf8(out.as_bytes()).is_ok());
+    assert_eq!(out.trim_start(), "\n1".trim_start());
+}
+
+#[test]
+fn strip_unterminated_block_comment_blanks_to_eof() {
+    assert_eq!(stripped("1 /* open"), "1        ");
+}
+
+#[test]
+fn strip_lone_slash_is_untouched() {
+    assert_eq!(stripped("1 / 2"), "1 / 2");
+}
+
+// --- CLI behavior ------------------------------------------------------------
+
+#[test]
+fn jsonc_stdin_line_and_block_comments() {
+    let input = "// header\n{\n  \"a\": 1, /* inline */\n  \"b\": \"http://x\"\n}\n";
+    let (stdout, _, code) = run_stdin(&["-c", "--jsonc", "."], input);
+    assert_eq!(stdout.trim_end(), "{\"a\":1,\"b\":\"http://x\"}");
+    assert_eq!(code, Some(0));
+}
+
+#[test]
+fn without_flag_comments_are_a_parse_error() {
+    let (stdout, _, code) = run_stdin(&["-c", "."], "// c\n{\"a\":1}\n");
+    assert_eq!(stdout, "");
+    assert_eq!(code, Some(5));
+}
+
+#[test]
+fn jsonc_preserves_input_line_number() {
+    // Blanking keeps every newline, so the value on line 3 still reports 3.
+    let input = "/* a\n b */\n{\"a\":1}\n";
+    let (stdout, _, code) = run_stdin(&["--jsonc", "-c", "input_line_number"], input);
+    assert_eq!(stdout.trim_end(), "3");
+    assert_eq!(code, Some(0));
+}
+
+#[test]
+fn jsonc_with_unbuffered_json_stdin_is_rejected() {
+    let (stdout, stderr, code) = run_stdin(&["-c", "--jsonc", "--unbuffered", "."], "{}\n");
+    assert_eq!(stdout, "");
+    assert!(stderr.contains("--jsonc"), "stderr: {stderr}");
+    assert_eq!(code, Some(2));
+}
+
+#[test]
+fn jsonc_file_input() {
+    let dir = std::env::temp_dir().join(format!("jq-jit-jsonc-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("config.jsonc");
+    std::fs::write(&path, "{\n  // port to bind\n  \"port\": 8080 /* tcp */\n}\n").unwrap();
+
+    let jq_jit = env!("CARGO_BIN_EXE_jq-jit");
+    let out = Command::new(jq_jit)
+        .args(["-c", "--jsonc", ".port", path.to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert_eq!(String::from_utf8_lossy(&out.stdout).trim_end(), "8080");
+    assert_eq!(out.status.code(), Some(0));
+
+    // --unbuffered with a FILE stays supported — only streaming stdin is not.
+    let out = Command::new(jq_jit)
+        .args(["-c", "--jsonc", "--unbuffered", ".port", path.to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert_eq!(String::from_utf8_lossy(&out.stdout).trim_end(), "8080");
+    assert_eq!(out.status.code(), Some(0));
+
+    // -n + input reads the same file through the inputs queue.
+    let out = Command::new(jq_jit)
+        .args(["-c", "-n", "--jsonc", "input.port", path.to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert_eq!(String::from_utf8_lossy(&out.stdout).trim_end(), "8080");
+    assert_eq!(out.status.code(), Some(0));
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn jsonc_slurp_and_multiple_documents() {
+    let input = "// two docs\n1\n/* between */\n2\n";
+    let (stdout, _, code) = run_stdin(&["-c", "--jsonc", "-s", "add"], input);
+    assert_eq!(stdout.trim_end(), "3");
+    assert_eq!(code, Some(0));
+}
+
+#[test]
+fn jsonc_raw_input_is_unaffected() {
+    // -R reads lines as strings; comment syntax must pass through verbatim.
+    let (stdout, _, code) = run_stdin(&["-c", "--jsonc", "-R", "."], "// not json\n");
+    assert_eq!(stdout.trim_end(), "\"// not json\"");
+    assert_eq!(code, Some(0));
+}


### PR DESCRIPTION
## Summary

Adds `--jsonc`, an opt-in jqx extension that lets the JSON input parser accept `//` line comments and `/* */` block comments, for running filters directly over JSONC-style config files (tsconfig, editor settings, `.jsonc`) without a preprocessing step.

Closes #1141

## Design (as investigated in the issue)

Comments are **blanked with spaces** (newlines preserved) in one string-aware O(n) pass at the input boundary. Blanking instead of removing keeps buffer length and every `\n` position intact, so:

- the downstream parser, projection, and all ~50 raw-byte fast paths see standard JSON with unchanged byte offsets — none of the ~145 inlined whitespace-skip sites change;
- `input_line_number` and parse-error line/column reporting stay accurate for free.

An unescaped `"` toggles in-string state (`"http://x"` keeps its slashes); `\` escapes the next byte. Only ASCII spaces are written, so multi-byte comment text stays valid UTF-8.

## Scope decisions (the issue's open questions)

- **Flag name**: `--jsonc` only; no alias (easy to add later, hard to remove).
- **`--unbuffered`**: the incremental JSON stdin reader never holds the whole buffer, so `--jsonc` + streaming stdin is rejected with an explicit error (exit 2). `--jsonc --unbuffered` with file inputs works normally.
- **Reach**: top-level input only (stdin, positional files, and the `input`/`inputs` queue paths). `fromjson`, `--argjson`, `--slurpfile` stay strict JSON.
- Comments only — trailing commas / JSON5 remain parse errors.

## Application sites

Four input-boundary sites: the stdin pre-read, the two `inputs`-queue preload paths (stdin and files), the `-` stdin case in the file loop, and the mmap file path (which takes an owned copy only when the flag is on; the flag-off path stays zero-copy mmap).

## Testing

- `tests/jsonc_input.rs`: 14 tests — strip-function coverage (string-awareness, escaped quotes, length/newline preservation, multi-byte comments, unterminated block, lone slash) and CLI behavior (stdin/file/slurp/`input`, `input_line_number` preservation, flag-off parse error, `--unbuffered` rejection, `-R` passthrough).
- Full `cargo test --release` green locally except `diff_corpus`, which also fails on unmodified `main` with the identical 3 divergences: the local Homebrew jq moved to 1.8.2 while the suite targets 1.8.x behavior pinned in CI at 1.8.1. Unrelated to this change.
- Flag-off A/B (interleaved best-of-7, 36MB / 500k-record NDJSON, old `main` binary vs this branch): ratio 0.993 (stdin) / 0.994 (file) — no regression, as structurally expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)