### PR TITLE
release v1.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jq-jit"
-version = "1.10.0"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jq-jit"
-version = "1.10.0"
+version = "1.11.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A JIT-compiling implementation of jq using Cranelift"

--- a/docs/benchmark-history.md
+++ b/docs/benchmark-history.md
@@ -6,297 +6,297 @@ Recent slice (last 5 columns). Full history lives in
 
 ```text
 --- NDJSON workloads (2M objects) ---
-  Benchmark                    v1.8.3  v1.9.0  v1.9.1  v1.9.2  v1.10.0
-  ---                          ------  ------  ------  ------  -------
-  empty                        0.017s  0.018s  0.018s  0.019s  0.019s
-  identity -c                  0.085s  0.088s  0.085s  0.087s  0.088s
-  identity (pretty)            0.106s  0.109s  0.112s  0.111s  0.109s
-  field access .name           0.114s  0.084s  0.081s  0.084s  0.085s
-  nested .x,.y,.name           0.200s  0.119s  0.123s  0.121s  0.121s
-  arithmetic .x + .y           0.084s  0.088s  0.090s  0.088s  0.091s
-  select .x > 1500000          0.081s  0.083s  0.083s  0.084s  0.088s
-  string concat                0.093s  0.092s  0.094s  0.096s  0.095s
-  object construct             0.137s  0.118s  0.120s  0.121s  0.124s
-  array construct              0.136s  0.108s  0.105s  0.106s  0.111s
-  .[]                          0.116s  0.120s  0.120s  0.120s  0.121s
-  to_entries                   0.148s  0.155s  0.151s  0.150s  0.151s
-  keys                         0.103s  0.107s  0.104s  0.104s  0.109s
-  keys_unsorted                0.099s  0.101s  0.102s  0.103s  0.104s
-  length                       0.084s  0.090s  0.087s  0.092s  0.086s
-  has("x")                     0.039s  0.040s  0.039s  0.040s  0.040s
-  type                         0.020s  0.021s  0.020s  0.020s  0.021s
-  del(.name)                   0.113s  0.117s  0.115s  0.114s  0.112s
-  @csv                         0.118s  0.123s  0.117s  0.122s  0.118s
-  split/join                   0.088s  0.090s  0.088s  0.089s  0.094s
-  select|field                 0.097s  0.097s  0.098s  0.097s  0.099s
-  select|remap                 0.102s  0.100s  0.101s  0.099s  0.107s
-  computed remap               0.224s  0.206s  0.205s  0.201s  0.201s
-  [.x,.y]|add                  0.084s  0.090s  0.091s  0.089s  0.090s
-  [.x,.y]|avg                  0.112s  0.112s  0.114s  0.113s  0.115s
-  map(*2)|add                  0.102s  0.108s  0.108s  0.108s  0.107s
-  keys|length                  0.253s  0.263s  0.260s  0.261s  0.263s
-  .+{z=0}                      0.150s  0.150s  0.152s  0.158s  0.159s
-  split|first                  0.086s  0.088s  0.090s  0.088s  0.089s
-  slice[0..5]                  0.091s  0.091s  0.093s  0.095s  0.096s
-  dynkey {(.name)}             0.117s  0.115s  0.115s  0.115s  0.114s
-  .x += 1                      0.128s  0.133s  0.135s  0.133s  0.138s
-  {a}+{b} merge                0.166s  0.132s  0.131s  0.137s  0.132s
-  .x*2+1                       0.062s  0.062s  0.062s  0.062s  0.064s
-  .x+.y*2                      0.100s  0.100s  0.101s  0.101s  0.103s
-  .x > .y                      0.078s  0.080s  0.082s  0.082s  0.083s
-  to_entries|len               0.387s  0.392s  0.388s  0.389s  0.409s
-  .x|.+1 (pipe)                0.058s  0.058s  0.058s  0.058s  0.058s
-  .x|.*2|.+1                   0.061s  0.062s  0.062s  0.062s  0.062s
-  .name|.+"_x"                 0.093s  0.093s  0.095s  0.094s  0.094s
-  .x>N | not                   0.051s  0.052s  0.051s  0.052s  0.054s
-  and (2 cmp)                  0.085s  0.085s  0.087s  0.084s  0.086s
-  if-then-else                 0.053s  0.054s  0.053s  0.052s  0.055s
-  sel(and)|field               0.079s  0.080s  0.083s  0.086s  0.082s
-  sel(and)|remap               0.080s  0.083s  0.085s  0.084s  0.085s
-  arith|cmp                    0.054s  0.057s  0.055s  0.056s  0.057s
-  if cmp .field                0.122s  0.115s  0.116s  0.113s  0.118s
-  split|length                 0.086s  0.090s  0.087s  0.089s  0.089s
-  [x,y]|min                    0.093s  0.098s  0.098s  0.096s  0.095s
-  [x,y]|max                    0.097s  0.099s  0.102s  0.099s  0.101s
-  [x,y]|sort|.[0]              0.093s  0.099s  0.097s  0.094s  0.098s
-  .name|len>5                  0.085s  0.088s  0.087s  0.086s  0.092s
-  sel(len>5)|.x                0.108s  0.112s  0.109s  0.113s  0.116s
-  if .x>.y .name               0.092s  0.094s  0.098s  0.092s  0.095s
-  sel(.x>.y)|.name             0.071s  0.076s  0.076s  0.077s  0.076s
-  .x*2|tostring                0.057s  0.057s  0.060s  0.058s  0.059s
-  .x*.x+1                      0.067s  0.067s  0.068s  0.069s  0.070s
-  {k=.name,v=tostr}            0.170s  0.144s  0.143s  0.145s  0.147s
-  str add chain                0.385s  0.403s  0.396s  0.395s  0.397s
-  if>.y .name|empty            0.074s  0.078s  0.078s  0.077s  0.077s
-  if .x%2==0                   0.054s  0.057s  0.055s  0.055s  0.057s
-  if .x*2+1>1M                 0.057s  0.057s  0.057s  0.056s  0.058s
-  sel(.x%2==0)|.name           0.084s  0.084s  0.086s  0.085s  0.086s
-  sel(.x*2+1>1M)               0.153s  0.161s  0.160s  0.162s  0.167s
-  .x|@json                     0.060s  0.061s  0.062s  0.061s  0.051s
-  .x|@text                     0.060s  0.062s  0.059s  0.062s  0.052s
-  .name|@json                  0.104s  0.105s  0.100s  0.103s  0.101s
-  sel|[arr]                    0.180s  0.184s  0.173s  0.175s  0.184s
-  sel(and)|[arr]               0.080s  0.084s  0.080s  0.080s  0.084s
-  if>.y [arr]                  0.217s  0.221s  0.216s  0.214s  0.216s
-  if sw then .f                0.142s  0.144s  0.141s  0.143s  0.145s
-  dynkey {(.n)=.x*2}           0.119s  0.117s  0.113s  0.117s  0.114s
-  sel(and)|.x*.y               0.079s  0.082s  0.084s  0.080s  0.083s
-  sel>N|str chain              0.166s  0.167s  0.161s  0.166s  0.167s
-  .f+"_"+arith_ts              0.137s  0.137s  0.135s  0.140s  0.139s
-  sel(sw)|str ch               0.309s  0.317s  0.309s  0.320s  0.326s
-  split|rev|join               0.116s  0.115s  0.117s  0.118s  0.122s
-  dynkey+static                0.351s  0.343s  0.348s  0.344s  0.360s
-  if>.y str chain              0.173s  0.171s  0.173s  0.172s  0.181s
-  remap+str chain              0.178s  0.165s  0.167s  0.163s  0.175s
-  sel(len>8)                   0.161s  0.163s  0.159s  0.163s  0.168s
-  up|split|join                0.096s  0.097s  0.097s  0.098s  0.098s
-  .name|index                  0.118s  0.119s  0.121s  0.121s  0.125s
-  .name|index+1                0.121s  0.128s  0.127s  0.127s  0.129s
-  .name|rindex                 0.129s  0.127s  0.128s  0.130s  0.132s
-  .name|indices                0.147s  0.151s  0.148s  0.151s  0.151s
-  [x,y]|sort                   0.178s  0.178s  0.179s  0.183s  0.179s
-  .name|scan                   0.204s  0.204s  0.203s  0.210s  0.205s
-  .name|gsub                   0.164s  0.168s  0.166s  0.166s  0.166s
-  walk(if num .+1)             0.142s  0.141s  0.142s  0.143s  0.143s
-  tojson                       0.117s  0.119s  0.118s  0.119s  0.126s
-  {name,x}                     0.166s  0.127s  0.135s  0.131s  0.132s
-  .z//.name                    0.174s  0.177s  0.175s  0.179s  0.184s
-  .x|=test(re)                 0.174s  0.173s  0.171s  0.174s  0.175s
-  ./sep|first                  0.180s  0.185s  0.189s  0.188s  0.192s
-  .y=(.x*2)                    0.179s  0.183s  0.180s  0.184s  0.187s
-  .y=(.x+.y)                   0.237s  0.234s  0.235s  0.238s  0.244s
-  objects                      0.146s  0.150s  0.145s  0.140s  0.152s
-  .tag|=if..then N             0.624s  0.613s  0.615s  0.612s  0.634s
-  .x=(.x+1)                    0.127s  0.133s  0.131s  0.138s  0.140s
-  sel>N|.y+=1                  0.125s  0.127s  0.127s  0.129s  0.130s
-  sel(and)|.x+=1               0.108s  0.109s  0.107s  0.108s  0.108s
-  sel(sw)|.x+=1                0.165s  0.169s  0.165s  0.166s  0.167s
-  match(re)                    0.372s  0.382s  0.369s  0.376s  0.378s
-  capture(re)                  0.303s  0.301s  0.294s  0.305s  0.315s
-  first(.name,.x)              0.116s  0.083s  0.082s  0.081s  0.085s
-  if .x==null                  0.048s  0.049s  0.050s  0.048s  0.049s
-  we(sw(.key))                 0.117s  0.118s  0.120s  0.120s  0.120s
-  sel(sw or ew)                0.199s  0.208s  0.203s  0.210s  0.212s
-  path(.name,.x)               0.300s  0.308s  0.311s  0.307s  0.354s
-  sel(str+num+num)             0.154s  0.155s  0.154s  0.152s  0.162s
-  nested if|field              0.079s  0.084s  0.083s  0.082s  0.084s
-  .f|floor|.*2                 0.062s  0.062s  0.063s  0.063s  0.065s
-  split|len>1                  0.110s  0.110s  0.111s  0.113s  0.116s
-  .name|len|.*2                0.102s  0.104s  0.100s  0.103s  0.105s
-  if len>5 .x .y               0.114s  0.114s  0.113s  0.112s  0.121s
-  sel(len>5)|remap             0.203s  0.204s  0.205s  0.206s  0.216s
-  .x|tostr|len                 0.059s  0.061s  0.061s  0.061s  0.063s
-  if .x>.y .x .y               0.096s  0.097s  0.104s  0.099s  0.101s
-  split|last|tonum             0.094s  0.096s  0.095s  0.093s  0.099s
-  split|rev|.[0]               0.091s  0.094s  0.089s  0.092s  0.094s
-  split|.[0]+.[1]              0.111s  0.112s  0.113s  0.113s  0.116s
-  .[]|strings                  0.105s  0.110s  0.103s  0.106s  0.109s
-  .[]|numbers                  0.124s  0.127s  0.125s  0.127s  0.130s
-  [x,y]|any(>1M)               0.084s  0.087s  0.088s  0.088s  0.092s
-  sel(dc|sw)                   0.095s  0.095s  0.097s  0.097s  0.100s
-  [[x,y],[n]]|flat             0.488s  0.460s  0.460s  0.459s  0.551s
-  .x|floor|.*2                 0.062s  0.064s  0.063s  0.062s  0.063s
-  tojson|fromjson              0.084s  0.085s  0.087s  0.089s  0.090s
-  [.x]|add                     0.071s  0.048s  0.049s  0.050s  0.051s
-  if>N {o}+.                   0.137s  0.137s  0.136s  0.138s  0.144s
-  if>N .+{o}                   0.133s  0.132s  0.137s  0.142s  0.143s
-  if .n=="s" .+{o}             0.159s  0.160s  0.158s  0.157s  0.168s
-  sel(.n>"s")                  0.088s  0.089s  0.087s  0.087s  0.091s
-  [x,y,z]|min                  0.313s  0.315s  0.318s  0.316s  0.305s
-  if .n|len>5 l s              0.101s  0.101s  0.100s  0.100s  0.104s
-  if .x|flr>N b s              0.056s  0.056s  0.056s  0.056s  0.058s
-  if .n|test l e               0.104s  0.105s  0.106s  0.101s  0.108s
-  if .n|sw l e                 0.083s  0.086s  0.086s  0.083s  0.087s
-  if .n|ew l e                 0.084s  0.086s  0.084s  0.085s  0.088s
-  .n|len|tostr                 0.089s  0.092s  0.091s  0.092s  0.090s
+  Benchmark                    v1.9.0  v1.9.1  v1.9.2  v1.10.0  v1.11.0
+  ---                          ------  ------  ------  -------  -------
+  empty                        0.018s  0.018s  0.019s  0.019s   0.017s
+  identity -c                  0.088s  0.085s  0.087s  0.088s   0.089s
+  identity (pretty)            0.109s  0.112s  0.111s  0.109s   0.104s
+  field access .name           0.084s  0.081s  0.084s  0.085s   0.081s
+  nested .x,.y,.name           0.119s  0.123s  0.121s  0.121s   0.119s
+  arithmetic .x + .y           0.088s  0.090s  0.088s  0.091s   0.083s
+  select .x > 1500000          0.083s  0.083s  0.084s  0.088s   0.082s
+  string concat                0.092s  0.094s  0.096s  0.095s   0.092s
+  object construct             0.118s  0.120s  0.121s  0.124s   0.117s
+  array construct              0.108s  0.105s  0.106s  0.111s   0.103s
+  .[]                          0.120s  0.120s  0.120s  0.121s   0.118s
+  to_entries                   0.155s  0.151s  0.150s  0.151s   0.148s
+  keys                         0.107s  0.104s  0.104s  0.109s   0.104s
+  keys_unsorted                0.101s  0.102s  0.103s  0.104s   0.100s
+  length                       0.090s  0.087s  0.092s  0.086s   0.085s
+  has("x")                     0.040s  0.039s  0.040s  0.040s   0.037s
+  type                         0.021s  0.020s  0.020s  0.021s   0.019s
+  del(.name)                   0.117s  0.115s  0.114s  0.112s   0.101s
+  @csv                         0.123s  0.117s  0.122s  0.118s   0.116s
+  split/join                   0.090s  0.088s  0.089s  0.094s   0.088s
+  select|field                 0.097s  0.098s  0.097s  0.099s   0.099s
+  select|remap                 0.100s  0.101s  0.099s  0.107s   0.096s
+  computed remap               0.206s  0.205s  0.201s  0.201s   0.201s
+  [.x,.y]|add                  0.090s  0.091s  0.089s  0.090s   0.086s
+  [.x,.y]|avg                  0.112s  0.114s  0.113s  0.115s   0.110s
+  map(*2)|add                  0.108s  0.108s  0.108s  0.107s   0.102s
+  keys|length                  0.263s  0.260s  0.261s  0.263s   0.260s
+  .+{z=0}                      0.150s  0.152s  0.158s  0.159s   0.156s
+  split|first                  0.088s  0.090s  0.088s  0.089s   0.086s
+  slice[0..5]                  0.091s  0.093s  0.095s  0.096s   0.089s
+  dynkey {(.name)}             0.115s  0.115s  0.115s  0.114s   0.111s
+  .x += 1                      0.133s  0.135s  0.133s  0.138s   0.129s
+  {a}+{b} merge                0.132s  0.131s  0.137s  0.132s   0.130s
+  .x*2+1                       0.062s  0.062s  0.062s  0.064s   0.059s
+  .x+.y*2                      0.100s  0.101s  0.101s  0.103s   0.099s
+  .x > .y                      0.080s  0.082s  0.082s  0.083s   0.078s
+  to_entries|len               0.392s  0.388s  0.389s  0.409s   0.395s
+  .x|.+1 (pipe)                0.058s  0.058s  0.058s  0.058s   0.057s
+  .x|.*2|.+1                   0.062s  0.062s  0.062s  0.062s   0.060s
+  .name|.+"_x"                 0.093s  0.095s  0.094s  0.094s   0.093s
+  .x>N | not                   0.052s  0.051s  0.052s  0.054s   0.050s
+  and (2 cmp)                  0.085s  0.087s  0.084s  0.086s   0.083s
+  if-then-else                 0.054s  0.053s  0.052s  0.055s   0.052s
+  sel(and)|field               0.080s  0.083s  0.086s  0.082s   0.079s
+  sel(and)|remap               0.083s  0.085s  0.084s  0.085s   0.079s
+  arith|cmp                    0.057s  0.055s  0.056s  0.057s   0.055s
+  if cmp .field                0.115s  0.116s  0.113s  0.118s   0.111s
+  split|length                 0.090s  0.087s  0.089s  0.089s   0.086s
+  [x,y]|min                    0.098s  0.098s  0.096s  0.095s   0.091s
+  [x,y]|max                    0.099s  0.102s  0.099s  0.101s   0.099s
+  [x,y]|sort|.[0]              0.099s  0.097s  0.094s  0.098s   0.092s
+  .name|len>5                  0.088s  0.087s  0.086s  0.092s   0.084s
+  sel(len>5)|.x                0.112s  0.109s  0.113s  0.116s   0.111s
+  if .x>.y .name               0.094s  0.098s  0.092s  0.095s   0.090s
+  sel(.x>.y)|.name             0.076s  0.076s  0.077s  0.076s   0.073s
+  .x*2|tostring                0.057s  0.060s  0.058s  0.059s   0.058s
+  .x*.x+1                      0.067s  0.068s  0.069s  0.070s   0.066s
+  {k=.name,v=tostr}            0.144s  0.143s  0.145s  0.147s   0.140s
+  str add chain                0.403s  0.396s  0.395s  0.397s   0.385s
+  if>.y .name|empty            0.078s  0.078s  0.077s  0.077s   0.076s
+  if .x%2==0                   0.057s  0.055s  0.055s  0.057s   0.053s
+  if .x*2+1>1M                 0.057s  0.057s  0.056s  0.058s   0.057s
+  sel(.x%2==0)|.name           0.084s  0.086s  0.085s  0.086s   0.082s
+  sel(.x*2+1>1M)               0.161s  0.160s  0.162s  0.167s   0.157s
+  .x|@json                     0.061s  0.062s  0.061s  0.051s   0.048s
+  .x|@text                     0.062s  0.059s  0.062s  0.052s   0.048s
+  .name|@json                  0.105s  0.100s  0.103s  0.101s   0.093s
+  sel|[arr]                    0.184s  0.173s  0.175s  0.184s   0.168s
+  sel(and)|[arr]               0.084s  0.080s  0.080s  0.084s   0.080s
+  if>.y [arr]                  0.221s  0.216s  0.214s  0.216s   0.207s
+  if sw then .f                0.144s  0.141s  0.143s  0.145s   0.134s
+  dynkey {(.n)=.x*2}           0.117s  0.113s  0.117s  0.114s   0.109s
+  sel(and)|.x*.y               0.082s  0.084s  0.080s  0.083s   0.077s
+  sel>N|str chain              0.167s  0.161s  0.166s  0.167s   0.158s
+  .f+"_"+arith_ts              0.137s  0.135s  0.140s  0.139s   0.133s
+  sel(sw)|str ch               0.317s  0.309s  0.320s  0.326s   0.303s
+  split|rev|join               0.115s  0.117s  0.118s  0.122s   0.109s
+  dynkey+static                0.343s  0.348s  0.344s  0.360s   0.303s
+  if>.y str chain              0.171s  0.173s  0.172s  0.181s   0.172s
+  remap+str chain              0.165s  0.167s  0.163s  0.175s   0.161s
+  sel(len>8)                   0.163s  0.159s  0.163s  0.168s   0.155s
+  up|split|join                0.097s  0.097s  0.098s  0.098s   0.092s
+  .name|index                  0.119s  0.121s  0.121s  0.125s   0.117s
+  .name|index+1                0.128s  0.127s  0.127s  0.129s   0.120s
+  .name|rindex                 0.127s  0.128s  0.130s  0.132s   0.122s
+  .name|indices                0.151s  0.148s  0.151s  0.151s   0.143s
+  [x,y]|sort                   0.178s  0.179s  0.183s  0.179s   0.175s
+  .name|scan                   0.204s  0.203s  0.210s  0.205s   0.202s
+  .name|gsub                   0.168s  0.166s  0.166s  0.166s   0.166s
+  walk(if num .+1)             0.141s  0.142s  0.143s  0.143s   0.138s
+  tojson                       0.119s  0.118s  0.119s  0.126s   0.122s
+  {name,x}                     0.127s  0.135s  0.131s  0.132s   0.125s
+  .z//.name                    0.177s  0.175s  0.179s  0.184s   0.173s
+  .x|=test(re)                 0.173s  0.171s  0.174s  0.175s   0.170s
+  ./sep|first                  0.185s  0.189s  0.188s  0.192s   0.182s
+  .y=(.x*2)                    0.183s  0.180s  0.184s  0.187s   0.173s
+  .y=(.x+.y)                   0.234s  0.235s  0.238s  0.244s   0.225s
+  objects                      0.150s  0.145s  0.140s  0.152s   0.133s
+  .tag|=if..then N             0.613s  0.615s  0.612s  0.634s   0.602s
+  .x=(.x+1)                    0.133s  0.131s  0.138s  0.140s   0.129s
+  sel>N|.y+=1                  0.127s  0.127s  0.129s  0.130s   0.121s
+  sel(and)|.x+=1               0.109s  0.107s  0.108s  0.108s   0.105s
+  sel(sw)|.x+=1                0.169s  0.165s  0.166s  0.167s   0.159s
+  match(re)                    0.382s  0.369s  0.376s  0.378s   0.371s
+  capture(re)                  0.301s  0.294s  0.305s  0.315s   0.293s
+  first(.name,.x)              0.083s  0.082s  0.081s  0.085s   0.080s
+  if .x==null                  0.049s  0.050s  0.048s  0.049s   0.047s
+  we(sw(.key))                 0.118s  0.120s  0.120s  0.120s   0.114s
+  sel(sw or ew)                0.208s  0.203s  0.210s  0.212s   0.197s
+  path(.name,.x)               0.308s  0.311s  0.307s  0.354s   0.313s
+  sel(str+num+num)             0.155s  0.154s  0.152s  0.162s   0.147s
+  nested if|field              0.084s  0.083s  0.082s  0.084s   0.078s
+  .f|floor|.*2                 0.062s  0.063s  0.063s  0.065s   0.062s
+  split|len>1                  0.110s  0.111s  0.113s  0.116s   0.110s
+  .name|len|.*2                0.104s  0.100s  0.103s  0.105s   0.097s
+  if len>5 .x .y               0.114s  0.113s  0.112s  0.121s   0.109s
+  sel(len>5)|remap             0.204s  0.205s  0.206s  0.216s   0.194s
+  .x|tostr|len                 0.061s  0.061s  0.061s  0.063s   0.059s
+  if .x>.y .x .y               0.097s  0.104s  0.099s  0.101s   0.092s
+  split|last|tonum             0.096s  0.095s  0.093s  0.099s   0.091s
+  split|rev|.[0]               0.094s  0.089s  0.092s  0.094s   0.087s
+  split|.[0]+.[1]              0.112s  0.113s  0.113s  0.116s   0.109s
+  .[]|strings                  0.110s  0.103s  0.106s  0.109s   0.104s
+  .[]|numbers                  0.127s  0.125s  0.127s  0.130s   0.122s
+  [x,y]|any(>1M)               0.087s  0.088s  0.088s  0.092s   0.083s
+  sel(dc|sw)                   0.095s  0.097s  0.097s  0.100s   0.092s
+  [[x,y],[n]]|flat             0.460s  0.460s  0.459s  0.551s   0.489s
+  .x|floor|.*2                 0.064s  0.063s  0.062s  0.063s   0.060s
+  tojson|fromjson              0.085s  0.087s  0.089s  0.090s   0.083s
+  [.x]|add                     0.048s  0.049s  0.050s  0.051s   0.047s
+  if>N {o}+.                   0.137s  0.136s  0.138s  0.144s   0.134s
+  if>N .+{o}                   0.132s  0.137s  0.142s  0.143s   0.135s
+  if .n=="s" .+{o}             0.160s  0.158s  0.157s  0.168s   0.160s
+  sel(.n>"s")                  0.089s  0.087s  0.087s  0.091s   0.084s
+  [x,y,z]|min                  0.315s  0.318s  0.316s  0.305s   0.300s
+  if .n|len>5 l s              0.101s  0.100s  0.100s  0.104s   0.095s
+  if .x|flr>N b s              0.056s  0.056s  0.056s  0.058s   0.054s
+  if .n|test l e               0.105s  0.106s  0.101s  0.108s   0.102s
+  if .n|sw l e                 0.086s  0.086s  0.083s  0.087s   0.080s
+  if .n|ew l e                 0.086s  0.084s  0.085s  0.088s   0.082s
+  .n|len|tostr                 0.092s  0.091s  0.092s  0.090s   0.088s
 
 --- String operations (2M objects) ---
-  Benchmark                    v1.8.3  v1.9.0  v1.9.1  v1.9.2  v1.10.0
-  ---                          ------  ------  ------  ------  -------
-  ascii_downcase               0.092s  0.095s  0.094s  0.095s  0.095s
-  ascii_upcase                 0.094s  0.094s  0.096s  0.095s  0.095s
-  ltrimstr                     0.095s  0.095s  0.098s  0.095s  0.099s
-  rtrimstr                     0.097s  0.094s  0.098s  0.096s  0.098s
-  split                        0.157s  0.159s  0.162s  0.164s  0.161s
-  case+split                   0.116s  0.114s  0.117s  0.120s  0.120s
-  join                         0.096s  0.092s  0.097s  0.096s  0.097s
-  startswith                   0.090s  0.090s  0.091s  0.090s  0.089s
-  endswith                     0.088s  0.093s  0.091s  0.089s  0.092s
-  tostring                     0.064s  0.065s  0.066s  0.065s  0.067s
-  tonumber                     0.108s  0.113s  0.111s  0.113s  0.113s
-  string interpolation         0.127s  0.126s  0.124s  0.128s  0.123s
+  Benchmark                    v1.9.0  v1.9.1  v1.9.2  v1.10.0  v1.11.0
+  ---                          ------  ------  ------  -------  -------
+  ascii_downcase               0.095s  0.094s  0.095s  0.095s   0.091s
+  ascii_upcase                 0.094s  0.096s  0.095s  0.095s   0.090s
+  ltrimstr                     0.095s  0.098s  0.095s  0.099s   0.092s
+  rtrimstr                     0.094s  0.098s  0.096s  0.098s   0.093s
+  split                        0.159s  0.162s  0.164s  0.161s   0.151s
+  case+split                   0.114s  0.117s  0.120s  0.120s   0.110s
+  join                         0.092s  0.097s  0.096s  0.097s   0.090s
+  startswith                   0.090s  0.091s  0.090s  0.089s   0.085s
+  endswith                     0.093s  0.091s  0.089s  0.092s   0.086s
+  tostring                     0.065s  0.066s  0.065s  0.067s   0.064s
+  tonumber                     0.113s  0.111s  0.113s  0.113s   0.105s
+  string interpolation         0.126s  0.124s  0.128s  0.123s   0.108s
 
 --- String ops (200K objects) ---
-  Benchmark                    v1.8.3  v1.9.0  v1.9.1  v1.9.2  v1.10.0
-  ---                          ------  ------  ------  ------  -------
-  test (regex)                 0.014s  0.015s  0.015s  0.015s  0.015s
-  match (regex)                0.033s  0.033s  0.033s  0.033s  0.035s
-  @base64                      0.011s  0.012s  0.012s  0.012s  0.012s
-  @uri                         0.011s  0.013s  0.012s  0.012s  0.012s
-  @html                        0.012s  0.013s  0.012s  0.012s  0.013s
-  @csv (array)                 0.016s  0.016s  0.016s  0.016s  0.017s
-  @tsv (array)                 0.015s  0.016s  0.017s  0.017s  0.018s
-  gsub                         0.018s  0.019s  0.019s  0.019s  0.020s
-  case+gsub                    0.181s  0.178s  0.181s  0.180s  0.184s
-  case+test                    0.118s  0.119s  0.117s  0.119s  0.124s
-  ltrim+tonum+arith            0.110s  0.116s  0.112s  0.111s  0.119s
+  Benchmark                    v1.9.0  v1.9.1  v1.9.2  v1.10.0  v1.11.0
+  ---                          ------  ------  ------  -------  -------
+  test (regex)                 0.015s  0.015s  0.015s  0.015s   0.014s
+  match (regex)                0.033s  0.033s  0.033s  0.035s   0.032s
+  @base64                      0.012s  0.012s  0.012s  0.012s   0.011s
+  @uri                         0.013s  0.012s  0.012s  0.012s   0.011s
+  @html                        0.013s  0.012s  0.012s  0.013s   0.010s
+  @csv (array)                 0.016s  0.016s  0.016s  0.017s   0.015s
+  @tsv (array)                 0.016s  0.017s  0.017s  0.018s   0.015s
+  gsub                         0.019s  0.019s  0.019s  0.020s   0.018s
+  case+gsub                    0.178s  0.181s  0.180s  0.184s   0.176s
+  case+test                    0.119s  0.117s  0.119s  0.124s   0.116s
+  ltrim+tonum+arith            0.116s  0.112s  0.111s  0.119s   0.107s
 
 --- Numeric & math (2M objects) ---
-  Benchmark                    v1.8.3  v1.9.0  v1.9.1  v1.9.2  v1.10.0
-  ---                          ------  ------  ------  ------  -------
-  floor                        0.058s  0.058s  0.060s  0.059s  0.062s
-  sqrt                         0.079s  0.081s  0.080s  0.079s  0.084s
-  modulo                       0.059s  0.059s  0.060s  0.059s  0.062s
-  if-elif-else                 0.131s  0.127s  0.127s  0.130s  0.136s
-  select|del                   0.096s  0.100s  0.099s  0.098s  0.104s
-  select|merge                 0.121s  0.121s  0.121s  0.123s  0.128s
-  select(test)|merge           0.021s  0.023s  0.022s  0.022s  0.023s
+  Benchmark                    v1.9.0  v1.9.1  v1.9.2  v1.10.0  v1.11.0
+  ---                          ------  ------  ------  -------  -------
+  floor                        0.058s  0.060s  0.059s  0.062s   0.057s
+  sqrt                         0.081s  0.080s  0.079s  0.084s   0.078s
+  modulo                       0.059s  0.060s  0.059s  0.062s   0.058s
+  if-elif-else                 0.127s  0.127s  0.130s  0.136s   0.127s
+  select|del                   0.100s  0.099s  0.098s  0.104s   0.089s
+  select|merge                 0.121s  0.121s  0.123s  0.128s   0.120s
+  select(test)|merge           0.023s  0.022s  0.022s  0.023s   0.021s
 
 --- Array generators ---
-  Benchmark                    v1.8.3  v1.9.0  v1.9.1  v1.9.2  v1.10.0
-  ---                          ------  ------  ------  ------  -------
-  range(2M) | length           0.011s  0.009s  0.009s  0.009s  0.009s
-  reverse(2M)                  0.018s  0.016s  0.016s  0.018s  0.017s
-  sort(2M)                     0.024s  0.025s  0.026s  0.027s  0.026s
-  unique(1M)                   0.033s  0.034s  0.034s  0.035s  0.034s
-  flatten(500K)                0.010s  0.010s  0.010s  0.010s  0.010s
-  min, max(2M)                 0.020s  0.016s  0.017s  0.017s  0.016s
-  add numbers(2M)              0.013s  0.011s  0.011s  0.010s  0.011s
-  any/all(2M)                  0.028s  0.031s  0.032s  0.031s  0.031s
-  limit(10; range(10M))        0.002s  0.003s  0.003s  0.003s  0.003s
-  first(range(10M))            0.002s  0.003s  0.002s  0.003s  0.003s
-  last(range(2M))              0.002s  0.003s  0.002s  0.003s  0.003s
-  indices(1M)                  0.017s  0.018s  0.017s  0.018s  0.018s
+  Benchmark                    v1.9.0  v1.9.1  v1.9.2  v1.10.0  v1.11.0
+  ---                          ------  ------  ------  -------  -------
+  range(2M) | length           0.009s  0.009s  0.009s  0.009s   0.008s
+  reverse(2M)                  0.016s  0.016s  0.018s  0.017s   0.015s
+  sort(2M)                     0.025s  0.026s  0.027s  0.026s   0.024s
+  unique(1M)                   0.034s  0.034s  0.035s  0.034s   0.034s
+  flatten(500K)                0.010s  0.010s  0.010s  0.010s   0.010s
+  min, max(2M)                 0.016s  0.017s  0.017s  0.016s   0.017s
+  add numbers(2M)              0.011s  0.011s  0.010s  0.011s   0.009s
+  any/all(2M)                  0.031s  0.032s  0.031s  0.031s   0.030s
+  limit(10; range(10M))        0.003s  0.003s  0.003s  0.003s   0.002s
+  first(range(10M))            0.003s  0.002s  0.003s  0.003s   0.002s
+  last(range(2M))              0.003s  0.002s  0.003s  0.003s   0.002s
+  indices(1M)                  0.018s  0.017s  0.018s  0.018s   0.017s
 
 --- Reduce & foreach ---
-  Benchmark                    v1.8.3  v1.9.0  v1.9.1  v1.9.2  v1.10.0
-  ---                          ------  ------  ------  ------  -------
-  reduce (sum)                 0.009s  0.010s  0.010s  0.010s  0.010s
-  reduce (array build)         0.004s  0.005s  0.005s  0.005s  0.005s
-  reduce (obj build)           0.010s  0.010s  0.010s  0.010s  0.011s
-  reduce (setpath)             0.016s  0.018s  0.017s  0.017s  0.019s
-  foreach (running sum)        0.010s  0.011s  0.011s  0.011s  0.011s
-  foreach + emit               0.010s  0.011s  0.011s  0.011s  0.011s
-  reduce (sum-of-squares)      0.033s  0.036s  0.034s  0.036s  0.037s
-  reduce (conditional)         0.035s  0.037s  0.037s  0.037s  0.038s
-  reduce (product)             0.034s  0.036s  0.035s  0.036s  0.040s
-  foreach (conditional)        0.010s  0.011s  0.011s  0.011s  0.012s
-  until (100M)                 0.312s  0.322s  0.325s  0.324s  0.348s
-  reduce (harmonic)            0.035s  0.036s  0.035s  0.035s  0.037s
-  reduce (floor pipe)          0.033s  0.035s  0.034s  0.035s  0.036s
-  reduce (sqrt pipe)           0.034s  0.035s  0.035s  0.035s  0.037s
-  reduce (sin+cos)             0.052s  0.053s  0.053s  0.052s  0.054s
+  Benchmark                    v1.9.0  v1.9.1  v1.9.2  v1.10.0  v1.11.0
+  ---                          ------  ------  ------  -------  -------
+  reduce (sum)                 0.010s  0.010s  0.010s  0.010s   0.009s
+  reduce (array build)         0.005s  0.005s  0.005s  0.005s   0.004s
+  reduce (obj build)           0.010s  0.010s  0.010s  0.011s   0.009s
+  reduce (setpath)             0.018s  0.017s  0.017s  0.019s   0.017s
+  foreach (running sum)        0.011s  0.011s  0.011s  0.011s   0.010s
+  foreach + emit               0.011s  0.011s  0.011s  0.011s   0.010s
+  reduce (sum-of-squares)      0.036s  0.034s  0.036s  0.037s   0.032s
+  reduce (conditional)         0.037s  0.037s  0.037s  0.038s   0.035s
+  reduce (product)             0.036s  0.035s  0.036s  0.040s   0.034s
+  foreach (conditional)        0.011s  0.011s  0.011s  0.012s   0.011s
+  until (100M)                 0.322s  0.325s  0.324s  0.348s   0.298s
+  reduce (harmonic)            0.036s  0.035s  0.035s  0.037s   0.032s
+  reduce (floor pipe)          0.035s  0.034s  0.035s  0.036s   0.032s
+  reduce (sqrt pipe)           0.035s  0.035s  0.035s  0.037s   0.032s
+  reduce (sin+cos)             0.053s  0.053s  0.052s  0.054s   0.051s
 
 --- Object operations ---
-  Benchmark                    v1.8.3  v1.9.0  v1.9.1  v1.9.2  v1.10.0
-  ---                          ------  ------  ------  ------  -------
-  large obj construct          0.004s  0.004s  0.004s  0.004s  0.004s
-  large obj keys               0.011s  0.011s  0.011s  0.011s  0.012s
-  large obj to_entries         0.012s  0.012s  0.012s  0.013s  0.013s
-  with_entries                 0.009s  0.009s  0.010s  0.010s  0.010s
+  Benchmark                    v1.9.0  v1.9.1  v1.9.2  v1.10.0  v1.11.0
+  ---                          ------  ------  ------  -------  -------
+  large obj construct          0.004s  0.004s  0.004s  0.004s   0.004s
+  large obj keys               0.011s  0.011s  0.011s  0.012s   0.011s
+  large obj to_entries         0.012s  0.012s  0.013s  0.013s   0.012s
+  with_entries                 0.009s  0.010s  0.010s  0.010s   0.009s
 
 --- Assignment operators ---
-  Benchmark                    v1.8.3  v1.9.0  v1.9.1  v1.9.2  v1.10.0
-  ---                          ------  ------  ------  ------  -------
-  .[] |= f (100K)              0.005s  0.005s  0.006s  0.005s  0.006s
-  .[] += 1 (100K)              0.005s  0.006s  0.006s  0.006s  0.006s
-  .[k] = v reduce(50K)         0.008s  0.009s  0.009s  0.009s  0.009s
-  p126-shape nested reduce     0.121s  0.118s  0.120s  0.119s  0.114s
-  p126-shape w/ mutate         0.124s  0.124s  0.120s  0.132s  0.117s
-  p150-shape serial mutate     0.012s  0.013s  0.012s  0.013s  0.013s
+  Benchmark                    v1.9.0  v1.9.1  v1.9.2  v1.10.0  v1.11.0
+  ---                          ------  ------  ------  -------  -------
+  .[] |= f (100K)              0.005s  0.006s  0.005s  0.006s   0.005s
+  .[] += 1 (100K)              0.006s  0.006s  0.006s  0.006s   0.005s
+  .[k] = v reduce(50K)         0.009s  0.009s  0.009s  0.009s   0.008s
+  p126-shape nested reduce     0.118s  0.120s  0.119s  0.114s   0.105s
+  p126-shape w/ mutate         0.124s  0.120s  0.132s  0.117s   0.103s
+  p150-shape serial mutate     0.013s  0.012s  0.013s  0.013s   0.012s
 
 --- String-heavy generators ---
-  Benchmark                    v1.8.3  v1.9.0  v1.9.1  v1.9.2  v1.10.0
-  ---                          ------  ------  ------  ------  -------
-  gsub(100K)                   0.028s  0.029s  0.029s  0.029s  0.029s
-  join large(100K)             0.006s  0.006s  0.006s  0.006s  0.006s
-  explode/implode(100K)        0.027s  0.029s  0.028s  0.028s  0.029s
-  reduce str concat(100K)      0.008s  0.008s  0.008s  0.008s  0.009s
+  Benchmark                    v1.9.0  v1.9.1  v1.9.2  v1.10.0  v1.11.0
+  ---                          ------  ------  ------  -------  -------
+  gsub(100K)                   0.029s  0.029s  0.029s  0.029s   0.028s
+  join large(100K)             0.006s  0.006s  0.006s  0.006s   0.005s
+  explode/implode(100K)        0.029s  0.028s  0.028s  0.029s   0.028s
+  reduce str concat(100K)      0.008s  0.008s  0.008s  0.009s   0.008s
 
 --- Try-catch & alternative ---
-  Benchmark                    v1.8.3  v1.9.0  v1.9.1  v1.9.2  v1.10.0
-  ---                          ------  ------  ------  ------  -------
-  alternative //               0.033s  0.034s  0.034s  0.034s  0.035s
-  try-catch                    0.024s  0.024s  0.024s  0.025s  0.026s
-  label-break                  0.004s  0.004s  0.004s  0.004s  0.005s
+  Benchmark                    v1.9.0  v1.9.1  v1.9.2  v1.10.0  v1.11.0
+  ---                          ------  ------  ------  -------  -------
+  alternative //               0.034s  0.034s  0.034s  0.035s   0.033s
+  try-catch                    0.024s  0.024s  0.025s  0.026s   0.024s
+  label-break                  0.004s  0.004s  0.004s  0.005s   0.004s
 
 --- Type conversion ---
-  Benchmark                    v1.8.3  v1.9.0  v1.9.1  v1.9.2  v1.10.0
-  ---                          ------  ------  ------  ------  -------
-  tojson/fromjson(100K)        0.022s  0.022s  0.023s  0.022s  0.023s
-  null propagation(2M)         0.090s  0.091s  0.090s  0.090s  0.096s
+  Benchmark                    v1.9.0  v1.9.1  v1.9.2  v1.10.0  v1.11.0
+  ---                          ------  ------  ------  -------  -------
+  tojson/fromjson(100K)        0.022s  0.023s  0.022s  0.023s   0.022s
+  null propagation(2M)         0.091s  0.090s  0.090s  0.096s   0.089s
 
 --- jaq-derived ---
-  Benchmark                    v1.8.3  v1.9.0  v1.9.1  v1.9.2  v1.10.0
-  ---                          ------  ------  ------  ------  -------
-  jaq: reverse                 -       -       -       -       -
-  jaq: sort                    -       -       -       -       -
-  jaq: group-by                -       -       -       -       -
-  jaq: min-max                 -       -       -       -       -
-  jaq: ex-implode              -       -       -       -       -
-  jaq: repeat                  -       -       -       -       -
-  jaq: from                    -       -       -       -       -
-  jaq: last                    -       -       -       -       -
-  jaq: cumsum                  -       -       -       -       -
-  jaq: cumsum-xy               -       -       -       -       -
-  jaq: try-catch               -       -       -       -       -
-  jaq: add                     -       -       -       -       -
-  jaq: reduce                  -       -       -       -       -
-  jaq: reduce-update           -       -       -       -       -
-  jaq: kv                      -       -       -       -       -
-  jaq: kv-update               -       -       -       -       -
-  jaq: kv-entries              -       -       -       -       -
-  jaq: pyramid                 -       -       -       -       -
-  jaq: upto                    -       -       -       -       -
-  jaq: tree-flatten            -       -       -       -       -
-  jaq: tree-update             -       -       -       -       -
-  jaq: to-fromjson             -       -       -       -       -
-  jaq: str-slice               -       -       -       -       -
+  Benchmark                    v1.9.0  v1.9.1  v1.9.2  v1.10.0  v1.11.0
+  ---                          ------  ------  ------  -------  -------
+  jaq: reverse                 -       -       -       -        -
+  jaq: sort                    -       -       -       -        -
+  jaq: group-by                -       -       -       -        -
+  jaq: min-max                 -       -       -       -        -
+  jaq: ex-implode              -       -       -       -        -
+  jaq: repeat                  -       -       -       -        -
+  jaq: from                    -       -       -       -        -
+  jaq: last                    -       -       -       -        -
+  jaq: cumsum                  -       -       -       -        -
+  jaq: cumsum-xy               -       -       -       -        -
+  jaq: try-catch               -       -       -       -        -
+  jaq: add                     -       -       -       -        -
+  jaq: reduce                  -       -       -       -        -
+  jaq: reduce-update           -       -       -       -        -
+  jaq: kv                      -       -       -       -        -
+  jaq: kv-update               -       -       -       -        -
+  jaq: kv-entries              -       -       -       -        -
+  jaq: pyramid                 -       -       -       -        -
+  jaq: upto                    -       -       -       -        -
+  jaq: tree-flatten            -       -       -       -        -
+  jaq: tree-update             -       -       -       -        -
+  jaq: to-fromjson             -       -       -       -        -
+  jaq: str-slice               -       -       -       -        -
 
 --- Memoization (jqx) ---
-  Benchmark                    v1.8.3  v1.9.0  v1.9.1  v1.9.2  v1.10.0
-  ---                          ------  ------  ------  ------  -------
-  memo fib (1K)                0.003s  0.003s  0.003s  0.003s  0.004s
-  memo collatz sum (10K)       0.014s  0.015s  0.015s  0.015s  0.016s
-  memo by .id (100K, 1K keys)  0.020s  0.020s  0.021s  0.021s  0.023s
+  Benchmark                    v1.9.0  v1.9.1  v1.9.2  v1.10.0  v1.11.0
+  ---                          ------  ------  ------  -------  -------
+  memo fib (1K)                0.003s  0.003s  0.003s  0.004s   0.003s
+  memo collatz sum (10K)       0.015s  0.015s  0.015s  0.016s   0.014s
+  memo by .id (100K, 1K keys)  0.020s  0.021s  0.021s  0.023s   0.020s
 ```

--- a/docs/benchmark-history.tsv
+++ b/docs/benchmark-history.tsv
@@ -6674,3 +6674,223 @@ Type conversion	null propagation(2M)	v1.10.0	0.096
 Memoization (jqx)	memo fib (1K)	v1.10.0	0.004
 Memoization (jqx)	memo collatz sum (10K)	v1.10.0	0.016
 Memoization (jqx)	memo by .id (100K, 1K keys)	v1.10.0	0.023
+NDJSON workloads (2M objects)	empty	v1.11.0	0.017
+NDJSON workloads (2M objects)	identity -c	v1.11.0	0.089
+NDJSON workloads (2M objects)	identity (pretty)	v1.11.0	0.104
+NDJSON workloads (2M objects)	field access .name	v1.11.0	0.081
+NDJSON workloads (2M objects)	nested .x,.y,.name	v1.11.0	0.119
+NDJSON workloads (2M objects)	arithmetic .x + .y	v1.11.0	0.083
+NDJSON workloads (2M objects)	select .x > 1500000	v1.11.0	0.082
+NDJSON workloads (2M objects)	string concat	v1.11.0	0.092
+NDJSON workloads (2M objects)	object construct	v1.11.0	0.117
+NDJSON workloads (2M objects)	array construct	v1.11.0	0.103
+NDJSON workloads (2M objects)	.[]	v1.11.0	0.118
+NDJSON workloads (2M objects)	to_entries	v1.11.0	0.148
+NDJSON workloads (2M objects)	keys	v1.11.0	0.104
+NDJSON workloads (2M objects)	keys_unsorted	v1.11.0	0.100
+NDJSON workloads (2M objects)	length	v1.11.0	0.085
+NDJSON workloads (2M objects)	has("x")	v1.11.0	0.037
+NDJSON workloads (2M objects)	type	v1.11.0	0.019
+NDJSON workloads (2M objects)	del(.name)	v1.11.0	0.101
+NDJSON workloads (2M objects)	@csv	v1.11.0	0.116
+NDJSON workloads (2M objects)	split/join	v1.11.0	0.088
+NDJSON workloads (2M objects)	select|field	v1.11.0	0.099
+NDJSON workloads (2M objects)	select|remap	v1.11.0	0.096
+NDJSON workloads (2M objects)	computed remap	v1.11.0	0.201
+NDJSON workloads (2M objects)	[.x,.y]|add	v1.11.0	0.086
+NDJSON workloads (2M objects)	[.x,.y]|avg	v1.11.0	0.110
+NDJSON workloads (2M objects)	map(*2)|add	v1.11.0	0.102
+NDJSON workloads (2M objects)	keys|length	v1.11.0	0.260
+NDJSON workloads (2M objects)	.+{z=0}	v1.11.0	0.156
+NDJSON workloads (2M objects)	split|first	v1.11.0	0.086
+NDJSON workloads (2M objects)	slice[0..5]	v1.11.0	0.089
+NDJSON workloads (2M objects)	dynkey {(.name)}	v1.11.0	0.111
+NDJSON workloads (2M objects)	.x += 1	v1.11.0	0.129
+NDJSON workloads (2M objects)	{a}+{b} merge	v1.11.0	0.130
+NDJSON workloads (2M objects)	.x*2+1	v1.11.0	0.059
+NDJSON workloads (2M objects)	.x+.y*2	v1.11.0	0.099
+NDJSON workloads (2M objects)	.x > .y	v1.11.0	0.078
+NDJSON workloads (2M objects)	to_entries|len	v1.11.0	0.395
+NDJSON workloads (2M objects)	.x|.+1 (pipe)	v1.11.0	0.057
+NDJSON workloads (2M objects)	.x|.*2|.+1	v1.11.0	0.060
+NDJSON workloads (2M objects)	.name|.+"_x"	v1.11.0	0.093
+NDJSON workloads (2M objects)	.x>N | not	v1.11.0	0.050
+NDJSON workloads (2M objects)	and (2 cmp)	v1.11.0	0.083
+NDJSON workloads (2M objects)	if-then-else	v1.11.0	0.052
+NDJSON workloads (2M objects)	sel(and)|field	v1.11.0	0.079
+NDJSON workloads (2M objects)	sel(and)|remap	v1.11.0	0.079
+NDJSON workloads (2M objects)	arith|cmp	v1.11.0	0.055
+NDJSON workloads (2M objects)	if cmp .field	v1.11.0	0.111
+NDJSON workloads (2M objects)	split|length	v1.11.0	0.086
+NDJSON workloads (2M objects)	[x,y]|min	v1.11.0	0.091
+NDJSON workloads (2M objects)	[x,y]|max	v1.11.0	0.099
+NDJSON workloads (2M objects)	[x,y]|sort|.[0]	v1.11.0	0.092
+NDJSON workloads (2M objects)	.name|len>5	v1.11.0	0.084
+NDJSON workloads (2M objects)	sel(len>5)|.x	v1.11.0	0.111
+NDJSON workloads (2M objects)	if .x>.y .name	v1.11.0	0.090
+NDJSON workloads (2M objects)	sel(.x>.y)|.name	v1.11.0	0.073
+NDJSON workloads (2M objects)	.x*2|tostring	v1.11.0	0.058
+NDJSON workloads (2M objects)	.x*.x+1	v1.11.0	0.066
+NDJSON workloads (2M objects)	{k=.name,v=tostr}	v1.11.0	0.140
+NDJSON workloads (2M objects)	str add chain	v1.11.0	0.385
+NDJSON workloads (2M objects)	if>.y .name|empty	v1.11.0	0.076
+NDJSON workloads (2M objects)	if .x%2==0	v1.11.0	0.053
+NDJSON workloads (2M objects)	if .x*2+1>1M	v1.11.0	0.057
+NDJSON workloads (2M objects)	sel(.x%2==0)|.name	v1.11.0	0.082
+NDJSON workloads (2M objects)	sel(.x*2+1>1M)	v1.11.0	0.157
+NDJSON workloads (2M objects)	.x|@json	v1.11.0	0.048
+NDJSON workloads (2M objects)	.x|@text	v1.11.0	0.048
+NDJSON workloads (2M objects)	.name|@json	v1.11.0	0.093
+NDJSON workloads (2M objects)	sel|[arr]	v1.11.0	0.168
+NDJSON workloads (2M objects)	sel(and)|[arr]	v1.11.0	0.080
+NDJSON workloads (2M objects)	if>.y [arr]	v1.11.0	0.207
+NDJSON workloads (2M objects)	if sw then .f	v1.11.0	0.134
+NDJSON workloads (2M objects)	dynkey {(.n)=.x*2}	v1.11.0	0.109
+NDJSON workloads (2M objects)	sel(and)|.x*.y	v1.11.0	0.077
+NDJSON workloads (2M objects)	sel>N|str chain	v1.11.0	0.158
+NDJSON workloads (2M objects)	.f+"_"+arith_ts	v1.11.0	0.133
+NDJSON workloads (2M objects)	sel(sw)|str ch	v1.11.0	0.303
+NDJSON workloads (2M objects)	split|rev|join	v1.11.0	0.109
+NDJSON workloads (2M objects)	dynkey+static	v1.11.0	0.303
+NDJSON workloads (2M objects)	if>.y str chain	v1.11.0	0.172
+NDJSON workloads (2M objects)	remap+str chain	v1.11.0	0.161
+NDJSON workloads (2M objects)	sel(len>8)	v1.11.0	0.155
+NDJSON workloads (2M objects)	up|split|join	v1.11.0	0.092
+NDJSON workloads (2M objects)	.name|index	v1.11.0	0.117
+NDJSON workloads (2M objects)	.name|index+1	v1.11.0	0.120
+NDJSON workloads (2M objects)	.name|rindex	v1.11.0	0.122
+NDJSON workloads (2M objects)	.name|indices	v1.11.0	0.143
+NDJSON workloads (2M objects)	[x,y]|sort	v1.11.0	0.175
+NDJSON workloads (2M objects)	.name|scan	v1.11.0	0.202
+NDJSON workloads (2M objects)	.name|gsub	v1.11.0	0.166
+NDJSON workloads (2M objects)	walk(if num .+1)	v1.11.0	0.138
+NDJSON workloads (2M objects)	tojson	v1.11.0	0.122
+NDJSON workloads (2M objects)	{name,x}	v1.11.0	0.125
+NDJSON workloads (2M objects)	.z//.name	v1.11.0	0.173
+NDJSON workloads (2M objects)	.x|=test(re)	v1.11.0	0.170
+NDJSON workloads (2M objects)	./sep|first	v1.11.0	0.182
+NDJSON workloads (2M objects)	.y=(.x*2)	v1.11.0	0.173
+NDJSON workloads (2M objects)	.y=(.x+.y)	v1.11.0	0.225
+NDJSON workloads (2M objects)	objects	v1.11.0	0.133
+NDJSON workloads (2M objects)	.tag|=if..then N	v1.11.0	0.602
+NDJSON workloads (2M objects)	.x=(.x+1)	v1.11.0	0.129
+NDJSON workloads (2M objects)	sel>N|.y+=1	v1.11.0	0.121
+NDJSON workloads (2M objects)	sel(and)|.x+=1	v1.11.0	0.105
+NDJSON workloads (2M objects)	sel(sw)|.x+=1	v1.11.0	0.159
+NDJSON workloads (2M objects)	match(re)	v1.11.0	0.371
+NDJSON workloads (2M objects)	capture(re)	v1.11.0	0.293
+NDJSON workloads (2M objects)	first(.name,.x)	v1.11.0	0.080
+NDJSON workloads (2M objects)	if .x==null	v1.11.0	0.047
+NDJSON workloads (2M objects)	we(sw(.key))	v1.11.0	0.114
+NDJSON workloads (2M objects)	sel(sw or ew)	v1.11.0	0.197
+NDJSON workloads (2M objects)	path(.name,.x)	v1.11.0	0.313
+NDJSON workloads (2M objects)	sel(str+num+num)	v1.11.0	0.147
+NDJSON workloads (2M objects)	nested if|field	v1.11.0	0.078
+NDJSON workloads (2M objects)	.f|floor|.*2	v1.11.0	0.062
+NDJSON workloads (2M objects)	split|len>1	v1.11.0	0.110
+NDJSON workloads (2M objects)	.name|len|.*2	v1.11.0	0.097
+NDJSON workloads (2M objects)	if len>5 .x .y	v1.11.0	0.109
+NDJSON workloads (2M objects)	sel(len>5)|remap	v1.11.0	0.194
+NDJSON workloads (2M objects)	.x|tostr|len	v1.11.0	0.059
+NDJSON workloads (2M objects)	if .x>.y .x .y	v1.11.0	0.092
+NDJSON workloads (2M objects)	split|last|tonum	v1.11.0	0.091
+NDJSON workloads (2M objects)	split|rev|.[0]	v1.11.0	0.087
+NDJSON workloads (2M objects)	split|.[0]+.[1]	v1.11.0	0.109
+NDJSON workloads (2M objects)	.[]|strings	v1.11.0	0.104
+NDJSON workloads (2M objects)	.[]|numbers	v1.11.0	0.122
+NDJSON workloads (2M objects)	[x,y]|any(>1M)	v1.11.0	0.083
+NDJSON workloads (2M objects)	sel(dc|sw)	v1.11.0	0.092
+NDJSON workloads (2M objects)	[[x,y],[n]]|flat	v1.11.0	0.489
+NDJSON workloads (2M objects)	.x|floor|.*2	v1.11.0	0.060
+NDJSON workloads (2M objects)	tojson|fromjson	v1.11.0	0.083
+NDJSON workloads (2M objects)	[.x]|add	v1.11.0	0.047
+NDJSON workloads (2M objects)	if>N {o}+.	v1.11.0	0.134
+NDJSON workloads (2M objects)	if>N .+{o}	v1.11.0	0.135
+NDJSON workloads (2M objects)	if .n=="s" .+{o}	v1.11.0	0.160
+NDJSON workloads (2M objects)	sel(.n>"s")	v1.11.0	0.084
+NDJSON workloads (2M objects)	[x,y,z]|min	v1.11.0	0.300
+NDJSON workloads (2M objects)	if .n|len>5 l s	v1.11.0	0.095
+NDJSON workloads (2M objects)	if .x|flr>N b s	v1.11.0	0.054
+NDJSON workloads (2M objects)	if .n|test l e	v1.11.0	0.102
+NDJSON workloads (2M objects)	if .n|sw l e	v1.11.0	0.080
+NDJSON workloads (2M objects)	if .n|ew l e	v1.11.0	0.082
+NDJSON workloads (2M objects)	.n|len|tostr	v1.11.0	0.088
+String operations (2M objects)	ascii_downcase	v1.11.0	0.091
+String operations (2M objects)	ascii_upcase	v1.11.0	0.090
+String operations (2M objects)	ltrimstr	v1.11.0	0.092
+String operations (2M objects)	rtrimstr	v1.11.0	0.093
+String operations (2M objects)	split	v1.11.0	0.151
+String operations (2M objects)	case+split	v1.11.0	0.110
+String operations (2M objects)	join	v1.11.0	0.090
+String operations (2M objects)	startswith	v1.11.0	0.085
+String operations (2M objects)	endswith	v1.11.0	0.086
+String operations (2M objects)	tostring	v1.11.0	0.064
+String operations (2M objects)	tonumber	v1.11.0	0.105
+String operations (2M objects)	string interpolation	v1.11.0	0.108
+String ops (200K objects)	test (regex)	v1.11.0	0.014
+String ops (200K objects)	match (regex)	v1.11.0	0.032
+String ops (200K objects)	@base64	v1.11.0	0.011
+String ops (200K objects)	@uri	v1.11.0	0.011
+String ops (200K objects)	@html	v1.11.0	0.010
+String ops (200K objects)	@csv (array)	v1.11.0	0.015
+String ops (200K objects)	@tsv (array)	v1.11.0	0.015
+String ops (200K objects)	gsub	v1.11.0	0.018
+String ops (200K objects)	case+gsub	v1.11.0	0.176
+String ops (200K objects)	case+test	v1.11.0	0.116
+String ops (200K objects)	ltrim+tonum+arith	v1.11.0	0.107
+Numeric & math (2M objects)	floor	v1.11.0	0.057
+Numeric & math (2M objects)	sqrt	v1.11.0	0.078
+Numeric & math (2M objects)	modulo	v1.11.0	0.058
+Numeric & math (2M objects)	if-elif-else	v1.11.0	0.127
+Numeric & math (2M objects)	select|del	v1.11.0	0.089
+Numeric & math (2M objects)	select|merge	v1.11.0	0.120
+Numeric & math (2M objects)	select(test)|merge	v1.11.0	0.021
+Array generators	range(2M) | length	v1.11.0	0.008
+Array generators	reverse(2M)	v1.11.0	0.015
+Array generators	sort(2M)	v1.11.0	0.024
+Array generators	unique(1M)	v1.11.0	0.034
+Array generators	flatten(500K)	v1.11.0	0.010
+Array generators	min, max(2M)	v1.11.0	0.017
+Array generators	add numbers(2M)	v1.11.0	0.009
+Array generators	any/all(2M)	v1.11.0	0.030
+Array generators	limit(10; range(10M))	v1.11.0	0.002
+Array generators	first(range(10M))	v1.11.0	0.002
+Array generators	last(range(2M))	v1.11.0	0.002
+Array generators	indices(1M)	v1.11.0	0.017
+Reduce & foreach	reduce (sum)	v1.11.0	0.009
+Reduce & foreach	reduce (array build)	v1.11.0	0.004
+Reduce & foreach	reduce (obj build)	v1.11.0	0.009
+Reduce & foreach	reduce (setpath)	v1.11.0	0.017
+Reduce & foreach	foreach (running sum)	v1.11.0	0.010
+Reduce & foreach	foreach + emit	v1.11.0	0.010
+Reduce & foreach	reduce (sum-of-squares)	v1.11.0	0.032
+Reduce & foreach	reduce (conditional)	v1.11.0	0.035
+Reduce & foreach	reduce (product)	v1.11.0	0.034
+Reduce & foreach	foreach (conditional)	v1.11.0	0.011
+Reduce & foreach	until (100M)	v1.11.0	0.298
+Reduce & foreach	reduce (harmonic)	v1.11.0	0.032
+Reduce & foreach	reduce (floor pipe)	v1.11.0	0.032
+Reduce & foreach	reduce (sqrt pipe)	v1.11.0	0.032
+Reduce & foreach	reduce (sin+cos)	v1.11.0	0.051
+Object operations	large obj construct	v1.11.0	0.004
+Object operations	large obj keys	v1.11.0	0.011
+Object operations	large obj to_entries	v1.11.0	0.012
+Object operations	with_entries	v1.11.0	0.009
+Assignment operators	.[] |= f (100K)	v1.11.0	0.005
+Assignment operators	.[] += 1 (100K)	v1.11.0	0.005
+Assignment operators	.[k] = v reduce(50K)	v1.11.0	0.008
+Assignment operators	p126-shape nested reduce	v1.11.0	0.105
+Assignment operators	p126-shape w/ mutate	v1.11.0	0.103
+Assignment operators	p150-shape serial mutate	v1.11.0	0.012
+String-heavy generators	gsub(100K)	v1.11.0	0.028
+String-heavy generators	join large(100K)	v1.11.0	0.005
+String-heavy generators	explode/implode(100K)	v1.11.0	0.028
+String-heavy generators	reduce str concat(100K)	v1.11.0	0.008
+Try-catch & alternative	alternative //	v1.11.0	0.033
+Try-catch & alternative	try-catch	v1.11.0	0.024
+Try-catch & alternative	label-break	v1.11.0	0.004
+Type conversion	tojson/fromjson(100K)	v1.11.0	0.022
+Type conversion	null propagation(2M)	v1.11.0	0.089
+Memoization (jqx)	memo fib (1K)	v1.11.0	0.003
+Memoization (jqx)	memo collatz sum (10K)	v1.11.0	0.014
+Memoization (jqx)	memo by .id (100K, 1K keys)	v1.11.0	0.020


### PR DESCRIPTION
## Summary

Release v1.11.0 — adds the `--jsonc` input flag (#1141, #1142) on top of the post-1.10.0 perf work (#1137, #1138) and dependency bumps.

Benchmark history columns appended for v1.11.0 (220 rows).

## Bench

No regression > 5% except a single reading: `Array generators/min, max(2M)` at ratio 1.062 (0.016s → 0.017s). Verified with same-machine interleaved A/B (4 independent rounds, v1.10.0 / intermediate commits / HEAD): HEAD vs v1.10.0 ranged 0.996–1.087 with unstable ordering across rounds, and an intermediate deps-only commit measured slower than HEAD in every round — attribution flips, so this is run-to-run noise at 1 ms TSV quantization on a 16 ms microbench, not a real regression. The `--jsonc` change executes zero instructions on that path when the flag is off.

Best improvements vs v1.10.0 include `first/last/limit(range)` (0.667) and `add numbers(2M)` (0.818).

🤖 Generated with [Claude Code](https://claude.com/claude-code)