### PR TITLE
fix: keep the preserved number repr in tostring/tojson (#1149)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A JIT-compiling [jq](https://jqlang.github.io/jq/) in Rust using [Cranelift](htt
 
 A few divergences from jq are deliberate engineering tradeoffs rather than bugs:
 
-- **Number representation** — values are IEEE 754 doubles throughout (there is no decimal-number backend), so integers beyond 2^53 and out-of-range literals such as `1e1000` lose precision or saturate where jq's optional decimal build (`have_decnum`) would preserve them — including through `tojson`/`fromjson` round-trips.
+- **Number representation** — values are IEEE 754 doubles throughout (there is no decimal-number backend). A number that is only *carried and printed* keeps its original literal, so `1e1000`, `13911860366432393` and friends survive `tostring` / `tojson` / `fromjson` round-trips and the `@csv` / `@tsv` / `@text` formatters exactly as jq's decimal build prints them. The moment a value is *computed* — arithmetic, or a comparison — it collapses to the nearest double, so `1e1000 + 0` saturates and `13911860366432393 == 13911860366432392` is `true` where jq's optional decimal build (`have_decnum`) says `false`. `have_decnum` therefore reports `false`: it is the honest answer for the comparison and arithmetic side.
 - **Regex anchors** — the regex engine is the linear-time Rust [`regex`](https://docs.rs/regex) crate (no lookaround or backtracking, which is what keeps matching ReDoS-resistant). As a result `$` matches only end-of-text, not also just before a trailing newline as jq's Oniguruma does; `^` is likewise start-of-text only.
 
 ## Performance

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -420,6 +420,40 @@ JIT にまで降りる filter はここ。`flatten_scalar` / `flatten_gen` の m
 
 ## 3. 守るべき invariant
 
+### 数値の literal repr — 出力は decnum 互換、比較・算術は f64
+
+`Value::Num(f64, NumRepr)` の第 2 フィールドは parse 時の literal を保持する。
+**repr を持つ値は、f64 で表現できるかに関係なく、常に repr を canonical 形で
+出力する**（#1149）。`1e500` が `1E+500`、`13911860366432393` が丸められずに
+そのまま出るのはこれ。jq の decNumber が literal を保持するのと同じ挙動。
+
+出力経路は 2 系統あり、**両者は同じルールでなければならない**:
+
+- value printer — `write_value_compact_ext_inner` と固定バッファ writer。
+  `canonical_repr_bytes(repr)` を無条件に使う
+- 文字列化 writer — `num_repr_text` を共有する `tostring` / `tojson` /
+  `@csv` / `@tsv` / `@json` / `@text`
+
+#1149 以前は後者だけが「f64 に厳密に載るか」で gate していたため、
+`1e500` は `1E+500` と印字されるのに `1e500 | tostring` は
+`"1.7976931348623157e+308"` になっていた。gate を足す変更は同じ穴を再発させる。
+
+repr が落ちるのは **値が計算された時だけ**。算術・比較の結果は
+`Value::number(n)`（repr なし）になり、canonical f64 writer に乗る。
+したがって:
+
+- `1e500 + 0` → 飽和して `1.7976931348623157e+308`
+- `13911860366432393 == 13911860366432392` → `true`（jq decnum は `false`）
+
+**`have_decnum` は `false` のまま**にする。出力側は decnum 互換だが、比較・算術は
+f64 のままで、そちらは decimal backend 無しには埋められない。`false` は後者に
+対する正直な答えで、過小申告する側に倒している。`tests/official/jq.test` の
+decnum 分岐行のうち出力系 5 行は、この理由で jq-jit ローカルの期待値に pin
+してある（実 jq 1.8.2 で検証済み）。
+
+既知の残ギャップ: 入力値への単項マイナス（`-.`）は repr を落とす。jq は
+literal の符号を反転して精度を保つ。#1149 のスコープ外。
+
 ### オブジェクト重複キーの dedup
 
 jq は `{a:1, a:2}` → `{"a":2}`（後勝ち、最初の位置を保持）。

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1992,9 +1992,9 @@ fn rt_tostring(v: &Value) -> Result<Value> {
         Value::Str(_) => Ok(v.clone()),
         // Preserve the lexical form of numbers (#75 / #110) — `-0` stays `"-0"`,
         // `0.0` stays `"0.0"`, etc. `value_to_json_tojson` honours the repr
-        // when f64 can round-trip it exactly, otherwise falls back to the
-        // canonical f64 form (which matches jq's no-decnum rounding, cf. the
-        // `13911860366432393` regression test).
+        // whenever one was preserved, matching the value printer and jq's
+        // decnum output — including literals f64 cannot hold exactly, such as
+        // `13911860366432393` and `1e500` (#1149).
         _ => Ok(Value::from_string(crate::value::value_to_json_tojson(v))),
     }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -6209,14 +6209,21 @@ pub fn push_jq_number_str(buf: &mut String, n: f64) {
 /// should be kept, or `None` when the caller must fall back to the
 /// computed-f64 writer ([`write_jq_number`]).
 ///
-/// The repr is kept in two cases:
-/// - it round-trips exactly per `repr_is_exact_for_f64` (emitted in jq's
-///   canonical uppercase-E decnum form, so `1.0` stays `1.0` and `0e10`
-///   becomes `0E+10`);
-/// - subnormal/precision-edge literals (#616): `repr_is_exact_for_f64` is
-///   too conservative for >15-sig-digit mantissas and exponents < -323,
-///   but the canonical literal still round-trips through f64 — e.g.
-///   DBL_MAX `1.7976931348623157e308` and the smallest subnormal `5e-324`.
+/// A preserved repr is always kept, emitted in jq's canonical uppercase-E
+/// decnum form (`1.0` stays `1.0`, `0e10` becomes `0E+10`). This is the same
+/// rule the value printer applies (`write_value_compact_ext_inner` and the
+/// fixed-buffer writer both take `canonical_repr_bytes(repr)` unconditionally),
+/// and the two paths must agree: they render the same `Value::Num`.
+///
+/// The repr deliberately wins even when f64 cannot represent it — that is the
+/// whole point of preserving it, and it is how jq's decnum literals survive
+/// `tostring` / `tojson` / `@csv` / `@text`. Gating on an f64 round-trip used
+/// to drop the literal here while the value printer kept it, so `1e500` printed
+/// as `1E+500` but `1e500 | tostring` as `"1.7976931348623157e+308"` (#1149,
+/// found by the nightly differential fuzz; supersedes the output half of #415).
+///
+/// Note this covers *output* only. jq-jit stays f64 for comparison and
+/// arithmetic, so `have_decnum` remains `false` — see `docs/maintenance.md`.
 fn num_repr_text<'a>(n: f64, repr: Option<&'a Rc<str>>) -> Option<std::borrow::Cow<'a, str>> {
     // One-pass fast path for the dominant lexeme shape in number-heavy hot
     // loops (#1077): a plain short decimal is simultaneously a valid JSON
@@ -6228,29 +6235,31 @@ fn num_repr_text<'a>(n: f64, repr: Option<&'a Rc<str>>) -> Option<std::borrow::C
             return Some(std::borrow::Cow::Borrowed(&**r));
         }
     }
-    if let Some(r) = repr.filter(|r| is_valid_json_number(r) && repr_is_exact_for_f64(r, n)) {
-        return Some(match normalize_jq_repr(r) {
-            Some(canonical) => std::borrow::Cow::Owned(canonical),
-            None => std::borrow::Cow::Borrowed(&**r),
-        });
+    // Every computed value reaches here with `repr == None`, so short-circuit on
+    // that before touching `n` — the checks below are only worth running when a
+    // literal was actually preserved.
+    let r = repr?;
+    // NaN never carries a repr: the `nan` literal is built without one and no
+    // JSON-valid number lexes to NaN. Keep the guard anyway so
+    // `push_num_tojson_str` can still promise `null` for it.
+    if n.is_nan() || !is_valid_json_number(r) {
+        return None;
     }
-    repr.filter(|r| is_valid_json_number(r) && n.is_finite() && n != 0.0)
-        .and_then(|r| normalize_jq_repr(r))
-        .filter(|c| c.as_str().parse::<f64>().ok() == Some(n))
-        .map(std::borrow::Cow::Owned)
+    Some(match normalize_jq_repr(r) {
+        Some(canonical) => std::borrow::Cow::Owned(canonical),
+        None => std::borrow::Cow::Borrowed(&**r),
+    })
 }
 
 /// One-pass test for a plain decimal lexeme (optional `-`, integer part
 /// without leading zeros, optional non-empty fraction, no exponent) of at
 /// most 15 total digits whose fraction does not open with six zeros.
-/// Such a lexeme passes all three of `num_repr_text`'s checks verbatim:
-/// it is a valid JSON number by shape, exact for its paired f64
-/// (`repr_is_exact_for_f64` accepts any ≤15-sig-digit finite lexeme, and
-/// total digits bound sig digits), and `normalize_jq_repr` returns `None`
-/// for every plain decimal whose effective exponent stays in the
-/// canonical window — which the ≤15-digit and no-`.000000` constraints
-/// guarantee. Conservative by construction: any rejected lexeme simply
-/// takes the full checks.
+/// Such a lexeme passes both of `num_repr_text`'s checks verbatim: it is a
+/// valid JSON number by shape, and `normalize_jq_repr` returns `None` for
+/// every plain decimal whose effective exponent stays in the canonical
+/// window — which the ≤15-digit and no-`.000000` constraints guarantee.
+/// Conservative by construction: any rejected lexeme simply takes the full
+/// checks.
 #[inline]
 fn repr_is_short_canonical_plain(repr: &str) -> bool {
     let b = repr.as_bytes();
@@ -6791,28 +6800,27 @@ pub fn value_to_json_precise(v: &Value) -> String {
     value_to_json_depth(v, 0, true)
 }
 
-/// Convert Value to compact JSON string for `tojson`. Uses the repr when it
-/// exactly represents the stored f64, otherwise falls back to the f64 form.
-/// jq 1.8.1 decnum preserves all reprs; without decnum we can only honor the
-/// ones f64 can hold exactly (so `1.0` stays `"1.0"` but `13911860366432393`
-/// renders as the rounded `"13911860366432392"`).
+/// Convert Value to compact JSON string for `tojson`. Keeps the preserved
+/// literal repr in jq's canonical form, matching both the value printer and
+/// jq's decnum output — so `1.0` stays `"1.0"` and `13911860366432393` stays
+/// `"13911860366432393"` rather than collapsing to the nearest double (#1149).
 pub fn value_to_json_tojson(v: &Value) -> String {
     let mut out = String::new();
     push_value_tojson(v, &mut out, 0);
     out
 }
 
-/// Append a number in tojson/tostring form: a valid, exactly round-tripping
-/// literal repr is kept in jq's canonical (uppercase-E decnum) form; anything
-/// else — a computed value, a NaN/Infinity lexeme (`nan`, `infinity`), or a
-/// repr that doesn't round-trip — takes the canonical f64 writer (`null` for
-/// NaN, the clamped max double for Infinity). Shared by `tojson`/`tostring`,
-/// the JIT string-interpolation buffer, and `@json`/`@text` so a parsed-input
-/// NaN or non-canonical lexeme cannot leak through one formatter after being
-/// fixed in another (#771, #1021).
+/// Append a number in tojson/tostring form: a valid literal repr is kept in
+/// jq's canonical (uppercase-E decnum) form; anything else — a computed value
+/// or a NaN/Infinity lexeme (`nan`, `infinity`), neither of which carries a
+/// repr — takes the canonical f64 writer (`null` for NaN, the clamped max
+/// double for Infinity). Shared by `tojson`/`tostring`, the JIT
+/// string-interpolation buffer, and `@json`/`@text` so a parsed-input NaN or
+/// non-canonical lexeme cannot leak through one formatter after being fixed in
+/// another (#771, #1021).
 pub fn push_num_tojson_str(out: &mut String, n: f64, repr: Option<&Rc<str>>) {
     // Same repr selection as the @csv/@tsv writers (see `num_repr_text`);
-    // here a NaN — whose repr never qualifies — falls through to the
+    // here a NaN — which never carries a repr — falls through to the
     // canonical f64 writer and renders as `null`.
     match num_repr_text(n, repr) {
         Some(text) => out.push_str(&text),
@@ -6850,48 +6858,6 @@ fn push_value_tojson(v: &Value, out: &mut String, depth: usize) {
             out.push('}');
         }
     }
-}
-
-/// True iff `repr` (a JSON-valid decimal literal) represents a value that f64
-/// can hold exactly. Rejects mantissas with more than 15 significant decimal
-/// digits and exponents outside f64's dynamic range.
-pub(crate) fn repr_is_exact_for_f64(repr: &str, n: f64) -> bool {
-    if !n.is_finite() { return false; }
-    let bytes = repr.as_bytes();
-    let mut i = 0;
-    if matches!(bytes.first(), Some(b'-') | Some(b'+')) { i += 1; }
-    let mut sig_digits = 0u32;
-    let mut trailing_zeros = 0u32;
-    let mut started = false;
-    while i < bytes.len() && bytes[i] != b'e' && bytes[i] != b'E' {
-        let c = bytes[i];
-        if c == b'.' { i += 1; continue; }
-        if !c.is_ascii_digit() { return false; }
-        if c != b'0' { started = true; trailing_zeros = 0; }
-        if started {
-            sig_digits += 1;
-            if c == b'0' { trailing_zeros += 1; }
-        }
-        i += 1;
-    }
-    let mut exp_val: i32 = 0;
-    if i < bytes.len() {
-        i += 1;
-        let mut exp_neg = false;
-        if matches!(bytes.get(i), Some(b'-')) { exp_neg = true; i += 1; }
-        else if matches!(bytes.get(i), Some(b'+')) { i += 1; }
-        while i < bytes.len() && bytes[i].is_ascii_digit() {
-            exp_val = exp_val.saturating_mul(10).saturating_add((bytes[i] - b'0') as i32);
-            i += 1;
-        }
-        if exp_neg { exp_val = -exp_val; }
-    }
-    if exp_val > 308 || exp_val < -323 { return false; }
-    // Trailing zeros (after the last non-zero digit, integer or fractional)
-    // do not contribute precision: `100000000000000.0` has effective sig=1
-    // even though the digit count is 16. Subtract them so the cap matches
-    // the actual precision the literal claims.
-    sig_digits.saturating_sub(trailing_zeros) <= 15
 }
 
 fn value_to_json_depth(v: &Value, depth: usize, precise: bool) -> String {

--- a/tests/contract_number_format.rs
+++ b/tests/contract_number_format.rs
@@ -131,8 +131,9 @@ fn render_repr_all(n: f64, repr: Option<&str>) -> (String, String) {
 #[test]
 fn repr_preserving_corpus_pins() {
     // (n, repr, expected) — jq's literal-preserving canonical form (#475,
-    // #457, #616): exact reprs keep their shape in uppercase-E decnum style;
-    // non-roundtripping reprs fall back to the computed-f64 form.
+    // #457, #616, #1149): a preserved repr always keeps its shape in
+    // uppercase-E decnum style, including literals f64 cannot hold exactly.
+    // Only a value with no repr at all takes the computed-f64 form.
     let cases: &[(f64, Option<&str>, &str)] = &[
         (1.0, Some("1.0"), "1.0"),
         (1.0, Some("1.00"), "1.00"),
@@ -142,8 +143,16 @@ fn repr_preserving_corpus_pins() {
         (1e-5, Some("1e-5"), "0.00001"),
         (5e-324, Some("5e-324"), "5E-324"), // #616: smallest subnormal
         (f64::MAX, Some("1.7976931348623157e308"), "1.7976931348623157E+308"),
-        // 16 significant digits: not exactly representable, repr dropped.
-        (13911860366432393u64 as f64, Some("13911860366432393"), "13911860366432392"),
+        // 16+ significant digits: f64 cannot hold these exactly, but the
+        // preserved repr still wins — matching jq 1.8.2's decnum output (#1149).
+        (13911860366432393u64 as f64, Some("13911860366432393"), "13911860366432393"),
+        (f64::INFINITY, Some("1e500"), "1E+500"), // literal overflows f64
+        (0.0, Some("1e-500"), "1E-500"),          // literal underflows f64
+        (
+            0.1000000000000000000000001,
+            Some("0.1000000000000000000000001"),
+            "0.1000000000000000000000001",
+        ),
         (1.5, None, "1.5"),
         (-0.0, None, "-0"),
     ];
@@ -161,11 +170,10 @@ fn repr_preserving_corpus_pins() {
 }
 
 /// #1077: `num_repr_text` short-circuits plain short decimal lexemes with a
-/// single scan instead of the three full checks (validity / exactness /
-/// normalization). Pin the boundary shapes on both sides of the gate so the
-/// fast path can never drift from the semantics it replaces — every
-/// expected value below was cross-checked against jq 1.8.1 (the 16-digit
-/// integer is the known no-decnum fallback, #236/#415).
+/// single scan instead of the full checks (validity / normalization). Pin the
+/// boundary shapes on both sides of the gate so the fast path can never drift
+/// from the semantics it replaces — every expected value below was
+/// cross-checked against jq 1.8.2.
 #[test]
 fn short_canonical_plain_fast_path_boundary_pins() {
     let cases: &[(&str, &str)] = &[
@@ -185,7 +193,11 @@ fn short_canonical_plain_fast_path_boundary_pins() {
         ("0.0000001", "1E-7"),      // #611 normalization
         ("-0.0000001", "-1E-7"),
         ("1e3", "1E+3"),            // exponent → canonical uppercase-E form
-        ("9999999999999999", "1e+16"), // 16 digits → repr dropped, f64 form
+        // 16 digits: past the fast path's 15-digit cap, so the full checks
+        // run — and they keep the repr rather than collapsing to `1e+16` (#1149).
+        ("9999999999999999", "9999999999999999"),
+        ("1e500", "1E+500"),   // beyond f64 range, repr still wins
+        ("1e-500", "1E-500"),
     ];
     for &(lexeme, expected) in cases {
         let n: f64 = lexeme.parse().expect("test lexeme parses");

--- a/tests/destructure_pattern_strict.rs
+++ b/tests/destructure_pattern_strict.rs
@@ -4,7 +4,7 @@
 //! compile-time syntax errors (exit 3), which the diff/regression harnesses
 //! skip, so assert acceptance/rejection at the process level here.
 
-use std::io::Write;
+use std::io::{ErrorKind, Write};
 use std::process::{Command, Stdio};
 
 /// Returns true if jq-jit *compiled* the program (it may still fail at
@@ -20,7 +20,17 @@ fn accepts(filter: &str) -> bool {
         .stderr(Stdio::null())
         .spawn()
         .expect("failed to spawn jq-jit");
-    child.stdin.take().unwrap().write_all(b"[1,2]").unwrap();
+    // Every rejected pattern is a *compile* error, so jq-jit exits (code 3)
+    // without ever reading stdin. Whether this write lands before the child is
+    // gone is a race that a loaded CI runner loses, and `EPIPE` there is the
+    // expected outcome rather than a failure — only the exit code decides.
+    let mut stdin = child.stdin.take().expect("stdin was piped");
+    match stdin.write_all(b"[1,2]") {
+        Ok(()) => {}
+        Err(e) if e.kind() == ErrorKind::BrokenPipe => {}
+        Err(e) => panic!("failed to write jq-jit stdin: {e}"),
+    }
+    drop(stdin);
     let code = child.wait_with_output().expect("wait failed").status.code();
     code != Some(3)
 }

--- a/tests/differential/corpus.test
+++ b/tests/differential/corpus.test
@@ -4331,3 +4331,15 @@ null
 # jq 1.8.2 alignment (#1144): truncate_stream on a scalar dumps the .[0] key
 try truncate_stream(5) catch .
 null
+
+# #1149: tostring/tojson keep the preserved literal repr (jq decnum parity)
+[(1e500, 1e-500, 13911860366432393, 0.1000000000000000000000001, 9999999999999999 | tostring), (1e500 | tojson)]
+null
+
+# #1149: the shared repr writer also backs @csv / @tsv / @json / @text
+[([1e500, 13911860366432393] | @csv), ([1e500, 13911860366432393] | @tsv), ([1e500] | @json), (1e500 | @text)]
+null
+
+# #1149: computed values still take the f64 writer (repr dropped by arithmetic)
+[(1e500 + 0), (13911860366432393 - 10), (1e500 | tostring | length)]
+null

--- a/tests/official/jq.test
+++ b/tests/official/jq.test
@@ -2163,11 +2163,17 @@ map(. == 1)
 
 # When no arithmetic is involved jq should preserve the literal value
 
-.[0] | tostring | . == if have_decnum then "13911860366432393" else "13911860366432392" end
+# jq-jit local: number OUTPUT matches decnum (the preserved literal repr survives
+# tostring/tojson/@csv/@text, #1149), but comparison and arithmetic stay f64, so
+# have_decnum reports false. Pinned to the decnum branch, verified against jq 1.8.2.
+.[0] | tostring | . == "13911860366432393"
 [13911860366432393]
 true
 
-.x | tojson | . == if have_decnum then "13911860366432393" else "13911860366432392" end
+# jq-jit local: number OUTPUT matches decnum (the preserved literal repr survives
+# tostring/tojson/@csv/@text, #1149), but comparison and arithmetic stay f64, so
+# have_decnum reports false. Pinned to the decnum branch, verified against jq 1.8.2.
+.x | tojson | . == "13911860366432393"
 {"x":13911860366432393}
 true
 
@@ -2191,6 +2197,9 @@ true
 13911860366432382
 
 # Unary negation preserves numerical precision
+# jq-jit local note: the two rows below pass via the have_decnum=false branch,
+# NOT by agreeing with jq 1.8.2 — `-.` on an input value drops the preserved
+# repr and falls back to f64 (jq keeps it). Tracked separately from #1149.
 -. | tojson == if have_decnum then "-13911860366432393" else "-13911860366432392" end
 13911860366432393
 true
@@ -2199,7 +2208,10 @@ true
 -0.12345678901234567890123456789
 true
 
-[1E+1000,-1E+1000 | tojson] == if have_decnum then ["1E+1000","-1E+1000"] else ["1.7976931348623157e+308","-1.7976931348623157e+308"] end
+# jq-jit local: number OUTPUT matches decnum (the preserved literal repr survives
+# tostring/tojson/@csv/@text, #1149), but comparison and arithmetic stay f64, so
+# have_decnum reports false. Pinned to the decnum branch, verified against jq 1.8.2.
+[1E+1000,-1E+1000 | tojson] == ["1E+1000","-1E+1000"]
 null
 true
 
@@ -2238,11 +2250,17 @@ map(abs)
 [0.1,1000000000000000002]
 [1e-1, 1000000000000000002]
 
-[1E+1000,-1E+1000 | abs | tojson] | unique == if have_decnum then ["1E+1000"] else ["1.7976931348623157e+308"] end
+# jq-jit local: number OUTPUT matches decnum (the preserved literal repr survives
+# tostring/tojson/@csv/@text, #1149), but comparison and arithmetic stay f64, so
+# have_decnum reports false. Pinned to the decnum branch, verified against jq 1.8.2.
+[1E+1000,-1E+1000 | abs | tojson] | unique == ["1E+1000"]
 null
 true
 
-[1E+1000,-1E+1000 | length | tojson] | unique == if have_decnum then ["1E+1000"] else ["1.7976931348623157e+308"] end
+# jq-jit local: number OUTPUT matches decnum (the preserved literal repr survives
+# tostring/tojson/@csv/@text, #1149), but comparison and arithmetic stay f64, so
+# have_decnum reports false. Pinned to the decnum branch, verified against jq 1.8.2.
+[1E+1000,-1E+1000 | length | tojson] | unique == ["1E+1000"]
 null
 true
 

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -8048,10 +8048,12 @@ null
 null
 "100.50"
 
-# Issue #507: literal with significant non-zero digits beyond 15 still drops repr
+# Issue #507 / #1149: a literal with significant non-zero digits beyond 15 keeps
+# its repr through tojson (it used to collapse to the nearest double, giving 17).
+# jq 1.8.2 agrees: "13911860366432393.0" is 19 characters.
 13911860366432393.0 | tojson | length
 null
-17
+19
 
 # Issue #509: getpath with non-array path uses jq's "Path must be specified as an array"
 try getpath("x") catch .
@@ -14308,3 +14310,26 @@ null
 [try ([[1],5] | transpose) catch ., try ([[1,"x"]] | from_entries) catch .]
 null
 ["Cannot index number with number (0)","Cannot index array with string (\"key\")"]
+
+# #1149: a preserved literal repr survives tostring/tojson even when f64 cannot
+# hold it — the value printer already kept it, so the two paths now agree
+[1e500, 1e-500, 13911860366432393, 0.1000000000000000000000001 | tostring]
+null
+["1E+500","1E-500","13911860366432393","0.1000000000000000000000001"]
+
+# #1149: the same repr reaches @csv / @tsv / @text / @json, which share the writer
+[([1e500] | @csv), ([1e500] | @tsv), ([1e500] | @json), (1e500 | @text)]
+null
+["1E+500","1E+500","[1E+500]","1E+500"]
+
+# #1149: arithmetic still collapses to f64 — the repr is dropped the moment a
+# value is computed, so overflow saturates to the clamped max double
+[(1e500 + 0 | tostring), (13911860366432393 - 10 | tostring)]
+null
+["1.7976931348623157e+308","13911860366432382"]
+
+# #1149: values with no repr keep the canonical f64 writer (nan -> null,
+# infinite -> clamped max double)
+[(nan | tostring), (infinite | tostring), (-infinite | tostring)]
+null
+["null","1.7976931348623157e+308","-1.7976931348623157e+308"]

--- a/tests/selfdiff_jit_interp.rs
+++ b/tests/selfdiff_jit_interp.rs
@@ -157,22 +157,12 @@ fn normalize(output: &str) -> String {
 /// rationale, which is the point: the allowlist is the audit trail of "we
 /// know about this, here's why we haven't fixed it yet."
 ///
-/// Current entries (#323):
-/// - `tojson` on numbers that overflow `f64` (`1e1000` → `±INFINITY`):
-///   the raw-byte fast path on stdin lexes the digits and emits the
-///   canonicalised literal (`"1E+1000"`); the interpreter routes through
-///   `Value::Num(f64, repr)` and `push_jq_number_str` saturates non-finite
-///   values to `±1.7976931348623157e+308`. Plumbing the original `repr`
-///   through `value_to_json_tojson` is the obvious local fix, but doing so
-///   without also flipping `have_decnum` to `true` breaks the upstream
-///   `tests/official/jq.test` decnum consistency check (#443). Tracked
-///   in #415.
-const KNOWN_DIVERGENCES: &[(&str, &str)] = &[
-    ("tojson", "1e1000"),
-    ("tojson", "[1.5e-10, 1e1000, 17.5]"),
-    ("tojson", r#"{"a": 1.5e-10, "b": 1e1000}"#),
-    ("tojson", "-1e1000"),
-];
+/// Currently empty (#1149). The last entries were `tojson` on literals that
+/// overflow `f64` (`1e1000`): the raw-byte fast path lexed the digits and
+/// emitted the canonical literal while the interpreter saturated to
+/// `±1.7976931348623157e+308`. Both paths now keep the preserved repr, so the
+/// two agree — and they agree with jq 1.8.2 as well.
+const KNOWN_DIVERGENCES: &[(&str, &str)] = &[];
 
 /// Index of the allowlist entry matching this case's content, if any.
 fn known_divergence_idx(case: &Case) -> Option<usize> {

--- a/tests/selfdiff_layers.rs
+++ b/tests/selfdiff_layers.rs
@@ -219,12 +219,7 @@ fn normalize(output: &str) -> String {
 /// Entries are keyed by `(filter, input)` content — not
 /// `tests/regression.test` line numbers — so the corpus can be edited
 /// anywhere without renumbering the allowlist (#1026).
-const KNOWN_DIVERGENCES: &[(&str, &str)] = &[
-    ("tojson", "1e1000"),
-    ("tojson", "[1.5e-10, 1e1000, 17.5]"),
-    ("tojson", r#"{"a": 1.5e-10, "b": 1e1000}"#),
-    ("tojson", "-1e1000"),
-];
+const KNOWN_DIVERGENCES: &[(&str, &str)] = &[];
 
 /// Index of the allowlist entry matching this case's content, if any.
 fn known_divergence_idx(case: &Case) -> Option<usize> {


### PR DESCRIPTION
## Summary

`Value::Num(f64, NumRepr)` carries the original literal, and the value printer emits it unconditionally. The string-forming writers went through `num_repr_text`, which *additionally* required the literal to round-trip exactly through f64 and dropped it otherwise — so the same value rendered two different ways depending on which builtin asked for it:

```
$ jq-jit -n '1e500'              # value printer
1E+500
$ jq-jit -n '1e500 | tostring'   # tostring/tojson writer (before)
"1.7976931348623157e+308"
```

jq's decnum keeps the literal on both paths and only collapses to a double when arithmetic touches the value. `num_repr_text` now follows the value printer: a JSON-valid repr always wins, emitted in canonical uppercase-E form; only NaN (which never carries a repr) falls through to the f64 writer. `repr_is_exact_for_f64` had no other caller and is removed.

The same writer backs `@csv` / `@tsv` / `@json` / `@text`, so those pick up the fix too.

| filter | jq 1.8.2 | before | after |
|---|---|---|---|
| `1e500 \| tostring` | `"1E+500"` | `"1.7976931348623157e+308"` | `"1E+500"` |
| `1e-500 \| tostring` | `"1E-500"` | `"0"` | `"1E-500"` |
| `13911860366432393 \| tostring` | `"13911860366432393"` | `"13911860366432392"` | `"13911860366432393"` |
| `0.1000000000000000000000001 \| tostring` | `"0.1000000000000000000000001"` | `"0.1"` | `"0.1000000000000000000000001"` |
| `[1e500] \| @csv` | `"1E+500"` | `"1.7976931348623157e+308"` | `"1E+500"` |

Found by the nightly `schedule` fuzz run (32869246354, `fuzz_restricted_against_jq_1_8`). `1e500` was one instance of the whole "does not round-trip through f64" class.

## Scope: output only, `have_decnum` stays `false`

Comparison and arithmetic remain f64 — `13911860366432393 == 13911860366432392` is still `true`, `1e500 + 0` still saturates. Those need a decimal backend and are out of scope, so `have_decnum` deliberately keeps reporting `false`: under-reporting is the honest answer for the side that would need one.

This supersedes the **output half** of #415 (closed wontfix). That conclusion holds for the semantic decnum cases; it does not hold for the output cases, which the value printer already satisfied — the repr was sitting right there, only one of the two paths was using it.

The five output-side `have_decnum` rows in `tests/official/jq.test` are pinned to jq-jit-local expectations with that rationale inline. The two unary-negation rows still ride the `false` branch and are annotated as a separate known gap — `-.` on an input value drops the repr where jq keeps it. Filed as #1150 with a fix sketch (`rt_abs` from #578 is the working precedent).

## Test plan

- [x] `cargo build --release` — zero warnings
- [x] `cargo test --release` — all green (81 test binaries, 0 failures)
- [x] `tests/regression.test`: 4 new groups — the writers, the four formatters, the arithmetic fallback, the no-repr specials (`nan` / `±infinite`)
- [x] `tests/differential/corpus.test`: 3 new live-compared groups. Checked first that all three jq 1.8.2 release binaries (linux-amd64 / macos-arm64 / windows-amd64) ship decNumber, so the rows are stable on every CI leg
- [x] `tests/contract_number_format.rs`: repinned the two pins that encoded the drop-repr behaviour, added overflow / underflow / high-precision cases
- [x] `KNOWN_DIVERGENCES` emptied in both self-diff harnesses (the 4 `tojson` overflow entries now agree; the harness fails on stale entries, which is how they were caught)
- [x] Probed against jq 1.8.2 across `tostring` / `tojson` / `fromjson` round-trips and all four formatters for `1e500`, `1e-500`, `13911860366432393`, `0.1000000000000000000000001`, `9999999999999999`, 38-digit integers, `5e-324`, `DBL_MAX`, `nan`, `±infinite`

### Benchmark

`num_repr_text` is a documented hot path (#1077), so this was measured rather than assumed.

The `bench/comprehensive.sh` vs `docs/benchmark-history.md` comparison showed a uniform ~3.6% median slowdown across all 220 benchmarks — including `until (100M)`, a pure integer loop that this change cannot touch. Same-machine interleaved A/B (15 reps × best-of-6) against **`main`** rather than the `v1.11.0` history column isolated it: most of that offset is the dependency bump in #1148, not this change.

The residual on number-writing paths was real, though — an early `n.is_nan()` check ran before the `repr == None` short-circuit, adding work to every computed value. Reordered so `None` bails first. Final same-machine A/B:

```
benchmark                      main      HEAD     ratio
CONTROL .name (string)         1.22      1.20     0.984
CONTROL .name|ascii_upcase     1.39      1.38     0.993
.x | tostring                  1.00      0.97     0.970
.x | @json                     0.75      0.74     0.987
[.x] | add                     0.73      0.72     0.986
```

Number paths land at or below the non-numeric controls — no regression.

## Unrelated flake fixed here (second commit)

The first CI run failed on `destructure_pattern_strict`, not on anything this branch touches:

```
called `Result::unwrap()` on an `Err` value:
Os { code: 32, kind: BrokenPipe, message: "Broken pipe" }
```

`accepts()` pipes `[1,2]` into jq-jit and unwraps the write, but every filter in the reject set is a *compile* error — jq-jit exits with code 3 without ever reading stdin. Whether the write lands first is a race; a loaded runner loses it. Reproduced deterministically by sleeping 300ms between spawn and write.

EPIPE there is the expected outcome, not a failure: only the exit code decides the verdict, and it is unchanged when the input never arrives (`. as [] | "ok"` exits 3 on `</dev/null`, `[1,2] as [$a,$b] | $a` exits 0). The write now swallows `BrokenPipe` and still panics on any other error. Kept as its own commit.

## Docs

- `docs/maintenance.md`: new invariant section — the two output paths must share one rule, the repr is dropped only by computation, and why `have_decnum` stays `false`
- `README.md`: the "Number representation" limitation rewrote from "doubles, so you lose it" to the actual output-vs-compute split, since the `tojson` / `fromjson` claim in it is no longer true

Closes #1149

🤖 Generated with [Claude Code](https://claude.com/claude-code)
